### PR TITLE
Check ptr_num on y channels too.

### DIFF
--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -387,6 +387,12 @@ void check_rr_node(int inode, enum e_route_type route_type, const DeviceContext&
                 nodes_per_chan = 1;
                 tracks_per_node = device_ctx.chan_width.y_list[xlow];
             }
+
+            if (ptc_num >= nodes_per_chan) {
+                vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                        "in check_rr_node: inode %d (type %d) has a ptc_num of %d.\n", inode, rr_type, ptc_num);
+            }
+
             if (capacity != tracks_per_node) {
                 vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
                         "in check_rr_node: inode %d (type %d) has a capacity of %d.\n", inode, rr_type, capacity);


### PR DESCRIPTION
#### Description
When loading the rr graph, bounds check ptr_num (e.g. track_num) for type == CHANY.

#### Related Issue

#### Motivation and Context
CHANX ptr_num's have to abide this restriction.

#### How Has This Been Tested?
Ran "./run_reg_test.pl vtr_reg_basic"

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
