### PR TITLE
Prevent assert failure in route_connection_delay code

### DIFF
--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -164,8 +164,7 @@ static int get_best_class(enum e_pin_type pintype, t_type_ptr type) {
         } else
             currpin += type->class_inf[i].num_pins;
     }
-    VTR_ASSERT(best_class >= 0 && best_class < type->num_class);
-    return (best_class);
+    return best_class;
 }
 
 static int get_longest_segment_length(
@@ -263,16 +262,24 @@ static float route_connection_delay(int source_x, int source_y,
 
     auto& device_ctx = g_vpr_ctx.device();
 
-
     //Get the rr nodes to route between
     int driver_ptc = get_best_class(DRIVER, device_ctx.grid[source_x][source_y].type);
-    int source_rr_node = get_rr_node_index(device_ctx.rr_node_indices, source_x, source_y, SOURCE, driver_ptc);
-    int sink_ptc = get_best_class(RECEIVER, device_ctx.grid[sink_x][sink_y].type);
-    int sink_rr_node = get_rr_node_index(device_ctx.rr_node_indices, sink_x, sink_y, SINK, sink_ptc);
+    int source_rr_node = -1;
+    if (driver_ptc > 0)
+        source_rr_node = get_rr_node_index(device_ctx.rr_node_indices, source_x, source_y, SOURCE, driver_ptc);
 
-    bool successfully_routed = calculate_delay(source_rr_node, sink_rr_node,
+    int sink_ptc = get_best_class(RECEIVER, device_ctx.grid[sink_x][sink_y].type);
+    int sink_rr_node = -1;
+    if (sink_ptc > 0)
+        sink_rr_node = get_rr_node_index(device_ctx.rr_node_indices, sink_x, sink_y, SINK, sink_ptc);
+
+    bool successfully_routed = false;
+    if (source_rr_node >= 0 && sink_rr_node >= 0) {
+        successfully_routed = calculate_delay(
+            source_rr_node, sink_rr_node,
             router_opts.astar_fac, router_opts.bend_cost,
             &net_delay_value);
+    }
 
     if (!successfully_routed) {
         vtr::printf_warning(__FILE__, __LINE__,

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -265,12 +265,12 @@ static float route_connection_delay(int source_x, int source_y,
     //Get the rr nodes to route between
     int driver_ptc = get_best_class(DRIVER, device_ctx.grid[source_x][source_y].type);
     int source_rr_node = -1;
-    if (driver_ptc > 0)
+    if (driver_ptc > -1)
         source_rr_node = get_rr_node_index(device_ctx.rr_node_indices, source_x, source_y, SOURCE, driver_ptc);
 
     int sink_ptc = get_best_class(RECEIVER, device_ctx.grid[sink_x][sink_y].type);
     int sink_rr_node = -1;
-    if (sink_ptc > 0)
+    if (sink_ptc > -1)
         sink_rr_node = get_rr_node_index(device_ctx.rr_node_indices, sink_x, sink_y, SINK, sink_ptc);
 
     bool successfully_routed = false;
@@ -702,4 +702,3 @@ static bool calculate_delay(int source_node, int sink_node,
     free_route_tree(rt_root);
     return (true);
 }
-


### PR DESCRIPTION
#### Description

In `route_connection_delay function` if `get_rr_node_index` fails to find a the `rr_node_index`, don't call `calculate_delay` (as it will fail with an assert). Instead just force a false return code.