### PR TITLE
Router exit condition

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -38,7 +38,7 @@
 /* IGNORE_ITERATION_LIMIT_HEAP_PUSH_FACTOR when defined changes the router
  * behavior to ignore max_router_iterations. Instead of terminating the router loop
  * when the iteration count is hit, the router will monitor average heap ops per
- * iteration, and will allow the router to continue past max_router_iterations
+ * iteration, and will allow the router loop to continue past max_router_iterations
  * if the number of heap ops done per iteration is "meaningfully smaller" than the average;
  * "meaningfully smaller" is based on the factor specified.
  * The idea behind this is to let the router proceed, if it seems close to converging,


### PR DESCRIPTION
#define guarded change to modify router loop exit behavior (not enabled by default). Instead of exiting at max_router_iterations, if IGNORE_ITERATION_LIMIT_HEAP_PUSH_FACTOR is defined, the router will continue to run iterations if the number of heap pushes per iteration is less than the average number of heap pushes per iteration by the factor specified.

#### Motivation and Context
With a hard iteration limit, sometimes the router aborts even though it appears to be converging because it is down to only a few overused nodes. When the number of heap pushes per iteration is small, each iteration runs quickly relative to earlier iterations, so it may be advantageous to let the router continue in the hopes that with a little extra time, the router will converge.

This change is guarded so that further evaluation can be done (over a period of time) in the context of other VTR experiments. If the change is generally helpful, then we might want to enable it by default -- though finding a clean way to do it might require some thought as simply ignoring max_router_iterations can be confusing.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
