### PR TITLE
Produce better error messages instead of failing with asserts.

### DIFF
--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -1115,8 +1115,16 @@ void SyncModelsPbTypes_rec(t_arch *arch,
 						model_port->min_size = pb_type->ports[p].num_pins;
 					}
 					pb_type->ports[p].model_port = model_port;
-					VTR_ASSERT(pb_type->ports[p].type == model_port->dir);
-					VTR_ASSERT(pb_type->ports[p].is_clock == model_port->is_clock);
+					if(pb_type->ports[p].type != model_port->dir) {
+						archfpga_throw(get_arch_file_name(), 0,
+								"Direction for port '%s' on model does not match port direction in pb_type '%s'\n",
+								pb_type->ports[p].name, pb_type->name);
+					}
+					if(pb_type->ports[p].is_clock != model_port->is_clock) {
+						archfpga_throw(get_arch_file_name(), 0,
+								"Port '%s' on model does not match is_clock in pb_type '%s'\n",
+								pb_type->ports[p].name, pb_type->name);
+					}
 					found = true;
 				}
 				model_port = model_port->next;
@@ -1131,8 +1139,13 @@ void SyncModelsPbTypes_rec(t_arch *arch,
 							|| model_port->min_size == -1) {
 						model_port->min_size = pb_type->ports[p].num_pins;
 					}
+
 					pb_type->ports[p].model_port = model_port;
-					VTR_ASSERT(pb_type->ports[p].type == model_port->dir);
+					if(pb_type->ports[p].type != model_port->dir) {
+						archfpga_throw(get_arch_file_name(), 0,
+								"Direction for port '%s' on model does not match port direction in pb_type '%s'\n",
+								pb_type->ports[p].name, pb_type->name);
+					}
 					found = true;
 				}
 				model_port = model_port->next;

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -110,10 +110,13 @@ void check_rr_graph(const t_graph_type graph_type,
                     /* Between two wire segments.  Two connections are legal only if  *
                      * one connection is a buffer and the other is a pass transistor. */
 
-                else if (num_edges_from_current_to_node[to_node] != 2
-                        || switch_types_from_current_to_node[to_node] != BUF_AND_PTRANS_FLAG) {
+                else if (num_edges_from_current_to_node[to_node] != 2) {
                     vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
                             "in check_rr_graph: node %d connects to node %d %d times.\n", inode, to_node, num_edges_from_current_to_node[to_node]);
+                }
+                else if (switch_types_from_current_to_node[to_node] != BUF_AND_PTRANS_FLAG) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_graph: node %d connects to node %d %d times but not BUF_AND_PTRANS_FLAG.\n", inode, to_node, num_edges_from_current_to_node[to_node]);
                 }
             }
 

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -2031,7 +2031,9 @@ static void get_switch_type(
 
         /* Take the smaller index unless the other 
          * pass_trans is bigger (smaller R). */
-        VTR_ASSERT(used < 2);
+        if (used < 2) {
+            VPR_THROW(VPR_ERROR_ROUTE, "Used %d (min: %d max: %d)", used, min_switch, max_switch);
+	}
         switch_types[used] = min_switch;
         if (device_ctx.arch_switch_inf[max_switch].R < device_ctx.arch_switch_inf[min_switch].R) {
             switch_types[used] = max_switch;


### PR DESCRIPTION
During #245 I have been generating rr_graph and other xml files. In a couple of places vpr would just die with a cryptic assert.

These changes make vpr instead die with a useful error message about what went wrong.