### PR TITLE
Rewrite output_clustering using pugixml

### DIFF
--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -27,7 +27,8 @@ target_link_libraries(libvpr
                         libblifparse
                         libeasygl
                         libtatum
-                        libargparse)
+                        libargparse
+                        libpugixml)
 
 #Create the executable
 add_executable(vpr ${EXEC_SOURCES})

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -17,6 +17,8 @@ using namespace std;
 #include "vpr_types.h"
 #include "vpr_error.h"
 
+#include "pugixml.hpp"
+
 #include "globals.h"
 #include "atom_netlist.h"
 #include "pack_types.h"
@@ -36,459 +38,6 @@ static t_pb_graph_pin ***pb_graph_pin_lookup_from_index_by_type = NULL; /* [0..d
 
 
 /**************** Subroutine definitions ************************************/
-
-static void print_string(const char *str_ptr, int *column, int num_tabs, FILE * fpout) {
-
-	/* 
-     * Column points to the column in which the next character will go (both 
-     * used and updated), and fpout points to the output file.
-     */
-
-	int len;
-
-	len = strlen(str_ptr);
-
-	if (*column + len + 2 > LINELENGTH) {
-		fprintf(fpout, "\n");
-		print_tabs(fpout, num_tabs);
-		*column = num_tabs * TAB_LENGTH;
-	}
-
-	fprintf(fpout, "%s ", str_ptr);
-	*column += len + 1;
-}
-
-static void print_net_name(AtomNetId net_id, int *column, int num_tabs, FILE * fpout) {
-
-	/* This routine prints out the atom_ctx.nlist net name (or open).  
-     * net_num is the index of the atom_ctx.nlist net to be printed, while     *
-	 * column points to the current printing column (column is both     *
-	 * used and updated by this routine).  fpout is the output file     *
-	 * pointer.                                                         */
-
-	const char *str_ptr;
-
-	if (!net_id) {
-		str_ptr = "open";
-    } else {
-        auto& atom_ctx = g_vpr_ctx.atom();
-		str_ptr = atom_ctx.nlist.net_name(net_id).c_str();
-    }
-
-	print_string(str_ptr, column, num_tabs, fpout);
-}
-
-static void print_interconnect(t_type_ptr type, int inode, int *column, int num_tabs, t_pb_route *pb_route, 
-		FILE * fpout) {
-
-	char *str_ptr, *name;
-	int prev_node, prev_edge;
-	int len;
-
-
-	if (!pb_route[inode].atom_net_id) {
-		print_string("open", column, num_tabs, fpout);
-	} else {
-		str_ptr = NULL;
-		prev_node = pb_route[inode].driver_pb_pin_id;
-
-		if (prev_node == OPEN) {
-			/* No previous driver implies that this is either a top-level input pin or a primitive output pin */
-			t_pb_graph_pin *cur_pin = pb_graph_pin_lookup_from_index_by_type[type->index][inode];
-			VTR_ASSERT(cur_pin->parent_node->pb_type->parent_mode == NULL || 
-					(cur_pin->parent_node->pb_type->num_modes == 0 && cur_pin->port->type == OUT_PORT)
-					);
-			print_net_name(pb_route[inode].atom_net_id, column, num_tabs, fpout);
-		} else {
-			t_pb_graph_pin *cur_pin = pb_graph_pin_lookup_from_index_by_type[type->index][inode];
-			t_pb_graph_pin *prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
-			
-			for(prev_edge = 0; prev_edge < prev_pin->num_output_edges; prev_edge++) {
-				VTR_ASSERT(prev_pin->output_edges[prev_edge]->num_output_pins == 1);
-				if(prev_pin->output_edges[prev_edge]->output_pins[0]->pin_count_in_cluster == inode) {
-					break;
-				}
-			}
-			VTR_ASSERT(prev_edge < prev_pin->num_output_edges);
-
-			name =	prev_pin->output_edges[prev_edge]->interconnect->name;
-			if (prev_pin->port->parent_pb_type->depth
-					>= cur_pin->port->parent_pb_type->depth) {
-				/* Connections from siblings or children should have an explicit index, connections from parent does not need an explicit index */
-				len = strlen(prev_pin->parent_node->pb_type->name)
-                      + prev_pin->parent_node->placement_index / 10
-                      + strlen( prev_pin->port->name)
-                      + prev_pin->pin_number / 10 
-                      + strlen(name)
-                      + 11;
-				str_ptr = (char*)vtr::malloc(len * sizeof(char));
-				sprintf(str_ptr, "%s[%d].%s[%d]->%s ",
-						prev_pin->parent_node->pb_type->name,
-						prev_pin->parent_node->placement_index,
-						prev_pin->port->name,
-						prev_pin->pin_number, name);
-			} else {
-				len = strlen(prev_pin->parent_node->pb_type->name)
-					  + strlen(prev_pin->port->name)
-					  + prev_pin->pin_number / 10 
-                      + strlen(name)
-                      + 8;
-				str_ptr = (char*)vtr::malloc(len * sizeof(char));
-				sprintf(str_ptr, "%s.%s[%d]->%s ",
-						prev_pin->parent_node->pb_type->name,
-						prev_pin->port->name,
-						prev_pin->pin_number, name);
-			}
-			print_string(str_ptr, column, num_tabs, fpout);
-		}
-		if (str_ptr)
-			free(str_ptr);
-	}
-}
-
-static void print_open_pb_graph_node(t_type_ptr type, t_pb_graph_node * pb_graph_node,
-		int pb_index, bool is_used, t_pb_route *pb_route, int tab_depth, FILE * fpout) {
-	int column = 0;
-	int i, j, k, m;
-	const t_pb_type * pb_type, *child_pb_type;
-	t_mode * mode = NULL;
-	int prev_edge, prev_node;
-	int mode_of_edge, port_index, node_index;
-
-	mode_of_edge = UNDEFINED;
-
-	pb_type = pb_graph_node->pb_type;
-
-	print_tabs(fpout, tab_depth);
-
-	if (is_used) {
-		/* Determine mode if applicable */
-		port_index = 0;
-		for (i = 0; i < pb_type->num_ports; i++) {
-			if (pb_type->ports[i].type == OUT_PORT) {
-				VTR_ASSERT(!pb_type->ports[i].is_clock);
-				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-					node_index =
-							pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
-					if (pb_type->num_modes > 0
-						&& pb_route[node_index].atom_net_id) {
-						prev_node = pb_route[node_index].driver_pb_pin_id;
-						t_pb_graph_pin *prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
-						for(prev_edge = 0; prev_edge < prev_pin->num_output_edges; prev_edge++) {
-							VTR_ASSERT(prev_pin->output_edges[prev_edge]->num_output_pins == 1);
-							if(prev_pin->output_edges[prev_edge]->output_pins[0]->pin_count_in_cluster == node_index) {
-								break;
-							}
-						}
-						VTR_ASSERT(prev_edge < prev_pin->num_output_edges);
-						mode_of_edge =
-								prev_pin->output_edges[prev_edge]->interconnect->parent_mode_index;
-						VTR_ASSERT(
-								mode == NULL || &pb_type->modes[mode_of_edge] == mode);
-						VTR_ASSERT(mode_of_edge == 0); /* for now, unused blocks must always default to use mode 0 */
-						mode = &pb_type->modes[mode_of_edge];
-					}
-				}
-				port_index++;
-			}
-		}
-
-		VTR_ASSERT(mode != NULL && mode_of_edge != UNDEFINED);
-		fprintf(fpout,
-				"<block name=\"open\" instance=\"%s[%d]\" mode=\"%s\">\n",
-				pb_graph_node->pb_type->name, pb_index, mode->name);
-
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "\t<inputs>\n");
-		port_index = 0;
-		for (i = 0; i < pb_type->num_ports; i++) {
-			if (!pb_type->ports[i].is_clock
-					&& pb_type->ports[i].type == IN_PORT) {
-				print_tabs(fpout, tab_depth);
-				fprintf(fpout, "\t\t<port name=\"%s\">",
-						pb_graph_node->pb_type->ports[i].name);
-				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-					node_index =
-							pb_graph_node->input_pins[port_index][j].pin_count_in_cluster;
-					print_interconnect(type, node_index, &column, tab_depth + 2, pb_route,
-							fpout);
-				}
-				fprintf(fpout, "</port>\n");
-				port_index++;
-			}
-		}
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "\t</inputs>\n");
-
-		column = tab_depth * TAB_LENGTH + 8; /* Next column I will write to. */
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "\t<outputs>\n");
-		port_index = 0;
-		for (i = 0; i < pb_type->num_ports; i++) {
-			if (pb_type->ports[i].type == OUT_PORT) {
-				print_tabs(fpout, tab_depth);
-				fprintf(fpout, "\t\t<port name=\"%s\">",
-						pb_graph_node->pb_type->ports[i].name);
-				VTR_ASSERT(!pb_type->ports[i].is_clock);
-				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-					node_index =
-							pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
-					print_interconnect(type, node_index, &column, tab_depth + 2, pb_route,
-							fpout);
-				}
-				fprintf(fpout, "</port>\n");
-				port_index++;
-			}
-		}
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "\t</outputs>\n");
-
-		column = tab_depth * TAB_LENGTH + 8; /* Next column I will write to. */
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "\t<clocks>\n");
-		port_index = 0;
-		for (i = 0; i < pb_type->num_ports; i++) {
-			if (pb_type->ports[i].is_clock
-					&& pb_type->ports[i].type == IN_PORT) {
-				print_tabs(fpout, tab_depth);
-				fprintf(fpout, "\t\t<port name=\"%s\">",
-						pb_graph_node->pb_type->ports[i].name);
-				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-					node_index =
-							pb_graph_node->clock_pins[port_index][j].pin_count_in_cluster;
-					print_interconnect(type, node_index, &column, tab_depth + 2, pb_route,
-							fpout);
-				}
-				fprintf(fpout, "</port>\n");
-				port_index++;
-			}
-		}
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "\t</clocks>\n");
-
-		if (pb_type->num_modes > 0) {
-			for (i = 0; i < mode->num_pb_type_children; i++) {
-				child_pb_type = &mode->pb_type_children[i];
-				for (j = 0; j < mode->pb_type_children[i].num_pb; j++) {
-					port_index = 0;
-					is_used = false;
-					for (k = 0; k < child_pb_type->num_ports && !is_used; k++) {
-						if (child_pb_type->ports[k].type == OUT_PORT) {
-							for (m = 0; m < child_pb_type->ports[k].num_pins;
-									m++) {
-								node_index =
-										pb_graph_node->child_pb_graph_nodes[mode_of_edge][i][j].output_pins[port_index][m].pin_count_in_cluster;
-								if (pb_route[node_index].atom_net_id) {
-									is_used = true;
-									break;
-								}
-							}
-							port_index++;
-						}
-					}
-					print_open_pb_graph_node(type, 
-							&pb_graph_node->child_pb_graph_nodes[mode_of_edge][i][j],
-							j, is_used, pb_route, tab_depth + 1, fpout);
-				}
-			}
-		}
-
-		print_tabs(fpout, tab_depth);
-		fprintf(fpout, "</block>\n");
-	} else {
-		fprintf(fpout, "<block name=\"open\" instance=\"%s[%d]\"/>\n",
-				pb_graph_node->pb_type->name, pb_index);
-	}
-}
-
-static void print_pb(FILE *fpout, t_type_ptr type, t_pb * pb, int pb_index, t_pb_route *pb_route, int tab_depth) {
-
-	int column;
-	int i, j, k, m;
-	const t_pb_type *pb_type, *child_pb_type;
-	t_pb_graph_node *pb_graph_node;
-	t_mode *mode;
-	int port_index, node_index;
-	bool is_used;
-	
-	pb_type = pb->pb_graph_node->pb_type;
-	pb_graph_node = pb->pb_graph_node;
-	mode = &pb_type->modes[pb->mode];
-	column = tab_depth * TAB_LENGTH + 8; /* Next column I will write to. */
-	print_tabs(fpout, tab_depth);
-	if (pb_type->num_modes == 0) {
-		fprintf(fpout, "<block name=\"%s\" instance=\"%s[%d]\">\n", pb->name,
-				pb_type->name, pb_index);
-	} else {
-		fprintf(fpout, "<block name=\"%s\" instance=\"%s[%d]\" mode=\"%s\">\n",
-				pb->name, pb_type->name, pb_index, mode->name);
-	}
-
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "\t<inputs>\n");
-	port_index = 0;
-	for (i = 0; i < pb_type->num_ports; i++) {
-		if (!pb_type->ports[i].is_clock && pb_type->ports[i].type == IN_PORT) {
-
-			print_tabs(fpout, tab_depth);
-			fprintf(fpout, "\t\t<port name=\"%s\">", pb_graph_node->pb_type->ports[i].name);
-			for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-				node_index = pb->pb_graph_node->input_pins[port_index][j].pin_count_in_cluster;
-
-				if (pb_type->parent_mode == NULL) {
-					print_net_name(pb_route[node_index].atom_net_id, &column, tab_depth, fpout);
-				} else {
-					print_interconnect(type, node_index, &column, tab_depth + 2, pb_route, fpout);
-				}
-			}
-			fprintf(fpout, "</port>\n");
-
-            //The cluster router may have rotated equivalent pins (e.g. LUT inputs), 
-            //record the resulting rotation here so it can be unambigously mapped 
-            //back to the atom netlist
-            if(pb_type->ports[i].equivalent && pb_type->parent_mode != NULL && pb_type->num_modes == 0) {
-                //This is a primitive with equivalent inputs
-
-                auto& atom_ctx = g_vpr_ctx.atom();
-                AtomBlockId atom_blk = atom_ctx.nlist.find_block(pb->name);
-                VTR_ASSERT(atom_blk);
-
-                AtomPortId atom_port = atom_ctx.nlist.find_atom_port(atom_blk, pb_type->ports[i].model_port);
-
-                if(atom_port) { //Port exists (some LUTs may have no input and hence no port in the atom netlist)
-
-                    print_tabs(fpout, tab_depth);
-                    fprintf(fpout, "\t\t<port_rotation_map name=\"%s\">", pb_graph_node->pb_type->ports[i].name);
-
-                    std::set<AtomPinId> recorded_pins;
-
-                    for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-                        node_index = pb->pb_graph_node->input_pins[port_index][j].pin_count_in_cluster;
-                        AtomNetId atom_net = pb_route[node_index].atom_net_id;
-
-                        if(atom_net) {
-                            //This physical pin is in use, find the original pin in the atom netlist
-                            AtomPinId orig_pin;
-                            for(AtomPinId atom_pin : atom_ctx.nlist.port_pins(atom_port)) {
-                                if(recorded_pins.count(atom_pin)) continue; //Don't add pins twice
-
-                                AtomNetId atom_pin_net = atom_ctx.nlist.pin_net(atom_pin);
-
-                                if(atom_pin_net == atom_net) {
-                                    recorded_pins.insert(atom_pin);
-                                    orig_pin = atom_pin;
-                                    break;
-                                }
-                            }
-
-                            VTR_ASSERT(orig_pin);
-                            //The physical pin j, maps to a pin in the atom netlist
-                            fprintf(fpout, "%d ", atom_ctx.nlist.pin_port_bit(orig_pin));
-                        } else {
-                            //The physical pin is disconnected
-                            fprintf(fpout, "open ");
-                        }
-                    }
-                    fprintf(fpout, "</port_rotation_map>\n");
-                }
-            }
-
-
-			port_index++;
-		}
-	}
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "\t</inputs>\n");
-
-	column = tab_depth * TAB_LENGTH + 8; /* Next column I will write to. */
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "\t<outputs>\n");
-	port_index = 0;
-	for (i = 0; i < pb_type->num_ports; i++) {
-		if (pb_type->ports[i].type == OUT_PORT) {
-			VTR_ASSERT(!pb_type->ports[i].is_clock);
-			print_tabs(fpout, tab_depth);
-			fprintf(fpout, "\t\t<port name=\"%s\">",
-					pb_graph_node->pb_type->ports[i].name);
-			for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-				node_index =
-						pb->pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
-				print_interconnect(type, node_index, &column, tab_depth + 2, pb_route, fpout);
-			}
-			fprintf(fpout, "</port>\n");
-			port_index++;
-		}
-	}
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "\t</outputs>\n");
-
-	column = tab_depth * TAB_LENGTH + 8; /* Next column I will write to. */
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "\t<clocks>\n");
-	port_index = 0;
-	for (i = 0; i < pb_type->num_ports; i++) {
-		if (pb_type->ports[i].is_clock && pb_type->ports[i].type == IN_PORT) {
-			print_tabs(fpout, tab_depth);
-			fprintf(fpout, "\t\t<port name=\"%s\">", pb_graph_node->pb_type->ports[i].name);
-			for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-				node_index = pb->pb_graph_node->clock_pins[port_index][j].pin_count_in_cluster;
-				if (pb_type->parent_mode == NULL) {
-					print_net_name(pb_route[node_index].atom_net_id, &column, tab_depth, fpout);
-				} else {
-					print_interconnect(type, node_index, &column, tab_depth + 2, pb_route, fpout);
-				}
-			}
-			fprintf(fpout, "</port>\n");
-			port_index++;
-		}
-	}
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "\t</clocks>\n");
-
-	if (pb_type->num_modes > 0) {
-		for (i = 0; i < mode->num_pb_type_children; i++) {
-			for (j = 0; j < mode->pb_type_children[i].num_pb; j++) {
-				/* If child pb is not used but routing is used, I must print things differently */
-				if ((pb->child_pbs[i] != NULL) && (pb->child_pbs[i][j].name != NULL)) {
-					print_pb(fpout, type, &pb->child_pbs[i][j], j, pb_route, tab_depth + 1);
-				} else {
-					is_used = false;
-					child_pb_type = &mode->pb_type_children[i];
-					port_index = 0;
-
-					for (k = 0; k < child_pb_type->num_ports && !is_used; k++) {
-						if (child_pb_type->ports[k].type == OUT_PORT) {
-							for (m = 0; m < child_pb_type->ports[k].num_pins; m++) {
-								node_index = pb_graph_node->child_pb_graph_nodes[pb->mode][i][j].output_pins[port_index][m].pin_count_in_cluster;
-								if (pb_route[node_index].atom_net_id) {
-									is_used = true;
-									break;
-								}
-							}
-							port_index++;
-						}
-					}
-					print_open_pb_graph_node(type, 
-							&pb_graph_node->child_pb_graph_nodes[pb->mode][i][j],
-							j, is_used, pb_route, tab_depth + 1, fpout);
-				}
-			}
-		}
-	}
-	print_tabs(fpout, tab_depth);
-	fprintf(fpout, "</block>\n");
-}
-
-/* Prints out one cluster (clb).  Both the external pins and the *
-* internal connections are printed out.                         */
-static void print_clusters(FILE *fpout) {
-	auto& cluster_ctx = g_vpr_ctx.clustering();
-
-	for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
-		/* TODO: Must do check that total CLB pins match top-level pb pins, perhaps check this earlier? */
-		print_pb(fpout, cluster_ctx.clb_nlist.block_type(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id), size_t(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id)->pb_route, 1);
-	}
-}
 
 /* Prints out one cluster (clb).  Both the external pins and the *
 * internal connections are printed out.                         */
@@ -576,14 +125,392 @@ static void print_stats() {
 	/* TODO: print more stats */
 }
 
+static const char * clustering_xml_net_text(AtomNetId net_id) {
+	/* This routine prints out the atom_ctx.nlist net name (or open).  
+     * net_num is the index of the atom_ctx.nlist net to be printed
+	 */
+	
+	if (!net_id) {
+		return "open";
+	} else {
+        auto& atom_ctx = g_vpr_ctx.atom();
+		return atom_ctx.nlist.net_name(net_id).c_str();		
+	}
+}
+
+static std::string clustering_xml_interconnect_text(t_type_ptr type, int inode, t_pb_route *pb_route) {
+	if (!pb_route[inode].atom_net_id) {
+		return "open";
+	}
+
+	int prev_node = pb_route[inode].driver_pb_pin_id;
+	int prev_edge;
+	if (prev_node == OPEN) {
+		/* No previous driver implies that this is either a top-level input pin or a primitive output pin */
+		t_pb_graph_pin *cur_pin = pb_graph_pin_lookup_from_index_by_type[type->index][inode];
+		VTR_ASSERT(cur_pin->parent_node->pb_type->parent_mode == NULL || 
+				(cur_pin->parent_node->pb_type->num_modes == 0 && cur_pin->port->type == OUT_PORT)
+				);
+		return clustering_xml_net_text(pb_route[inode].atom_net_id);
+	} else {
+		t_pb_graph_pin *cur_pin = pb_graph_pin_lookup_from_index_by_type[type->index][inode];
+		t_pb_graph_pin *prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
+		
+		for(prev_edge = 0; prev_edge < prev_pin->num_output_edges; prev_edge++) {
+			VTR_ASSERT(prev_pin->output_edges[prev_edge]->num_output_pins == 1);
+			if(prev_pin->output_edges[prev_edge]->output_pins[0]->pin_count_in_cluster == inode) {
+				break;
+			}
+		}
+		VTR_ASSERT(prev_edge < prev_pin->num_output_edges);
+
+		char *name = prev_pin->output_edges[prev_edge]->interconnect->name;
+		if (prev_pin->port->parent_pb_type->depth
+				>= cur_pin->port->parent_pb_type->depth) {
+			/* Connections from siblings or children should have an explicit index, connections from parent does not need an explicit index */
+			return vtr::string_fmt("%s[%d].%s[%d]->%s",
+					prev_pin->parent_node->pb_type->name,
+					prev_pin->parent_node->placement_index,
+					prev_pin->port->name,
+					prev_pin->pin_number, name);
+		} else {
+			return vtr::string_fmt("%s.%s[%d]->%s",
+					prev_pin->parent_node->pb_type->name,
+					prev_pin->port->name,
+					prev_pin->pin_number, name);
+		}
+	}
+}
+
+/* outputs a block that is open or unused.
+ * In some cases, a block is unused for logic but is used for routing. When that happens, the block
+ * cannot simply be marked open as that would lose the routing information. Instead, a block must be
+ * output that reflects the routing resources used. This function handles both cases.
+ */
+static void clustering_xml_open_block(pugi::xml_node parent_node, t_type_ptr type, t_pb_graph_node * pb_graph_node,
+		int pb_index, bool is_used, t_pb_route *pb_route) {
+	int i, j, k, m;
+	const t_pb_type * pb_type, *child_pb_type;
+	t_mode * mode = NULL;
+	int prev_edge, prev_node;
+	int mode_of_edge, port_index, node_index;
+
+	mode_of_edge = UNDEFINED;
+
+	pb_type = pb_graph_node->pb_type;
+
+	pugi::xml_node block_node = parent_node.append_child("block");
+	block_node.append_attribute("name") = "open";
+	block_node.append_attribute("instance") = vtr::string_fmt("%s[%d]", pb_graph_node->pb_type->name, pb_index).c_str();
+
+	if (is_used) {
+		/* Determine mode if applicable */
+		port_index = 0;
+		for (i = 0; i < pb_type->num_ports; i++) {
+			if (pb_type->ports[i].type == OUT_PORT) {
+				VTR_ASSERT(!pb_type->ports[i].is_clock);
+				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+					node_index =
+							pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
+					if (pb_type->num_modes > 0
+						&& pb_route[node_index].atom_net_id) {
+						prev_node = pb_route[node_index].driver_pb_pin_id;
+						t_pb_graph_pin *prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
+						for(prev_edge = 0; prev_edge < prev_pin->num_output_edges; prev_edge++) {
+							VTR_ASSERT(prev_pin->output_edges[prev_edge]->num_output_pins == 1);
+							if(prev_pin->output_edges[prev_edge]->output_pins[0]->pin_count_in_cluster == node_index) {
+								break;
+							}
+						}
+						VTR_ASSERT(prev_edge < prev_pin->num_output_edges);
+						mode_of_edge =
+								prev_pin->output_edges[prev_edge]->interconnect->parent_mode_index;
+						VTR_ASSERT(
+								mode == NULL || &pb_type->modes[mode_of_edge] == mode);
+						VTR_ASSERT(mode_of_edge == 0); /* for now, unused blocks must always default to use mode 0 */
+						mode = &pb_type->modes[mode_of_edge];
+					}
+				}
+				port_index++;
+			}
+		}
+
+		VTR_ASSERT(mode != NULL && mode_of_edge != UNDEFINED);
+
+		block_node.append_attribute("mode") = mode->name;
+
+
+		pugi::xml_node inputs_node = block_node.append_child("inputs");
+
+		port_index = 0;
+		for (i = 0; i < pb_type->num_ports; i++) {
+			if (!pb_type->ports[i].is_clock && pb_type->ports[i].type == IN_PORT) {
+				pugi::xml_node port_node = inputs_node.append_child("port");
+				port_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+
+				std::vector<std::string> pins;
+				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+					node_index = pb_graph_node->input_pins[port_index][j].pin_count_in_cluster;
+
+					if (pb_type->parent_mode == NULL) {
+						pins.push_back(clustering_xml_net_text(pb_route[node_index].atom_net_id));
+					} else {
+						pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+					}
+				}
+				port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
+				port_index++;
+			}
+		}
+
+		pugi::xml_node outputs_node = block_node.append_child("outputs");
+
+		port_index = 0;
+		for (i = 0; i < pb_type->num_ports; i++) {
+			if (pb_type->ports[i].type == OUT_PORT) {
+				VTR_ASSERT(!pb_type->ports[i].is_clock);
+
+				pugi::xml_node port_node = outputs_node.append_child("port");
+				port_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+				std::vector<std::string> pins;
+				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+					node_index =
+							pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
+					pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+				}
+				port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
+				port_index++;
+			}
+		}
+
+		pugi::xml_node clock_node = block_node.append_child("clocks");
+
+		port_index = 0;
+		for (i = 0; i < pb_type->num_ports; i++) {
+			if (pb_type->ports[i].is_clock && pb_type->ports[i].type == IN_PORT) {
+				pugi::xml_node port_node = clock_node.append_child("port");
+				port_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+
+				std::vector<std::string> pins;			
+				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+					node_index = pb_graph_node->clock_pins[port_index][j].pin_count_in_cluster;
+					if (pb_type->parent_mode == NULL) {
+						pins.push_back(clustering_xml_net_text(pb_route[node_index].atom_net_id));
+					} else {
+						pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+					}
+				}
+				port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
+				port_index++;
+			}
+		}
+
+		if (pb_type->num_modes > 0) {
+			for (i = 0; i < mode->num_pb_type_children; i++) {
+				child_pb_type = &mode->pb_type_children[i];
+				for (j = 0; j < mode->pb_type_children[i].num_pb; j++) {
+					port_index = 0;
+					is_used = false;
+					for (k = 0; k < child_pb_type->num_ports && !is_used; k++) {
+						if (child_pb_type->ports[k].type == OUT_PORT) {
+							for (m = 0; m < child_pb_type->ports[k].num_pins;
+									m++) {
+								node_index =
+										pb_graph_node->child_pb_graph_nodes[mode_of_edge][i][j].output_pins[port_index][m].pin_count_in_cluster;
+								if (pb_route[node_index].atom_net_id) {
+									is_used = true;
+									break;
+								}
+							}
+							port_index++;
+						}
+					}
+					clustering_xml_open_block(block_node, type, 
+							&pb_graph_node->child_pb_graph_nodes[mode_of_edge][i][j],
+							j, is_used, pb_route);
+				}
+			}
+		}
+	}
+}
+
+/* outputs a block that is used (i.e. has configuration) and all of its child blocks */
+static void clustering_xml_block(pugi::xml_node parent_node, t_type_ptr type, t_pb * pb, int pb_index, t_pb_route *pb_route) {
+	int i, j, k, m;
+	const t_pb_type *pb_type, *child_pb_type;
+	t_pb_graph_node *pb_graph_node;
+	t_mode *mode;
+	int port_index, node_index;
+	bool is_used;
+	
+	pb_type = pb->pb_graph_node->pb_type;
+	pb_graph_node = pb->pb_graph_node;
+	mode = &pb_type->modes[pb->mode];
+
+	pugi::xml_node block_node = parent_node.append_child("block");
+	block_node.append_attribute("name") = pb->name;
+	block_node.append_attribute("instance") = vtr::string_fmt("%s[%d]", pb_type->name, pb_index).c_str();
+
+	if (pb_type->num_modes > 0) {
+		block_node.append_attribute("mode") = mode->name;
+	}
+
+	pugi::xml_node inputs_node = block_node.append_child("inputs");
+
+	port_index = 0;
+	for (i = 0; i < pb_type->num_ports; i++) {
+		if (!pb_type->ports[i].is_clock && pb_type->ports[i].type == IN_PORT) {
+			pugi::xml_node port_node = inputs_node.append_child("port");
+			port_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+
+			std::vector<std::string> pins;
+			for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+				node_index = pb->pb_graph_node->input_pins[port_index][j].pin_count_in_cluster;
+
+				if (pb_type->parent_mode == NULL) {
+					pins.push_back(clustering_xml_net_text(pb_route[node_index].atom_net_id));
+				} else {
+					pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+				}
+			}
+			port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
+
+            //The cluster router may have rotated equivalent pins (e.g. LUT inputs), 
+            //record the resulting rotation here so it can be unambigously mapped 
+            //back to the atom netlist
+            if(pb_type->ports[i].equivalent && pb_type->parent_mode != NULL && pb_type->num_modes == 0) {
+                //This is a primitive with equivalent inputs
+
+                auto& atom_ctx = g_vpr_ctx.atom();
+                AtomBlockId atom_blk = atom_ctx.nlist.find_block(pb->name);
+                VTR_ASSERT(atom_blk);
+
+                AtomPortId atom_port = atom_ctx.nlist.find_atom_port(atom_blk, pb_type->ports[i].model_port);
+
+                if(atom_port) { //Port exists (some LUTs may have no input and hence no port in the atom netlist)
+
+					pugi::xml_node port_rotation_node = inputs_node.append_child("port_rotation_map");
+					port_rotation_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+
+                    std::set<AtomPinId> recorded_pins;
+					std::vector<std::string> pin_map_list;
+
+                    for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+                        node_index = pb->pb_graph_node->input_pins[port_index][j].pin_count_in_cluster;
+                        AtomNetId atom_net = pb_route[node_index].atom_net_id;
+
+                        if(atom_net) {
+                            //This physical pin is in use, find the original pin in the atom netlist
+                            AtomPinId orig_pin;
+                            for(AtomPinId atom_pin : atom_ctx.nlist.port_pins(atom_port)) {
+                                if(recorded_pins.count(atom_pin)) continue; //Don't add pins twice
+
+                                AtomNetId atom_pin_net = atom_ctx.nlist.pin_net(atom_pin);
+
+                                if(atom_pin_net == atom_net) {
+                                    recorded_pins.insert(atom_pin);
+                                    orig_pin = atom_pin;
+                                    break;
+                                }
+                            }
+
+                            VTR_ASSERT(orig_pin);
+                            //The physical pin j, maps to a pin in the atom netlist
+							pin_map_list.push_back(vtr::string_fmt("%d", atom_ctx.nlist.pin_port_bit(orig_pin)));
+                        } else {
+                            //The physical pin is disconnected
+							pin_map_list.push_back("open");
+                        }
+                    }
+					port_rotation_node.text().set(vtr::join(pin_map_list.begin(), pin_map_list.end(), " ").c_str());
+                }
+            }
+
+			port_index++;
+		}
+	}
+
+
+	pugi::xml_node outputs_node = block_node.append_child("outputs");
+
+	port_index = 0;
+	for (i = 0; i < pb_type->num_ports; i++) {
+		if (pb_type->ports[i].type == OUT_PORT) {
+			VTR_ASSERT(!pb_type->ports[i].is_clock);
+
+			pugi::xml_node port_node = outputs_node.append_child("port");
+			port_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+			std::vector<std::string> pins;
+			for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+				node_index =
+						pb->pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
+				pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+			}
+			port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
+			port_index++;
+		}
+	}
+	
+
+	pugi::xml_node clock_node = block_node.append_child("clocks");
+
+	port_index = 0;
+	for (i = 0; i < pb_type->num_ports; i++) {
+		if (pb_type->ports[i].is_clock && pb_type->ports[i].type == IN_PORT) {
+			pugi::xml_node port_node = clock_node.append_child("port");
+			port_node.append_attribute("name") = pb_graph_node->pb_type->ports[i].name;
+
+			std::vector<std::string> pins;			
+			for (j = 0; j < pb_type->ports[i].num_pins; j++) {
+				node_index = pb->pb_graph_node->clock_pins[port_index][j].pin_count_in_cluster;
+				if (pb_type->parent_mode == NULL) {
+					pins.push_back(clustering_xml_net_text(pb_route[node_index].atom_net_id));
+				} else {
+					pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+				}
+			}
+			port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
+			port_index++;
+		}
+	}
+
+	if (pb_type->num_modes > 0) {
+		for (i = 0; i < mode->num_pb_type_children; i++) {
+			for (j = 0; j < mode->pb_type_children[i].num_pb; j++) {
+				/* If child pb is not used but routing is used, I must print things differently */
+				if ((pb->child_pbs[i] != NULL) && (pb->child_pbs[i][j].name != NULL)) {
+					clustering_xml_block(block_node, type, &pb->child_pbs[i][j], j, pb_route);
+				} else {
+					is_used = false;
+					child_pb_type = &mode->pb_type_children[i];
+					port_index = 0;
+
+					for (k = 0; k < child_pb_type->num_ports && !is_used; k++) {
+						if (child_pb_type->ports[k].type == OUT_PORT) {
+							for (m = 0; m < child_pb_type->ports[k].num_pins; m++) {
+								node_index = pb_graph_node->child_pb_graph_nodes[pb->mode][i][j].output_pins[port_index][m].pin_count_in_cluster;
+								if (pb_route[node_index].atom_net_id) {
+									is_used = true;
+									break;
+								}
+							}
+							port_index++;
+						}
+					}
+					clustering_xml_open_block(block_node, type, 
+							&pb_graph_node->child_pb_graph_nodes[pb->mode][i][j],
+							j, is_used, pb_route);
+				}
+			}
+		}
+	}
+}
+
 /* This routine dumps out the output netlist in a format suitable for  *
 * input to vpr. This routine also dumps out the internal structure of *
 * the cluster, in essentially a graph based format.                   */
 void output_clustering(const vtr::vector_map<ClusterBlockId, std::vector<t_intra_lb_net>*> &intra_lb_routing, bool global_clocks,
 		const std::unordered_set<AtomNetId>& is_clock, const std::string& architecture_id, const char *out_fname, bool skip_clustering) {
-
-	FILE *fpout;
-	int column;
     auto& device_ctx = g_vpr_ctx.device();
     auto& atom_ctx = g_vpr_ctx.atom();
 	auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
@@ -600,49 +527,34 @@ void output_clustering(const vtr::vector_map<ClusterBlockId, std::vector<t_intra
 		pb_graph_pin_lookup_from_index_by_type[itype] = alloc_and_load_pb_graph_pin_lookup_from_index(&device_ctx.block_types[itype]);
 	}
 
-	
-	fpout = fopen(out_fname, "w");
+	pugi::xml_document out_xml;
 
-	fprintf(fpout, "<block name=\"%s\" instance=\"FPGA_packed_netlist[0]\" architecture_id=\"%s\" atom_netlist_id=\"%s\">\n",
-			out_fname, architecture_id.c_str(), atom_ctx.nlist.netlist_id().c_str());
-	fprintf(fpout, "\t<inputs>\n\t\t");
+	pugi::xml_node block_node = out_xml.append_child("block");
+	block_node.append_attribute("name") = out_fname;
+	block_node.append_attribute("instance") = "FPGA_packed_netlist[0]";
+	block_node.append_attribute("architecture_id") = architecture_id.c_str();
+	block_node.append_attribute("atom_netlist_id") = atom_ctx.nlist.netlist_id().c_str();
 
-	column = 2 * TAB_LENGTH; /* Organize whitespace to indent data inside block */
-    for(auto blk_id : atom_ctx.nlist.blocks()) {
-		if (atom_ctx.nlist.block_type(blk_id) == AtomBlockType::INPAD) {
-			print_string(atom_ctx.nlist.block_name(blk_id).c_str(), &column, 2, fpout);
-		}
-	}
-	fprintf(fpout, "\n\t</inputs>\n");
-	fprintf(fpout, "\n\t<outputs>\n\t\t");
-
-	column = 2 * TAB_LENGTH;
-    for(auto blk_id : atom_ctx.nlist.blocks()) {
-		if (atom_ctx.nlist.block_type(blk_id) == AtomBlockType::OUTPAD) {
-			print_string(atom_ctx.nlist.block_name(blk_id).c_str(), &column, 2, fpout);
-		}
-	}
-	fprintf(fpout, "\n\t</outputs>\n");
-
-	column = 2 * TAB_LENGTH;
-	if (global_clocks) {
-		fprintf(fpout, "\n\t<clocks>\n\t\t");
-
-        for(auto net_id : atom_ctx.nlist.nets()) {
-            if(is_clock.count(net_id)) {
-				print_string(atom_ctx.nlist.net_name(net_id).c_str(), &column, 2, fpout);
-			}
-		}
-		fprintf(fpout, "\n\t</clocks>\n\n");
-	}
-
-	/* Print out all input and output pads. */
+	std::vector<std::string> inputs;
+	std::vector<std::string> outputs;
 
     for(auto blk_id : atom_ctx.nlist.blocks()) {
         auto type = atom_ctx.nlist.block_type(blk_id);
 		switch (type) {
         case AtomBlockType::INPAD:
+			if (skip_clustering) {
+				VTR_ASSERT(0);
+			}
+			inputs.push_back(atom_ctx.nlist.block_name(blk_id));
+			break;
+			
         case AtomBlockType::OUTPAD:
+			if (skip_clustering) {
+				VTR_ASSERT(0);
+			}
+			outputs.push_back(atom_ctx.nlist.block_name(blk_id));
+			break;
+
         case AtomBlockType::BLOCK:
 			if (skip_clustering) {
 				VTR_ASSERT(0);
@@ -656,14 +568,31 @@ void output_clustering(const vtr::vector_map<ClusterBlockId, std::vector<t_intra
 		}
 	}
 
-	if (skip_clustering == false)
-		print_clusters(fpout);
+	block_node.append_child("inputs").text().set(vtr::join(inputs.begin(), inputs.end(), " ").c_str());
+	block_node.append_child("outputs").text().set(vtr::join(outputs.begin(), outputs.end(), " ").c_str());
 
-	fprintf(fpout, "</block>\n\n");
+	if (global_clocks) {
+		std::vector<std::string> clocks;
+        for(auto net_id : atom_ctx.nlist.nets()) {
+            if(is_clock.count(net_id)) {
+				clocks.push_back(atom_ctx.nlist.net_name(net_id));
+			}
+		}
 
-	fclose(fpout);
+		block_node.append_child("clocks").text().set(vtr::join(clocks.begin(), clocks.end(), " ").c_str());
+	}
+
+	if (skip_clustering == false) {
+		for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
+			/* TODO: Must do check that total CLB pins match top-level pb pins, perhaps check this earlier? */
+			clustering_xml_block(block_node, cluster_ctx.clb_nlist.block_type(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id), size_t(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id)->pb_route);
+		}
+	}
+
+	out_xml.save_file(out_fname);
 
 	print_stats();
+
 	if(!intra_lb_routing.empty()) {
 		for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
 			free_pb_route(cluster_ctx.clb_nlist.block_pb(blk_id)->pb_route);


### PR DESCRIPTION
#### Description

Replaces hand-written XML generation of cluster packing output (.net file) with equivalent pugixml calls.

#### Related Issue
#291 

#### Motivation and Context
Reduce likelihood of errors and overall complexity of output generation code by leveraging a well-tested library.

#### How Has This Been Tested?
Output from the original and pugixml implementations were passed through 'xmllint --c14n' and then diffed. Inputs, outputs, and clocks tags have differences in leading/trailing white space but no other meaningful changes were noticed. 

#### Types of changes
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
