### PR TITLE
force initial value of 0 for Odin if there is a DC pin so that it is …

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -452,13 +452,15 @@ if ( $starting_stage <= $stage_idx_odin and !$error_code ) {
 		if ( $use_odin_xml_config ) {
 			$q = &system_with_timeout( "$odin2_path", "odin.out", $timeout, $temp_dir,
 				"-c", $odin_config_file_name, 
-				"--adder_type", $odin_adder_config_path,);
+				"--adder_type", $odin_adder_config_path,
+				"-U0");
 		} else {
 			$q = &system_with_timeout( "$odin2_path", "odin.out", $timeout, $temp_dir,
 				"--adder_type", $odin_adder_config_path,
 				"-a", $temp_dir . $architecture_file_name,
 				"-V", $temp_dir . $circuit_file_name,
-				"-o", $temp_dir . $odin_output_file_name);
+				"-o", $temp_dir . $odin_output_file_name,
+				"-U0");
 		}
 
 		if ( ! -e $odin_output_file_path or $q ne "success") {
@@ -546,7 +548,8 @@ if (    $starting_stage <= $stage_idx_abc
 			"-a", $temp_dir . $architecture_file_name,
 			"-sim_dir", $temp_dir."simulation_init/",
 			"-g", "1000",
-			"--best_coverage");
+			"--best_coverage",
+			"-U0");	#ABC sets DC bits as 0
 			
 		if ( $q ne "success") {
 			$odin_run_simulation = 0;
@@ -729,7 +732,8 @@ if (    $starting_stage <= $stage_idx_abc
 			"-a", $temp_dir . $architecture_file_name,
 			"-t", $temp_dir . "simulation_init/input_vectors",
 			"-T", $temp_dir . "simulation_init/output_vectors",
-			"-sim_dir", $temp_dir."simulation_test/");
+			"-sim_dir", $temp_dir."simulation_test/",
+			"-U0");
 
 		if ( $q ne "success") {
 			if ( $disable_simulation_failure )


### PR DESCRIPTION
## result

Approach | test_name | status
---|---|---
blanket: | and_latch.v/common | OK
blanket: | multiclock_separate_and_latch.v/common | OK
blanket: | multiclock_output_and_latch.v/common | failed: Simulation
blanket: | multiclock_reader_writer.v/common | failed: Simulation
blanket: | ch_intrinsics.v/common | failed: Simulation
blanket: | diffeq1.v/common | failed: Simulation
blanket: | mkPktMerge.v/common | failed: Simulation
blanket: | raygentop.v/common | failed: Simulation
blanket: | stereovision3.v/common | failed: Simulation

Approach | test_name | status
---|---|---
original: | and_latch.v/common | OK
original: | multiclock_separate_and_latch.v/common | OK
original: | multiclock_output_and_latch.v/common | OK
original: | multiclock_reader_writer.v/common | failed: Simulation
original: | ch_intrinsics.v/common | OK
original: | diffeq1.v/common | OK
original: | mkPktMerge.v/common | OK
original: | raygentop.v/common | OK
original: | stereovision3.v/common | failed: Simulation

Approach | test_name | status
---|---|---
skip_abc: | and_latch.v/common | OK
skip_abc: | multiclock_separate_and_latch.v/common | OK
skip_abc: | multiclock_output_and_latch.v/common | OK
skip_abc: | multiclock_reader_writer.v/common | failed: vpr
skip_abc: | ch_intrinsics.v/common | failed: vpr
skip_abc: | diffeq1.v/common | failed: vpr
skip_abc: | mkPktMerge.v/common | OK
skip_abc: | raygentop.v/common | failed: vpr
skip_abc: | stereovision3.v/common | failed: vpr

Approach | test_name | status
---|---|---
iterative: | and_latch.v/common | OK
iterative: | multiclock_separate_and_latch.v/common | OK
iterative: | multiclock_output_and_latch.v/common | OK
iterative: | multiclock_reader_writer.v/common | OK
iterative: | ch_intrinsics.v/common | OK
iterative: | diffeq1.v/common | OK
iterative: | mkPktMerge.v/common | OK
iterative: | raygentop.v/common | OK
iterative: | stereovision3.v/common | OK

Approach | test_name | status
---|---|---
vanilla: | and_latch.v/common | OK
vanilla: | multiclock_separate_and_latch.v/common | failed: Simulation
vanilla: | multiclock_output_and_latch.v/common | failed: Simulation
vanilla: | multiclock_reader_writer.v/common | failed: Simulation
vanilla: | ch_intrinsics.v/common | OK
vanilla: | diffeq1.v/common | OK
vanilla: | mkPktMerge.v/common | OK
vanilla: | raygentop.v/common | OK
vanilla: | stereovision3.v/common | failed: Simulation


