### PR TITLE
tex no longer draws above bounding box

### DIFF
--- a/libeasygl/src/graphics.cpp
+++ b/libeasygl/src/graphics.cpp
@@ -2440,7 +2440,7 @@ void drawtext(float xc, float yc, const std::string& str_text, float boundx, flo
             current_font,
             // more magic offsets
             xworld_to_scrn(text_bbox.left()) + extents.x,
-            yworld_to_scrn(text_bbox.top()) + extents.y - extents.height,
+            yworld_to_scrn(text_bbox.bottom()) + extents.y - extents.height,
             reinterpret_cast<const FcChar8*>(text),
             text_byte_length
             );


### PR DESCRIPTION
the old code was drawing the text above the bounding box. Now, the text will actually be centred on the given point.

quite embarrassingly, I introduced this bug years ago.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
