### PR TITLE
Fixed [-Wmissing-declarations] warning in VTR/master

### DIFF
--- a/ODIN_II/SRC/include/verilog_preprocessor.h
+++ b/ODIN_II/SRC/include/verilog_preprocessor.h
@@ -81,6 +81,7 @@ void push(veri_flag_stack *stack, int flag);
 
 
 /* General Utility methods ------------------------------------------------- */
+bool is_whitespace(const char in);
 char *trim(char *input_str);
 char* trim(char *input_string, size_t n);
 


### PR DESCRIPTION
Signed-off-by: Prayas Arora <arora.prayas@gmail.com>

Fixed [-Wmissing-declarations] warning in VTR/master

#### Description
- wrote function prototype in ODIN_II/SRC/include/verilog_preprocessor.h file.

#### Related Issue
Run the following commands from VTR root directory:
```
$ make clean
$ make
```
Issue Link: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/540

#### Motivation and Context
VTR should compile cleanly without warnings in favor of the user.

#### How Has This Been Tested?
Command: ./run_quick_test.pl
All tests of vtr_reg_basic passed

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [`x`] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [`x`] All new and existing tests passed