### PR TITLE
ODIN_MEMLEAK: freed ref_string in netlist_create_from_ast.cpp

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -3436,8 +3436,6 @@ void terminate_registered_assignment(ast_node_t *always_node, signal_list_t* ass
 
 				ff_node->has_initial_value = 1;
 				ff_node->initial_value = ((char *)(local_symbol_table_sc->data[sc_spot]))[0];
-				vtr::free(ref_string);
-
 			}
 			else{
 
@@ -3446,8 +3444,9 @@ void terminate_registered_assignment(ast_node_t *always_node, signal_list_t* ass
 
 				ff_node->has_initial_value = net->has_initial_value;
 				ff_node->initial_value = net->initial_value;
-				vtr::free(ref_string);
 			}
+			/* free the reference string */
+			vtr::free(ref_string);
 
 
 			/* allocate the pins needed */

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -3446,6 +3446,7 @@ void terminate_registered_assignment(ast_node_t *always_node, signal_list_t* ass
 
 				ff_node->has_initial_value = net->has_initial_value;
 				ff_node->initial_value = net->initial_value;
+				vtr::free(ref_string);
 			}
 
 


### PR DESCRIPTION
#### Motivation and Context
memory leaks in odin

#### How Has This Been Tested?
odin pre_commit regression suite

#### Types of changes
- [x] Bug fix (change which fixes an issue)

#### Checklist:
- [x] All new and existing tests passed
