### PR TITLE
Adding generic function for getting a port's bit name

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -919,6 +919,27 @@ public:
     // Returns a string containing the hierarchical type name of the pb_graph_node
     // Ex: clb[0][default]/lab[0][default]/fle[3][n1_lut6]/ble6[0][default]/lut6[0]
     std::string hierarchical_type_name() const;
+
+    //Returns the number of input pins on this graph node
+    int total_input_pins() const {
+        return std::accumulate(num_input_pins, num_input_pins + num_input_ports, 0);
+    }
+
+    //Returns the number of output pins on this graph node
+    int total_output_pins() const {
+        return std::accumulate(num_output_pins, num_output_pins + num_output_ports, 0);
+    }
+
+    //Returns the number of clockpins on this graph node
+    int total_clock_pins() const {
+        return std::accumulate(num_clock_pins, num_clock_pins + num_clock_ports, 0);
+    }
+
+    //Returns the number of pins on this graph node
+    //  Note this is the total for all ports on this node excluding any children (i.e. sum of all num_input_pins, num_output_pins, num_clock_pins)
+    int num_pins() const {
+	    return total_input_pins() + total_output_pins() + total_clock_pins();
+    }
 };
 
 

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -170,8 +170,21 @@ enum e_pin_location_distr {
 
 /* pb_type class */
 enum e_pb_type_class {
-	UNKNOWN_CLASS = 0, LUT_CLASS = 1, LATCH_CLASS = 2, MEMORY_CLASS = 3
+    UNKNOWN_CLASS = 0,
+    LUT_CLASS = 1,
+    LATCH_CLASS = 2,
+    MEMORY_CLASS = 3,
+    NUM_CLASSES
 };
+
+// Set of all pb_type classes
+constexpr std::array<e_pb_type_class, NUM_CLASSES> TYPE_CLASSES = {
+    {UNKNOWN_CLASS, LUT_CLASS, LATCH_CLASS, MEMORY_CLASS} };
+
+// String versions of pb_type class values
+constexpr std::array<const char*, NUM_CLASSES> TYPE_CLASS_STRING = {
+    {"unknown", "lut", "flipflop", "memory"} };
+
 
 /* Annotations for pin-to-pin connections */
 enum e_pin_to_pin_annotation_type {

--- a/vpr/src/base/netlist.h
+++ b/vpr/src/base/netlist.h
@@ -580,6 +580,9 @@ class Netlist {
         //Returns the constructed name (derived from block and port) for the specified pin
         std::string pin_name(const PinId pin_id) const;
 
+        //Returns the constructed name (derived from block and port) for the specified pin
+        std::string port_bit_name(const PinId pin_id) const;
+
         //Returns the type of the specified pin
         PinType     pin_type(const PinId pin_id) const;
 

--- a/vpr/src/base/netlist.tpp
+++ b/vpr/src/base/netlist.tpp
@@ -269,9 +269,18 @@ PortType Netlist<BlockId, PortId, PinId, NetId>::port_type(const PortId port_id)
 template<typename BlockId, typename PortId, typename PinId, typename NetId>
 std::string Netlist<BlockId, PortId, PinId, NetId>::pin_name(const PinId pin_id) const {
     BlockId blk = pin_block(pin_id);
-    PortId port = pin_port(pin_id);
 
-    return block_name(blk) + "." + port_name(port) + "[" + std::to_string(pin_port_bit(pin_id)) + "]";
+    return block_name(blk) + "." + port_bit_name(pin_id);
+}
+
+template<typename BlockId, typename PortId, typename PinId, typename NetId>
+std::string Netlist<BlockId, PortId, PinId, NetId>::port_bit_name(const PinId pin_id) const {
+    PortId port = pin_port(pin_id);
+    if (port_width(port) > 1) {
+        return port_name(port) + "[" + std::to_string(pin_port_bit(pin_id)) + "]";
+    } else {
+        return port_name(port);
+    }
 }
 
 template<typename BlockId, typename PortId, typename PinId, typename NetId>

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -1103,7 +1103,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
         //Returns an Instance object representing the LUT
         std::shared_ptr<Instance> make_lut_instance(const t_pb* atom)  {
             //Determine what size LUT
-            int lut_size = find_num_inputs(atom);
+            const int lut_size = atom->pb_graph_node->total_input_pins();
 
             //Determine the truth table
             auto lut_mask = load_lut_mask(lut_size, atom);
@@ -1924,7 +1924,6 @@ class NetlistWriterVisitor : public NetlistVisitor {
             return input_values;
         }
 
-
         //Returns the total number of input pins on the given pb
         int find_num_inputs(const t_pb* pb) {
             int count = 0;
@@ -1933,6 +1932,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
             }
             return count;
         }
+
         //Returns the logical net ID
         AtomNetId find_atom_input_logical_net(const t_pb* atom, int atom_input_idx) {
             const t_pb_graph_node* pb_node = atom->pb_graph_node;


### PR DESCRIPTION
#### Description

Adding a generic function for getting a port's bit name to` Netlist` class. Follows the convention of the existing functions.

Also does some minor additions to `physcial_types.h` by adding strings for the `pb_type_class` enum and convenience functions for getting the number of input, clock and output pins.

#### Motivation and Context
This makes a bunch of upcoming code simpler.

#### How Has This Been Tested?
It is used by upcoming code and the existing netlist writer.