### PR TITLE
Add custom CSS to fix broken (too long) descnames styling

### DIFF
--- a/doc/src/_static/css/vtr.css
+++ b/doc/src/_static/css/vtr.css
@@ -1,0 +1,1 @@
+code.descname { white-space: pre-wrap }

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -178,7 +178,7 @@ numfig = True
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = []
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -331,3 +331,4 @@ def setup(app):
             'github_code_repo': 'https://github.com/verilog-to-routing/vtr-verilog-to-routing',
         }, True)
     app.add_transform(MarkdownCodeSymlinks)
+    app.add_stylesheet('css/vtr.css')


### PR DESCRIPTION
#### Description

Adding a one-liner CSS stylesheet (can be used for other custom additions in the future) to fix the problem where XML definitions extend beyond the line width and generally look bad.

A simple `white-space: pre-wrap` fixes the issue.

See e.g. here: https://docs.verilogtorouting.org/en/latest/arch/reference/#tag-recognized-blif-models-models-port

The reason I am fixing it in a custom CSS and not in the theme is that you are using a custom domain for XML and it's a very niche use case. In practice, no one in RTD is expecting the class name to have spaces - your extension is putting the entire XML tag (which is long and includes spaces, so can be wrapped) into the code.classname element.

#### Related Issue

#421

#### Motivation and Context

Makes docs look like they're not broken!

#### How Has This Been Tested?

Tested the changes on a local build and also live in browser (Chromium, Firefox) HTML editors.

#### Types of changes

- [X] Bug fix (fixes the wrapping problem)
- [X] New feature (adds custom CSS file, can potentially be used for other things too to extend beyond the standard theme)

#### Checklist:
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- N/A I have added tests to cover my changes
- N/A All new and existing tests passed
