### PR TITLE
Add stub check to check_route

### DIFF
--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -631,7 +631,10 @@ void free_route_tree(t_rt_node * rt_node) {
 		rt_edge = next_edge;
 	}
 
-    rr_node_to_rt_node[rt_node->inode] = nullptr;
+    if(!rr_node_to_rt_node.empty()) {
+        rr_node_to_rt_node.at(rt_node->inode) = nullptr;
+    }
+
 	free_rt_node(rt_node);
 }
 


### PR DESCRIPTION
#### Description

Adds stub check to check_route.

#### Related Issue

https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/526

#### Motivation and Context

Detects stub nodes in routing graph.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
