### PR TITLE
Check that cost_index fits within storage.

### DIFF
--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -201,6 +201,10 @@ void t_rr_node::set_class_num(short new_class_num) {
 }
 
 void t_rr_node::set_cost_index(size_t new_cost_index) {
+    if (new_cost_index >= std::numeric_limits<decltype(cost_index_)>::max()) {
+        VPR_THROW(VPR_ERROR_ROUTE, "Attempted to set cost_index_ %zu above cost_index storage max value.",
+                  new_cost_index);
+    }
     cost_index_ = new_cost_index;
 }
 


### PR DESCRIPTION
#### Description

Previous code would allow for integer overflow, resulting in negative indices or alias other cost indicies.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
