### PR TITLE
Add useful error message on CHAN PTC check.

### DIFF
--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -771,14 +771,24 @@ void process_rr_node_indices(const DeviceGrid& grid) {
             for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
                 for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                     count = node.ptc_num();
-                    indices[CHANX][iy][ix][0].at(count) = inode;
+                    if(count >= indices[CHANX][iy][ix][0].size()) {
+                        VPR_THROW(VPR_ERROR_ROUTE,
+                            "Ptc index %d for CHANX (%d, %d) is out of bounds, size = %zu",
+                            count, ix, iy, indices[CHANX][iy][ix][0].size());
+                    }
+                    indices[CHANX][iy][ix][0][count] = inode;
                 }
             }
         } else if (node.type() == CHANY) {
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
                     count = node.ptc_num();
-                    indices[CHANY][ix][iy][0].at(count) = inode;
+                    if(count >= indices[CHANY][ix][iy][0].size()) {
+                        VPR_THROW(VPR_ERROR_ROUTE,
+                            "Ptc index %d for CHANY (%d, %d) is out of bounds, size = %zu",
+                            count, ix, iy, indices[CHANY][ix][iy][0].size());
+                    }
+                    indices[CHANY][ix][iy][0][count] = inode;
                 }
             }
         }


### PR DESCRIPTION
Previous error would only indicate out of bounds, but not which array or index.