### PR TITLE
[Odin] Add Ability to Treat Latches as BlackBoxes and Output them to the BLIF File as Such

### DIFF
--- a/ODIN_II/SRC/lib_blif/output_blif.cpp
+++ b/ODIN_II/SRC/lib_blif/output_blif.cpp
@@ -690,19 +690,69 @@ void define_ff(nnode_t *node, FILE *out)
 
 	/* input, output, clock */
 	if (global_args.high_level_block != NULL)
-		fprintf(out, ".latch %s^^%i-%i %s^^%i-%i re %s^^%i-%i %d", node->input_pins[0]->net->driver_pin->node->name, node->input_pins[0]->net->driver_pin->node->related_ast_node->far_tag, node->input_pins[0]->net->driver_pin->node->related_ast_node->high_number, node->name, node->related_ast_node->far_tag, node->related_ast_node->high_number, node->input_pins[1]->net->driver_pin->node->name, node->input_pins[1]->net->driver_pin->node->related_ast_node->far_tag, node->input_pins[1]->net->driver_pin->node->related_ast_node->high_number, initial_value);
+	{
+		if(global_args.black_box_latches)
+		{
+			haveOutputLatchBlackbox = TRUE;
+
+			fprintf(out, ".subckt bb_latch i0=%s^^%i-%i o0=%s^^%i-%i re %s^^%i-%i %d",
+							node->input_pins[0]->net->driver_pin->node->name,
+							node->input_pins[0]->net->driver_pin->node->related_ast_node->far_tag,
+							node->input_pins[0]->net->driver_pin->node->related_ast_node->high_number,
+							node->name, node->related_ast_node->far_tag,
+							node->related_ast_node->high_number,
+							node->input_pins[1]->net->driver_pin->node->name,
+							node->input_pins[1]->net->driver_pin->node->related_ast_node->far_tag,
+							node->input_pins[1]->net->driver_pin->node->related_ast_node->high_number,
+							initial_value);
+		}
+		else
+		{
+			fprintf(out, ".latch %s^^%i-%i %s^^%i-%i re %s^^%i-%i %d",
+							node->input_pins[0]->net->driver_pin->node->name,
+							node->input_pins[0]->net->driver_pin->node->related_ast_node->far_tag,
+							node->input_pins[0]->net->driver_pin->node->related_ast_node->high_number,
+							node->name, node->related_ast_node->far_tag,
+							node->related_ast_node->high_number,
+							node->input_pins[1]->net->driver_pin->node->name,
+							node->input_pins[1]->net->driver_pin->node->related_ast_node->far_tag,
+							node->input_pins[1]->net->driver_pin->node->related_ast_node->high_number,
+							initial_value);
+		}
+	}
 	else
 	{
 		if (node->input_pins[0]->net->driver_pin->name == NULL)
-			fprintf(out, ".latch %s %s re ", node->input_pins[0]->net->driver_pin->node->name, node->name);
+		{
+			if(global_args.black_box_latches)
+			{
+				haveOutputLatchBlackbox = TRUE;
+
+				fprintf(out, ".subckt bb_latch i0=%s o0=%s re ", node->input_pins[0]->net->driver_pin->node->name, node->name);
+			}
+			else
+			{
+				fprintf(out, ".latch %s %s re ", node->input_pins[0]->net->driver_pin->node->name, node->name);
+			}
+		}
 		else
-			fprintf(out, ".latch %s %s re ", node->input_pins[0]->net->driver_pin->name, node->name);
+		{
+			if(global_args.black_box_latches)
+			{
+				haveOutputLatchBlackbox = TRUE;
+
+				fprintf(out, ".subckt bb_latch i0=%s o0=%s re ", node->input_pins[0]->net->driver_pin->name, node->name);
+			}
+			else
+			{
+				fprintf(out, ".latch %s %s re ", node->input_pins[0]->net->driver_pin->name, node->name);
+			}
+		}
 
 		if (node->input_pins[1]->net->driver_pin->name == NULL)
 			fprintf(out, "%s %d\n", node->input_pins[1]->net->driver_pin->node->name, initial_value);
 		else
 			fprintf(out, "%s %d\n", node->input_pins[1]->net->driver_pin->name, initial_value);
-
 	}
 	fprintf(out, "\n");
 }

--- a/ODIN_II/SRC/lib_blif/output_blif.cpp
+++ b/ODIN_II/SRC/lib_blif/output_blif.cpp
@@ -38,6 +38,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "vtr_util.h"
 #include "vtr_memory.h"
 
+short haveOutputLatchBlackbox = FALSE;
+
 void depth_first_traversal_to_output(short marker_value, FILE *fp, netlist_t *netlist);
 void depth_traverse_output_blif(nnode_t *node, int traverse_mark_number, FILE *fp);
 void output_node(nnode_t *node, short traverse_number, FILE *fp);
@@ -46,6 +48,7 @@ void define_set_input_logical_function(nnode_t *node, const char *bit_output, FI
 void define_ff(nnode_t *node, FILE *out);
 void define_decoded_mux(nnode_t *node, FILE *out);
 void output_blif_pin_connect(nnode_t *node, FILE *out);
+void add_the_blackbox_for_latches(FILE *out);
 void output_blif(char *file_name, netlist_t *netlist);
 
 /*---------------------------------------------------------------------------
@@ -218,6 +221,13 @@ void output_blif(char *file_name, netlist_t *netlist)
 	/* Print out any hard block modules */
 	add_the_blackbox_for_mults(out);
 	add_the_blackbox_for_adds(out);
+
+	//Check if blackbox latches are enabled && one has been included in the BLIF file
+	if(global_args.black_box_latches && (TRUE == haveOutputLatchBlackbox))
+	{
+		add_the_blackbox_for_latches(out);
+	}
+
 	output_hard_blocks(out);
 	fclose(out);
 }
@@ -795,6 +805,31 @@ void define_decoded_mux(nnode_t *node, FILE *out)
 	}
 
 	fprintf(out, "\n");
+}
+
+/*--------------------------------------------------------------------------
+ * (function: add_the_blackbox_for_latches)
+ *------------------------------------------------------------------------*/
+void add_the_blackbox_for_latches(FILE *out)
+{
+	fprintf(out, ".model bb_latch\n");
+
+	/* add the inputs */
+	fprintf(out, ".inputs");
+	fprintf(out, " i0");
+	fprintf(out, "\n");
+
+	/* add the outputs */
+	fprintf(out, ".outputs");
+	fprintf(out, " o0");
+	fprintf(out, "\n");
+
+	fprintf(out, ".blackbox\n");
+	fprintf(out, ".end\n");
+	fprintf(out, "\n");
+
+
+	return;
 }
 
 /*--------------------------------------------------------------------------

--- a/ODIN_II/SRC/types.h
+++ b/ODIN_II/SRC/types.h
@@ -155,6 +155,8 @@ struct global_args_t_t
     argparse::ArgValue<bool> all_warnings;
     argparse::ArgValue<bool> show_help;
 
+    argparse::ArgValue<bool> black_box_latches; //Weather or not to treat and output latches as black boxes
+
 	/////////////////////
 	// For simulation.
 	/////////////////////


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add Command Line Option `-black_box_latches` to Treat Latches as BlackBoxes and Output them as such
- Add flag in output_bliff.cpp to track if we have generated a BlackBoxed Latch
- Output Latch BlackBox Model to BLIF File if Command Line Argument is specified and if we have previously generated a BlackBoxed Latch in the BLIF File
- Output Latches as BlackBoxed Latch when Command Line Argument has been specified

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
`ABC` not handling Latches correctly.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves an issue with `ABC` not handling Latches correctly.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `ODIN_II/verify_full.sh`, `run_quick_test.pl`, `vtr_reg_basic` and `vtr_reg_strong` regression tests with no qor test or run failures.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
