### PR TITLE
Avoid seg-fault on bidirectional buses

### DIFF
--- a/vpr/SRC/base/read_blif.c
+++ b/vpr/SRC/base/read_blif.c
@@ -929,6 +929,7 @@ static int add_vpack_net(char *ptr, int type, int bnum, int bport, int bpin,
 			} else {
 				vpack_net[nindex].num_sinks++;
 				if ((num_driver[nindex] < 0) || (num_driver[nindex] > 1)) {
+					assert(index < num_logical_nets);
 					vpr_throw(VPR_ERROR_BLIF_F, __FILE__, __LINE__,
 							"Number of drivers for net #%d (%s) has %d drivers.\n",
 							nindex, ptr, num_driver[index]);


### PR DESCRIPTION
When inout net created in Verilog, and passed to VPR from BLIF with both .input and .output VPR generates segmentation fault when reporting:

```
                if ((num_driver[nindex] < 0) || (num_driver[nindex] > 1)) {
                    vpr_throw(VPR_ERROR_BLIF_F, __FILE__, __LINE__,
                            "Number of drivers for net #%d (%s) has %d drivers.\n",
                            nindex, ptr, num_driver[index]);
                }
```

This error it not repeatable. When run with Valgrind message produced without segfault.
GDB log reports something like this

```
952                             nindex, ptr, num_driver[index]);
#0  0x00000000004cd160 in add_vpack_net (ptr=0x5d24790 "spi_miso", type=1, bnum=45936, bport=0, bpin=2, is_global=false, doall=true)
    at SRC/base/read_blif.c:952
#1  0x00000000004cae7e in add_lut (doall=true, logic_model=0x1e02bc0) at SRC/base/read_blif.c:434
#2  0x00000000004ca5f5 in get_blif_tok (buffer=0x7fffb0aea340 ".names", doall=true, done=0x7fffb0aea315, add_truth_table=0x7fffb0aea316, 
```

I suggest to add assertion to check whether 'index' point inside num_driver array, which is 'num_logical_nets' number of elements.
