### PR TITLE
vpr: Print route before doing cleanup.

### DIFF
--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -367,26 +367,26 @@ bool try_intra_lb_route(t_lb_router_data *router_data,
 	if (is_routed) {
 		save_and_reset_lb_route(router_data);
 	} else {
-        //Unroutable
+		//Unroutable
+#ifdef PRINT_INTRA_LB_ROUTE
+		print_route("intra_lb_failed_route.echo", router_data);
+#endif
 
-        if (debug_clustering) {
-            if (!is_impossible) {
-                //Report the congested nodes and associated nets
-                auto congested_rr_nodes = find_congested_rr_nodes(lb_type_graph, router_data->lb_rr_node_stats);
-                if (!congested_rr_nodes.empty()) {
-                    vtr::printf("%s\n", describe_congested_rr_nodes(congested_rr_nodes, router_data).c_str());
-                }
-            }
-        }
+		if (debug_clustering) {
+			if (!is_impossible) {
+				//Report the congested nodes and associated nets
+				auto congested_rr_nodes = find_congested_rr_nodes(lb_type_graph, router_data->lb_rr_node_stats);
+				if (!congested_rr_nodes.empty()) {
+					vtr::printf("%s\n", describe_congested_rr_nodes(congested_rr_nodes, router_data).c_str());
+				}
+			}
+		}
 
-        //Clean-up
+		//Clean-up
 		for (unsigned int inet = 0; inet < lb_nets.size(); inet++) {
 			free_lb_net_rt(lb_nets[inet].rt_tree);
 			lb_nets[inet].rt_tree = nullptr;
 		}
-#ifdef PRINT_INTRA_LB_ROUTE
-		print_route("intra_lb_failed_route.echo", router_data);
-#endif
 	}
 	return is_routed;
 }


### PR DESCRIPTION
Before;
```
net temp0 num targets 2
NULL

net outc num targets 2
NULL
```

After;
```
net temp0 num targets 2
(1207-->0) (0-->45) (45-->90) (90-->103) (103-->108) (108-->112) (112-->107) (107-->130) (130-->180) (180-->1253)

net outc num targets 2
(181-->131) (131-->223) (223-->224) (224-->99) (99-->80) (80-->35) (35-->1209) (1209-->1208)
```