### PR TITLE
infra: Adding a probot autolabeler configuration.

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,32 @@
+# Tools
+ABC:            ["abc_with_bb_support"]
+ACE2:           ["ace2"]
+blifexplorer:   ["blifexplorer"]
+Odin:           ["ODIN_II", "odin2_helper"]
+VPR:            ["vpr"]
+VTR Flow:       ["vtr_flow"]
+
+# Libraries
+libarchfpga:    ["libs/libarchfpga"]
+libeasygl:      ["libs/libeasygl"]
+liblog:         ["libs/liblog"]
+libpugiutil:    ["libs/libpugiutil"]
+libvtrutil:     ["libs/libvtrutil"]
+
+# General areas
+type-docs:      ["docs/", "README.md", "*.md", "tutorial", "README", "*.rst"]
+type-infra:     [".travis.yml", ".travis.yml", ".travis/", "scripts/", ".github/", "Dockerfile"]
+type-build:     ["Makefile", "*.make", "CMakeLists.txt", "cmake"]
+type-tests:     ["*_test.pl", "*test*", "*TESTS*"]
+type-external:  ["libs/EXTERNAL"]
+type-scripts:   ["scripts", "*.pl", "*.sh"]
+
+# Tag pull requests with the languages used to make it easy to see what is
+# being used.
+lang-hdl:       ["*.v", "*.sv"]
+lang-cpp:       ["*.c*", "*.h"]
+lang-perl:      ["*.pl", "*perl*"]
+lang-python:    ["*.py"]
+lang-shell:     ["*.sh"]
+lang-netlist:   ["*.blif", "*.eblif", "*.edif"]
+lang-make:      ["*.make", "Makefile", "CMakeLists.txt"]


### PR DESCRIPTION
Probot AutoLabeler bot will add labels to pull requests automatically
based on this config.

Having these labels makes it easier to see at a quick glance what a pull
request is about.

More info here;
 * https://github.com/probot/autolabeler
 * https://github.com/apps/probot-autolabeler

## Setting up

After merging this pull request. Add the [Probot AutoLabeler GitHub app](https://github.com/apps/probot-autolabeler) to either all verilog-to-routing repos or just the vtr-verilog-to-routing repo. Then on the next pull request the bot will add labels as shown in the screenshot below;

![image](https://user-images.githubusercontent.com/21212/37006396-06364e60-208d-11e8-95c0-08acc38d7439.png)
