### PR TITLE
vpr/pack: Fix weird wrapping in output_clustering.cpp

### DIFF
--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -208,10 +208,8 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_type_ptr typ
 			if (pb_type->ports[i].type == OUT_PORT) {
 				VTR_ASSERT(!pb_type->ports[i].is_clock);
 				for (j = 0; j < pb_type->ports[i].num_pins; j++) {
-					node_index =
-							pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
-					if (pb_type->num_modes > 0
-						&& pb_route[node_index].atom_net_id) {
+					node_index = pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
+					if (pb_type->num_modes > 0 && pb_route[node_index].atom_net_id) {
 						prev_node = pb_route[node_index].driver_pb_pin_id;
 						t_pb_graph_pin *prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
 						for(prev_edge = 0; prev_edge < prev_pin->num_output_edges; prev_edge++) {
@@ -221,10 +219,8 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_type_ptr typ
 							}
 						}
 						VTR_ASSERT(prev_edge < prev_pin->num_output_edges);
-						mode_of_edge =
-								prev_pin->output_edges[prev_edge]->interconnect->parent_mode_index;
-						VTR_ASSERT(
-								mode == nullptr || &pb_type->modes[mode_of_edge] == mode);
+						mode_of_edge = prev_pin->output_edges[prev_edge]->interconnect->parent_mode_index;
+						VTR_ASSERT(mode == nullptr || &pb_type->modes[mode_of_edge] == mode);
 						VTR_ASSERT(mode_of_edge == 0); /* for now, unused blocks must always default to use mode 0 */
 						mode = &pb_type->modes[mode_of_edge];
 					}


### PR DESCRIPTION
Minor style cleanup in `output_clustering.cpp` file.