### PR TITLE
Allow ace2 to compile with BUILD_TYPE=debug

### DIFF
--- a/ace2/ace.h
+++ b/ace2/ace.h
@@ -19,6 +19,8 @@
 #define MAX(a,b) 				(a > b ? a : b)
 #endif
 
+#define __unused 			__attribute__((unused))
+
 #define ACE_P0TO1(P1,PS)		((P1)==0.0)?0.0:(((P1)==1.0)?1.0:0.5*PS/(1.0-(P1)))
 #define ACE_P1TO0(P1,PS)		((P1)==0.0)?1.0:(((P1)==0.0)?0.0:0.5*PS/(P1))
 

--- a/ace2/sim.c
+++ b/ace2/sim.c
@@ -288,7 +288,7 @@ void update_FFs(Abc_Ntk_t * ntk) {
 }
 
 void ace_sim_activities(Abc_Ntk_t * ntk, Vec_Ptr_t * nodes, int max_cycles,
-		double /*threshold*/) {
+		double threshold __unused) {
 	Abc_Obj_t * obj;
 	Ace_Obj_Info_t * info;
 	int i;


### PR DESCRIPTION
#### Description

When using `BUILD_TYPE=debug` ace2 fails to compile with the following error;
```
[100%] Building CXX object ace2/CMakeFiles/ace.dir/sim.c.o
In file included from /vtr-verilog-to-routing/abc/src/misc/extra/extra.h:44:0,
                 from /vtr-verilog-to-routing/abc/src/base/abc/abc.h:42,
                 from /vtr-verilog-to-routing/ace2/ace.h:6,
                 from /vtr-verilog-to-routing/ace2/sim.c:1:
/vtr-verilog-to-routing/ace2/sim.c: In function ‘void ace_sim_activities(Abc_Ntk_t*, Vec_Ptr_t*, int, double)’:
/vtr-verilog-to-routing/ace2/sim.c:297:9: error: ‘threshold’ was not declared in this scope
  assert(threshold > 0.0);
         ^
ace2/CMakeFiles/ace.dir/build.make:230: recipe for target 'ace2/CMakeFiles/ace.dir/sim.c.o' failed
make[3]: *** [ace2/CMakeFiles/ace.dir/sim.c.o] Error 1
make[3]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:1347: recipe for target 'ace2/CMakeFiles/ace.dir/all' failed
make[2]: *** [ace2/CMakeFiles/ace.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
[100%] Built target vpr
Makefile:140: recipe for target 'all' failed
make[1]: *** [all] Error 2
Makefile:45: recipe for target 'all' failed
make: *** [all] Error 2
```

This is caused by the assert here
https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/95a6df3bf297ce7985d2dd24ccc9e4cd212497b2/ace2/sim.c#L288-L301

This can be fixed by using the `__unused` environment.

```
diff --git a/Makefile b/Makefile
index e0641eff8..6014f4d94 100644
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Possible values:
 #    release
 #    debug
-BUILD_TYPE = release
+BUILD_TYPE = debug
 
 #Allows users to pass parameters to cmake
 #  e.g. make CMAKE_PARAMS="-DVTR_ENABLE_SANITIZE=true"
```
