### PR TITLE
vpr: Slightly better error message.

### DIFF
--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -219,8 +219,8 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch,
 				default:
 					vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
 						"in count_routing_transistors:\n"
-						 "\tUnexpected connection from node %d (type %d) to node %d (type %d).\n",
-						from_node, from_rr_type, to_node, to_rr_type);
+						 "\tUnexpected connection from node %d (type %s) to node %d (type %s).\n",
+						from_node, rr_node_typename[from_rr_type], to_node, rr_node_typename[to_rr_type]);
 					break;
 
 				} /* End switch on to_rr_type. */


### PR DESCRIPTION
Output the human name for the node type.