### PR TITLE
Avoid duplicate work during flow.

### DIFF
--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -122,10 +122,6 @@ bool read_route(const char* route_file, const t_router_opts& router_opts, bool v
     /* Finished loading in the routing, now check it*/
 	recompute_occupancy_from_scratch();
     bool is_feasible = feasible_routing();
-    if (is_feasible) {
-        check_route(router_opts.route_type);
-    }
-    get_serial_num();
 
     VTR_LOG("Finished loading route file\n");
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -776,9 +776,6 @@ RouteStatus vpr_load_routing(t_vpr_setup& vpr_setup, const t_arch& arch, int fix
         VPR_THROW(VPR_ERROR_ROUTE, "Fixed channel width must be specified when loading routing (was %d)", fixed_channel_width);
     }
 
-    //Create the routing resource graph
-    vpr_create_rr_graph(vpr_setup, arch, fixed_channel_width);
-
     auto& filename_opts = vpr_setup.FileNameOpts;
 
     //Load the routing from a file


### PR DESCRIPTION
#### Description

These are two cases where work is being done twice.  The first case is
that the routing graph is being generated (or read from a file) twice.
The second is that when a routing graph load is done, the check_route
routine is called twice, once in the load function and another in the
root level flow function.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
