### PR TITLE
Check out-of-bound signal access

### DIFF
--- a/vpr/SRC/base/read_blif.c
+++ b/vpr/SRC/base/read_blif.c
@@ -703,6 +703,12 @@ static void add_subckt(bool doall, t_model *user_models) {
 								subckt_signal_name[i], subckt_name);
 					}
 					found_subckt_signal = true;
+					if(my_atoi(pin_number) >= port->size)
+					{
+						vpr_throw(VPR_ERROR_BLIF_F, __FILE__, __LINE__,
+								"Out-of-bound access to index %d of signal %s.%s [%d:0].\n",
+								my_atoi(pin_number), subckt_name, port->name, port->size-1);
+					}
 					if (port->is_clock) {
 						assert(
 								logical_block[num_logical_blocks - 1].clock_net
@@ -737,6 +743,12 @@ static void add_subckt(bool doall, t_model *user_models) {
 								subckt_signal_name[i], subckt_name);
 					}
 					found_subckt_signal = true;
+					if(my_atoi(pin_number) >= port->size)
+					{
+						vpr_throw(VPR_ERROR_BLIF_F, __FILE__, __LINE__,
+								"Out-of-bound access to index %d of signal %s.%s [%d:0].\n",
+								my_atoi(pin_number), subckt_name, port->name/*subckt_signal_name[i]*/, port->size-1);
+					}
 					logical_block[num_logical_blocks - 1].output_nets[port->index][my_atoi(
 							pin_number)] = add_vpack_net(circuit_signal_name[i],
 							DRIVER, num_logical_blocks - 1, port->index,


### PR DESCRIPTION
In some cases when incorrect blif netlist given VPR fails with double_free error.
Valgrind reports invalid write in this case.

Consider following example. Assume some block 'dsp' has 4-bit input port 'amode' as specified by XML.
Assume blif connects extra pin 'amode[4]=some_signal' for 'dsp' subckt.
VPR try to execute following code, where 'my_itoa(pin_number)' = 4, but port->size = 4(3:0). Thus out-of-bound memory access happen.
                        logical_block[num_logical_blocks - 1].input_nets[port->index][my_atoi(
                                pin_number)] = add_vpack_net(
                                circuit_signal_name[i], RECEIVER,
                                num_logical_blocks - 1, port->index,
                                my_atoi(pin_number), false, doall);

Added report for such case to provide user information about incorrect input data.
