### PR TITLE
Improve errors on direct CLB to CLB interconnects.

### DIFF
--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2444,7 +2444,9 @@ static t_clb_to_clb_directs * alloc_and_load_clb_to_clb_directs(const t_direct_i
                 break;
             }
         }
-        VTR_ASSERT(j < device_ctx.num_block_types);
+        if (j >= device_ctx.num_block_types) {
+            vpr_throw(VPR_ERROR_ARCH, get_arch_file_name(), directs[i].line, "Unable to find block %s.\n", pb_type_name);
+        }
         clb_to_clb_directs[i].from_clb_type = &device_ctx.block_types[j];
         pb_type = clb_to_clb_directs[i].from_clb_type->pb_type;
 
@@ -2453,7 +2455,9 @@ static t_clb_to_clb_directs * alloc_and_load_clb_to_clb_directs(const t_direct_i
                 break;
             }
         }
-        VTR_ASSERT(j < pb_type->num_ports);
+        if (j >= pb_type->num_ports) {
+            vpr_throw(VPR_ERROR_ARCH, get_arch_file_name(), directs[i].line, "Unable to find port %s (on block %s).\n", port_name, pb_type_name);
+        }
 
         if (start_pin_index == OPEN) {
             VTR_ASSERT(start_pin_index == end_pin_index);
@@ -2473,7 +2477,9 @@ static t_clb_to_clb_directs * alloc_and_load_clb_to_clb_directs(const t_direct_i
                 break;
             }
         }
-        VTR_ASSERT(j < device_ctx.num_block_types);
+        if (j >= device_ctx.num_block_types) {
+            vpr_throw(VPR_ERROR_ARCH, get_arch_file_name(), directs[i].line, "Unable to find block %s.\n", pb_type_name);
+        }
         clb_to_clb_directs[i].to_clb_type = &device_ctx.block_types[j];
         pb_type = clb_to_clb_directs[i].to_clb_type->pb_type;
 
@@ -2482,7 +2488,9 @@ static t_clb_to_clb_directs * alloc_and_load_clb_to_clb_directs(const t_direct_i
                 break;
             }
         }
-        VTR_ASSERT(j < pb_type->num_ports);
+        if (j >= pb_type->num_ports) {
+            vpr_throw(VPR_ERROR_ARCH, get_arch_file_name(), directs[i].line, "Unable to find port %s (on block %s).\n", port_name, pb_type_name);
+        }
 
         if (start_pin_index == OPEN) {
             VTR_ASSERT(start_pin_index == end_pin_index);


### PR DESCRIPTION
Previously it would either fail the assert or segfault. Now it outputs
errors like the following;
```
Error 1:
Type: Architecture file
File: artix7/arch/xc7a50t-roi-virt/merged.xml
Line: 22106
Message: Unable to find block BLK_MB-INT_R-CLBLL_R-INT_R.
```