### PR TITLE
vpr: Adding pb_type to match other enum values.

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -184,11 +184,11 @@ enum e_pb_type_class {
 };
 
 // Set of all pb_type classes
-constexpr std::array<e_pb_type_class, NUM_CLASSES> TYPE_CLASSES = {
+constexpr std::array<e_pb_type_class, NUM_CLASSES> PB_TYPE_CLASSES = {
     {UNKNOWN_CLASS, LUT_CLASS, LATCH_CLASS, MEMORY_CLASS}};
 
 // String versions of pb_type class values
-constexpr std::array<const char*, NUM_CLASSES> TYPE_CLASS_STRING = {
+constexpr std::array<const char*, NUM_CLASSES> PB_TYPE_CLASS_STRING = {
     {"unknown", "lut", "flipflop", "memory"}};
 
 /* Annotations for pin-to-pin connections */

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -179,8 +179,17 @@ enum e_pb_type_class {
     UNKNOWN_CLASS = 0,
     LUT_CLASS = 1,
     LATCH_CLASS = 2,
-    MEMORY_CLASS = 3
+    MEMORY_CLASS = 3,
+    NUM_CLASSES
 };
+
+// Set of all pb_type classes
+constexpr std::array<e_pb_type_class, NUM_CLASSES> TYPE_CLASSES = {
+    {UNKNOWN_CLASS, LUT_CLASS, LATCH_CLASS, MEMORY_CLASS}};
+
+// String versions of pb_type class values
+constexpr std::array<const char*, NUM_CLASSES> TYPE_CLASS_STRING = {
+    {"unknown", "lut", "flipflop", "memory"}};
 
 /* Annotations for pin-to-pin connections */
 enum e_pin_to_pin_annotation_type {

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1020,11 +1020,11 @@ static void ProcessPb_Type(pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mo
     class_name = vtr::strdup(Prop);
 
     if (class_name) {
-        if (0 == strcmp(class_name, "lut")) {
+        if (0 == strcmp(class_name, TYPE_CLASS_STRING[LUT_CLASS])) {
             pb_type->class_type = LUT_CLASS;
-        } else if (0 == strcmp(class_name, "flipflop")) {
+        } else if (0 == strcmp(class_name, TYPE_CLASS_STRING[LATCH_CLASS])) {
             pb_type->class_type = LATCH_CLASS;
-        } else if (0 == strcmp(class_name, "memory")) {
+        } else if (0 == strcmp(class_name, TYPE_CLASS_STRING[MEMORY_CLASS])) {
             pb_type->class_type = MEMORY_CLASS;
         } else {
             archfpga_throw(loc_data.filename_c_str(), loc_data.line(Parent),

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1020,11 +1020,11 @@ static void ProcessPb_Type(pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mo
     class_name = vtr::strdup(Prop);
 
     if (class_name) {
-        if (0 == strcmp(class_name, TYPE_CLASS_STRING[LUT_CLASS])) {
+        if (0 == strcmp(class_name, PB_TYPE_CLASS_STRING[LUT_CLASS])) {
             pb_type->class_type = LUT_CLASS;
-        } else if (0 == strcmp(class_name, TYPE_CLASS_STRING[LATCH_CLASS])) {
+        } else if (0 == strcmp(class_name, PB_TYPE_CLASS_STRING[LATCH_CLASS])) {
             pb_type->class_type = LATCH_CLASS;
-        } else if (0 == strcmp(class_name, TYPE_CLASS_STRING[MEMORY_CLASS])) {
+        } else if (0 == strcmp(class_name, PB_TYPE_CLASS_STRING[MEMORY_CLASS])) {
             pb_type->class_type = MEMORY_CLASS;
         } else {
             archfpga_throw(loc_data.filename_c_str(), loc_data.line(Parent),


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR is a little enhancement to have the different pb_type classes enum easy accessible in an array structure. There is also an index addressable array to get the name of the class as a `const char *`. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better access capability to the `e_pb_type_class` enum.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
