### PR TITLE
vpr: Fixing the output of edges in the lb_type_rr_graph.echo file.

### DIFF
--- a/vpr/src/pack/lb_type_rr_graph.cpp
+++ b/vpr/src/pack/lb_type_rr_graph.cpp
@@ -638,12 +638,12 @@ static void print_lb_type_rr_graph(FILE *fp, const std::vector<t_lb_type_rr_node
 		fprintf(fp, "\tIntrinsic Cost: %g\n", lb_type_rr_graph[inode].intrinsic_cost);
 		for(int imode = 0; imode < get_num_modes_of_lb_type_rr_node(lb_type_rr_graph[inode]); imode++) {
 			if(lb_type_rr_graph[inode].num_fanout != nullptr) {
-				fprintf(fp, "\tMode: %d   # Outedges: %d\n\t\t", imode, lb_type_rr_graph[inode].num_fanout[imode]);
+				fprintf(fp, "\tMode: %d   # Outedges: %d", imode, lb_type_rr_graph[inode].num_fanout[imode]);
 				int count = 0;
 				for(int iedge = 0; iedge < lb_type_rr_graph[inode].num_fanout[imode]; iedge++) {
 					if(count % 5 == 0) {
 						/* Formatting to prevent very long lines */
-						fprintf(fp, "\n");
+						fprintf(fp, "\n\t\t");
 					}
 					count++;
 					fprintf(fp, "(%d, %g) ", lb_type_rr_graph[inode].outedges[imode][iedge].node_index,


### PR DESCRIPTION
This makes the output *much* easier to read.

Before;
```
Node 127
	BEL_FF-SB_FF[0].E[0]
	Type: LB_INTERMEDIATE
	Capacity: 1
	Intrinsic Cost: 0
	Mode: 0   # Outedges: 0

	Mode: 1   # Outedges: 0

	Mode: 2   # Outedges: 5

(140, 1) (141, 1) (142, 1) (143, 1) (144, 1)
(145, 1)

	Mode: 3   # Outedges: 1

(144, 1)
```

After;
```
Node 127
	BEL_FF-SB_FF[0].E[0]
	Type: LB_INTERMEDIATE
	Capacity: 1
	Intrinsic Cost: 0
	Mode: 0   # Outedges: 0
	Mode: 1   # Outedges: 0
	Mode: 2   # Outedges: 5
		(140, 1) (141, 1) (142, 1) (143, 1) (144, 1)
		(145, 1)
	Mode: 3   # Outedges: 1
		(144, 1)
```