### PR TITLE
Allow BUILD_TYPE to be overridden in environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Possible values:
 #    release
 #    debug
-BUILD_TYPE = release
+BUILD_TYPE ?= release
 
 #Allows users to pass parameters to cmake
 #  e.g. make CMAKE_PARAMS="-DVTR_ENABLE_SANITIZE=true"


### PR DESCRIPTION
Means you don't have to modify the Makefile to set BUILD_TYPE. You can just go `export BUILD_TYPE=debug` and you get a debug build.