### PR TITLE
librtlnumber - Register Transfer Level (RTL) Verilog Number Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,11 @@ set_target_properties(libtatum
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/EXTERNAL/libtatum"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/EXTERNAL/libtatum"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/EXTERNAL/libtatum")
+set_target_properties(librtlnumber rtl_number
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber")
 set_target_properties(libabc abc 
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/abc"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(VTR_ENABLE_COVERAGE "Enable code coverage tracking (gcov)" OFF)
 option(VTR_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
 
 option(WITH_BLIFEXPLORER "Enable build with blifexplorer" OFF)
+option(WITH_LIBRTLNUMBER "Enable build with librtlnumber" OFF)
 option(WITH_OLD_ABC "Enable build with old abc" OFF)
 option(ODIN_DEBUG "Enable building oding with extra debug flags" OFF)
 
@@ -331,11 +332,13 @@ set_target_properties(libtatum
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/EXTERNAL/libtatum"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/EXTERNAL/libtatum"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/EXTERNAL/libtatum")
-set_target_properties(librtlnumber rtl_number
-    PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber")
+if(WITH_LIBRTLNUMBER)
+    set_target_properties(librtlnumber rtl_number
+        PROPERTIES
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libs/librtlnumber")
+endif()
 set_target_properties(libabc abc 
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/abc"

--- a/ODIN_II/CMakeLists.txt
+++ b/ODIN_II/CMakeLists.txt
@@ -114,6 +114,7 @@ endforeach()
 
 target_link_libraries(libodin_ii
                         libvtrutil
+                        librtlnumber
                         libarchfpga
                         libabc
                         libargparse
@@ -121,7 +122,10 @@ target_link_libraries(libodin_ii
 
 #Create the executable
 add_executable(odin_II ${EXEC_SOURCES})
+
+
 target_link_libraries(odin_II
                         libodin_ii)
+
 
 install(TARGETS odin_II libodin_ii DESTINATION bin)

--- a/ODIN_II/CMakeLists.txt
+++ b/ODIN_II/CMakeLists.txt
@@ -112,6 +112,7 @@ foreach(ODIN_FLAG ${ODIN_EXTRA_FLAGS})
 
 endforeach()
 
+if(WITH_LIBRTLNUMBER)
 target_link_libraries(libodin_ii
                         libvtrutil
                         librtlnumber
@@ -119,10 +120,17 @@ target_link_libraries(libodin_ii
                         libabc
                         libargparse
                         ${CMAKE_DL_LIBS})
+else()
+target_link_libraries(libodin_ii
+                        libvtrutil
+                        libarchfpga
+                        libabc
+                        libargparse
+                        ${CMAKE_DL_LIBS})
+endif()
 
 #Create the executable
 add_executable(odin_II ${EXEC_SOURCES})
-
 
 target_link_libraries(odin_II
                         libodin_ii)

--- a/ODIN_II/SRC/odin_ii.cpp
+++ b/ODIN_II/SRC/odin_ii.cpp
@@ -69,6 +69,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "vtr_path.h"
 #include "vtr_memory.h"
 
+
 #define DEFAULT_OUTPUT "temp"
 
 int current_parse_file;

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(libvtrutil)
 add_subdirectory(liblog)
 add_subdirectory(libpugiutil)
 add_subdirectory(libeasygl)
+add_subdirectory(librtlnumber)
 
 #Externally developed libraries
 add_subdirectory(EXTERNAL)

--- a/libs/librtlnumber/.gitignore
+++ b/libs/librtlnumber/.gitignore
@@ -1,0 +1,1 @@
+rtl_number

--- a/libs/librtlnumber/CMakeLists.txt
+++ b/libs/librtlnumber/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project("librtlnumber")
+
+file(GLOB_RECURSE EXEC_SOURCES main.cpp)
+file(GLOB_RECURSE LIB_SOURCES src/*.cpp)
+file(GLOB_RECURSE LIB_HEADERS src/include/*.hpp)
+files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
+
+#Create the library
+add_library(librtlnumber STATIC
+             ${LIB_HEADERS}
+             ${LIB_SOURCES})
+target_include_directories(librtlnumber PUBLIC ${LIB_INCLUDE_DIRS})
+set_target_properties(librtlnumber PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
+
+#Create the test executable
+target_link_libraries(librtlnumber)
+
+#Create the executable
+add_executable(rtl_number ${EXEC_SOURCES})
+
+
+target_link_libraries(rtl_number
+                        librtlnumber)
+
+install(TARGETS rtl_number librtlnumber DESTINATION bin)

--- a/libs/librtlnumber/Makefile
+++ b/libs/librtlnumber/Makefile
@@ -1,0 +1,75 @@
+# If the first argument is "run"...
+ifeq (build,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (run,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (gdb,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (valgrind,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (debug,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+
+INCLUDE =-Isrc/include
+SRC =src/*.cpp
+
+BIN = rtl_number
+
+C = clang++ -std=c++14 -lpthread
+
+cleanup_flags=\
+-ferror-limit=1000 \
+-Werror \
+-Wpedantic \
+-Weverything \
+-Wall \
+-ggdb -O0 -g \
+-Wno-c++98-compat \
+-Wno-padded
+#  \
+# -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls
+
+PHONY: error
+
+error: 
+	echo "can only use 'clean', 'debug <testname>.cpp', 'build <testname>.cpp' or 'run <arguments>'"
+
+debug: clean
+	mkdir -p bin
+	$(C) $(cleanup_flags) $(INCLUDE) $(SRC) main.cpp -o $(BIN)
+
+build: clean
+	$(C) $(INCLUDE) $(SRC) main.cpp -o $(BIN)
+
+run:
+	./$(BIN) $(RUN_ARGS) 
+
+valgrind: build
+	valgrind --tool=helgrind $(BIN) $(RUN_ARGS) 
+
+gdb:
+	gdb --args $(BIN) $(RUN_ARGS)
+
+clean:
+	$(RM) -Rf bin
+

--- a/libs/librtlnumber/README.md
+++ b/libs/librtlnumber/README.md
@@ -1,0 +1,10 @@
+librtlnumber - Register Transfer Level (RTL) Verilog Number Library
+
+Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+         Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com)
+		  and Dr. Kenneth B. Kent (ken@unb.ca)
+           for the Reconfigurable Computing Research Lab at the
+            Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+
+Arbitrary Length Verilog Number Library that can Handle 'X' and 'Z' inputs.
+

--- a/libs/librtlnumber/main.cpp
+++ b/libs/librtlnumber/main.cpp
@@ -1,0 +1,172 @@
+/* Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+ *           Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+ *            Dr. Kenneth B. Kent (ken@unb.ca)
+ *            for the Reconfigurable Computing Research Lab at the
+ *             Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+ */
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+#include "rtl_int.hpp"
+#include "rtl_utils.hpp"
+
+#define bad_ops(test) _bad_ops(test, __func__, __LINE__)
+inline static std::string _bad_ops(std::string test, const char *FUNCT, int LINE)	
+{	
+	std::cerr << "INVALID INPUT OPS: (" << test << ")@" << FUNCT << "::" << std::to_string(LINE) << std::endl;	
+	std::abort();
+}
+
+/***
+ *     __   __       ___  __   __           ___       __       
+ *    /  ` /  \ |\ |  |  |__) /  \ |       |__  |    /  \ |  | 
+ *    \__, \__/ | \|  |  |  \ \__/ |___    |    |___ \__/ |/\| 
+ *                                                             
+ * 	This is used for testing purposes only, unused in ODIN as the input is already preprocessed
+ */
+
+static std::string arithmetic(std::string op, std::string a_in)
+{
+
+	VNumber a(a_in);
+
+	
+	/* return Process Operator via ternary */
+	return (
+		(op == "~")		?		V_BITWISE_NOT(a):
+		(op == "-")		?		V_MINUS(a):
+		(op == "+")		?		V_ADD(a):
+		(op == "&")		?		V_BITWISE_AND(a):
+		(op == "|")		?		V_BITWISE_OR(a):
+		(op == "^")		?		V_BITWISE_XOR(a):
+		(op == "~&")	?		V_BITWISE_NAND(a):
+		(op == "~|")	?		V_BITWISE_NOR(a):
+		(op == "~^"	
+		|| op == "^~")	?		V_BITWISE_XNOR(a):
+		(op == "!")		?		V_LOGICAL_NOT(a):
+								bad_ops(op)
+	).to_string();
+}
+
+static std::string arithmetic(std::string a_in, std::string op, std::string b_in)
+{
+
+	VNumber a(a_in);
+	VNumber b(b_in);
+
+
+	/* return Process Operator via ternary */
+	return (
+		(op == "&")		?		V_BITWISE_AND(a, b):
+		(op == "|")		?		V_BITWISE_OR(a, b):
+		(op == "^")		?		V_BITWISE_XOR(a, b):
+		(op == "~&")	?		V_BITWISE_NAND(a, b):
+		(op == "~|")	?		V_BITWISE_NOR(a, b):
+		(op == "~^"	
+		|| op == "^~")	?		V_BITWISE_XNOR(a, b):
+		/*	Case test	*/
+		(op == "===" )	?		V_CASE_EQUAL(a, b):
+		(op == "!==")	?		V_CASE_NOT_EQUAL(a, b):
+		/*	Shift Operator	*/
+		(op == "<<")	?		V_SHIFT_LEFT(a, b):
+		(op == "<<<")	?		V_SIGNED_SHIFT_LEFT(a, b):
+		(op == ">>")	?		V_SHIFT_RIGHT(a, b):
+		(op == ">>>")	?		V_SIGNED_SHIFT_RIGHT(a, b):
+		/* Logical Operators */
+		(op == "&&")	?		V_LOGICAL_AND(a, b):
+		(op == "||")	?		V_LOGICAL_OR(a, b):
+		(op == "<")		?		V_LT(a, b):																																													
+		(op == ">")		?		V_GT(a, b):
+		(op == "<=")	?		V_LE(a, b):
+		(op == ">=")	?		V_GE(a, b):
+		(op == "==")	?		V_EQUAL(a, b):
+		(op == "!=")	?		V_NOT_EQUAL(a, b):
+		/* arithmetic Operators */																
+		(op == "+")		?		V_ADD(a, b):
+		(op == "-")		?		V_MINUS(a, b):
+		(op == "*")		?		V_MULTIPLY(a, b):
+		(op == "**")	?		V_POWER(a, b):
+		/* cannot div by 0 */
+		(op == "/")		?		V_DIV(a, b):
+		(op == "%")		?		V_MOD(a, b):
+								bad_ops(op)
+	).to_string();
+}
+
+static std::string arithmetic(std::string a_in, std::string op1 ,std::string b_in, std::string op2, std::string c_in)
+{
+
+	VNumber a(a_in);
+	VNumber b(b_in);
+	VNumber c(c_in);
+
+	
+	/* return Process Operator via ternary */
+	return(	(op1 == "?" && op2 == ":")	?	V_TERNARY(a, b, c):
+											bad_ops("?:")
+	).to_string();
+}
+
+int main(int argc, char** argv) 
+{
+
+	std::vector<std::string> input;
+	for(int i=0; i < argc; i++)		input.push_back(argv[i]);
+
+	std::string result = "";
+
+	if(argc < 3)
+	{
+		ERR_MSG("Not Enough Arguments: " << std::to_string(argc - 1));
+
+
+		return -1;
+	}
+	else if(argc == 3 && input[1] == "is_true")
+	{
+
+		VNumber input_2(input[2]);
+
+
+		result = (V_TRUE(input_2) ? "pass" : "fail");
+	}
+	else if(argc == 3)
+	{
+
+		result = arithmetic(input[1], input[2]);
+	}
+	else if(argc == 4)
+	{
+
+		result = arithmetic(input[1], input[2], input[3]);
+	}
+	else if(argc == 5)
+	{
+		// Binary or Ternary?
+		ERR_MSG("Either Too Few (Ternary) or Too Many (Binary) Arguments: " << std::to_string(argc - 1));
+
+
+		return -1;
+	}
+	else if(argc == 6)
+	{
+
+		result = arithmetic(input[1], input[2], input[3], input[4], input[5]);
+	}
+	else				
+	{
+		ERR_MSG("Too Many Arguments: " << std::to_string(argc - 1));
+
+
+		return -1;
+	}
+
+
+	std::cout << result << std::endl;
+
+
+	return 0;
+}

--- a/libs/librtlnumber/regression_tests/basic_regression_tests.csv
+++ b/libs/librtlnumber/regression_tests/basic_regression_tests.csv
@@ -1,0 +1,64 @@
+#####################
+# Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+#  Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+#   Dr. Kenneth B. Kent (ken@unb.ca)
+#   for the Reconfigurable Computing Research Lab at the
+#    Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+#####################
+
+# Sign modifier
+Sign_minus,		        -,  10'b1010101010,	'b0101010110
+Sign_plus,			    +,  4'b1010,	'b1010
+
+# Reduction
+Reduction-and,			&,  4'b1010,	0
+#Reduction-or,			|,  4'b1010,	1
+Reduction-xor,			^,  4'b1010,	0
+#Reduction-nand,			~&,	4'b1010,	1
+#Reduction-nor,			~|,	4'b1010,	1
+#Reduction-xnor,			~^,	4'b1010,	1
+
+# bitwise
+Bitwise-Not,	            ~,  4'b1010,	'b0101
+Bitwise-And,	4'b1010,	&,  4'b1000,	'b1000
+Bitwise-Or,		5'b1010,	|,  5'b1000,	'b1010
+#Bitwise-Nor,	5'b1010,	~|, 5'b1000,	5
+#Bitwise-Nand,   5'b1010,	~&, 5'b1000,	7
+#Bitwise-Xnor,   5'b1010,	~^, 5'b1000,	4'b1101
+#Bitwise-Xor,	5'b1010,	^,  5'b1000,	2
+
+# case equivalence
+#Case-eq,		4'b1x10,	===,  4'b1x10,	1
+#Case-ne,		4'b1x11,	!==,  4'b1x10,	1
+Case-ne,		4'b1x10,	!==,  4'b1x10,	0
+Case-eq,		4'b1x11,	===,  4'b1x10,	0
+
+# logical operation
+Logical-Not,	                    !,  4'b1010,	'b0
+#Logical-And,			4'b1010,	&&, 4'b1000,	'b1
+Logical-Or,				4'b1010,	||, 4'b1000,	'b1
+#Logical-Or,				4'b0000,	||, 4'b1000,	'b1
+Logical-Or,				4'b0000,	||, 4'b0000,	'b0	
+Logical-less,			4'b0000,	<,	4'b0001,	'b1
+Logical-greater,		4'b0000,	>,	4'b0001,	'b0	
+Logical-greater-equal,	4'b0000,	>=, 4'b0000,	'b1	
+Logical-less-equal,		4'b0000,	<=, 4'b0000,	'b1	
+Logical-equal,			4'b0000,	==, 4'b0000,	'b1	
+Logical-not-equal,		4'b0000,	!=,	4'b0001,	'b1
+
+# shift operation
+#Shift-left,				2,	<<,	    3,	5'b10000
+#Shift-right, 			5'b00100,	>>,		2'b10,	'b1
+#Signed-shift-left,		5'b00100,	<<<,	2'b10,	5'b10000
+#Signed-shift-right,		5'b10100,	>>>,	2'b10,	'b11101
+
+# arithmetic
+#Addition,			4'b0110,    +,  4'b0011,  'b1001
+#Subtraction,		4'b0100,    -,  4'b0010,  'b10
+#Division,			4'b1010,    /,  4'b0010,  'b10
+#Multiplication,	    4'b0010,    *,  4'b0010,  'b100
+#Modulo,			    4'b1011,    %,  4'b0010,  'b1
+#Power,              4'b0010,    **, 4'b0000,  'b1
+
+# Ternary operations
+Ternary,			1'b1,   ?,  2'b01,  :,  2'b10,  2'b01

--- a/libs/librtlnumber/regression_tests/compound_regression_test.csv
+++ b/libs/librtlnumber/regression_tests/compound_regression_test.csv
@@ -1,0 +1,10 @@
+#####################
+# Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+#  Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+#   Dr. Kenneth B. Kent (ken@unb.ca)
+#   for the Reconfigurable Computing Research Lab at the
+#    Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+#####################
+
+# compound operations
+#Compound-Compare, 1, 			1 + 1 > 1

--- a/libs/librtlnumber/src/include/internal_bits.hpp
+++ b/libs/librtlnumber/src/include/internal_bits.hpp
@@ -1,0 +1,731 @@
+#ifndef INTERNAL_BITS_HPP
+#define INTERNAL_BITS_HPP
+
+#include <cstdint>
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <bitset>
+#include "rtl_utils.hpp"
+
+typedef uint64_t veri_internal_bits_t;
+
+namespace BitSpace {
+    typedef uint8_t bit_value_t;
+
+    static const veri_internal_bits_t _All_0 = static_cast<veri_internal_bits_t>(0x0000000000000000UL);
+    static const veri_internal_bits_t _All_1 = static_cast<veri_internal_bits_t>(0x5555555555555555UL);
+    static const veri_internal_bits_t _All_x = static_cast<veri_internal_bits_t>(0xAAAAAAAAAAAAAAAAUL);
+    static const veri_internal_bits_t _All_z = static_cast<veri_internal_bits_t>(0xFFFFFFFFFFFFFFFFUL);
+
+    static const bit_value_t _0 = 0x0;
+    static const bit_value_t _1 = 0x1;
+    static const bit_value_t _x = 0x2;
+    static const bit_value_t _z = 0x3;
+
+    /***                                                              
+     * these are taken from the raw verilog truth tables so that the evaluation are correct.
+     * only use this to evaluate any expression for the number_t binary digits.
+     * reference: http://staff.ustc.edu.cn/~songch/download/IEEE.1364-2005.pdf
+     * 
+     *******************************************************/
+
+    static const bit_value_t l_buf[4] = {
+        /*	 0   1   x   z  <- a*/
+            _0,_1,_x,_x
+    };
+
+    static const bit_value_t l_not[4] = {
+        /*   0   1   x   z 	<- a */
+            _1,_0,_x,_x
+    };
+
+    #define unroll_1d(lut) { lut[_0], lut[_1], lut[_x], lut[_z] }
+    #define unroll_2d(lut) { unroll_1d(lut[_0]), unroll_1d(lut[_1]), unroll_1d(lut[_x]), unroll_1d(lut[_z]) }
+
+    #define unroll_1d_invert(lut) { l_not[lut[_0]], l_not[lut[_1]], l_not[lut[_x]], l_not[lut[_z]] }
+    #define unroll_2d_invert(lut) { unroll_1d_invert(lut[_0]), unroll_1d_invert(lut[_1]), unroll_1d_invert(lut[_x]), unroll_1d_invert(lut[_z]) }
+
+    static const bit_value_t l_and[4][4] = {
+        /* a  /	 0   1   x   z 	<-b */	
+        /* 0 */	{_0,_0,_0,_0},	
+        /* 1 */	{_0,_1,_x,_x},	
+        /* x */	{_0,_x,_x,_x},	
+        /* z */	{_0,_x,_x,_x}
+    };
+    static const bit_value_t l_nand[4][4] = 
+        unroll_2d_invert(l_and);
+
+    static const bit_value_t l_or[4][4] = {
+        /* a  /	 0   1   x   z 	<-b */	
+        /* 0 */	{_0,_1,_x,_x},	
+        /* 1 */	{_1,_1,_1,_1},	
+        /* x */	{_x,_1,_x,_x},	
+        /* z */	{_x,_1,_x,_x}
+    };
+    static const bit_value_t l_nor[4][4] = 
+        unroll_2d_invert(l_or);
+
+    static const bit_value_t l_xor[4][4] = {
+        /* a  /	 0   1   x   z 	<-b */	
+        /* 0 */	{_0,_1,_x,_x},	
+        /* 1 */	{_1,_0,_x,_x},	
+        /* x */	{_x,_x,_x,_x},	
+        /* z */	{_x,_x,_x,_x}
+    };
+    static const bit_value_t l_xnor[4][4] = 
+        unroll_2d_invert(l_xor);
+
+
+    /*****************************************************
+     *  Tran NO SUPPORT FOR THESE YET 
+     */
+    static const bit_value_t l_notif1[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_z,_1,_x,_x},
+        /* 1 */	{_z,_0,_x,_x},
+        /* x */	{_z,_x,_x,_x},
+        /* z */	{_z,_x,_x,_x}
+    };
+
+    static const bit_value_t l_notif0[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_1,_z,_x,_x},
+        /* 1 */	{_0,_z,_x,_x},
+        /* x */	{_x,_z,_x,_x},
+        /* z */	{_x,_z,_x,_x}
+    };
+
+    static const bit_value_t l_bufif1[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_z,_0,_x,_x},
+        /* 1 */	{_z,_1,_x,_x},
+        /* x */	{_z,_x,_x,_x},
+        /* z */	{_z,_x,_x,_x}
+    };
+
+    static const bit_value_t l_bufif0[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_0,_z,_x,_x},
+        /* 1 */	{_1,_z,_x,_x},
+        /* x */	{_x,_z,_x,_x},
+        /* z */	{_x,_z,_x,_x}
+    };
+
+    /* cmos gates */
+    static const bit_value_t l_rpmos[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_0,_z,_x,_x},
+        /* 1 */	{_1,_z,_x,_x},
+        /* x */	{_x,_z,_x,_x},
+        /* z */	{_z,_z,_z,_z}
+    };
+
+    static const bit_value_t l_rnmos[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_z,_0,_x,_x},
+        /* 1 */	{_z,_1,_x,_x},
+        /* x */	{_z,_x,_x,_x},
+        /* z */	{_z,_z,_z,_z}
+    };
+
+    static const bit_value_t l_nmos[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_z,_0,_x,_x},
+        /* 1 */	{_z,_1,_x,_x},
+        /* x */	{_z,_x,_x,_x},
+        /* z */	{_z,_z,_z,_z}
+    };
+
+
+    // see table 5-21 p:54 IEEE 1364-2005
+    static const bit_value_t l_ternary[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_0,_x,_x,_x},
+        /* 1 */	{_x,_1,_x,_x},
+        /* x */	{_x,_x,_x,_x},
+        /* z */	{_x,_x,_x,_x}
+    };
+
+    /*****
+     * these extend the library and simplify the process
+     */
+    /* helper */
+    static const bit_value_t l_unk[4][4] = {
+        /* in /	 0   1   x   z 	<-control */	
+        /* 0 */	{_x,_x,_x,_x},
+        /* 1 */	{_x,_x,_x,_x},
+        /* x */	{_x,_x,_x,_x},
+        /* z */	{_x,_x,_x,_x}
+    };
+
+    static const bit_value_t l_case_eq[4][4] = {
+        /* a  /	 0   1   x   z 	<-b */	
+        /* 0 */	{_1,_0,_0,_0},	
+        /* 1 */	{_0,_1,_0,_0},	
+        /* x */	{_0,_0,_1,_0},	
+        /* z */	{_0,_0,_0,_1}
+    };
+
+    static const bit_value_t l_case_neq[4][4] =
+        unroll_2d_invert(l_case_eq);
+
+
+    static const bit_value_t l_lt[4][4] = {
+        /* a  /	 0   1   x   z 	<-b */	
+        /* 0 */	{_0,_0,_x,_x},	
+        /* 1 */	{_1,_0,_x,_x},	
+        /* x */	{_x,_x,_x,_x},	
+        /* z */	{_x,_x,_x,_x}
+    };
+    static const bit_value_t l_ge[4][4] = unroll_2d(l_lt);
+
+    static const bit_value_t l_gt[4][4] = {
+        /* a  /	 0   1   x   z 	<-b */	
+        /* 0 */	{_0,_1,_x,_x},	
+        /* 1 */	{_0,_0,_x,_x},	
+        /* x */	{_x,_x,_x,_x},	
+        /* z */	{_x,_x,_x,_x}
+    };
+    static const bit_value_t l_le[4][4] = unroll_2d(l_gt);
+
+    static const bit_value_t l_eq[4][4] = 
+        unroll_2d(l_xnor);
+
+    static const bit_value_t l_sum[4][4][4] = {
+        /* c_in */ 
+        /* 0 */ unroll_2d(l_xor),
+        /* 1 */ unroll_2d(l_xnor),
+        /* x */ unroll_2d(l_unk),
+        /* z */ unroll_2d(l_unk)
+    };
+
+    static const bit_value_t l_carry[4][4][4] = {
+        /* c_in */
+        /* 0 */ unroll_2d(l_and),
+        /* 1 */ unroll_2d(l_or),
+        /* x */ unroll_2d(l_ternary),
+        /* z */ unroll_2d(l_ternary)
+    };
+
+    static const bit_value_t l_half_carry[4][4] = unroll_2d(l_carry[_0]);
+    static const bit_value_t l_half_sum[4][4] = unroll_2d(l_sum[_0]);
+
+    static char bit_to_c(bit_value_t bit)
+    {
+        switch(bit)
+        {
+            case _0:    return '0';
+            case _1:    return '1';
+            case _z:    return 'z';
+            default:    return 'x';
+        }
+    }
+
+    static bit_value_t c_to_bit(char c)
+    {
+        switch(c)
+        {
+            case '0':   return _0;
+            case '1':   return _1;
+            case 'z':   return _z;
+            default:    return _x;
+        }
+    }
+    template<typename T>
+    class BitFields
+    {
+    private :
+
+        T bits = _All_x;
+
+        size_t get_bit_location(size_t address)
+        {
+            return ((address%this->size())<<1);
+        }
+
+        T make_insert(size_t loc, bit_value_t value)
+        {
+            return (static_cast<T>(value) << (loc));
+        }
+
+        T make_mask(size_t loc)
+        {
+            return (~make_insert(loc,_0));
+        }
+
+    public :
+
+        BitFields(bit_value_t init_v)
+        {
+            
+            this->bits = 
+                (_0 == init_v)? _All_0:
+                (_1 == init_v)? _All_1:
+                (_z == init_v)? _All_z:
+                                _All_x;
+        } 
+        
+        bit_value_t get_bit(size_t address)
+        {
+            return ((this->bits >> (this->get_bit_location(address))) & 0x3UL);
+        }
+
+        void set_bit(size_t address, bit_value_t value)
+        {	
+            size_t real_address = this->get_bit_location(address);
+
+            T long_value = static_cast<T>(value);
+
+            T set_value = long_value << real_address;
+            T zero_out_location = ~(0x3UL << real_address);
+
+            this->bits &= zero_out_location;
+            this->bits |= set_value;
+        }
+
+        static size_t size()
+        {
+            return (sizeof(T)<<2); // 8 bit in a byte, 2 bits for a verilog bits = 4 bits in a byte, << 2 = sizeof x 4
+        }
+
+        bool has_unknowns()
+        {
+            return static_cast<bool>(this->bits & _All_x);
+        }
+    };
+
+    #define DEBUG_V_BITS
+
+    /*****
+     * we use large array since we process the bits in chunks
+     */
+    class VerilogBits
+    {
+    private:
+
+        std::vector<BitFields<veri_internal_bits_t>> bits;
+        size_t bit_size;
+
+        size_t to_index(size_t address)
+        {
+            return (address / BitFields<veri_internal_bits_t>::size() );
+        }
+
+        size_t list_size()
+        {
+            return this->bits.size();
+        }
+
+        VerilogBits()
+        {
+        }
+
+    public:
+
+        VerilogBits(size_t data_size, bit_value_t value_in)
+        {
+            this->bit_size = data_size;
+            bits = std::vector<BitSpace::BitFields<veri_internal_bits_t>>(
+                (this->bit_size / BitFields<veri_internal_bits_t>::size() +1),
+                BitSpace::BitFields<veri_internal_bits_t>(value_in)
+            );
+        }
+
+        size_t size()
+        {
+            return bit_size;
+        }
+
+        BitFields<veri_internal_bits_t> *get_bitfield(size_t index)
+        {
+
+    #ifdef DEBUG_V_BITS
+            if (index >= this->bits.size() )
+            {
+                std::cout << "Bit array indexing out of bounds " << index << " but size is " << this->bit_size  << std::endl;
+                std::abort();
+            }
+    #endif
+
+            return (&this->bits[index]);
+        }   
+
+        bit_value_t get_bit(size_t address)
+        {
+    #ifdef DEBUG_V_BITS
+            if (address >= this->bit_size )
+            {
+                std::cout << "Bit index array out of bounds " << address << " but size is " << this->bit_size  << std::endl;
+                std::abort();
+            }
+    #endif
+
+            return (this->get_bitfield(to_index(address))->get_bit(address));
+        }
+
+        void set_bit(size_t address, bit_value_t value)
+        {
+    #ifdef DEBUG_V_BITS
+            if (address >= this->bit_size )
+            {
+                std::cout << "Bit index array out of bounds " << address << " but size is " << this->bit_size  << std::endl;
+                std::abort();
+            }
+    #endif
+            (this->get_bitfield(to_index(address))->set_bit(address, value));
+        }
+
+        std::string to_string(bool big_endian)
+        {
+            // make a big endian string
+            std::string to_return = "";
+            for(size_t address=0x0; address < this->size(); address++)
+            {
+                to_return.push_back(BitSpace::bit_to_c(this->get_bit(address)));
+            }
+
+            if(!big_endian)
+                return std::string(to_return.crbegin(), to_return.crend());
+            else
+                return to_return;              
+        }
+
+        bool has_unknowns()
+        {
+            for(auto bitField : this->bits)
+                if(bitField.has_unknowns())
+                    return true;
+            
+            return false;
+        }
+
+        /**
+         * Unary Reduction operations
+         * This is Msb to Lsb on purpose, as per specs
+         */
+        VerilogBits *bitwise_reduce(const bit_value_t lut[4][4])
+        {
+
+            bit_value_t result = this->get_bit(this->size()-1);
+            for(size_t i=this->size()-2; i < this->size(); i--)
+            {
+                result = lut[result][this->get_bit(i)];
+            }
+
+            return new VerilogBits(1, result);
+        }
+
+        VerilogBits *invert()
+        {
+            VerilogBits *other = new VerilogBits(this->bit_size, _0);
+
+            for(size_t i=0; i<this->size(); i++)
+                other->set_bit(i, BitSpace::l_not[this->get_bit(i)]);
+                        
+            return other;
+        }
+
+        VerilogBits *twos_complement()
+        {
+            BitSpace::bit_value_t previous_carry = BitSpace::_1;
+            VerilogBits *other = new VerilogBits(this->bit_size, _0);
+
+            for(size_t i=0; i<this->size(); i++)
+            {
+                BitSpace::bit_value_t not_bit_i = BitSpace::l_not[this->get_bit(i)];
+
+                other->set_bit(i,BitSpace::l_half_sum[previous_carry][not_bit_i]);
+                previous_carry = BitSpace::l_half_carry[previous_carry][not_bit_i];
+            }
+                        
+            return other;
+        }
+    }; 
+}
+
+class VNumber 
+{
+private:
+    bool sign;
+    BitSpace::VerilogBits *bitstring = nullptr;
+
+    VNumber(BitSpace::VerilogBits *other_bitstring, bool other_sign)
+    {
+        bitstring = other_bitstring;
+        sign = other_sign;
+    }
+
+
+
+public:
+
+    VNumber(){}
+
+    ~VNumber()
+    {
+
+        
+        delete bitstring;
+
+    }
+
+    VNumber(VNumber&&) = default;
+    VNumber& operator=(VNumber&&) = default;
+    VNumber& operator=(const VNumber& other) = default;
+
+    VNumber(const VNumber& other)
+    {
+
+        this->sign = other.sign;
+        this->bitstring = new BitSpace::VerilogBits(*other.bitstring);
+
+    }
+
+    VNumber(const std::string& verilog_string)
+    {
+
+        set_value(verilog_string);
+
+    }
+
+    VNumber(int64_t numeric_value)
+    {
+
+        set_value(numeric_value);
+
+    }
+
+    VNumber(size_t len, BitSpace::bit_value_t initial_bits, bool input_sign)
+    {
+
+        this->bitstring = new BitSpace::VerilogBits(len, initial_bits);
+        this->sign = input_sign;
+
+    }
+    
+    /***
+     * getters
+     */
+    int64_t get_value()
+    {
+        
+        assert_Werr( (! this->bitstring->has_unknowns() ) ,
+                    "Invalid Number contains dont care values. number: " + this->bitstring->to_string(false)
+        );
+
+        // We need to accomodate for signed values
+        assert_Werr( (this->bitstring->size() < BitSpace::BitFields<veri_internal_bits_t>::size()),
+                    "Invalid Number. Too large to be converted. number size: " + std::to_string(this->bitstring->size())
+        );      
+
+        int64_t result = 0;
+        int8_t pad = this->is_negative();
+        for(size_t bit_index = 0; bit_index < this->size(); bit_index++)
+        {
+            int64_t current_bit = pad;
+            if(bit_index < this->size())
+                current_bit = this->bitstring->get_bit(bit_index);
+
+            result |= (current_bit << bit_index);
+        }
+
+
+        return result;
+    }
+
+    // convert lsb_msb bitstring to verilog
+    std::string to_string()
+    {
+        std::string out = this->bitstring->to_string(false);
+        size_t len = this->bitstring->size();
+
+        return std::to_string(len) + ((this->is_signed())? "\'sb": "\'b") + out;
+    }
+
+    /***
+     * setters
+     */
+    void set_value(const std::string& input)
+    {
+
+        std::string verilog_string(input);
+        if(!verilog_string.size())
+            return;
+
+        size_t loc = verilog_string.find("\'");
+        if(loc == std::string::npos)
+        {
+            verilog_string.insert(0, "\'sd");
+            loc = 0;
+        }
+
+        size_t bitsize = 0;
+        if(loc != 0)
+        {
+            bitsize = strtoul(verilog_string.substr(0,loc).c_str(), nullptr, 10);
+        }
+
+        this->sign = false;
+        if(std::tolower(verilog_string[loc+1]) == 's')
+            this->sign = true;
+
+        char base = static_cast<char>(std::tolower(verilog_string[loc+1+sign]));
+        uint8_t radix = 0;
+        switch(base){
+            case 'b':   radix = 2;  break;
+            case 'o':   radix = 8;  break;
+            case 'd':   radix = 10; break;
+            case 'h':   radix = 16; break;
+            default:    
+                assert_Werr( false,
+                        "Invalid radix base for number: " + std::string(1,base)
+                ); 
+                break;
+        }
+
+        //remove underscores
+        std::string v_value_str = verilog_string.substr(loc+2+sign);
+        verilog_string.erase(std::remove(v_value_str.begin(), v_value_str.end(), '_'), v_value_str.end());
+
+        //little endian bitstring string
+        std::string temp_bitstring = string_of_radix_to_bitstring(v_value_str, radix);
+
+        if(bitsize <= 0)
+        {
+            while(temp_bitstring.size() && temp_bitstring[0] == temp_bitstring[1])
+                temp_bitstring.erase(0, 1);
+
+            bitsize = temp_bitstring.size();
+        }
+        else if(bitsize > temp_bitstring.length())
+        {
+            char pad = temp_bitstring[0];
+            if(!this->sign && pad == '1')
+                pad = '0';
+
+            while(bitsize != temp_bitstring.length())
+                temp_bitstring.insert(temp_bitstring.begin(),pad);
+        }
+        else if(bitsize < temp_bitstring.length())
+        {
+            while(bitsize != temp_bitstring.length())
+                temp_bitstring.erase(0, 1);
+        }
+
+        if(this->bitstring)
+            delete this->bitstring;
+
+        // convert the bits to the internal data struct (bit at index 0 in string is msb since string go from msb to lsb)
+        this->bitstring = new BitSpace::VerilogBits(bitsize, BitSpace::_0);
+        size_t counter = bitsize-1;
+        for(char in: temp_bitstring)
+            this->bitstring->set_bit(counter--,BitSpace::c_to_bit(in));
+    }
+
+    void set_value(int64_t in)
+    {
+        this->set_value(std::to_string(in));
+    }
+
+    size_t msb_index()
+    {
+        return this->bitstring->size()-1;
+    }
+
+    /****
+     * bit twiddling functions
+     */
+    BitSpace::bit_value_t get_bit_from_msb(size_t index)
+    {
+        return this->bitstring->get_bit(msb_index()-index);
+    }
+
+    BitSpace::bit_value_t get_bit_from_lsb(size_t index)
+    {
+        return this->bitstring->get_bit(index);
+    }
+
+    void set_bit_from_msb(size_t index, BitSpace::bit_value_t val)
+    {
+        this->bitstring->set_bit(msb_index()-index, val);
+    }
+
+    void set_bit_from_lsb(size_t index, BitSpace::bit_value_t val)
+    {
+        this->bitstring->set_bit(index, val);
+    }
+
+    /***
+     *  other
+     */
+    size_t size()
+    {
+        return this->bitstring->size();
+    }
+
+    bool is_signed() const
+    {
+        return this->sign;
+    }
+
+    bool is_negative()
+    {
+        return ( this->get_bit_from_msb(0) == BitSpace::_1 && this->sign );
+    }
+
+    BitSpace::bit_value_t get_padding_bit()
+    {
+        return this->is_negative()? BitSpace::_1:BitSpace::_0;
+    }
+
+    bool is_dont_care_string()
+    {
+        return this->bitstring->has_unknowns();
+    }
+
+    VNumber twos_complement()
+    {
+        return VNumber(this->bitstring->twos_complement(),this->sign);
+    }
+
+    VNumber invert()
+    {
+        return VNumber(this->bitstring->invert(),this->sign);
+    }
+
+    VNumber bitwise_reduce(const BitSpace::bit_value_t lut[4][4])
+    {
+        return VNumber(this->bitstring->bitwise_reduce(lut),false);
+    }
+
+    /**
+     * Binary Reduction operations
+     */
+    VNumber bitwise(VNumber& b, const BitSpace::bit_value_t lut[4][4])
+    {
+        size_t std_length = std::max(this->size(), b.size());
+        const BitSpace::bit_value_t pad_a = this->get_padding_bit();
+        const BitSpace::bit_value_t pad_b = b.get_padding_bit();
+
+        VNumber result(std_length, BitSpace::_x, false);
+
+        for(size_t i=0; i < result.size(); i++)
+        {
+            BitSpace::bit_value_t bit_a = pad_a;
+            if(i < this->size())
+                bit_a = this->get_bit_from_lsb(i);
+
+            BitSpace::bit_value_t bit_b = pad_b;
+            if(i < b.size())
+                bit_b = b.get_bit_from_lsb(i);
+
+            result.set_bit_from_lsb(i, lut[bit_a][bit_b]);
+        }
+
+        return result;
+    }
+
+};
+
+#endif

--- a/libs/librtlnumber/src/include/rtl_int.hpp
+++ b/libs/librtlnumber/src/include/rtl_int.hpp
@@ -1,0 +1,71 @@
+/* Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+ *           Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+ *            Dr. Kenneth B. Kent (ken@unb.ca)
+ *            for the Reconfigurable Computing Research Lab at the
+ *             Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+ */
+
+#ifndef RTL_INT_H
+#define RTL_INT_H
+
+#include <string>
+#include "internal_bits.hpp"
+
+/**
+ * Unary Operator
+ */
+
+bool V_TRUE(VNumber& a);
+
+VNumber V_ADD(VNumber& a);
+VNumber V_MINUS(VNumber& a);
+
+VNumber V_BITWISE_NOT(VNumber& a);
+VNumber V_BITWISE_AND(VNumber& a);
+VNumber V_BITWISE_OR(VNumber& a);
+VNumber V_BITWISE_XOR(VNumber& a);
+VNumber V_BITWISE_NAND(VNumber& a);
+VNumber V_BITWISE_NOR(VNumber& a);
+VNumber V_BITWISE_XNOR(VNumber& a);
+VNumber V_LOGICAL_NOT(VNumber& a);
+
+/**
+ * Binary Operator
+ */
+VNumber V_BITWISE_AND(VNumber& a,VNumber& b);
+VNumber V_BITWISE_OR(VNumber& a,VNumber& b);
+VNumber V_BITWISE_XOR(VNumber& a,VNumber& b);
+VNumber V_BITWISE_NAND(VNumber& a,VNumber& b);
+VNumber V_BITWISE_NOR(VNumber& a,VNumber& b);
+VNumber V_BITWISE_XNOR(VNumber& a,VNumber& b);
+
+VNumber V_SIGNED_SHIFT_LEFT(VNumber& a, VNumber& b);
+VNumber V_SIGNED_SHIFT_RIGHT(VNumber& a, VNumber& b);
+VNumber V_SHIFT_LEFT(VNumber& a, VNumber& b);
+VNumber V_SHIFT_RIGHT(VNumber& a, VNumber& b);
+
+VNumber V_LOGICAL_AND(VNumber& a,VNumber& b);
+VNumber V_LOGICAL_OR(VNumber& a,VNumber& b);
+
+VNumber V_LT(VNumber& a,VNumber& b);
+VNumber V_GT(VNumber& a,VNumber& b);
+VNumber V_LE(VNumber& a,VNumber& b);
+VNumber V_GE(VNumber& a,VNumber& b);
+VNumber V_EQUAL(VNumber& a,VNumber& b);
+VNumber V_NOT_EQUAL(VNumber& a,VNumber& b);
+VNumber V_CASE_EQUAL(VNumber& a,VNumber& b);
+VNumber V_CASE_NOT_EQUAL(VNumber& a,VNumber& b);
+
+VNumber V_ADD(VNumber& a,VNumber& b);
+VNumber V_MINUS(VNumber& a,VNumber& b);
+VNumber V_MULTIPLY(VNumber& a,VNumber& b);
+VNumber V_POWER(VNumber& a,VNumber& b);
+VNumber V_DIV(VNumber& a,VNumber& b);
+VNumber V_MOD(VNumber& a,VNumber& b);
+
+/**
+ * Ternary Operator
+ */
+VNumber V_TERNARY(VNumber& a, VNumber& b, VNumber& c);
+
+#endif //RTL_INT_H

--- a/libs/librtlnumber/src/include/rtl_utils.hpp
+++ b/libs/librtlnumber/src/include/rtl_utils.hpp
@@ -1,0 +1,38 @@
+/* Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+ *           Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+ *            Dr. Kenneth B. Kent (ken@unb.ca)
+ *            for the Reconfigurable Computing Research Lab at the
+ *             Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+ */
+
+#ifndef RTL_UTILS_H
+#define RTL_UTILS_H
+
+#include <string>
+#include <iostream>
+
+#include <string.h>
+
+#ifndef FILE_NAME
+#define FILE_NAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#ifndef ERR_MSG
+#define ERR_MSG(errMsg) {\
+    std::cout << std::endl << "ERROR: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" << ": " << errMsg << "!" << std::endl << std::endl;\
+    }
+#endif
+
+
+std::string string_of_radix_to_bitstring(std::string orig_string, short radix);
+
+inline void _assert_Werr(bool cond, const char *FUNCT, int LINE, std::string error_string)
+{
+    if (!cond) { 
+        std::cout << std::endl << "ERROR: " << FUNCT << "::" << std::to_string(LINE) << " Assert 'assert_Werr' Failed:\t" << error_string << "!" << std::endl << std::endl;
+        std::abort();
+    }
+}
+#define assert_Werr(cond, error_string) _assert_Werr((cond),  __func__, __LINE__, std::string(error_string))
+
+#endif

--- a/libs/librtlnumber/src/rtl_int.cpp
+++ b/libs/librtlnumber/src/rtl_int.cpp
@@ -1,0 +1,578 @@
+/* Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+ *           Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+ *            Dr. Kenneth B. Kent (ken@unb.ca)
+ *            for the Reconfigurable Computing Research Lab at the
+ *             Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+ */
+
+#include <string>
+
+#include "internal_bits.hpp"
+#include "rtl_int.hpp"
+#include "rtl_utils.hpp"
+
+using namespace BitSpace;
+
+class compare_bit
+{
+private:
+	uint8_t result = 0x0;
+
+public:
+	compare_bit(uint8_t set_to){result = set_to;}
+
+	bool is_unk(){	return (!result); }
+
+	bool is_gt(){	return (result&(0x1)); }
+	bool is_eq(){	return (result&(0x2)); }
+	bool is_lt(){	return (result&(0x4)); }
+
+	bool is_ne(){	return (!is_eq()); }
+	bool is_ge(){	return (result&(0x3)); }
+	bool is_le(){	return (result&(0x6)); }
+
+};
+
+#define UNK_EVAL compare_bit(0x0)
+#define GT_EVAL compare_bit(0x1)
+#define EQ_EVAL compare_bit(0x2)
+#define LT_EVAL compare_bit(0x4)
+
+static compare_bit eval_op(VNumber& a_in, VNumber& b_in)
+{
+
+	assert_Werr( a_in.size() ,
+		"empty 1st bit string" 
+	);
+
+	assert_Werr( b_in.size() ,
+		"empty 2nd bit string" 
+	);
+
+	bool neg_a = (a_in.is_negative());
+	bool neg_b = (b_in.is_negative());
+
+
+	if(neg_a && !neg_b)
+	{
+		return GT_EVAL;
+	}
+	else if(!neg_a && neg_b)
+	{
+		return LT_EVAL;
+	}
+
+	VNumber a;
+	VNumber b;
+
+
+	bool invert_result = (neg_a && neg_b);
+
+
+	if(invert_result)
+	{
+		a = a_in.twos_complement();
+		b = b_in.twos_complement();
+
+	}
+	else
+	{
+		a = a_in;
+		b = b_in;
+
+	}
+
+
+	size_t std_length = std::max(a.size(), b.size());
+	bit_value_t pad_a = a.get_padding_bit();
+	bit_value_t pad_b = b.get_padding_bit();
+
+
+	for(size_t i=std_length-1; i < std_length ; i--)
+	{
+		bit_value_t bit_a = pad_a;
+		if(i < a.size())
+			bit_a = a.get_bit_from_lsb(i);
+
+		bit_value_t bit_b = pad_b;
+		if(i < b.size())
+			bit_b = b.get_bit_from_lsb(i);
+
+		if	(bit_a == BitSpace::_x || bit_b == BitSpace::_x)	
+			return UNK_EVAL;
+		else if(bit_a != bit_b)
+		{
+			if(bit_a == BitSpace::_1)
+				return (invert_result)? LT_EVAL: GT_EVAL;
+			else
+				return (invert_result)? GT_EVAL: LT_EVAL;
+		}
+	}
+
+
+	return EQ_EVAL;
+}
+
+static compare_bit eval_op(VNumber a,int64_t b)
+{
+	VNumber bits_value =  VNumber(std::to_string(std::abs(b)));
+	if(b < 0)
+		bits_value = bits_value.twos_complement();
+
+	return eval_op(a, bits_value);
+}
+
+/**
+ * Addition operations
+ */
+static VNumber sum_op(VNumber& a, VNumber& b, const bit_value_t& initial_carry)
+{
+	assert_Werr( a.size() ,
+		"empty 1st bit string" 
+	);
+
+	assert_Werr( b.size() ,
+		"empty 2nd bit string" 
+	);
+
+	size_t std_length = std::max(a.size(), b.size());
+	const bit_value_t pad_a = a.get_padding_bit();
+	const bit_value_t pad_b = b.get_padding_bit();
+
+	bit_value_t previous_carry = initial_carry;
+	VNumber result(std_length+1, _x, false);
+
+	for(size_t i=0; i < std_length-1; i++)
+	{
+		bit_value_t bit_a = pad_a;
+		if(i < a.size())
+			bit_a = a.get_bit_from_lsb(i);
+
+		bit_value_t bit_b = pad_b;
+		if(i < b.size())
+			bit_b = b.get_bit_from_lsb(i);
+
+		result.set_bit_from_lsb(i, l_sum[previous_carry][bit_a][bit_b]);
+		previous_carry = l_carry[previous_carry][bit_a][bit_b];
+	}
+	result.set_bit_from_lsb(std_length-1, previous_carry);
+
+	return result;
+}
+
+static VNumber shift_op(VNumber& a, int64_t b, bool sign_shift)
+{
+	VNumber to_return;
+	if(b < static_cast<int64_t>(a.size()))
+		b = 0;
+
+	//if b is negative than shift right
+	if(b==0)
+	{
+		to_return = a;
+	}
+	else if(b < 0)
+	{
+		size_t u_b = static_cast<size_t>(-b);
+		bit_value_t pad = ( sign_shift ) ? a.get_padding_bit(): BitSpace::_0;
+		to_return = VNumber(a.size(), pad, sign_shift);
+		for(size_t i=0; i < (a.size() + u_b); i++)
+		{
+			to_return.set_bit_from_lsb(i, a.get_bit_from_lsb(i-u_b));
+		}
+	}
+	else
+	{
+		size_t u_b = static_cast<size_t>(b);
+		bit_value_t pad = BitSpace::_0;
+		to_return =VNumber((a.size() + u_b), pad, sign_shift);
+		for(size_t i=0; i < a.size(); i++)
+		{
+			to_return.set_bit_from_lsb(i+u_b, a.get_bit_from_lsb(i));
+		}
+	}
+	return to_return;
+}
+
+bool V_TRUE(VNumber& a)
+{
+	return (a.bitwise_reduce(l_or).get_value());
+}
+
+/***
+ *                    __          __   __   ___  __       ___    __       
+ *    |  | |\ |  /\  |__) \ /    /  \ |__) |__  |__)  /\   |  | /  \ |\ | 
+ *    \__/ | \| /~~\ |  \  |     \__/ |    |___ |  \ /~~\  |  | \__/ | \| 
+ *                                                                        
+ */
+
+VNumber V_BITWISE_NOT(VNumber& a)
+{
+	return a.invert();
+}
+
+VNumber V_LOGICAL_NOT(VNumber& a)
+{
+	VNumber ored = a.bitwise_reduce(l_or);
+	VNumber noted = ored.invert();
+	return noted;
+}
+
+VNumber V_ADD(VNumber& a)
+{
+	VNumber result(a);
+	return result;
+}
+
+VNumber V_MINUS(VNumber& a)
+{
+	return a.twos_complement();
+}
+
+VNumber V_BITWISE_AND(VNumber& a)
+{
+	VNumber to_return = a.bitwise_reduce(l_and);
+	return to_return;
+}
+
+VNumber V_BITWISE_OR(VNumber& a)
+{
+	VNumber to_return = a.bitwise_reduce(l_or);
+	return to_return;
+}
+
+VNumber V_BITWISE_XOR(VNumber& a)
+{
+	VNumber to_return = a.bitwise_reduce(l_xor);
+	return to_return;
+}
+
+VNumber V_BITWISE_NAND(VNumber& a)
+{
+	VNumber to_return = a.bitwise_reduce(l_nand);
+	return to_return;
+}
+
+VNumber V_BITWISE_NOR(VNumber& a)
+{
+	VNumber to_return = a.bitwise_reduce(l_nor);
+	return to_return;
+}
+
+VNumber V_BITWISE_XNOR(VNumber& a)
+{
+	VNumber to_return = a.bitwise_reduce(l_xnor);
+	return to_return;
+}
+
+/***
+ *     __               __          __   __   ___  __       ___    __       
+ *    |__) | |\ |  /\  |__) \ /    /  \ |__) |__  |__)  /\   |  | /  \ |\ | 
+ *    |__) | | \| /~~\ |  \  |     \__/ |    |___ |  \ /~~\  |  | \__/ | \| 
+ *                                                                          
+ */
+
+VNumber V_BITWISE_AND(VNumber& a, VNumber& b)
+{
+	return a.bitwise(b,l_and);
+}
+
+VNumber V_BITWISE_OR(VNumber& a, VNumber& b)
+{
+	return a.bitwise(b,l_or);
+}
+
+VNumber V_BITWISE_XOR(VNumber& a, VNumber& b)
+{
+	return a.bitwise(b,l_xor);
+}
+
+VNumber V_BITWISE_NAND(VNumber& a, VNumber& b)
+{
+	return a.bitwise(b,l_nand);
+}
+
+VNumber V_BITWISE_NOR(VNumber& a, VNumber& b)
+{
+	return a.bitwise(b,l_nor);
+}
+
+VNumber V_BITWISE_XNOR(VNumber& a, VNumber& b)
+{
+	return a.bitwise(b,l_xnor);
+}
+
+/**
+ * Logical Operations
+ */
+
+VNumber V_CASE_EQUAL(VNumber& a, VNumber& b)
+{
+	VNumber longEval = a.bitwise(b, l_case_eq);
+	VNumber eq = V_BITWISE_AND(longEval);
+	return eq;
+}
+
+VNumber V_CASE_NOT_EQUAL(VNumber& a, VNumber& b)
+{
+	VNumber eq = V_CASE_EQUAL(a,b);
+	VNumber neq = V_LOGICAL_NOT(eq);
+	return neq;
+}
+
+VNumber V_LOGICAL_AND(VNumber& a, VNumber& b)
+{
+	VNumber test = a.bitwise(b,l_or);
+	VNumber to_return = a.bitwise_reduce(l_and);
+
+	return to_return;
+}
+
+VNumber V_LOGICAL_OR(VNumber& a, VNumber& b)
+{
+	VNumber test = a.bitwise(b,l_or);
+	VNumber to_return = a.bitwise_reduce(l_or);
+
+	return to_return;
+}
+
+VNumber V_LT(VNumber& a, VNumber& b)
+{
+	compare_bit cmp = eval_op(a,b);
+	BitSpace::bit_value_t result = cmp.is_unk()? BitSpace::_x: cmp.is_lt()? BitSpace::_1: BitSpace::_0;
+	VNumber to_return(1, result, false);
+	return to_return;
+}
+
+VNumber V_GT(VNumber& a, VNumber& b)
+{
+	compare_bit cmp = eval_op(a,b);
+	BitSpace::bit_value_t result = cmp.is_unk()? BitSpace::_x: cmp.is_gt()? BitSpace::_1: BitSpace::_0;
+	VNumber to_return(1, result, false);
+	return to_return;
+}
+
+VNumber V_EQUAL(VNumber& a, VNumber& b)
+{
+
+	compare_bit cmp = eval_op(a,b);
+	BitSpace::bit_value_t result = cmp.is_unk()? BitSpace::_x: cmp.is_eq()? BitSpace::_1: BitSpace::_0;
+	VNumber to_return(1, result, false);
+	return to_return;
+}
+
+VNumber V_GE(VNumber& a, VNumber& b)
+{
+	compare_bit cmp = eval_op(a,b);
+	BitSpace::bit_value_t result = cmp.is_unk()? BitSpace::_x: cmp.is_ge()? BitSpace::_1: BitSpace::_0;
+	VNumber to_return(1, result, false);
+	return to_return;
+}
+
+VNumber V_LE(VNumber& a, VNumber& b)
+{
+	compare_bit cmp = eval_op(a,b);
+	BitSpace::bit_value_t result = cmp.is_unk()? BitSpace::_x: cmp.is_le()? BitSpace::_1: BitSpace::_0;
+	VNumber to_return(1, result, false);
+	return to_return;
+}
+
+VNumber V_NOT_EQUAL(VNumber& a, VNumber& b)
+{
+	compare_bit cmp = eval_op(a,b);
+	BitSpace::bit_value_t result = cmp.is_unk()? BitSpace::_x: cmp.is_ne()? BitSpace::_1: BitSpace::_0;
+	VNumber to_return(1, result, false);
+	return to_return;
+}
+
+VNumber V_SIGNED_SHIFT_LEFT(VNumber& a, VNumber& b)
+{
+	if(b.is_dont_care_string())	
+		return VNumber("x");
+	
+	return shift_op(a, b.get_value(), true);
+}
+
+VNumber V_SHIFT_LEFT(VNumber& a, VNumber& b)
+{
+	if(b.is_dont_care_string())	
+		return VNumber("x");
+	
+	return shift_op(a, b.get_value(), false);
+}
+
+VNumber V_SIGNED_SHIFT_RIGHT(VNumber& a, VNumber& b)
+{
+	if(b.is_dont_care_string())	
+		return VNumber("x");
+	
+	return shift_op(a, -1* b.get_value(), true);
+}
+
+VNumber V_SHIFT_RIGHT(VNumber& a, VNumber& b)
+{
+	if(b.is_dont_care_string())	
+		return VNumber("x");
+	
+	return shift_op(a, -1* b.get_value(), false);
+}
+
+VNumber V_ADD(VNumber& a, VNumber& b)
+{
+	return sum_op(a, b, _0);
+}
+
+VNumber V_MINUS(VNumber& a, VNumber& b)
+{
+	VNumber complement = V_MINUS(b);
+	return sum_op(a, complement, _1);
+}
+
+VNumber V_MULTIPLY(VNumber& a_in, VNumber& b_in)
+{
+	if(a_in.is_dont_care_string() || b_in.is_dont_care_string())
+		return VNumber("x");
+
+	VNumber a;
+	VNumber b;
+
+	bool neg_a = a_in.is_negative();
+	bool neg_b = b_in.is_negative();
+	
+	if(neg_a)	
+		a = V_MINUS(a_in);
+	else
+		a = a_in;
+
+	if(neg_b)	
+		b = V_MINUS(b_in);
+	else
+		b = b_in;
+		
+	bool invert_result = ((!neg_a && neg_b) || (neg_a && !neg_b));
+
+	VNumber result("0");
+	VNumber b_copy = b;
+
+	for(size_t i=0; i< a.size(); i++)
+	{
+		bit_value_t bit_a = a.get_bit_from_lsb(i);
+		if(bit_a == _1)
+			result = V_ADD(result,b);
+		shift_op(b_copy, 1, _0);
+	}
+
+	if(invert_result)	
+		result = V_MINUS(result);
+
+	return result;
+}
+
+VNumber V_POWER(VNumber& a, VNumber& b)
+{
+	if(a.is_dont_care_string() || b.is_dont_care_string())
+		return VNumber("'bx");
+	
+	compare_bit res_a = eval_op(a, 0);
+	short val_a = 	(res_a.is_eq()) 		? 	0: 
+					(res_a.is_lt()) 		? 	(eval_op(a,-1).is_lt())	?	-2: -1:
+					/* GREATHER_THAN */  		(eval_op(a,1).is_gt())	?	2: 1;
+
+	compare_bit res_b = eval_op(b, 0);
+	short val_b = 	(res_b.is_eq()) 			? 	0: 
+					(res_b.is_lt()) 		? 	-1:
+					/* GREATHER_THAN */				1;
+
+	//compute
+	if(val_b == 1 && (val_a < -1 || val_a > 1 ))
+	{
+		VNumber result("1");
+		VNumber one = VNumber("1");
+		VNumber tmp_b = b;
+		while(eval_op(tmp_b,0).is_gt())
+		{
+			tmp_b = V_MINUS(tmp_b, one);
+			result = V_MULTIPLY( result, a);
+		}
+		return result;
+	}
+	if (val_b == 0 || val_a == 1)	
+	{
+		return VNumber("1000");
+	}
+	else if(val_b == -1 && val_a == 0)
+	{
+		return VNumber("xxxx");
+	}
+	else if(val_a == -1)
+	{
+		if(a.is_negative()) 	// even
+			return VNumber("0111");
+		else				//	odd
+			return VNumber("1000");
+	}
+	else	
+	{
+		return VNumber("0000");
+	}
+}
+
+/////////////////////////////
+VNumber V_DIV(VNumber& a_in, VNumber& b)
+{
+	if(a_in.is_dont_care_string() || b.is_dont_care_string() || eval_op(b,0).is_eq())
+		return VNumber("x");
+
+	VNumber a(a_in);
+
+	VNumber result("0");
+	while(eval_op(a, b).is_gt() )
+	{
+		VNumber  count("1");
+		VNumber  sub_with = b;
+		VNumber  tmp = b;
+		while(eval_op(tmp, a).is_lt())
+		{
+			sub_with = tmp;
+			shift_op(count, 1,_0);
+			shift_op(tmp, 1,_0);
+		}
+		a = V_MINUS(a, sub_with);
+		result = V_ADD(result, count);
+	}
+	return result;
+}
+
+VNumber V_MOD(VNumber& a_in, VNumber& b)
+{
+	if(a_in.is_dont_care_string() || b.is_dont_care_string() || eval_op(b, 0).is_eq())
+		return VNumber("x");
+
+	VNumber to_return(a_in);
+	while(eval_op(b, to_return).is_lt())
+	{
+		VNumber  sub_with = b;
+		for( VNumber  tmp = b; eval_op(tmp, to_return).is_lt(); shift_op(tmp, 1,_0))
+		{
+			sub_with = tmp;
+		}
+		to_return = V_MINUS(to_return, sub_with);
+	}
+	return to_return;
+}
+
+/***
+ *    ___  ___  __             __          __   __   ___  __       ___    __       
+ *     |  |__  |__) |\ |  /\  |__) \ /    /  \ |__) |__  |__)  /\   |  | /  \ |\ | 
+ *     |  |___ |  \ | \| /~~\ |  \  |     \__/ |    |___ |  \ /~~\  |  | \__/ | \| 
+ *                                                                                 
+*/
+VNumber V_TERNARY(VNumber& a_in, VNumber& b_in, VNumber& c_in)
+{
+	/*	if a evaluates properly	*/
+	compare_bit eval = eval_op(V_LOGICAL_NOT(a_in),0);
+
+	return (eval.is_unk())?	b_in.bitwise(c_in, l_ternary):
+			(eval.is_eq())?	VNumber(b_in):
+							VNumber(c_in);
+}

--- a/libs/librtlnumber/src/rtl_utils.cpp
+++ b/libs/librtlnumber/src/rtl_utils.cpp
@@ -1,0 +1,178 @@
+/* Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+ *           Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+ *            Dr. Kenneth B. Kent (ken@unb.ca)
+ *            for the Reconfigurable Computing Research Lab at the
+ *             Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+ */
+
+#include "rtl_utils.hpp"
+#include <algorithm>
+#include <iostream>
+
+inline static std::string _radix_digit_to_bits_str(const char digit, short radix,  const char *FUNCT, int LINE)
+{
+    switch(radix)
+    {
+        case 2:
+        {
+            switch(std::tolower(digit))
+            {
+                case '0': return "0";
+                case '1': return "1";
+                case 'x': return "x";
+                case 'z': return "z";
+                default:  
+                    _assert_Werr( false, FUNCT, LINE,
+                            "INVALID BIT INPUT: " + std::string(1,digit) 
+                    );
+                    break;
+            }
+            break;
+        }
+        case 8:
+        {
+            switch(std::tolower(digit))
+            {
+                case '0': return "000";
+                case '1': return "001";
+                case '2': return "010";
+                case '3': return "011";
+                case '4': return "100";
+                case '5': return "101";
+                case '6': return "110";
+                case '7': return "111";
+                case 'x': return "xxx";
+                case 'z': return "zzz";
+                default:  
+                    _assert_Werr( false, FUNCT, LINE,
+                            "INVALID BIT INPUT: " + std::string(1,digit) 
+                    );
+                    break;
+            }
+            break;
+        }
+        case 16:
+        {
+            switch(std::tolower(digit))
+            {
+                case '0': return "0000";
+                case '1': return "0001";
+                case '2': return "0010";
+                case '3': return "0011";
+                case '4': return "0100";
+                case '5': return "0101";
+                case '6': return "0110";
+                case '7': return "0111";
+                case '8': return "1000";
+                case '9': return "1001";
+                case 'a': return "1010";
+                case 'b': return "1011";
+                case 'c': return "1100";
+                case 'd': return "1101";
+                case 'e': return "1110";
+                case 'f': return "1111";
+                case 'x': return "xxxx";
+                case 'z': return "zzzz";
+                default:  
+                    _assert_Werr( false, FUNCT, LINE,
+                            "INVALID BIT INPUT: " + std::string(1,digit) 
+                    );
+                    break;
+            }
+            break;
+        }
+        default:
+        {
+            _assert_Werr( false, FUNCT, LINE,
+                "Invalid base " + std::to_string(radix)
+            );
+            break;
+        }
+    }
+    std::abort();
+}
+
+#define radix_digit_to_bits(num,radix) _radix_digit_to_bits(num,radix,__func__, __LINE__)
+inline static std::string _radix_digit_to_bits(const char digit, short radix,  const char *FUNCT, int LINE)
+{
+    std::string result = _radix_digit_to_bits_str(digit, radix, FUNCT, LINE);
+    return std::string(result.crbegin(), result.crend());
+}
+
+/**********************
+ * convert from different radix to bitstring
+ */
+std::string string_of_radix_to_bitstring(std::string orig_string, short radix)
+{
+	std::string result = "";	
+
+    if(orig_string.empty())
+        return "";
+
+    switch(radix)
+	{
+		case 2:    
+            assert_Werr(std::string::npos == orig_string.find_first_not_of("xXzZ01"),
+                    "INVALID BIT INPUT: " + orig_string + "for radix 2"
+            );
+            break;
+
+		case 8:    
+            assert_Werr(std::string::npos == orig_string.find_first_not_of("xXzZ01234567"),
+                    "INVALID BIT INPUT: " + orig_string + "for radix 8"
+            );
+            break;
+
+		case 10:    
+            assert_Werr(std::string::npos == orig_string.find_first_not_of("0123456789"),
+                    "INVALID BIT INPUT: " + orig_string + "for radix 10"
+            );
+            break;
+
+		case 16:    
+            assert_Werr(std::string::npos == orig_string.find_first_not_of("xZzZ0123456789aAbBcCdDeEfF"),
+                    "INVALID BIT INPUT: " + orig_string + "for radix 16"
+            );
+            break;
+
+		default:	    
+            assert_Werr(false, 
+                    "invalid radix: " + std::to_string(radix)
+            );
+            break;
+	}
+
+	while(!orig_string.empty())
+	{
+		switch(radix)
+		{
+			case 10:
+			{
+				std::string new_number = "";
+
+				char rem_digit = '0';
+				for(char& current_digit : orig_string)
+				{
+					uint8_t new_pair = (static_cast<uint8_t>(rem_digit - '0')*10) + static_cast<uint8_t>(current_digit-'0');
+					new_number.push_back(static_cast<char>((new_pair/2) + '0'));
+                    rem_digit =         (static_cast<char>((new_pair%2) + '0'));
+				}
+
+                result.insert(result.begin(),rem_digit);
+                if(new_number == "0")
+                    orig_string = "";
+                else
+                    orig_string = new_number;
+
+				break;
+			}
+			default:
+			{
+                result = radix_digit_to_bits(orig_string.back(), radix) + result;
+                orig_string.pop_back();
+                break;
+			}
+		}
+	}
+	return result;
+}

--- a/libs/librtlnumber/unit_test/Makefile
+++ b/libs/librtlnumber/unit_test/Makefile
@@ -1,0 +1,73 @@
+# If the first argument is "run"...
+ifeq (build,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (run,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (gdb,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (valgrind,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+ifeq (debug,$(firstword $(MAKECMDGOALS)))	
+  # use the rest as arguments for "make"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+
+INCLUDE =-I../src/include
+
+BIN = bin/exec.out
+
+C = clang++ -std=c++14 -lpthread
+
+cleanup_flags=\
+-ferror-limit=1000 \
+-Werror \
+-Wpedantic \
+-Weverything \
+-Wall \
+-Wno-c++98-compat \
+-Wno-unused-parameter \
+-g -O0 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls
+
+PHONY: error
+
+error: 
+	echo "can only use 'clean', 'debug <testname>.cpp', 'build <testname>.cpp' or 'run <arguments>'"
+
+debug:
+	mkdir -p bin
+	$(C) -ggdb $(cleanup_flags) $(INCLUDE) $(RUN_ARGS) -o $(BIN)
+
+build:
+	mkdir -p bin
+	$(C) $(INCLUDE) $(RUN_ARGS) -o $(BIN)
+
+run:
+	$(BIN) $(RUN_ARGS) 
+
+valgrind: build
+	valgrind --tool=helgrind $(BIN) $(RUN_ARGS) 
+
+gdb:
+	gdb --args $(BIN) $(RUN_ARGS)
+
+clean:
+	$(RM) -Rf bin
+

--- a/libs/librtlnumber/unit_test/verilog_bits.cpp
+++ b/libs/librtlnumber/unit_test/verilog_bits.cpp
@@ -1,0 +1,23 @@
+#include "internal_bits.hpp"
+
+using namespace BitSpace;
+int main(int argc, char **argv)
+{
+    size_t size=0;
+    size = strtoul(argv[1],nullptr,10);
+	VerilogBits my_bits(size,'x');
+    printf("array_size(%zu) \n\n================\n", my_bits.size());
+
+	std::cout << my_bits.to_string(false) << std::endl;
+	
+	for(size_t value = 0; value <8; value++)
+	{
+		for(size_t i=0; i<size; i++)
+		{
+			BitSpace::bit_value_t val = static_cast<BitSpace::bit_value_t>(value);
+			printf("(%hhu)[%zu] : ",val,i);
+			my_bits.set_bit(i,val);
+			std::cout << my_bits.to_string(false) << std::endl;
+		}
+	}
+}

--- a/libs/librtlnumber/verify_librtlnumber.sh
+++ b/libs/librtlnumber/verify_librtlnumber.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
+#         Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com) and
+#          Dr. Kenneth B. Kent (ken@unb.ca)
+#          for the Reconfigurable Computing Research Lab at the
+#           Univerity of New Brunswick in Fredericton, New Brunswick, Canada
+
+# trap ctrl-c and call ctrl_c()
+trap ctrl_c INT
+
+TOTAL_TEST_RAN=0
+FAILURE_COUNT=0
+DEBUG=0
+
+function ctrl_c() {
+    FAILURE_COUNT=$((FAILURE_COUNT+1))
+	exit_code ${FAILURE_COUNT} "\n\n** EXITED FORCEFULLY **\n\n"
+}
+
+function exit_code() {
+	#print passed in value
+	echo -e $2
+	my_failed_count=$1
+	echo -e "$TOTAL_TEST_RAN Tests Ran; $my_failed_count Test Failures.\n"
+	[ "$my_failed_count" -gt "127" ] && echo "WARNING: Return Code may be unreliable: More than 127 Failures!"
+	echo "End."
+	exit ${my_failed_count}
+}
+
+# Check if Library 'file' "${0%/*}/librtlnumber.a" exists
+[ ! -f ${0%/*}/librtlnumber.a ] && exit_code 99 "${0%/*}/librtlnumber.a library file not found!\n"
+
+# Check if test harness binary "${0%/*}/rtl_number" exists
+[ ! -f ${0%/*}/rtl_number ] && exit_code 99 "${0%/*}/rtl_number test harness file not found!\n" 
+
+# Dynamically load in inputs and results from
+#  file(s) on disk.
+for INPUT in ${0%/*}/regression_tests/*.csv; do
+	[ ! -f $INPUT ] && exit_code 99 "$INPUT regression test file not found!\n"
+
+	echo -e "\nRunning Test File: $INPUT:"
+
+	LINE=0
+
+	while IFS= read -r input_line; do
+
+		LINE=$((LINE + 1))
+
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: LINE: $LINE\n"
+
+		#glob whitespace from line and remove everything after comment
+		input_line=$(echo ${input_line} | tr -d '[:space:]' | cut -d '#' -f1)
+
+		#skip empty lines
+		[  "_" ==  "_${input_line}" ] && continue
+
+		#split csv
+		IFS="," read -ra arr <<< ${input_line}
+		len=${#arr[@]}
+
+		if 	[ ${len} != "4" ] &&		# unary
+			[ ${len} != "5" ] &&		# binary
+			[ ${len} != "7" ]; then		# ternary
+				[ ! -z ${DEBUG} ] && echo -e "\nWARNING: Malformed Line in CSV File ($INPUT:$LINE) Input Line: ${input_line}! Skipping...\n"
+				continue
+		fi
+
+		TOTAL_TEST_RAN=$((TOTAL_TEST_RAN + 1))
+
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: TOTAL_TEST_RAN: $TOTAL_TEST_RAN\n"
+
+		#deal with multiplication
+		set -f
+
+		# everything between is the operation to pipe in so we slice the array and concatenate with space
+		TEST_LABEL=${arr[0]}
+		EXPECTED_RESULT=${arr[$(( len -1 ))]}
+		RTL_CMD_IN=$(printf "%s " "${arr[@]:1:$(( len -2 ))}")
+
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: TEST_LABEL: $TEST_LABEL\n"
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: EXPECTED_RESULT: $EXPECTED_RESULT\n"
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: RTL_CMD_IN: $RTL_CMD_IN\n"
+
+		# Check for Anything on standard out and any non-'0' exit codes:
+		OUTPUT_AND_RESULT=$(${0%/*}/rtl_number ${RTL_CMD_IN})
+		EXIT_CODE=$?
+
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: OUTPUT_AND_RESULT: $OUTPUT_AND_RESULT\n"
+		# echo -e "${0##*/}@${HOSTNAME}: DEBUG: EXIT_CODE: $EXIT_CODE\n"
+
+		if [[ 0 -ne $EXIT_CODE ]]
+		then
+			FAILURE_COUNT=$((FAILURE_COUNT+1))
+
+			# echo -e "${0##*/}@${HOSTNAME}: DEBUG: FAILURE_COUNT: $FAILURE_COUNT\n"
+
+			echo -e "\nERROR: Non-Zero Exit Code from ${0%/*}/rtl_number (on $INPUT:$LINE)\n"
+
+			echo -e "-X- FAILED == $TEST_LABEL\t  ./rtl_number ${RTL_CMD_IN}\t sOutput:<$OUTPUT_AND_RESULT> != <$EXPECTED_RESULT>"
+
+		elif [ "pass" == "$(${0%/*}/rtl_number is_true $(${0%/*}/rtl_number ${OUTPUT_AND_RESULT} == ${EXPECTED_RESULT}))" ]
+		then
+			echo "--- PASSED == $TEST_LABEL"
+
+		else
+			FAILURE_COUNT=$((FAILURE_COUNT+1))
+
+			# echo -e "${0##*/}@${HOSTNAME}: DEBUG: FAILURE_COUNT: $FAILURE_COUNT\n"
+
+			echo -e "\nERROR: Expected Result Didn't match what we got back from ${0%/*}/rtl_number (on $INPUT:$LINE)\n"
+
+			echo -e "-X- FAILED == $TEST_LABEL\t  ./rtl_number ${RTL_CMD_IN}\t sOutput:<$OUTPUT_AND_RESULT> != <$EXPECTED_RESULT>"
+
+		fi
+
+		#unset the multiplication token override
+		unset -f
+
+	done < "$INPUT"
+	#  Re-Enable Bash Wildcard Expanstion '*' 
+	set +f
+done
+
+exit_code ${FAILURE_COUNT} "Completed Tests\n"


### PR DESCRIPTION
#### Description
librtlnumber - Register Transfer Level (RTL) Verilog Number Library

- Arbitrary Length Verilog Number Library that can Handle 'X' and 'Z' inputs.

- Authors: Aaron Graham (aaron.graham@unb.ca, aarongraham9@gmail.com),
         Jean-Philippe Legault (jlegault@unb.ca, jeanphilippe.legault@gmail.com)
		  and Dr. Kenneth B. Kent (ken@unb.ca)
           for the Reconfigurable Computing Research Lab at the
            Univerity of New Brunswick in Fredericton, New Brunswick, Canada

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
