### PR TITLE
libarchfpga: Throw an error on missing blif.

### DIFF
--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -3316,7 +3316,11 @@ bool check_leaf_pb_model_timing_consistency(const t_pb_type* pb_type, const t_ar
             break;
         }
     }
-    VTR_ASSERT(model != nullptr);
+    if (model == nullptr) {
+        archfpga_throw(get_arch_file_name(), -1,
+            "Unable to find model for blif_model '%s' found on pb_type '%s'",
+            blif_model.c_str(), pb_type->name);
+    }
 
     //Now that we have the model we can compare the timing annotations
      


### PR DESCRIPTION
#### Description
Throw an error about the which blif_model is missing and on what pb_type that blif_model is referenced from. Previously it would just die with an assert which made it hard to figure out what was missing.