### PR TITLE
ODIN_DEBUG: Fix for [0:0] data width segmentation fault

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -1971,7 +1971,7 @@ void connect_memory_and_alias(ast_node_t* hb_instance, char *instance_name_prefi
 					else
 					{
 						name_of_hb_input = get_name_of_pin_at_bit(hb_instance_var_node, -1, instance_name_prefix);
-						full_name = make_full_ref_name(instance_name_prefix, NULL, NULL, name_of_hb_input, -1);
+						full_name = make_full_ref_name(instance_name_prefix, NULL, NULL, name_of_hb_input, j);
 						vtr::free(name_of_hb_input);
 					}
 


### PR DESCRIPTION
WIP ODIN_DEBUG: Fix for [0:0] data width crash using SPR
SRC: netlist_create_from_ast.cpp

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

#### Description
A function call to create a node's full name was fixed so that it would properly insert the end of the name in the case of a data width (port size) of 1.

#### Related Issue
The bug would cause a segmentation fault when specifying a data width of 1 in memory_controller.v and running it on odin_II.cpp. The issue seemed to arise because when using single-port-ram, certain input drivers could not be detected mid-synthesis.

#### Motivation and Context
Having a data width of 1 is a valid special case.

#### How Has This Been Tested?
memory_controller.v was tested primarily, using data/address widths of 1/1, 2/1, 2/2 as well as other larger values.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
