### PR TITLE
bug-fix: include cmath to avoid ODIN II compile errors

### DIFF
--- a/ODIN_II/SRC/multipliers.cpp
+++ b/ODIN_II/SRC/multipliers.cpp
@@ -25,6 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <stdio.h>
 #include <string.h>
 #include <algorithm>
+#include <cmath>
 #include "odin_types.h"
 #include "node_creation_library.h"
 #include "multipliers.h"


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
ODIN failed to compile with the following output:

```
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp: In function ‘void split_soft_multiplier(nnode_t*, netlist_t*)’:
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1232:33: error: ‘ceil’ is not a member of ‘std’
     const int add_levels = std::ceil(std::log((double)multiplicand_width)/std::log(2.));
                                 ^~~~
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1232:33: note: suggested alternative: ‘cerr’
     const int add_levels = std::ceil(std::log((double)multiplicand_width)/std::log(2.));
                                 ^~~~
                                 cerr
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1232:43: error: ‘log’ is not a member of ‘std’
     const int add_levels = std::ceil(std::log((double)multiplicand_width)/std::log(2.));
                                           ^~~
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1232:43: note: suggested alternative: ‘clog’
     const int add_levels = std::ceil(std::log((double)multiplicand_width)/std::log(2.));
                                           ^~~
                                           clog
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1232:80: error: ‘log’ is not a member of ‘std’
     const int add_levels = std::ceil(std::log((double)multiplicand_width)/std::log(2.));
                                                                                ^~~
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1232:80: note: suggested alternative: ‘clog’
     const int add_levels = std::ceil(std::log((double)multiplicand_width)/std::log(2.));
                                                                                ^~~
                                                                                clog
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1285:46: error: ‘ceil’ is not a member of ‘std’
         addition_stages[level+1].resize(std::ceil(addition_stages[level].size()/2.));
                                              ^~~~
/home/alessandro/projects/symbiflow/tmp/vtr-acomodi/ODIN_II/SRC/multipliers.cpp:1285:46: note: suggested alternative: ‘cerr’
         addition_stages[level+1].resize(std::ceil(addition_stages[level].size()/2.));
                                              ^~~~

```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
