### PR TITLE
Initial router diagnostic tool

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(fasm)
+add_subdirectory(route_diag)

--- a/utils/route_diag/CMakeLists.txt
+++ b/utils/route_diag/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(VERSION 3.9)
+
+project("route_diag")
+
+add_executable(route_diag src/main.cpp)
+target_link_libraries(route_diag
+  libvpr
+  libvtrutil
+  libarchfpga
+  libsdcparse
+  libblifparse
+  libeasygl
+  libtatum
+  libargparse
+  libpugixml)

--- a/utils/route_diag/CMakeLists.txt
+++ b/utils/route_diag/CMakeLists.txt
@@ -6,11 +6,4 @@ project("route_diag")
 add_executable(route_diag src/main.cpp)
 target_link_libraries(route_diag
   libvpr
-  libvtrutil
-  libarchfpga
-  libsdcparse
-  libblifparse
-  libeasygl
-  libtatum
-  libargparse
-  libpugixml)
+  )

--- a/utils/route_diag/src/main.cpp
+++ b/utils/route_diag/src/main.cpp
@@ -1,0 +1,276 @@
+// Tool to test routing from one node to another node.
+//
+// This tool is intended to allow extremely verbose router output on exactly
+// one path to diagnose router behavior, e.g. look ahead and A* characteristics.
+//
+// Usage follows typically VPR invocation, except that no circuit is actually
+// used.
+//
+// Tool can either perform one route between a source (--source_rr_node) and
+// a sink (--sink_rr_node), or profile a source to all tiles (set
+// --source_rr_node and "--profile_source true").
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+
+#include "vtr_error.h"
+#include "vtr_memory.h"
+#include "vtr_log.h"
+#include "vtr_time.h"
+
+#include "tatum/error.hpp"
+
+#include "vpr_error.h"
+#include "vpr_api.h"
+#include "vpr_signal_handler.h"
+
+#include "globals.h"
+
+#include "net_delay.h"
+#include "RoutingDelayCalculator.h"
+#include "place_and_route.h"
+#include "router_delay_profiling.h"
+#include "route_tree_type.h"
+#include "route_common.h"
+#include "route_timing.h"
+#include "route_tree_timing.h"
+#include "route_export.h"
+#include "rr_graph.h"
+#include "rr_graph2.h"
+#include "timing_place_lookup.h"
+
+/*
+ * Exit codes to signal success/failure to scripts
+ * calling vpr
+ */
+constexpr int SUCCESS_EXIT_CODE = 0; //Everything OK
+constexpr int ERROR_EXIT_CODE = 1; //Something went wrong internally
+constexpr int UNIMPLEMENTABLE_EXIT_CODE = 2; //Could not implement (e.g. unroutable)
+constexpr int INTERRUPTED_EXIT_CODE = 3; //VPR was interrupted by the user (e.g. SIGINT/ctr-C)
+
+static void do_one_route(int source_node, int sink_node,
+        const t_router_opts& router_opts) {
+    /* Returns true as long as found some way to hook up this net, even if that *
+     * way resulted in overuse of resources (congestion).  If there is no way   *
+     * to route this net, even ignoring congestion, it returns false.  In this  *
+     * case the rr_graph is disconnected and you can give up.                   */
+    auto& device_ctx = g_vpr_ctx.device();
+    auto& route_ctx = g_vpr_ctx.routing();
+
+    t_rt_node* rt_root = init_route_tree_to_source_no_net(source_node);
+    enable_router_debug(router_opts, ClusterNetId(), sink_node);
+
+    /* Update base costs according to fanout and criticality rules */
+    update_rr_base_costs(1);
+
+    //maximum bounding box for placement
+    t_bb bounding_box;
+    bounding_box.xmin = 0;
+    bounding_box.xmax = device_ctx.grid.width() + 1;
+    bounding_box.ymin = 0;
+    bounding_box.ymax = device_ctx.grid.height() + 1;
+
+    t_conn_cost_params cost_params;
+    cost_params.criticality = 1.;
+    cost_params.astar_fac = router_opts.astar_fac;
+    cost_params.bend_cost = router_opts.bend_cost;
+
+    route_budgets budgeting_inf;
+
+    init_heap(device_ctx.grid);
+
+    std::vector<int> modified_rr_node_inf;
+    RouterStats router_stats;
+    auto router_lookahead = make_router_lookahead(router_opts.lookahead_type);
+    t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root, sink_node, cost_params, bounding_box, *router_lookahead, modified_rr_node_inf, router_stats);
+
+    bool found_path = (cheapest != nullptr);
+    if (found_path) {
+        VTR_ASSERT(cheapest->index == sink_node);
+
+        t_rt_node* rt_node_of_sink = update_route_tree(cheapest, nullptr);
+        free_heap_data(cheapest);
+
+        //find delay
+        float net_delay = rt_node_of_sink->Tdel;
+        VTR_LOG("Routed successfully, delay = %g!\n", net_delay);
+        VTR_LOG("\n");
+        print_route_tree_node(rt_root);
+        VTR_LOG("\n");
+        print_route_tree(rt_root);
+        VTR_LOG("\n");
+
+        VTR_ASSERT_MSG(route_ctx.rr_node_route_inf[rt_root->inode].occ() <= device_ctx.rr_nodes[rt_root->inode].capacity(), "SOURCE should never be congested");
+        free_route_tree(rt_root);
+    } else {
+        VTR_LOG("Routed failed");
+    }
+
+    //Reset for the next router call
+    empty_heap();
+    reset_path_costs(modified_rr_node_inf);
+}
+
+static void profile_source(int source_rr_node,
+        const t_router_opts& router_opts) {
+    vtr::ScopedStartFinishTimer timer("Profiling source");
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& grid = device_ctx.grid;
+
+    int start_x = 0;
+    int end_x = grid.width() - 1;
+    int start_y = 0;
+    int end_y = grid.height() - 1;
+
+    vtr::Matrix<float> delays({grid.width(), grid.height()},
+            std::numeric_limits<float>::infinity());
+    vtr::Matrix<int> sink_nodes({grid.width(), grid.height()}, OPEN);
+
+    for (int sink_x = start_x; sink_x <= end_x; sink_x++) {
+        for (int sink_y = start_y; sink_y <= end_y; sink_y++) {
+            if(device_ctx.grid[sink_x][sink_y].type == device_ctx.EMPTY_TYPE) {
+                continue;
+            }
+
+            auto best_sink_ptcs = get_best_classes(RECEIVER,
+                    device_ctx.grid[sink_x][sink_y].type);
+            bool successfully_routed;
+            for (int sink_ptc : best_sink_ptcs) {
+                VTR_ASSERT(sink_ptc != OPEN);
+
+                int sink_rr_node = get_rr_node_index(device_ctx.rr_node_indices, sink_x, sink_y, SINK, sink_ptc);
+
+                if (directconnect_exists(source_rr_node, sink_rr_node)) {
+                    //Skip if we shouldn't measure direct connects and a direct connect exists
+                    continue;
+                }
+
+                VTR_ASSERT(sink_rr_node != OPEN);
+
+                {
+                    vtr::ScopedStartFinishTimer timer(vtr::string_fmt(
+                        "Routing Src: %d Sink: %d", source_rr_node,
+                        sink_rr_node));
+                    successfully_routed = calculate_delay(source_rr_node, sink_rr_node,
+                                                        router_opts,
+                                                        &delays[sink_x][sink_y]);
+                }
+
+                if (successfully_routed) {
+                    sink_nodes[sink_x][sink_y] = sink_rr_node;
+                    break;
+                }
+            }
+        }
+    }
+
+    VTR_LOG("Delay matrix from source_rr_node: %d\n", source_rr_node);
+    for(int iy = 0; iy < delays.dim_size(1); ++iy) {
+        for(int ix = 0; ix < delays.dim_size(0); ++ix) {
+            VTR_LOG("%g,", delays[ix][iy]);
+        }
+        VTR_LOG("\n");
+    }
+    VTR_LOG("\n");
+
+    VTR_LOG("Sink matrix used for delay matrix:\n");
+    for(int iy = 0; iy < sink_nodes.dim_size(1); ++iy) {
+        for(int ix = 0; ix < sink_nodes.dim_size(0); ++ix) {
+            VTR_LOG("%d,", sink_nodes[ix][iy]);
+        }
+        VTR_LOG("\n");
+    }
+    VTR_LOG("\n");
+}
+
+
+static t_chan_width setup_chan_width(t_router_opts router_opts,
+        t_chan_width_dist chan_width_dist) {
+    /*we give plenty of tracks, this increases routability for the */
+    /*lookup table generation */
+
+    int width_fac;
+
+    if (router_opts.fixed_channel_width == NO_FIXED_CHANNEL_WIDTH) {
+        auto& device_ctx = g_vpr_ctx.device();
+
+        auto type = find_most_common_block_type(device_ctx.grid);
+
+        width_fac = 4 * type->num_pins;
+        /*this is 2x the value that binary search starts */
+        /*this should be enough to allow most pins to   */
+        /*connect to tracks in the architecture */
+    } else {
+        width_fac = router_opts.fixed_channel_width;
+    }
+
+    return init_chan(width_fac, chan_width_dist);
+}
+
+int main(int argc, const char **argv) {
+    t_options Options = t_options();
+    t_arch Arch = t_arch();
+    t_vpr_setup vpr_setup = t_vpr_setup();
+
+    try {
+        vpr_install_signal_handler();
+
+        /* Read options, architecture, and circuit netlist */
+        vpr_init(argc, argv, &Options, &vpr_setup, &Arch);
+
+        vpr_create_device_grid(vpr_setup, Arch);
+
+        vpr_setup_clock_networks(vpr_setup, Arch);
+
+
+        t_chan_width chan_width = setup_chan_width(
+                vpr_setup.RouterOpts,
+                Arch.Chans);
+        alloc_routing_structs(
+                chan_width,
+                vpr_setup.RouterOpts,
+                &vpr_setup.RoutingArch,
+                vpr_setup.Segments,
+                Arch.Directs,
+                Arch.num_directs
+                );
+
+        if(Options.profile_source) {
+            profile_source(
+                Options.source_rr_node,
+                vpr_setup.RouterOpts
+                );
+        } else {
+            do_one_route(
+                    Options.source_rr_node, Options.sink_rr_node,
+                    vpr_setup.RouterOpts);
+        }
+        free_routing_structs();
+
+        /* free data structures */
+        vpr_free_all(Arch, vpr_setup);
+
+    } catch (const tatum::Error& tatum_error) {
+        vtr::printf_error(__FILE__, __LINE__, "STA Engine: %s\n", tatum_error.what());
+
+        return ERROR_EXIT_CODE;
+
+    } catch (const VprError& vpr_error) {
+        vpr_print_error(vpr_error);
+
+        if (vpr_error.type() == VPR_ERROR_INTERRUPTED) {
+            return INTERRUPTED_EXIT_CODE;
+        } else {
+            return ERROR_EXIT_CODE;
+        }
+
+    } catch (const vtr::VtrError& vtr_error) {
+        vtr::printf_error(__FILE__, __LINE__, "%s:%d %s\n", vtr_error.filename_c_str(), vtr_error.line(), vtr_error.what());
+
+        return ERROR_EXIT_CODE;
+    }
+
+    /* Signal success to scripts */
+    return SUCCESS_EXIT_CODE;
+}

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -46,7 +46,7 @@ static int find_ipin_cblock_switch_index(const t_arch& Arch);
 
 /* Sets VPR parameters and defaults. Does not do any error checking
  * as this should have been done by the various input checkers */
-void SetupVPR(t_options* Options,
+void SetupVPR(const t_options* Options,
               const bool TimingEnabled,
               const bool readArchFile,
               t_file_name_opts* FileNameOpts,

--- a/vpr/src/base/SetupVPR.h
+++ b/vpr/src/base/SetupVPR.h
@@ -6,7 +6,7 @@
 #include "physical_types.h"
 #include "vpr_types.h"
 
-void SetupVPR(t_options* Options,
+void SetupVPR(const t_options* Options,
               const bool TimingEnabled,
               const bool readArchFile,
               t_file_name_opts* FileNameOpts,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -13,10 +13,6 @@
 using argparse::ConvertedValue;
 using argparse::Provenance;
 
-static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args);
-static void set_conditional_defaults(t_options& args);
-static bool verify_args(const t_options& args);
-
 //Read and process VPR's command-line aruments
 t_options read_options(int argc, const char** argv) {
     t_options args = t_options(); //Explicitly initialize for zero initialization
@@ -752,7 +748,7 @@ struct ParseReducer {
     }
 };
 
-static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args) {
+argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args) {
     std::string description =
         "Implements the specified circuit onto the target FPGA architecture"
         " by performing packing/placement/routing, and analyzes the result.\n"
@@ -1641,23 +1637,10 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .help("Signal activities file for all nets (see documentation).")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    auto& route_diag_grp = parser.add_argument_group("route diagnostic options");
-    route_diag_grp.add_argument(args.sink_rr_node, "--sink_rr_node")
-        .help("Sink RR node to route for route_diag.")
-        .show_in(argparse::ShowIn::HELP_ONLY);
-    route_diag_grp.add_argument(args.source_rr_node, "--source_rr_node")
-        .help("Source RR node to route for route_diag.")
-        .show_in(argparse::ShowIn::HELP_ONLY);
-    route_diag_grp.add_argument(args.profile_source, "--profile_source")
-        .help(
-            "Profile routes from source to IPINs at all locations."
-            "This is similiar to the placer delay matrix construction.")
-        .show_in(argparse::ShowIn::HELP_ONLY);
-
     return parser;
 }
 
-static void set_conditional_defaults(t_options& args) {
+void set_conditional_defaults(t_options& args) {
     //Some arguments are set conditionally based on other options.
     //These are resolved here.
 
@@ -1820,7 +1803,7 @@ static void set_conditional_defaults(t_options& args) {
     }
 }
 
-static bool verify_args(const t_options& args) {
+bool verify_args(const t_options& args) {
     /*
      * Check for conflicting paramaters
      */

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1641,6 +1641,19 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .help("Signal activities file for all nets (see documentation).")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    auto& route_diag_grp = parser.add_argument_group("route diagnostic options");
+    route_diag_grp.add_argument(args.sink_rr_node, "--sink_rr_node")
+        .help("Sink RR node to route for route_diag.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+    route_diag_grp.add_argument(args.source_rr_node, "--source_rr_node")
+        .help("Source RR node to route for route_diag.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+    route_diag_grp.add_argument(args.profile_source, "--profile_source")
+        .help(
+            "Profile routes from source to IPINs at all locations."
+            "This is similiar to the placer delay matrix construction.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     return parser;
 }
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -148,6 +148,10 @@ struct t_options {
     argparse::ArgValue<int> timing_report_npaths;
     argparse::ArgValue<e_timing_report_detail> timing_report_detail;
     argparse::ArgValue<bool> timing_report_skew;
+    /* Router diag tool Options */
+    argparse::ArgValue<int> source_rr_node;
+    argparse::ArgValue<int> sink_rr_node;
+    argparse::ArgValue<bool> profile_source;
 };
 
 t_options read_options(int argc, const char** argv);

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -5,6 +5,7 @@
 #include "vpr_types.h"
 #include "constant_nets.h"
 #include "argparse_value.hpp"
+#include "argparse.hpp"
 
 struct t_options {
     /* File names */
@@ -148,12 +149,11 @@ struct t_options {
     argparse::ArgValue<int> timing_report_npaths;
     argparse::ArgValue<e_timing_report_detail> timing_report_detail;
     argparse::ArgValue<bool> timing_report_skew;
-    /* Router diag tool Options */
-    argparse::ArgValue<int> source_rr_node;
-    argparse::ArgValue<int> sink_rr_node;
-    argparse::ArgValue<bool> profile_source;
 };
 
+argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args);
 t_options read_options(int argc, const char** argv);
+void set_conditional_defaults(t_options& args);
+bool verify_args(const t_options& args);
 
 #endif

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -128,13 +128,7 @@ void vpr_print_args(int argc, const char** argv) {
     VTR_LOG("\n\n");
 }
 
-/* Initialize VPR
- * 1. Read Options
- * 2. Read Arch
- * 3. Read Circuit
- * 4. Sanity check all three
- */
-void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup* vpr_setup, t_arch* arch) {
+void vpr_initialize_logging() {
     {
         //Allow the default vpr log file to be overwritten
         const char* env_value = std::getenv("VPR_LOG_FILE");
@@ -150,6 +144,16 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
             vtr::set_log_file("vpr_stdout.log");
         }
     }
+}
+
+/* Initialize VPR
+ * 1. Read Options
+ * 2. Read Arch
+ * 3. Read Circuit
+ * 4. Sanity check all three
+ */
+void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup* vpr_setup, t_arch* arch) {
+    vpr_initialize_logging();
 
     /* Print title message */
     vpr_print_title();
@@ -162,6 +166,15 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
     //how VPR was run, aiding in re-producibility
     vpr_print_args(argc, argv);
 
+    vpr_init_with_options(options, vpr_setup, arch);
+}
+
+/* Initialize VPR with options
+ * 1. Read Arch
+ * 2. Read Circuit
+ * 3. Sanity check all three
+ */
+void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_arch* arch) {
     //Set the number of parallel workers
     // We determine the number of workers in the following order:
     //  1. An explicitly specified command-line argument

--- a/vpr/src/base/vpr_api.h
+++ b/vpr/src/base/vpr_api.h
@@ -44,6 +44,8 @@
  * Main VPR Operations 
  */
 void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup* vpr_setup, t_arch* arch);
+void vpr_initialize_logging();
+void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_arch* arch);
 
 bool vpr_flow(t_vpr_setup& vpr_setup, t_arch& arch); //Run the VPR CAD flow
 

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -100,7 +100,6 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
 static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model);
 
 static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays);
-static std::vector<int> get_best_classes(enum e_pin_type pintype, t_type_ptr type);
 
 static int get_longest_segment_length(std::vector<t_segment_inf>& segment_inf);
 
@@ -108,8 +107,6 @@ static void fix_empty_coordinates(vtr::Matrix<float>& delta_delays);
 static void fix_uninitialized_coordinates(vtr::Matrix<float>& delta_delays);
 
 static float find_neightboring_average(vtr::Matrix<float>& matrix, int x, int y, int max_distance);
-
-static bool directconnect_exists(int src_rr_node, int sink_rr_node);
 
 /******* Globally Accessible Functions **********/
 
@@ -157,7 +154,7 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
 
 /******* File Accessible Functions **********/
 
-static std::vector<int> get_best_classes(enum e_pin_type pintype, t_type_ptr type) {
+std::vector<int> get_best_classes(enum e_pin_type pintype, t_type_ptr type) {
     /*
      * This function tries to identify the best pin classes to hook up
      * for delay calculation.  The assumption is that we should pick

--- a/vpr/src/place/timing_place_lookup.h
+++ b/vpr/src/place/timing_place_lookup.h
@@ -10,4 +10,7 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
                                                            const t_direct_inf* directs,
                                                            const int num_directs);
 
+std::vector<int> get_best_classes(enum e_pin_type pintype, t_type_ptr type);
+bool directconnect_exists(int src_rr_node, int sink_rr_node);
+
 #endif

--- a/vpr/src/route/route_timing.h
+++ b/vpr/src/route/route_timing.h
@@ -55,6 +55,8 @@ void alloc_timing_driven_route_structs(float** pin_criticality_ptr,
                                        t_rt_node*** rt_node_of_sink_ptr);
 void free_timing_driven_route_structs(float* pin_criticality, int* sink_order, t_rt_node** rt_node_of_sink);
 
+void enable_router_debug(const t_router_opts& router_opts, ClusterNetId net, int sink_rr);
+
 //Delay budget information for a specific connection
 struct t_conn_delay_budget {
     float short_path_criticality; //Hold criticality

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -642,6 +642,10 @@ void free_route_tree(t_rt_node* rt_node) {
     free_rt_node(rt_node);
 }
 
+void print_route_tree(const t_rt_node* rt_node) {
+    print_route_tree(rt_node, 0);
+}
+
 void print_route_tree(const t_rt_node* rt_node, int depth) {
     std::string indent;
     for (int i = 0; i < depth; ++i) {
@@ -1142,7 +1146,7 @@ void print_route_tree_inf(const t_rt_node* rt_root) {
     VTR_LOG("\n");
 }
 
-void print_route_tree(const t_rt_node* rt_root) {
+void print_route_tree_node(const t_rt_node* rt_root) {
     traverse_indented_route_tree(rt_root, 0, false, print_node, 34);
     VTR_LOG("\n");
 }

--- a/vpr/src/route/route_tree_timing.h
+++ b/vpr/src/route/route_tree_timing.h
@@ -15,7 +15,8 @@ void free_route_tree_timing_structs();
 t_rt_node* init_route_tree_to_source(ClusterNetId inet);
 
 void free_route_tree(t_rt_node* rt_node);
-void print_route_tree(const t_rt_node* rt_node, int depth = 0);
+void print_route_tree(const t_rt_node* rt_node);
+void print_route_tree(const t_rt_node* rt_node, int depth);
 
 t_rt_node* update_route_tree(t_heap* hptr, SpatialRouteTreeLookup* spatial_rt_lookup);
 
@@ -41,7 +42,7 @@ bool verify_traceback_route_tree_equivalent(const t_trace* trace_head, const t_r
 // that don't legally lead to a sink and start routing with that partial route tree
 
 void print_edge(const t_linked_rt_edge* edge);
-void print_route_tree(const t_rt_node* rt_root);
+void print_route_tree_node(const t_rt_node* rt_root);
 void print_route_tree_inf(const t_rt_node* rt_root);
 void print_route_tree_congestion(const t_rt_node* rt_root);
 

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -18,6 +18,7 @@ bool calculate_delay(int source_node, int sink_node, const t_router_opts& router
     auto& route_ctx = g_vpr_ctx.routing();
 
     t_rt_node* rt_root = setup_routing_resources_no_net(source_node);
+    enable_router_debug(router_opts, ClusterNetId(), sink_node);
 
     /* Update base costs according to fanout and criticality rules */
     update_rr_base_costs(1);


### PR DESCRIPTION
#### Description

route_diag is intended to be used to probe router behavior and explore
interconnection delay behavior.

#### Related Issue

Used for exploring #592

#### Motivation and Context

The quality and behavior of the router lookahead and placer delay matrix are important to QoR, but current diagnostic flows are tied within an existing flow (e.g. place or route a circuit).  This tool allows running relevant flows without tying it to a circuit.

This can be used to diagnose router and placer inputs independent of flows.  The delay profile can be used to compare A* factors on a given graph, and compare delay grids for different rrgraphs on the same architecture grid.

An additional desired feature is to provide diagnostics on the A* heurstic, e.g. compare predicted forward cost vs true forward cost.

#### How Has This Been Tested?

Changes to main VPR should be limited to moving some functions from static to non-static.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
