### PR TITLE
check_rr_graph: make zero capacity nodes valid and not drawn.

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1340,7 +1340,12 @@ void draw_rr() {
 static void draw_rr_chan(int inode, const t_color color) {
     auto& device_ctx = g_vpr_ctx.device();
 
-    t_rr_type type = device_ctx.rr_nodes[inode].type();
+    auto& node = device_ctx.rr_nodes[inode];
+    if (node.capacity() == 0) {
+        return;
+    }
+
+    t_rr_type type = node.type();
 
     VTR_ASSERT(type == CHANX || type == CHANY);
 

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -168,7 +168,6 @@ void check_rr_graph(const t_graph_type graph_type,
 
                 const auto& node = device_ctx.rr_nodes[inode];
 
-
                 bool is_fringe = ((device_ctx.rr_nodes[inode].xlow() == 1)
                         || (device_ctx.rr_nodes[inode].ylow() == 1)
                         || (device_ctx.rr_nodes[inode].xhigh() == int(grid.width()) - 2)
@@ -176,7 +175,9 @@ void check_rr_graph(const t_graph_type graph_type,
                 bool is_wire = (device_ctx.rr_nodes[inode].type() == CHANX
                         || device_ctx.rr_nodes[inode].type() == CHANY);
 
-                if (!is_chain && !is_fringe && !is_wire) {
+                if (device_ctx.rr_nodes[inode].capacity() == 0) {
+                    // Zero-capacity nodes are fine to have no fan-in / fan out.
+                } else if (!is_chain && !is_fringe && !is_wire) {
                     if (node.type() == IPIN || node.type() == OPIN) {
 
                         if (has_adjacent_channel(node, device_ctx.grid)) {
@@ -378,42 +379,69 @@ void check_rr_node(int inode, enum e_route_type route_type, const DeviceContext&
             break;
 
         case CHANX:
-            if (route_type == DETAILED) {
-                nodes_per_chan = device_ctx.chan_width.max;
-                tracks_per_node = 1;
+            if (capacity == 0) {
+                auto fan_in = device_ctx.rr_nodes[inode].fan_in();
+                if (fan_in > 0) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a capacity of zero but fan_in of %d.\n", inode, rr_type, fan_in);
+                }
+                auto fan_out = device_ctx.rr_nodes[inode].fan_in();
+                if (fan_out > 0) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a capacity of zero but fan_out of %d.\n", inode, rr_type, fan_out);
+                }
             } else {
-                nodes_per_chan = 1;
-                tracks_per_node = device_ctx.chan_width.x_list[ylow];
-            }
+                if (route_type == DETAILED) {
+                    nodes_per_chan = device_ctx.chan_width.max;
+                    tracks_per_node = 1;
+                } else {
+                    nodes_per_chan = 1;
+                    tracks_per_node = device_ctx.chan_width.x_list[ylow];
+                }
 
-            if (ptc_num >= nodes_per_chan) {
-                vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
-                        "in check_rr_node: inode %d (type %d) has a ptc_num of %d.\n", inode, rr_type, ptc_num);
-            }
+                if (ptc_num >= nodes_per_chan) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a ptc_num of %d.\n", inode, rr_type, ptc_num);
+                }
 
-            if (capacity != tracks_per_node) {
-                vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
-                        "in check_rr_node: inode %d (type %d) has a capacity of %d.\n", inode, rr_type, capacity);
+                if (capacity != tracks_per_node) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a capacity of %d but required %d.\n", inode, rr_type, capacity, tracks_per_node);
+                }
             }
             break;
 
         case CHANY:
-            if (route_type == DETAILED) {
-                nodes_per_chan = device_ctx.chan_width.max;
-                tracks_per_node = 1;
+            if (capacity == 0) {
+                auto fan_in = device_ctx.rr_nodes[inode].fan_in();
+                if (fan_in > 0) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a capacity of zero but fan_in of %d.\n", inode, rr_type, fan_in);
+                }
+                auto fan_out = device_ctx.rr_nodes[inode].fan_in();
+                if (fan_out > 0) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a capacity of zero but fan_out of %d.\n", inode, rr_type, fan_out);
+                }
             } else {
-                nodes_per_chan = 1;
-                tracks_per_node = device_ctx.chan_width.y_list[xlow];
-            }
+                if (route_type == DETAILED) {
+                    nodes_per_chan = device_ctx.chan_width.max;
+                    tracks_per_node = 1;
+                } else {
+                    nodes_per_chan = 1;
+                    tracks_per_node = device_ctx.chan_width.y_list[xlow];
+                }
 
-            if (ptc_num >= nodes_per_chan) {
-                vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
-                        "in check_rr_node: inode %d (type %d) has a ptc_num of %d.\n", inode, rr_type, ptc_num);
-            }
+                if (ptc_num >= nodes_per_chan) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a ptc_num of %d.\n", inode, rr_type, ptc_num);
 
-            if (capacity != tracks_per_node) {
-                vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
-                        "in check_rr_node: inode %d (type %d) has a capacity of %d.\n", inode, rr_type, capacity);
+                }
+
+                if (capacity != tracks_per_node) {
+                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                            "in check_rr_node: inode %d (type %d) has a capacity of %d but required %d.\n", inode, rr_type, capacity, tracks_per_node);
+                }
             }
             break;
 
@@ -438,6 +466,10 @@ void check_rr_node(int inode, enum e_route_type route_type, const DeviceContext&
                 if (!has_adjacent_channel(device_ctx.rr_nodes[inode], device_ctx.grid)) {
                     check_for_out_edges = false;
                 }
+            }
+
+            if (capacity == 0) {
+                check_for_out_edges = false;
             }
 
             if (check_for_out_edges) {


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR allows to have zero-capacity nodes when checking the `rr_graph`. In addition zero-capacity nodes are not drawn.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested on my local machine, but it should not require any additional regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
