### PR TITLE
Fix the fasm unit test (and run it on travis).

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -27,6 +27,12 @@ end_section "vtr.du"
 
 $SPACER
 
+start_section "vtr.test.0" "${GREEN}Testing..${NC} ${CYAN}C++ unit tests${NC}"
+make test
+end_section "vtr.test.0"
+
+$SPACER
+
 start_section "vtr.test.1" "${GREEN}Testing..${NC} ${CYAN}vtr_reg_basic${NC}"
 ./run_reg_test.pl vtr_reg_basic
 end_section "vtr.test.1"

--- a/utils/fasm/test/test_parameters.cpp
+++ b/utils/fasm/test/test_parameters.cpp
@@ -16,9 +16,9 @@ TEST_CASE("parameters", "[fasm]") {
     // Unmatched features returns "".
     CHECK_THAT(params.EmitFasmFeature("C", "0"), Equals(""));
 
-    CHECK_THAT(params.EmitFasmFeature("A", "0"), Equals("B=1'b0"));
-    CHECK_THAT(params.EmitFasmFeature("INIT_0", "10100000000000000000000000000001"), Equals("INIT[31:0]=32'b10100000000000000000000000000001"));
-    CHECK_THAT(params.EmitFasmFeature("INIT_1", "00010000000000000000000000001001"), Equals("INIT[63:32]=32'b00010000000000000000000000001001"));
+    CHECK_THAT(params.EmitFasmFeature("A", "0"), Equals("B=1'b0\n"));
+    CHECK_THAT(params.EmitFasmFeature("INIT_0", "10100000000000000000000000000001"), Equals("INIT[31:0]=32'b10100000000000000000000000000001\n"));
+    CHECK_THAT(params.EmitFasmFeature("INIT_1", "00010000000000000000000000001001"), Equals("INIT[63:32]=32'b00010000000000000000000000001001\n"));
 }
 
 } // namespace


### PR DESCRIPTION
#### Description

Fixes the currently broken fasm unit test and makes it run on travis. They were failing due to missing newlines, see below;
```
./utils//fasm/test/test_parameters.cpp:19: FAILED:
  CHECK_THAT( params.EmitFasmFeature("A", "0"), Equals("B=1'b0") )
with expansion:
  "B=1'b0
  " equals: "B=1'b0"

./utils//fasm/test/test_parameters.cpp:20: FAILED:
  CHECK_THAT( params.EmitFasmFeature("INIT_0", "10100000000000000000000000000001"), Equals("INIT[31:0]=32'b10100000000000000000000000000001") )
with expansion:
  "INIT[31:0]=32'b10100000000000000000000000000001
  " equals: "INIT[31:0]=32'b10100000000000000000000000000001"

./utils//fasm/test/test_parameters.cpp:21: FAILED:
  CHECK_THAT( params.EmitFasmFeature("INIT_1", "00010000000000000000000000001001"), Equals("INIT[63:32]=32'b00010000000000000000000000001001") )
with expansion:
  "INIT[63:32]=32'b00010000000000000000000000001001
  " equals: "INIT[63:32]=32'b00010000000000000000000000001001"
```

#### Related Issue

 * Fixes https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/610

#### Types of changes

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
