### PR TITLE
Add license information

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,69 @@
+# VTR License
+
+The software package "VTR" includes the software tools ODIN II, ABC, and VPR as
+well as additional benchmarks, documentation, and scripts. The authors of the
+various components of VTR retain their ownership of their tools.
+
+* With the exception of ABC and the benchmark circuits, all software,
+documents, and scripts in VTR, follows the standard MIT license described
+[here](http://www.opensource.org/licenses/mit-license.php) copied below for
+your convenience:
+
+The MIT License (MIT) Copyright (c) 2012 copyright Jason Luu, Jeffrey Goeders,
+Chi Wai Yu, Opal Densmore, Andrew Somerville, Kenneth Kent, Peter Jamieson,
+Jason Anderson, Ian Kuon, Alexander Marquardt, Andy Ye, Ted Campbell, Wei Mark
+Fang, Vaughn Betz, Jonathan Rose
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+* Terms and conditions for ABC is found
+[here](http://www.eecs.berkeley.edu/~alanmi/abc/copyright.htm) copied below
+for your convenience:
+
+Copyright (c) The Regents of the University of California. All rights reserved.
+
+Permission is hereby granted, without written agreement and without license or
+royalty fees, to use, copy, modify, and distribute this software and its
+documentation for any purpose, provided that the above copyright notice and the
+following two paragraphs appear in all copies of this software.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
+CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE,
+SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+The Verilog benchmark circuits are all open source but each have their own
+individual terms and conditions which are listed in the source code of each
+benchmark.
+
+Subject to these conditions, the software is provided free of charge to all
+interested parties.
+
+If you do decide to use this tool, please reference our work as references are
+important in academia.
+
+Donations in the form of research grants to promote further research and
+development on the tools will be gladly accepted, either anonymously or with
+attribution on our future publications.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ Graduate Students: Kevin Murray, Jason Luu, Oleg Petelin, Jeffrey Goeders, Chi W
 Summer Students: Opal Densmore, Ted Campbell, Cong Wang, Peter Milankov, Scott Whitty, Michael Wainberg, Suya Liu, Miad Nasr, Nooruddin Ahmed, Thien Yu, Long Yu Wang, Matthew J.P. Walker, Amer Hesson, Sheng Zhong, Hanqing Zeng
 
 Companies: Altera Corporation, Texas Instruments
+
+License
+=======
+
+Generally most code is under MIT license, with the exception of ABC which is
+distributed under its own (permissive) terms. Full license details can be
+found [here](LICENSE.md).


### PR DESCRIPTION
This resolves #124. I have added license information according to @kmurray's answer mentioning [this page](http://www.eecg.utoronto.ca/vtr/terms.html).

I have only ommitted the registration statement ("Also, we appreciate it if users of the package register before downloading the tool but this is by no means a requirement.")

