### PR TITLE
Skip x locations that have no targets.

### DIFF
--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2096,9 +2096,11 @@ static bool find_to(t_type_ptr type, float rlim, const t_pl_loc from, t_pl_loc& 
         //The candidates are stored in a flat_map so we can efficiently find the set of valid
         //candidates with upper/lower bound.
         auto y_lower_iter = compressed_block_grid.grid[cx_to].lower_bound(min_cy);
-        auto y_upper_iter = compressed_block_grid.grid[cx_to].upper_bound(max_cy);
+        if (y_lower_iter == compressed_block_grid.grid[cx_to].end()) {
+            continue;
+        }
 
-        VTR_ASSERT_MSG(y_lower_iter != compressed_block_grid.grid[cx_to].end(), "Must have at least one block at this x location");
+        auto y_upper_iter = compressed_block_grid.grid[cx_to].upper_bound(max_cy);
 
         if (y_lower_iter->first > min_cy) {
             //No valid blocks at this x location which are within rlim_y


### PR DESCRIPTION
It is unclear why the assertion exists, it seems that not all ``cx_to`` will have items that conform to the ``min_cy``/``max_cy`` for spare architectures.