### PR TITLE
WIP: find_most_common_block: Only consider blocks with fc_specs.

### DIFF
--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -665,6 +665,10 @@ t_type_ptr find_most_common_block_type(const DeviceGrid& grid) {
     for (int itype = 0; itype < device_ctx.num_block_types; ++itype) {
         t_type_ptr type = &device_ctx.block_types[itype];
 
+	if (type->fc_specs.size() == 0) {
+		continue;
+	}
+
         size_t inst_cnt = grid.num_instances(type);
         if (max_count < inst_cnt) {
             max_count = inst_cnt;


### PR DESCRIPTION
#### Description
If a block doesn't have any `fc_specs`, then it should be skipped.

#### How Has This Been Tested?
I'm unsure how to test this? I assume I just need to create an architecture which has blocks with no `fc_specs`. Is there an example I should copy from?
