### PR TITLE
Odin: single port implicit ram wrongly initialized as dual port

### DIFF
--- a/ODIN_II/.gitignore
+++ b/ODIN_II/.gitignore
@@ -2,3 +2,4 @@ regression_test/runs
 OUTPUT/*
 temp
 regression_test/latest
+*_preproc.v

--- a/ODIN_II/SRC/implicit_memory.cpp
+++ b/ODIN_II/SRC/implicit_memory.cpp
@@ -106,15 +106,20 @@ implicit_memory *create_implicit_memory_block(int data_width, long memory_depth,
 	oassert(memory_depth > 0
 		&& "implicit memory depth must be greater than 0");
 
-	//find closest power of 2 fr memory depth.
-	long addr_width = 1;
-	while (shift_left_value_with_overflow_check(0x1, addr_width) < memory_depth)
-		addr_width++;
+	//find closest power of 2 from memory depth.
+	long addr_width = 0;
+	long real_memory_depth = 1;
+	while (real_memory_depth < memory_depth)
+	{
+		addr_width += 1;
+		real_memory_depth = shift_left_value_with_overflow_check(real_memory_depth, 0x1);
+	}
 
 	//verify if it is a power of two (only one bit set)
-	if(memory_depth - shift_left_value_with_overflow_check(0x1, addr_width) != 0)
+	if((memory_depth != real_memory_depth))
 	{
-		warning_message(NETLIST_ERROR, -1, -1, "Rounding memory <%s> of size <%ld> to closest power of two: %ld.", name, memory_depth, shift_left_value_with_overflow_check(0x1, addr_width));
+		warning_message(NETLIST_ERROR, -1, -1, "Rounding memory <%s> of size <%ld> to closest power of two: %ld.", name, memory_depth, real_memory_depth);
+		memory_depth = real_memory_depth;
 	}
 
 	nnode_t *node = allocate_nnode();

--- a/ODIN_II/SRC/memories.cpp
+++ b/ODIN_II/SRC/memories.cpp
@@ -170,7 +170,7 @@ void add_input_port_to_memory(nnode_t *node, signal_list_t *signalsvar, const ch
 		if (!strcmp(pin->mapping, port_name))
 		{
 			error_message(NETLIST_ERROR, -1, -1,
-					"Attempted to reassign output port %s to memory %s.", port_name, node->name);
+					"Attempted to reassign input port %s to memory %s.", port_name, node->name);
 		}
 	}
 

--- a/ODIN_II/regression_test/benchmark/syntax/inferred_DPram.v
+++ b/ODIN_II/regression_test/benchmark/syntax/inferred_DPram.v
@@ -1,0 +1,26 @@
+`define WORD_SIZE 32
+`define DEPTH_LOG2 3
+`define RAM_DEPTH 2**3
+
+module inferred_ram(
+	clk,
+	data_in,
+	data_out,
+	address
+);
+
+	input clk;
+	input [`DEPTH_LOG2-1:0] address;
+	input [`WORD_SIZE-1:0] data_in;
+	output [`WORD_SIZE-1:0] data_out;
+
+	reg  [`WORD_SIZE-1:0] mregs [`RAM_DEPTH-1:0];  
+
+	always @ (posedge clk )
+	begin
+		mregs[address] <= data_in;
+		// address may have changed so we need a dual port ram.
+		data_out <= mregs[address];
+	end
+
+endmodule

--- a/ODIN_II/regression_test/benchmark/syntax/inferred_SPram.v
+++ b/ODIN_II/regression_test/benchmark/syntax/inferred_SPram.v
@@ -18,8 +18,8 @@ module inferred_ram(
 
 	always @ (posedge clk )
 	begin
+		data_out <= data_in;
 		mregs[address] <= data_in;
-		data_out <= mregs[address];
 	end
 
 endmodule


### PR DESCRIPTION
#### Description
Leave the zero paddings of the implicit ram for later to be able to collapse it.

#### Related Issue
No issue raised, but SP ram was always initialized, now this fixes it to also use SP_ram when only a single call to the ram is used.

#### How Has This Been Tested?
added a test to assure that single port rams are initialized

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (change which fixes an issue)

#### Checklist:
- [x ] I have added tests to cover my changes
- [ ] All new and existing tests passed TBD
