### PR TITLE
Propagate attributes and parameters from eblif to post-clustering .net file

### DIFF
--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -233,7 +233,7 @@ For example:
 
 Would set the parameter ``mode`` of the above ``dsp`` ``.subckt`` to ``adder``.
 
-.. warning:: VPR currently ignores ``.param`` statements
+``.param`` statements propagate to ``<parameter>`` elements in the packed netlist.
 
 .attr
 ~~~~~
@@ -250,7 +250,7 @@ For example:
 
 Would set the attribute ``src`` of the above ``.latch`` to ``my_design.v:42``.
 
-.. warning:: VPR currently ignores ``.attr`` statements
+``.attr`` statements propagate to ``<attribute>`` elements in the packed netlist.
 
 Extended BLIF File Format Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -406,6 +406,9 @@ The io pad is set to inpad mode and is driven by the inpad:
 
                         <clocks>
                         </clocks>
+                        
+                        <attribute name="vccio">3.3</attribute>
+                        <parameter name="iostandard">LVCMOS33</parameter>
                 </block>
         </block>
     ...

--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -406,9 +406,14 @@ The io pad is set to inpad mode and is driven by the inpad:
 
                         <clocks>
                         </clocks>
-                        
-                        <attribute name="vccio">3.3</attribute>
-                        <parameter name="iostandard">LVCMOS33</parameter>
+
+                        <attributes>
+                                <attribute name="vccio">3.3</attribute>
+                        </attributes>
+
+                        <parameters>
+                                <parameter name="iostandard">LVCMOS33</parameter>
+                        </parameters>
                 </block>
         </block>
     ...

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1539,7 +1539,7 @@ static void ProcessMode(pugi::xml_node Parent, t_mode * mode, const t_arch& arch
 
 	if (0 == strcmp(Parent.name(), "pb_type")) {
 		/* implied mode */
-		mode->name = vtr::strdup(mode->parent_pb_type->name);
+		mode->name = vtr::strdup("default");
 	} else {
 		Prop = get_attribute(Parent, "name", loc_data).value();
 		mode->name = vtr::strdup(Prop);

--- a/vpr/src/base/netlist.h
+++ b/vpr/src/base/netlist.h
@@ -908,6 +908,12 @@ class Netlist {
         vtr::vector_map<BlockId, unsigned>                  block_num_output_pins_;    //Number of output pins on each block
         vtr::vector_map<BlockId, unsigned>                  block_num_clock_pins_;     //Number of clock pins on each block
 
+        vtr::vector_map<BlockId, std::vector<StringId>>     block_param_names_;        //Parameter names of each block
+        vtr::vector_map<BlockId, std::vector<StringId>>     block_param_values_;       //Parameter values of each block
+        
+        vtr::vector_map<BlockId, std::vector<StringId>>     block_attr_names_;         //Attribute names of each block
+        vtr::vector_map<BlockId, std::vector<StringId>>     block_attr_values_;        //Attribute values of each block
+
         //Port data
         vtr::vector_map<PortId, PortId>                 port_ids_;      //Valid port ids
         vtr::vector_map<PortId, StringId>               port_names_;    //Name of each port

--- a/vpr/src/base/netlist.h
+++ b/vpr/src/base/netlist.h
@@ -432,12 +432,16 @@ class IdMap;
 template<typename BlockId, typename PortId, typename PinId, typename NetId> 
 class Netlist {
     public: //Public Types
-        typedef typename vtr::vector_map<BlockId, BlockId>::const_iterator      block_iterator;
-        typedef typename vtr::vector_map<NetId, NetId>::const_iterator          net_iterator;
-        typedef typename vtr::vector_map<PinId, PinId>::const_iterator          pin_iterator;
-        typedef typename vtr::vector_map<PortId, PortId>::const_iterator        port_iterator;
+        typedef typename vtr::vector_map<BlockId, BlockId>::const_iterator              block_iterator;
+        typedef typename std::unordered_map<std::string, std::string>::const_iterator   attr_iterator;
+        typedef typename std::unordered_map<std::string, std::string>::const_iterator   param_iterator;
+        typedef typename vtr::vector_map<NetId, NetId>::const_iterator                  net_iterator;
+        typedef typename vtr::vector_map<PinId, PinId>::const_iterator                  pin_iterator;
+        typedef typename vtr::vector_map<PortId, PortId>::const_iterator                port_iterator;
         
         typedef typename vtr::Range<block_iterator> block_range;
+        typedef typename vtr::Range<attr_iterator>  attr_range;
+        typedef typename vtr::Range<param_iterator> param_range;
         typedef typename vtr::Range<net_iterator>   net_range;
         typedef typename vtr::Range<pin_iterator>   pin_range;
         typedef typename vtr::Range<port_iterator>  port_range;
@@ -482,6 +486,12 @@ class Netlist {
         //Returns true if the block is purely combinational (i.e. no input clocks
         //and not a primary input
         bool                block_is_combinational(const BlockId blk_id) const;
+
+        // Returns a range of all attributes associated with the specified block
+        attr_range          block_attrs(const BlockId blk_id) const;
+
+        // Returns a range of all parameters associated with the specified block
+        param_range         block_params(const BlockId blk_id) const;
 
         //Returns a range of all pins associated with the specified block
         pin_range           block_pins(const BlockId blk_id) const;
@@ -681,6 +691,18 @@ class Netlist {
         //  blk_id   : The block to be renamed
         //  new_name : The new name for the specified block
         void set_block_name(const BlockId blk_id, const std::string new_name);
+
+        //Set a block attribute
+        //  blk_id   : The block to which the attribute is attached
+        //  name     : The name of the attribute to set
+        //  value    : The new value for the specified attribute on the specified block
+        void set_block_attr(const BlockId blk_id, const std::string &name, const std::string &value);
+
+        //Set a block parameter
+        //  blk_id   : The block to which the parameter is attached
+        //  name     : The name of the parameter to set
+        //  value    : The new value for the specified parameter on the specified block
+        void set_block_param(const BlockId blk_id, const std::string &name, const std::string &value);
 
         //Merges sink_net into driver_net
         //After merging driver_net will contain all the sinks of sink_net
@@ -908,11 +930,8 @@ class Netlist {
         vtr::vector_map<BlockId, unsigned>                  block_num_output_pins_;    //Number of output pins on each block
         vtr::vector_map<BlockId, unsigned>                  block_num_clock_pins_;     //Number of clock pins on each block
 
-        vtr::vector_map<BlockId, std::vector<StringId>>     block_param_names_;        //Parameter names of each block
-        vtr::vector_map<BlockId, std::vector<StringId>>     block_param_values_;       //Parameter values of each block
-        
-        vtr::vector_map<BlockId, std::vector<StringId>>     block_attr_names_;         //Attribute names of each block
-        vtr::vector_map<BlockId, std::vector<StringId>>     block_attr_values_;        //Attribute values of each block
+        vtr::vector_map<BlockId, std::unordered_map<std::string,std::string>>       block_params_;        //Parameters of each block
+        vtr::vector_map<BlockId, std::unordered_map<std::string,std::string>>       block_attrs_;         //Attributes of each block
 
         //Port data
         vtr::vector_map<PortId, PortId>                 port_ids_;      //Valid port ids

--- a/vpr/src/base/netlist.tpp
+++ b/vpr/src/base/netlist.tpp
@@ -73,6 +73,20 @@ bool Netlist<BlockId, PortId, PinId, NetId>::block_is_combinational(const BlockI
 }
 
 template<typename BlockId, typename PortId, typename PinId, typename NetId>
+typename Netlist<BlockId, PortId, PinId, NetId>::attr_range Netlist<BlockId, PortId, PinId, NetId>::block_attrs(const BlockId blk_id) const {
+    VTR_ASSERT_SAFE(valid_block_id(blk_id));
+
+    return vtr::make_range(block_attrs_[blk_id].begin(), block_attrs_[blk_id].end());
+}
+
+template<typename BlockId, typename PortId, typename PinId, typename NetId>
+typename Netlist<BlockId, PortId, PinId, NetId>::param_range Netlist<BlockId, PortId, PinId, NetId>::block_params(const BlockId blk_id) const {
+    VTR_ASSERT_SAFE(valid_block_id(blk_id));
+
+    return vtr::make_range(block_params_[blk_id].begin(), block_params_[blk_id].end());
+}
+
+template<typename BlockId, typename PortId, typename PinId, typename NetId>
 typename Netlist<BlockId, PortId, PinId, NetId>::pin_range Netlist<BlockId, PortId, PinId, NetId>::block_pins(const BlockId blk_id) const {
     VTR_ASSERT_SAFE(valid_block_id(blk_id));
 
@@ -592,6 +606,8 @@ BlockId Netlist<BlockId, PortId, PinId, NetId>::create_block(const std::string n
 
         //Initialize the data
         block_names_.push_back(name_id);
+        block_attrs_.emplace_back();
+        block_params_.emplace_back();
 
         //Initialize the look-ups
         block_name_to_block_id_.insert(name_id, blk_id);
@@ -813,6 +829,20 @@ void Netlist<BlockId, PortId, PinId, NetId>::set_block_name(const BlockId blk_id
 
     //Update name-look-up
     block_name_to_block_id_.insert(new_string, blk_id);
+}
+
+template<typename BlockId, typename PortId, typename PinId, typename NetId>
+void Netlist<BlockId, PortId, PinId, NetId>::set_block_attr(const BlockId blk_id, const std::string &name, const std::string &value) {
+    VTR_ASSERT(valid_block_id(blk_id));
+
+    block_attrs_[blk_id][name] = value;
+}
+
+template<typename BlockId, typename PortId, typename PinId, typename NetId>
+void Netlist<BlockId, PortId, PinId, NetId>::set_block_param(const BlockId blk_id, const std::string &name, const std::string &value) {
+    VTR_ASSERT(valid_block_id(blk_id));
+
+    block_params_[blk_id][name] = value;
 }
 
 template<typename BlockId, typename PortId, typename PinId, typename NetId>

--- a/vpr/src/base/netlist.tpp
+++ b/vpr/src/base/netlist.tpp
@@ -1132,6 +1132,9 @@ void Netlist<BlockId, PortId, PinId, NetId>::clean_blocks(const vtr::vector_map<
     block_num_output_ports_ = clean_and_reorder_values(block_num_output_ports_, block_id_map);
     block_num_clock_ports_ = clean_and_reorder_values(block_num_clock_ports_, block_id_map);
 
+    block_attrs_ = clean_and_reorder_values(block_attrs_, block_id_map);
+    block_params_ = clean_and_reorder_values(block_params_, block_id_map);
+
     clean_blocks_impl(block_id_map);
 
     VTR_ASSERT(validate_block_sizes());
@@ -1466,6 +1469,8 @@ bool Netlist<BlockId, PortId, PinId, NetId>::validate_block_sizes() const {
         || block_num_input_ports_.size() != num_blocks
         || block_num_output_ports_.size() != num_blocks
         || block_num_clock_ports_.size() != num_blocks
+        || block_attrs_.size() != num_blocks
+        || block_params_.size() != num_blocks
         || !validate_block_sizes_impl(num_blocks)) {
         VPR_THROW(VPR_ERROR_NETLIST, "Inconsistent block data sizes");
     }

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -371,11 +371,7 @@ struct BlifAllocCallback : public blifparse::Callback {
                 parse_error(lineno_, ".attr", "Supported only in extended BLIF format");
             }
 
-            //Currently VPR doesn't track attributes, so warn user
-            vtr::printf_warning(__FILE__, __LINE__, "Ignoring attribute (%s: %s) set on block '%s'\n",
-                    name.c_str(),
-                    value.c_str(),
-                    curr_model().block_name(curr_block()).c_str());
+            curr_model().set_block_attr(curr_block(), name, value);
         }
 
         void param(std::string name, std::string value) override {
@@ -383,11 +379,7 @@ struct BlifAllocCallback : public blifparse::Callback {
                 parse_error(lineno_, ".param", "Supported only in extended BLIF format");
             }
 
-            //Currently VPR doesn't track params, so warn user
-            vtr::printf_warning(__FILE__, __LINE__, "Ignoring parameter (%s: %s) set on block '%s'\n",
-                    name.c_str(),
-                    value.c_str(),
-                    curr_model().block_name(curr_block()).c_str());
+            curr_model().set_block_param(curr_block(), name, value);
         }
 
 

--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -105,7 +105,7 @@ static std::string describe_congested_rr_nodes(const std::vector<int>& congested
 * Debug functions declarations
 ******************************************************************************************/
 #ifdef PRINT_INTRA_LB_ROUTE
-static void print_route(char *filename, t_lb_router_data *router_data);
+static void print_route(const char *filename, t_lb_router_data *router_data);
 static void print_trace(FILE *fp, t_lb_trace *trace);
 #endif
 
@@ -1082,12 +1082,12 @@ static t_lb_trace *find_node_in_rt(t_lb_trace *rt, int rt_index) {
 
 #ifdef PRINT_INTRA_LB_ROUTE
 /* Debug routine, print out current intra logic block route */
-static void print_route(char *filename, t_lb_router_data *router_data) {
+static void print_route(const char *filename, t_lb_router_data *router_data) {
 	FILE *fp;
 	vector <t_intra_lb_net> & lb_nets = *router_data->intra_lb_nets;
 	vector <t_lb_type_rr_node> & lb_type_graph = *router_data->lb_type_graph;
 
-	fp = my_fopen(filename, "w", 0);
+	fp = fopen(filename, "w");
 	
 	for(unsigned int inode = 0; inode < lb_type_graph.size(); inode++) {
 		fprintf(fp, "node %d occ %d cap %d\n", inode, router_data->lb_rr_node_stats[inode].occ, lb_type_graph[inode].capacity);

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -238,6 +238,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_type_ptr typ
 		VTR_ASSERT(mode != nullptr && mode_of_edge != UNDEFINED);
 
 		block_node.append_attribute("mode") = mode->name;
+		block_node.append_attribute("pb_type_num_modes") = pb_type->num_modes;
 
 
 		pugi::xml_node inputs_node = block_node.append_child("inputs");
@@ -353,6 +354,22 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_type_ptr type, t_
 
 	if (pb_type->num_modes > 0) {
 		block_node.append_attribute("mode") = mode->name;
+	} else {
+		const auto& atom_ctx = g_vpr_ctx.atom();
+		AtomBlockId atom_blk = atom_ctx.nlist.find_block(pb->name);
+		VTR_ASSERT(atom_blk);
+
+		for (const auto& attr : atom_ctx.nlist.block_attrs(atom_blk)) {
+			pugi::xml_node attr_node = parent_node.append_child("attribute");
+			attr_node.append_attribute("name") = attr.first.c_str();
+			attr_node.text().set(attr.second.c_str());
+		}
+		
+		for (const auto& param : atom_ctx.nlist.block_params(atom_blk)) {
+			pugi::xml_node param_node = parent_node.append_child("parameter");
+			param_node.append_attribute("name") = param.first.c_str();
+			param_node.text().set(param.second.c_str());
+		}
 	}
 
 	pugi::xml_node inputs_node = block_node.append_child("inputs");

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -359,14 +359,16 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_type_ptr type, t_
 		AtomBlockId atom_blk = atom_ctx.nlist.find_block(pb->name);
 		VTR_ASSERT(atom_blk);
 
+		pugi::xml_node attrs_node = block_node.append_child("attributes");
 		for (const auto& attr : atom_ctx.nlist.block_attrs(atom_blk)) {
-			pugi::xml_node attr_node = parent_node.append_child("attribute");
+			pugi::xml_node attr_node = attrs_node.append_child("attribute");
 			attr_node.append_attribute("name") = attr.first.c_str();
 			attr_node.text().set(attr.second.c_str());
 		}
-		
+
+		pugi::xml_node params_node = block_node.append_child("parameters");
 		for (const auto& param : atom_ctx.nlist.block_params(atom_blk)) {
-			pugi::xml_node param_node = parent_node.append_child("parameter");
+			pugi::xml_node param_node = params_node.append_child("parameter");
 			param_node.append_attribute("name") = param.first.c_str();
 			param_node.text().set(param.second.c_str());
 		}


### PR DESCRIPTION
This extends the work on EBLIF support by tracking the parameters and attributes of netlist block objects, and outputs them in the XML using the following syntax:
```
<attribute name="test_attr">1</attribute>
<parameter name="test_param">x</parameter>
```

#### Related Issue
This fixes #281

#### Motivation and Context
This will help in the efforts to support real FPGA architectures in VPR

#### How Has This Been Tested
Standard tests and specific tests with attributes and parameters in eblif types were done

#### Types of changes

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
