### PR TITLE
docs: Small spelling fixes.

### DIFF
--- a/doc/src/arch/reference.rst
+++ b/doc/src/arch/reference.rst
@@ -967,20 +967,20 @@ They describe how a complex block interfaces with the inter-block world.
 
     :req_param default_in_type:
         Indicates how the default :math:`F_c` values for input pins should be interpreted.
-        
+
         ``frac``: The fraction of tracks in the channel from which each input pin connects.
 
-        ``abs``: Inpterpretted as the absolute number of tracks from which each input pin connects.
+        ``abs``: Interpreted as the absolute number of tracks from which each input pin connects.
 
     :req_param default_in_val:
         Fraction or number of tracks in a channel from which each input pin connects.
 
     :req_param default_out_type:
         Indicates how the default :math:`F_c` values for output pins should be interpreted.
-        
+
         ``frac``: The fraction of tracks in the channel to which each output pin connects.
 
-        ``abs``: Inpterpretted as the absolute number of tracks to which each output pin connects.
+        ``abs``: Interpreted as the absolute number of tracks to which each output pin connects.
 
     :req_param default_out_val:
         Fraction or number of tracks in a channel to which each output pin connects.
@@ -997,10 +997,10 @@ They describe how a complex block interfaces with the inter-block world.
 
         :req_param fc_type:
             Indicates how the override :math:`F_c` value should be interpreted.
-            
+
             ``frac``: The fraction of tracks in the channel from which each pin connects.
 
-            ``abs``: Inpterpretted as the absolute number of tracks from which each connects.
+            ``abs``: Interpreted as the absolute number of tracks from which each connects.
 
         :req_param fc_val:
             Fraction or number of tracks in a channel.

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -586,11 +586,11 @@ struct t_mode {
 /** Describes an interconnect edge inside a cluster
  *
  *  This forms part of the t_pb_type hierarchical description of a clustered logic block.
- *  It corresponds to <interconnect/> tags in the FPGA archtiecture description
+ *  It corresponds to <interconnect/> tags in the FPGA architecture description
  *  
  *  Data members:
  *      type: type of the interconnect
- *      name: indentifier for interconnect
+ *      name: identifier for interconnect
  *      input_string: input string verbatim to parse later
  *      output_string: input string output to parse later
  *      annotations: Annotations for delay, power, etc


### PR DESCRIPTION
`s/Inpterpretted/Interpreted/`

[See the result here](http://vtr-verilog-to-routing.readthedocs.io/en/inpterpretted/arch/reference.html#tag-<fcdefault_in_type=).