### PR TITLE
ODIN_MEMLEAK: Freed per_case_statement_idx in create_mux_statements

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -4525,6 +4525,7 @@ signal_list_t *create_mux_statements(signal_list_t **statement_lists, nnode_t *m
 		free_signal_list(statement_lists[i]);
 	}
 	free_signal_list(combined_lists);
+	vtr::free(per_case_statement_idx);
 
 	return return_list;
 }


### PR DESCRIPTION
ODIN_MEMLEAK: Freed per_case_statement_idx in create_mux_statements
SRC: netlist_create_from_ast.cpp

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

Freed calloc'd per_case_statement_idx from create_mux_statements() in netlist_create_from_ast.cpp.

#### Description
A line was added to free the calloc'd memory used by per_case_statement_idx.

#### Related Issue
N/A

#### Motivation and Context
This change fixes a memory leak.

#### How Has This Been Tested?
ODIN_II regression tests were run using valgrind before and after the fix. The test ran was located at regression_test/benchmark/micro/bm_DL_4_16_encoder.v.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
