### PR TITLE
timing_builder: allow dangling combinational nodes

### DIFF
--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -949,6 +949,16 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
             "This option should be only used for development purposes.")
         .default_value("");
 
+    gen_grp.add_argument<bool, ParseOnOff>(args.allow_dangling_combinational_nodes, "--allow_dangling_combinational_nodes")
+        .help(
+            "Option to allow dangling combinational nodes in the timing graph.\n"
+            "This option should normally be off, as dangling combinational nodes are unusual\n"
+            "in the timing graph and may indicate a problem in the circuit or architecture.\n"
+            "Unless you understand why your architecture/circuit can have valid dangling combinational nodes, this option should be off.\n"
+            "In general this is a dev-only option and should not be turned on by the end-user.")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& file_grp = parser.add_argument_group("file options");
 
     file_grp.add_argument(args.BlifFile, "--circuit_file")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -52,6 +52,7 @@ struct t_options {
     argparse::ArgValue<bool> strict_checks;
     argparse::ArgValue<std::string> disable_errors;
     argparse::ArgValue<std::string> suppress_warnings;
+    argparse::ArgValue<bool> allow_dangling_combinational_nodes;
 
     /* Atom netlist options */
     argparse::ArgValue<bool> absorb_buffer_luts;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -304,7 +304,7 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
         auto& timing_ctx = g_vpr_ctx.mutable_timing();
         {
             vtr::ScopedStartFinishTimer t("Build Timing Graph");
-            timing_ctx.graph = TimingGraphBuilder(atom_ctx.nlist, atom_ctx.lookup).timing_graph();
+            timing_ctx.graph = TimingGraphBuilder(atom_ctx.nlist, atom_ctx.lookup).timing_graph(options->allow_dangling_combinational_nodes);
             VTR_LOG("  Timing Graph Nodes: %zu\n", timing_ctx.graph->nodes().size());
             VTR_LOG("  Timing Graph Edges: %zu\n", timing_ctx.graph->edges().size());
             VTR_LOG("  Timing Graph Levels: %zu\n", timing_ctx.graph->levels().size());

--- a/vpr/src/timing/timing_graph_builder.cpp
+++ b/vpr/src/timing/timing_graph_builder.cpp
@@ -40,8 +40,8 @@ TimingGraphBuilder::TimingGraphBuilder(const AtomNetlist& netlist,
     //pass
 }
 
-std::unique_ptr<TimingGraph> TimingGraphBuilder::timing_graph() {
-    build();
+std::unique_ptr<TimingGraph> TimingGraphBuilder::timing_graph(bool allow_dangling_combinational_nodes) {
+    build(allow_dangling_combinational_nodes);
     opt_memory_layout();
 
     VTR_ASSERT(tg_);
@@ -50,8 +50,12 @@ std::unique_ptr<TimingGraph> TimingGraphBuilder::timing_graph() {
     return std::move(tg_);
 }
 
-void TimingGraphBuilder::build() {
+void TimingGraphBuilder::build(bool allow_dangling_combinational_nodes) {
     tg_ = std::make_unique<tatum::TimingGraph>();
+
+    // Optionally allow dangling combinational nodes.
+    // Set by `--allow_dangling_combinational_nodes on`. Default value is false
+    tg_->set_allow_dangling_combinational_nodes(allow_dangling_combinational_nodes);
 
     for (AtomBlockId blk : netlist_.blocks()) {
         AtomBlockType blk_type = netlist_.block_type(blk);

--- a/vpr/src/timing/timing_graph_builder.h
+++ b/vpr/src/timing/timing_graph_builder.h
@@ -10,10 +10,10 @@ class TimingGraphBuilder {
     TimingGraphBuilder(const AtomNetlist& netlist,
                        AtomLookup& netlist_lookup);
 
-    std::unique_ptr<tatum::TimingGraph> timing_graph();
+    std::unique_ptr<tatum::TimingGraph> timing_graph(bool allow_dangling_combinational_nodes);
 
   private:
-    void build();
+    void build(bool allow_dangling_combinational_nodes);
     void opt_memory_layout();
 
     void add_io_to_timing_graph(const AtomBlockId blk);


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
In the [SymbiFlow](https://github.com/SymbiFlow/symbiflow-arch-defs) architectures, some of the tiles do not have combination sinks. This fix is needed to allow the architecture to have no combination sinks for specific tiles. Without this addition, the Timing graph builder would produce a `tatum` error and the failure of the VPR flow.

It may be better to have this fix under a command line option (e.g. --allow_non_combination_sinks). 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid Tatum error while building the Timing Graph within VPR.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
