### PR TITLE
ODIN_MEMLEAK: freed unused BITWISE_NOT node

### DIFF
--- a/ODIN_II/SRC/partial_map.cpp
+++ b/ODIN_II/SRC/partial_map.cpp
@@ -392,6 +392,7 @@ void instantiate_not_logic(nnode_t *node, short mark, netlist_t * /*netlist*/)
 	}
 
 	vtr::free(new_not_cells);
+	free_nnode(node);
 }
 
 /*---------------------------------------------------------------------------------------------


### PR DESCRIPTION
#### Motivation and Context
memory leaks in odin

#### How Has This Been Tested?
odin pre_commit regression suite

#### Types of changes
- [x] Bug fix (change which fixes an issue)

#### Checklist:
- [x] All new and existing tests passed
