### PR TITLE
rr_graph: write pin name in addition to index

### DIFF
--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -621,7 +621,7 @@ Switches
 
 A ``switches`` tag contains all the switches and its information within the FPGA. It should be noted that for values such as capacitance, Tdel, and sizing info all have high precision. This ensures a more accurate calculation when reading in the routing resource graph. Each switch tag has a ``switch`` subtag.
 
-.. arch:tag:: <switch id="int" name="unique_identifier" buffered="int" configurable="int">
+.. arch:tag:: <switch id="int" name="unique_identifier" buffered="int" type="{mux|tristate|pass_gate|short|buffer}" configurable="int">
 
     :req_param id:
         A unique identifier for that type of switch.
@@ -631,6 +631,9 @@ A ``switches`` tag contains all the switches and its information within the FPGA
 
     :req_param buffered:
         An integer value that describes whether the switch includes a buffer. 1 means a buffer is included.
+
+    :req_param type:
+        See arch doc.
 
     :opt_param configurable:
         Indicates whether the switch is configurable (``1``) or non-configurable (``0``).
@@ -697,15 +700,25 @@ The ``block_types`` tag outlines the information of a placeable complex logic bl
     :req_param width, height:
         The width and height of a large block in grid tiles.
 
-.. arch:tag:: <pin_class type="unique_type">content</pin_class>
+.. arch:tag:: <pin_class type="pin_type">
 
-        This optional subtag of ``block_type`` that describes class and the pins within each class for configurable logic blocks that share common properties.
+        This optional subtag of ``block_type`` describes groups of pins in configurable logic blocks that share common properties.
 
     :req_param type:
         This describes whether the pin class is a driver or receiver. Valid inputs are ``OPEN``, ``OUTPUT``, and ``INPUT``.
 
-    :req_param content:
-        A list of integers that represent the pin number of the class. These are separated by spaces and lists the CLB pin numbers that belongs to this class.
+.. arch:tag:: <pin index="class_pin_index" ptc="block_pin_index">name</pin>
+
+        This required subtag of ``pin_class`` describes its pins.
+
+    :req_param index:
+        The index of the pin within the ``pin_class``.
+
+    :req_param ptc:
+        The index of the pin within the ``block_type``.
+
+    :req_param name:
+        Human readable pin name.
 
 Grid
 ^^^^
@@ -803,52 +816,67 @@ An example of what a generated routing resource graph file would look like is sh
     :caption: Example of a routing resource graph in XML format
     :linenos:
 
-    <rr_graph tool_name="vpr" tool_version="82a3c72" tool_comment="Generated from arch file my_arch.xml">
+    <rr_graph tool_name="vpr" tool_version="82a3c72" tool_comment="Based on my_arch.xml">
         <channels>
-                <channel chan_width_max="2" x_min="2" y_min="2" x_max="2" y_max="2"/>
-                <x_list index="1" info="5"/>
-                <x_list index="2" info="5"/>
-                <y_list index="1" info="5"/>
-                <y_list index="2" info="5"/>
+            <channel chan_width_max="2" x_min="2" y_min="2" x_max="2" y_max="2"/>
+            <x_list index="1" info="5"/>
+            <x_list index="2" info="5"/>
+            <y_list index="1" info="5"/>
+            <y_list index="2" info="5"/>
         </channels>
         <switches>
-                <switch id="0" name="my_switch" buffered="1"/>
+            <switch id="0" name="my_switch" buffered="1"/>
                 <timing R="100" Cin="1233-12" Cout="123e-12" Tdel="1e-9"/>
                 <sizing mux_trans_size="2.32" buf_size="23.54"/>
-                </switch>
+            </switch>
         </switches>
         <segments>
-                <segment id="0" name="L4"/>
+            <segment id="0" name="L4"/>
                 <timing R_per_meter="201.7" C_per_meter="18.110e-15"/>
-                </segment>
+            </segment>
         </segments>
         <block_types>
-                <block_type id="0" name="io" width="1" height="1">
+            <block_type id="0" name="io" width="1" height="1">
                 <pin_class type="input">
-                        0 1 2 3
+                    <pin index="0" ptc="0">DATIN[0]</pin>
+                    <pin index="1" ptc="1">DATIN[1]</pin>
+                    <pin index="2" ptc="2">DATIN[2]</pin>
+                    <pin index="3" ptc="3">DATIN[3]</pin>
                 </pin_class>
                 <pin_class type="output">
-                        4 5 6 7
+                    <pin index="0" ptc="4">DATOUT[0]</pin>
+                    <pin index="1" ptc="5">DATOUT[1]</pin>
+                    <pin index="2" ptc="6">DATOUT[2]</pin>
+                    <pin index="3" ptc="7">DATOUT[3]</pin>
                 </pin_class>
-                </block_type>
+            </block_type>
+            <block_type id="1" name="buf" width="1" height="1">
+                <pin_class type="input">
+                    <pin index="0" ptc="0">IN</pin>
+                </pin_class>
+                <pin_class type="output">
+                    <pin index="0" ptc="1">OUT</pin>
+                </pin_class>
+            </block_type>
         </block_types>
         <grid>
-                <grid_loc x="0" y="0" block_type_id="0" width_offset="0" height_offset="0"/>
+            <grid_loc x="0" y="0" block_type_id="0" width_offset="0" height_offset="0"/>
+            <grid_loc x="1" y="0" block_type_id="1" width_offset="0" height_offset="0"/>
         </grid>
         <rr_nodes>
-                <node id="0" type="SOURCE" direction="NONE" capacity="1">
+            <node id="0" type="SOURCE" direction="NONE" capacity="1">
                 <loc xlow="0" ylow="0" xhigh="0" yhigh="0" ptc="0"/>
                 <timing R="0" C="0"/>
-                </node>
-                <node id="1" type="CHANX" direction="INC" capacity="1">
+            </node>
+            <node id="1" type="CHANX" direction="INC" capacity="1">
                 <loc xlow="0" ylow="0" xhigh="2" yhigh="0" ptc="0"/>
                 <timing R="100" C="12e-12"/>
                 <segment segment_id="0"/>
-                </node>
+            </node>
         </rr_nodes>
         <rr_edges>
-                <edge src_node="0" sink_node="1" switch_id="0"/>
-                <edge src_node="1" sink_node="2" switch_id="0"/>
+            <edge src_node="0" sink_node="1" switch_id="0"/>
+            <edge src_node="1" sink_node="2" switch_id="0"/>
         </rr_edges>
     </rr_graph>
 .. _end:

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -504,6 +504,7 @@ void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data & loc_data) {
 
     pugi::xml_node Block;
     pugi::xml_node pin_class;
+    pugi::xml_node pin;
     Block = get_first_child(parent, "block_type", loc_data);
     auto& device_ctx = g_vpr_ctx.mutable_device();
     while (Block) {
@@ -553,19 +554,25 @@ void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data & loc_data) {
                         "Architecture file does not match RR graph's block type");
             }
 
-            //Go through each pin of the pin list
-            string temp = pin_class.child_value();
-            std::vector<std::string> tokens;
-            tokens = vtr::split(temp);
-            if (!tokens.empty()) {
-                for (unsigned ipin = 0; ipin < tokens.size(); ipin++) {
-                    if (class_inf.pinlist[ipin] != atoi(tokens[ipin].c_str())) {
-                        vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
-                                "Architecture file does not match RR graph's block pin list");
-                    }
-                }
+            if (class_inf.num_pins != count_children(pin_class, "pin", loc_data)) {
+                vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
+                        "Incorrect number of pins in %d pin_class in block %s", classNum, block_info.name);
             }
-            tokens.clear();
+
+            pin = get_first_child(pin_class, "pin", loc_data, OPTIONAL);
+            while(pin) {
+                auto index = get_attribute(pin, "index", loc_data).as_uint();
+                auto num = get_attribute(pin, "ptc", loc_data).as_uint();
+                if (num != class_inf.pinlist[index]) {
+                    vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
+                            "Architecture file does not match RR graph's block pin list");
+                }
+                if (pin.child_value() != block_type_pin_index_to_name(&block_info, class_inf.pinlist[index])) {
+                    vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
+                            "Architecture file does not match RR graph's block pin list");
+                }
+                pin = pin.next_sibling("pin");
+            }
             pin_class = pin_class.next_sibling(pin_class.name());
         }
         Block = Block.next_sibling(Block.name());
@@ -639,6 +646,7 @@ void process_rr_node_indices(const DeviceGrid& grid) {
      * Note that CHANX and CHANY 's x and y are swapped due to the chan and seg convention.
      * Push back temporary incorrect nodes for CHANX and CHANY to set the length of the vector*/
 
+    std::cout << "\nStage 1\n\n";
     for (int inode = 0; inode < device_ctx.num_rr_nodes; inode++) {
         auto& node = device_ctx.rr_nodes[inode];
         if (node.type() == SOURCE || node.type() == SINK) {
@@ -669,38 +677,51 @@ void process_rr_node_indices(const DeviceGrid& grid) {
                 }
             }
         } else if (node.type() == CHANX) {
+            std::cout << "CHANX ";
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
+                    std::cout << "(" << ix << "," << iy << ") ";
                     indices[CHANX][iy][ix][0].push_back(inode);
                 }
             }
+            std::cout << "\n";
         } else if (node.type() == CHANY) {
+            std::cout << "CHANY ";
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
+                    std::cout << "(" << ix << "," << iy << ") ";
                     indices[CHANY][ix][iy][0].push_back(inode);
                 }
             }
+            std::cout << "\n";
         }
     }
 
+    std::cout << "\nStage 2\n\n";
     int count;
     /* CHANX and CHANY need to reevaluated with its ptc num as the correct index*/
     for (int inode = 0; inode < device_ctx.num_rr_nodes; inode++) {
         auto& node = device_ctx.rr_nodes[inode];
         if (node.type() == CHANX) {
+            std::cout << "CHANX ";
             for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
                 for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                     count = node.ptc_num();
+                    std::cout << " (" << ix << "," << iy << "@" << count << ") ";
                     indices[CHANX][iy][ix][0].at(count) = inode;
                 }
             }
+            std::cout << "\n";
         } else if (node.type() == CHANY) {
+            std::cout << "CHANY ";
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
                     count = node.ptc_num();
+                    std::cout << " (" << ix << "," << iy << "@" << count << ") ";
                     indices[CHANY][ix][iy][0].at(count) = inode;
                 }
             }
+            std::cout << "\n";
         }
     }
     //Copy the SOURCE/SINK nodes to all offset positions for blocks with width > 1 and/or height > 1

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -498,6 +498,15 @@ void verify_grid(pugi::xml_node parent, const pugiutil::loc_data & loc_data, con
     }
 }
 
+static int pin_index_by_num(const t_class &class_inf, int num) {
+	for (int index = 0; index < class_inf.num_pins; ++index) {
+		if (num == class_inf.pinlist[index]) {
+			return index;
+		}
+	}
+	return -1;
+}
+
 /* Blocks were initialized from the architecture file. This function checks
  * if it corresponds to the RR graph. Errors out if it doesn't correspond*/
 void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data & loc_data) {
@@ -561,12 +570,14 @@ void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data & loc_data) {
 
             pin = get_first_child(pin_class, "pin", loc_data, OPTIONAL);
             while (pin) {
-                auto index = get_attribute(pin, "index", loc_data).as_uint();
                 auto num = get_attribute(pin, "ptc", loc_data).as_uint();
-                if (num != class_inf.pinlist[index]) {
+                auto index = pin_index_by_num(class_inf, num);
+
+                if (index < 0) {
                     vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
-                            "Architecture file does not match RR graph's block pin list");
+                            "Architecture file does not match RR graph's block pin list: invalid ptc for pin class");
                 }
+
                 if (pin.child_value() != block_type_pin_index_to_name(&block_info, class_inf.pinlist[index])) {
                     vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
                             "Architecture file does not match RR graph's block pin list");

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -560,7 +560,7 @@ void verify_blocks(pugi::xml_node parent, const pugiutil::loc_data & loc_data) {
             }
 
             pin = get_first_child(pin_class, "pin", loc_data, OPTIONAL);
-            while(pin) {
+            while (pin) {
                 auto index = get_attribute(pin, "index", loc_data).as_uint();
                 auto num = get_attribute(pin, "ptc", loc_data).as_uint();
                 if (num != class_inf.pinlist[index]) {
@@ -646,7 +646,6 @@ void process_rr_node_indices(const DeviceGrid& grid) {
      * Note that CHANX and CHANY 's x and y are swapped due to the chan and seg convention.
      * Push back temporary incorrect nodes for CHANX and CHANY to set the length of the vector*/
 
-    std::cout << "\nStage 1\n\n";
     for (int inode = 0; inode < device_ctx.num_rr_nodes; inode++) {
         auto& node = device_ctx.rr_nodes[inode];
         if (node.type() == SOURCE || node.type() == SINK) {
@@ -677,51 +676,38 @@ void process_rr_node_indices(const DeviceGrid& grid) {
                 }
             }
         } else if (node.type() == CHANX) {
-            std::cout << "CHANX ";
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                    std::cout << "(" << ix << "," << iy << ") ";
                     indices[CHANX][iy][ix][0].push_back(inode);
                 }
             }
-            std::cout << "\n";
         } else if (node.type() == CHANY) {
-            std::cout << "CHANY ";
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                    std::cout << "(" << ix << "," << iy << ") ";
                     indices[CHANY][ix][iy][0].push_back(inode);
                 }
             }
-            std::cout << "\n";
         }
     }
 
-    std::cout << "\nStage 2\n\n";
     int count;
     /* CHANX and CHANY need to reevaluated with its ptc num as the correct index*/
     for (int inode = 0; inode < device_ctx.num_rr_nodes; inode++) {
         auto& node = device_ctx.rr_nodes[inode];
         if (node.type() == CHANX) {
-            std::cout << "CHANX ";
             for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
                 for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                     count = node.ptc_num();
-                    std::cout << " (" << ix << "," << iy << "@" << count << ") ";
                     indices[CHANX][iy][ix][0].at(count) = inode;
                 }
             }
-            std::cout << "\n";
         } else if (node.type() == CHANY) {
-            std::cout << "CHANY ";
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
                     count = node.ptc_num();
-                    std::cout << " (" << ix << "," << iy << "@" << count << ") ";
                     indices[CHANY][ix][iy][0].at(count) = inode;
                 }
             }
-            std::cout << "\n";
         }
     }
     //Copy the SOURCE/SINK nodes to all offset positions for blocks with width > 1 and/or height > 1

--- a/vpr/src/route/rr_graph_writer.cpp
+++ b/vpr/src/route/rr_graph_writer.cpp
@@ -226,8 +226,8 @@ void write_rr_block_types(fstream &fp) {
             for (int iPin = 0; iPin < class_inf.num_pins; iPin++) {
                 auto pin = class_inf.pinlist[iPin];
                 fp << vtr::string_fmt(
-                    "\t\t\t\t<pin index=\"%d\" ptc=\"%d\">%s</pin>\n",
-                    iPin, pin, block_type_pin_index_to_name(&btype, pin).c_str());
+                    "\t\t\t\t<pin ptc=\"%d\">%s</pin>\n",
+                    pin, block_type_pin_index_to_name(&btype, pin).c_str());
             }
             fp << "\t\t\t</pin_class>" << endl;
         }

--- a/vpr/src/route/rr_graph_writer.cpp
+++ b/vpr/src/route/rr_graph_writer.cpp
@@ -222,11 +222,14 @@ void write_rr_block_types(fstream &fp) {
             }
 
             //the pin list is printed out as the child values
-            fp << "\t\t\t<pin_class type=\"" << pin_type << "\">";
+            fp << "\t\t\t<pin_class type=\"" << pin_type << "\">\n";
             for (int iPin = 0; iPin < class_inf.num_pins; iPin++) {
-                fp << class_inf.pinlist[iPin] << " ";
+                auto pin = class_inf.pinlist[iPin];
+                fp << vtr::string_fmt(
+                    "\t\t\t\t<pin index=\"%d\" ptc=\"%d\">%s</pin>\n",
+                    iPin, pin, block_type_pin_index_to_name(&btype, pin).c_str());
             }
-            fp << "</pin_class>" << endl;
+            fp << "\t\t\t</pin_class>" << endl;
         }
         fp << "\t\t</block_type>" << endl;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add additional metadata to rr_graph <pin_class> entries to make manipulating rr_graphs easier outside VPR.

I've taken @mithro's changes towards this and made some minor cleanup for this PR (commit description, minor formatting, drop unrelated changes)

#### Description
<!--- Describe your changes in detail -->

rr_graph_writer.cpp was modified to output this new format with corresponding changes in rr_graph_reader.cpp

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This supports work in the symbiflow-arch-defs repo towards importing ice40 routing, which cannot be represented by the arch.xml format

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently rr_graph exports pin classes like this:

    <pin_class type="INPUT">0</pin_class>

Where the 0 index comes from a std::map internal to vpr. It is very difficult for external applications to predict how these indices are assigned to determine the original pin names.

@mithro proposed this should be written instead like:

    <pin_class type="INPUT">
    <pin index="0" ptc="2">bt.outpad[3]</pin>
    </pin_class>

Which is now very explicit in both name and indexing

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
"./run_reg_test.pl vtr_reg_basic vtr_reg_strong" passes, which includes an rr_graph test. I also ran some tests against the symbiflow-arch-defs repo

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

This is a breaking change to the rr_graph format, although I'm not under the impression its under widespread use

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
