### PR TITLE
ODIN: added check that branch is empty

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.c
+++ b/ODIN_II/SRC/netlist_create_from_ast.c
@@ -4254,8 +4254,8 @@ signal_list_t *create_mux_statements(signal_list_t **statement_lists, nnode_t *m
 
 			/* check if the current element for this case statement is defined */ 	
 			if (
-					   (per_case_statement_idx[j] < statement_lists[j]->count)
-					&& (strcmp(combined_lists->pins[i]->name, statement_lists[j]->pins[per_case_statement_idx[j]]->name) == 0)
+					   (per_case_statement_idx[j] < (statement_lists[j] ? statement_lists[j]->count : 0))
+					&& (statement_lists[j] ? (strcmp(combined_lists->pins[i]->name, statement_lists[j]->pins[per_case_statement_idx[j]]->name) == 0) : 0)
 			)
 			{
 				/* If they match then we have a signal with this name and we can attach the pin */ 

--- a/ODIN_II/SRC/netlist_utils.c
+++ b/ODIN_II/SRC/netlist_utils.c
@@ -628,8 +628,9 @@ signal_list_t *combine_lists_without_freeing_originals(signal_list_t **signal_li
 	for (i = 0; i < num_signal_lists; i++)
 	{
 		int j;
-		for (j = 0; j < signal_lists[i]->count; j++)
-			add_pin_to_signal_list(return_list, signal_lists[i]->pins[j]);
+		if(signal_lists[i])
+			for (j = 0; j < signal_lists[i]->count; j++)
+				add_pin_to_signal_list(return_list, signal_lists[i]->pins[j]);
 	}
 
 	return return_list;
@@ -678,7 +679,8 @@ static int compare_npin_t_names(const void *p1, const void *p2)
 
 void sort_signal_list_alphabetically(signal_list_t *list)
 {
-	qsort(list->pins, list->count,  sizeof(npin_t *), compare_npin_t_names);
+	if(list)
+		qsort(list->pins, list->count,  sizeof(npin_t *), compare_npin_t_names);
 }
 
 /*---------------------------------------------------------------------------------------------


### PR DESCRIPTION
When case item found without any statement function 'sort_signal_list_alphabetically' called from file 'netlist_create_from_ast.c' without check that list != NULL:
`	sort_signal_list_alphabetically(case_statement[i]);`
Allow sorting only when there are statements inside processed branch.

Same check made in 'combine_lists_without_freeing_originals' and 'create_mux_statements'.
