### PR TITLE
Forbid FPGA size expansion for explicit size

### DIFF
--- a/vpr/SRC/pack/cluster.c
+++ b/vpr/SRC/pack/cluster.c
@@ -350,8 +350,8 @@ void do_clustering(const t_arch *arch, t_pack_molecule *molecule_head,
 	}
 
 	/* TODO: make better estimate for nx and ny, was initializing nx = ny = 1 */
-	nx = (arch->clb_grid.IsAuto ? 1 : arch->clb_grid.W);
-	ny = (arch->clb_grid.IsAuto ? 1 : arch->clb_grid.H);
+	nx = arch->clb_grid.W;
+	ny = arch->clb_grid.H;
 
 	check_clocks(is_clock);
 #if 0
@@ -2028,6 +2028,9 @@ static void start_new_cluster(
 
 		/* Expand FPGA size and recalculate number of available cluster types*/
 		if (!success) {
+			/* Do not expand FPGA if fixed layout specified in architecture file */
+			if(!arch->clb_grid.IsAuto)
+				vpr_throw(VPR_ERROR_PACK, __FILE__, __LINE__, "Not enough resources inside fixed FPGA size to x = %d y = %d.\n", nx, ny);
 			if (aspect >= 1.0) {
 				ny++;
 				nx = nint(ny * aspect);


### PR DESCRIPTION
Do not expand FPGA size if width and height specified explicitly.
If width and height specified explicitly using <layout> tag in XML file I believe it should be treated as fixed FPGA size. But expansion happen regardless of layout type (auto or width/height).
On the other hand explicit specification can be used to specify initial size for packer. Especially when there is a big design which require to check all 1x1, 2x2, ... 100x100 iterations.
For later case I offer to use optional 'init_width' tag with 'auto' which will specify initial value for packer (height will be recalculated using specified ratio).