### PR TITLE
Add spaces to echo_arch file for fc_value_type output.

### DIFF
--- a/libs/libarchfpga/src/echo_arch.cpp
+++ b/libs/libarchfpga/src/echo_arch.cpp
@@ -86,9 +86,9 @@ void EchoArch(const char *EchoFile, const t_type_descriptor* Types,
             } else {
                 VTR_ASSERT(false);
             }
-            fprintf(Echo, "fc_value: %f", fc_spec.fc_value);
-            fprintf(Echo, "segment: %s", arch->Segments[fc_spec.seg_index].name);
-            fprintf(Echo, "pins:");
+            fprintf(Echo, " fc_value: %f", fc_spec.fc_value);
+            fprintf(Echo, " segment: %s", arch->Segments[fc_spec.seg_index].name);
+            fprintf(Echo, " pins:");
             for (int pin : fc_spec.pins) {
                 fprintf(Echo, " %d", pin);
             }


### PR DESCRIPTION
Small fix to the `arch.echo` file output.

Before: `fc_value_type: FRACTIONALfc_value: 0.000000segment: globalpins: 0 1 2 3`
After: `fc_value_type: FRACTIONAL fc_value: 0.000000 segment: global pins: 0 1 2 3`
