### PR TITLE
ODIN II: fixed output reg/output wire/input wire bug

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -1817,6 +1817,13 @@ void create_symbol_table_for_module(ast_node_t* module_items, char * /*module_na
 						(var_declare->types.variable.is_integer) ||
 						(var_declare->types.variable.is_wire));
 
+					if (var_declare->types.variable.is_input 
+						&& var_declare->types.variable.is_reg)
+						{
+							error_message(NETLIST_ERROR, var_declare->line_number, var_declare->file_number, "%s",
+									"Input cannot be defined as a reg\n");
+						}
+
 					/* make the string to add to the string cache */
 					temp_string = make_full_ref_name(NULL, NULL, NULL, var_declare->children[0]->types.identifier, -1);
 					/* look for that element */
@@ -1826,16 +1833,13 @@ void create_symbol_table_for_module(ast_node_t* module_items, char * /*module_na
 						/* ERROR checks here
 						 * output with reg is fine
 						 * output with wire is fine
+						 * input with wire is fine
 						 * Then update the stored string cache entry with information */
-						if ((var_declare->types.variable.is_input)
-								&& (
-									   (((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_reg)
-									|| (((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_wire)
-								)
-						)
+						if (var_declare->types.variable.is_input
+							&& ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_reg)
 						{
 							error_message(NETLIST_ERROR, var_declare->line_number, var_declare->file_number, "%s",
-									"Input defined as wire or reg means it is a driver in this module.  Not possible\n");
+									"Input cannot be defined as a reg\n");
 						}
 						/* MORE ERRORS ... could check for same declaration name ... */
 						else if (var_declare->types.variable.is_output)
@@ -1977,18 +1981,8 @@ void create_symbol_table_for_function(ast_node_t* function_items, char * /*funct
 						 * output with reg is fine
 						 * output with wire is fine
 						 * Then update the stored string chache entry with information */
-						if ((var_declare->types.variable.is_input)
-								&& (
-									   (((ast_node_t*)function_local_symbol_table_sc->data[sc_spot])->types.variable.is_reg)
-									|| (((ast_node_t*)function_local_symbol_table_sc->data[sc_spot])->types.variable.is_wire)
-								)
-						)
-						{
-							error_message(NETLIST_ERROR, var_declare->line_number, var_declare->file_number, "%s",
-									"Input defined as wire or reg means it is a driver in this module.  Not possible\n");
-						}
 						/* MORE ERRORS ... could check for same declaration name ... */
-						else if (var_declare->types.variable.is_output)
+						if (var_declare->types.variable.is_output)
 						{
 							/* copy all the reg and wire info over */
 							((ast_node_t*)function_local_symbol_table_sc->data[sc_spot])->types.variable.is_output = TRUE;

--- a/ODIN_II/SRC/parse_making_ast.cpp
+++ b/ODIN_II/SRC/parse_making_ast.cpp
@@ -551,7 +551,7 @@ ast_node_t *markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t *symbo
 			            /* add this output to the modules string cache */
 			            if ((sc_spot = sc_add_string(modules_outputs_sc, symbol_list->children[i]->children[0]->types.identifier)) == -1)
 			            {
-				            error_message(PARSE_ERROR, symbol_list->children[i]->children[0]->line_number, current_parse_file, "Module already has input with this name %s\n", symbol_list->children[i]->children[0]->types.identifier);
+				            error_message(PARSE_ERROR, symbol_list->children[i]->children[0]->line_number, current_parse_file, "Module already has output with this name %s\n", symbol_list->children[i]->children[0]->types.identifier);
 			            }
 			            /* store the data which is an idx here */
 			            modules_outputs_sc->data[sc_spot] = (void*)symbol_list->children[i];
@@ -645,7 +645,7 @@ ast_node_t *markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t *symbo
 				        /* add this output to the modules string cache */
 				        if ((sc_spot = sc_add_string(functions_outputs_sc, symbol_list->children[i]->children[0]->types.identifier)) == -1)
 				        {
-					        error_message(PARSE_ERROR, symbol_list->children[i]->children[0]->line_number, current_parse_file, "Module already has input with this name %s\n", symbol_list->children[i]->children[0]->types.identifier);
+					        error_message(PARSE_ERROR, symbol_list->children[i]->children[0]->line_number, current_parse_file, "Module already has output with this name %s\n", symbol_list->children[i]->children[0]->types.identifier);
 				        }
 				        /* store the data which is an idx here */
 				        functions_outputs_sc->data[sc_spot] = (void*)symbol_list->children[i];

--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -224,10 +224,12 @@ defparam_declaration:
 
 input_declaration:
 	vINPUT variable_list ';'	{$$ = markAndProcessSymbolListWith(MODULE,INPUT, $2);}
+	| vINPUT net_declaration	{$$ = markAndProcessSymbolListWith(MODULE,INPUT, $2);}
 	;
 
 output_declaration:
 	vOUTPUT variable_list ';'					{$$ = markAndProcessSymbolListWith(MODULE,OUTPUT, $2);}
+	| vOUTPUT net_declaration					{$$ = markAndProcessSymbolListWith(MODULE,OUTPUT, $2);}
 	;
 
 inout_declaration:

--- a/ODIN_II/regression_test/benchmark/syntax/multi_module_io_data_types.v
+++ b/ODIN_II/regression_test/benchmark/syntax/multi_module_io_data_types.v
@@ -1,0 +1,22 @@
+module testmodule (a,b,c,d);
+
+input [31:0] a;
+input [31:0] b;
+output reg [31:0] c;
+output wire [31:0] d;
+
+assign c = a & b;
+assign d = a | b;
+
+endmodule
+
+module define_tester (a,b, c);
+
+input [31:0] a;
+input wire [31:0] b;
+output reg [31:0] c;
+output wire [31:0] d;
+
+testmodule mymod (a,b,c,d);
+
+endmodule


### PR DESCRIPTION
#### Description
Fixed a bug that prevented input/output declarations to include a data type (i.e. output reg, input wire, output wire).

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/603

#### How Has This Been Tested?
odin pre-commit regression suite
new syntax test
local tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)

#### Checklist:
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
