### PR TITLE
rr_graph_reader: allow non-consecutive ptc

### DIFF
--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1607,7 +1607,10 @@ static void build_rr_chan(const int x_coord,
         }
 
         int node = get_rr_node_index(L_rr_node_indices, x_coord, y_coord, chan_type, track);
-        VTR_ASSERT(node >= 0);
+
+        if (node == OPEN) {
+            continue;
+        }
 
         /* Add the edges from this track to all it's connected pins into the list */
         int num_edges = 0;

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -733,6 +733,10 @@ int get_bidir_opin_connections(const int i,
                 to_switch = seg_details[to_track].arch_wire_switch();
                 to_node = get_rr_node_index(L_rr_node_indices, tr_i, tr_j, to_type, to_track);
 
+                if (to_node == OPEN) {
+                    continue;
+                }
+
                 rr_edges_to_create.emplace_back(from_rr_node, to_node, to_switch);
                 ++num_conn;
             }
@@ -807,6 +811,10 @@ int get_unidir_opin_connections(const int chan,
         /* Figure the inodes of those muxes */
         inc_inode_index = get_rr_node_index(L_rr_node_indices, x, y, chan_type, inc_track);
         dec_inode_index = get_rr_node_index(L_rr_node_indices, x, y, chan_type, dec_track);
+
+        if (inc_inode_index == OPEN || dec_inode_index == OPEN) {
+            continue;
+        }
 
         /* Add to the list. */
         rr_edges_to_create.emplace_back(from_rr_node, inc_inode_index, seg_details[inc_track].arch_opin_switch());
@@ -1237,7 +1245,10 @@ std::vector<int> get_rr_node_indices(const t_rr_node_indices& L_rr_node_indices,
     } else {
         //Sides do not effect non-pins so there should only be one per ptc
         int rr_node_index = get_rr_node_index(L_rr_node_indices, x, y, rr_type, ptc);
-        indices.push_back(rr_node_index);
+
+        if (rr_node_index != OPEN) {
+            indices.push_back(rr_node_index);
+        }
     }
 
     return indices;
@@ -1347,15 +1358,15 @@ int find_average_rr_node_index(int device_width,
     int inode = get_rr_node_index(L_rr_node_indices, (device_width) / 2, (device_height) / 2,
                                   rr_type, ptc);
 
-    if (inode == -1) {
+    if (inode == OPEN) {
         inode = get_rr_node_index(L_rr_node_indices, (device_width) / 4, (device_height) / 4,
                                   rr_type, ptc);
     }
-    if (inode == -1) {
+    if (inode == OPEN) {
         inode = get_rr_node_index(L_rr_node_indices, (device_width) / 4 * 3, (device_height) / 4 * 3,
                                   rr_type, ptc);
     }
-    if (inode == -1) {
+    if (inode == OPEN) {
         auto& device_ctx = g_vpr_ctx.device();
 
         for (int x = 0; x < device_width; ++x) {
@@ -1366,10 +1377,10 @@ int find_average_rr_node_index(int device_width,
                     continue;
 
                 inode = get_rr_node_index(L_rr_node_indices, x, y, rr_type, ptc);
-                if (inode != -1)
+                if (inode != OPEN)
                     break;
             }
-            if (inode != -1)
+            if (inode != OPEN)
                 break;
         }
     }
@@ -1730,6 +1741,10 @@ static int get_bidir_track_to_chan_seg(const std::vector<int> conn_tracks,
         to_track = conn_tracks[iconn];
         to_node = get_rr_node_index(L_rr_node_indices, to_x, to_y, to_type, to_track);
 
+        if (to_node == OPEN) {
+            continue;
+        }
+
         /* Get the switches for any edges between the two tracks */
         to_switch = seg_details[to_track].arch_wire_switch();
 
@@ -1804,6 +1819,10 @@ static int get_track_to_chan_seg(const int from_wire,
 
             int to_wire = conn_vector.at(iconn).to_wire;
             int to_node = get_rr_node_index(L_rr_node_indices, to_x, to_y, to_chan_type, to_wire);
+
+            if (to_node == OPEN) {
+                continue;
+            }
 
             /* Get the index of the switch connecting the two wires */
             int src_switch = conn_vector[iconn].switch_ind;
@@ -1900,6 +1919,10 @@ static int get_unidir_track_to_chan_seg(const int from_track,
             }
 
             int to_node = get_rr_node_index(L_rr_node_indices, to_x, to_y, to_type, to_track);
+
+            if (to_node == OPEN) {
+                continue;
+            }
 
             //Determine which switch to use
             int iswitch = seg_details[to_track].arch_wire_switch();

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -676,13 +676,18 @@ void process_rr_node_indices(const DeviceGrid& grid) {
 
     indices.resize(NUM_RR_TYPES);
 
+    typedef struct max_ptc {
+        short chanx_max_ptc = 0;
+        short chany_max_ptc = 0;
+    } t_max_ptc;
+
     /*
      * Local multi-dimensional vector to hold max_ptc for every coordinate.
      * It has same height and width as CHANY and CHANX are inverted
      */
-    vtr::Matrix<short> coordinates_max_ptc; /* [x][y] */
+    vtr::Matrix<t_max_ptc> coordinates_max_ptc; /* [x][y] */
     size_t max_coord_size = std::max(grid.width(), grid.height());
-    coordinates_max_ptc.resize({max_coord_size, max_coord_size}, 0);
+    coordinates_max_ptc.resize({max_coord_size, max_coord_size}, t_max_ptc());
 
     /* Alloc the lookup table */
     for (t_rr_type rr_type : RR_TYPES) {
@@ -705,9 +710,14 @@ void process_rr_node_indices(const DeviceGrid& grid) {
         }
     }
 
-    /*Add the correct node into the vector
+    /*
+     * Add the correct node into the vector
+     * For CHANX and CHANY no node is added yet, but the maximum ptc is counted for each
+     * x/y location. This is needed later to add the correct node corresponding to CHANX
+     * and CHANY.
+     *
      * Note that CHANX and CHANY 's x and y are swapped due to the chan and seg convention.
-     * Push back temporary incorrect nodes for CHANX and CHANY to set the length of the vector*/
+     */
     for (size_t inode = 0; inode < device_ctx.rr_nodes.size(); inode++) {
         auto& node = device_ctx.rr_nodes[inode];
         if (node.type() == SOURCE || node.type() == SINK) {
@@ -739,13 +749,13 @@ void process_rr_node_indices(const DeviceGrid& grid) {
         } else if (node.type() == CHANX) {
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                    coordinates_max_ptc[iy][ix] = std::max(coordinates_max_ptc[iy][ix], node.ptc_num());
+                    coordinates_max_ptc[iy][ix].chanx_max_ptc = std::max(coordinates_max_ptc[iy][ix].chanx_max_ptc, node.ptc_num());
                 }
             }
         } else if (node.type() == CHANY) {
             for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                 for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                    coordinates_max_ptc[ix][iy] = std::max(coordinates_max_ptc[ix][iy], node.ptc_num());
+                    coordinates_max_ptc[ix][iy].chany_max_ptc = std::max(coordinates_max_ptc[ix][iy].chany_max_ptc, node.ptc_num());
                 }
             }
         }
@@ -756,13 +766,13 @@ void process_rr_node_indices(const DeviceGrid& grid) {
         if (rr_type == CHANX) {
             for (size_t y = 0; y < grid.height(); ++y) {
                 for (size_t x = 0; x < grid.width(); ++x) {
-                    indices[CHANX][y][x][0].resize(coordinates_max_ptc[y][x] + 1, OPEN);
+                    indices[CHANX][y][x][0].resize(coordinates_max_ptc[y][x].chanx_max_ptc + 1, OPEN);
                 }
             }
         } else if (rr_type == CHANY) {
             for (size_t x = 0; x < grid.width(); ++x) {
                 for (size_t y = 0; y < grid.height(); ++y) {
-                    indices[CHANY][x][y][0].resize(coordinates_max_ptc[x][y] + 1, OPEN);
+                    indices[CHANY][x][y][0].resize(coordinates_max_ptc[x][y].chany_max_ptc + 1, OPEN);
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds the possibility to allow channel segments to have non-consecutive ptc.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
More information about the issue can be found here: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/606

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SymbiFlow architectures do have channels which have non-consecutive ptc, generating an error while reading the RR graph. More specifically, the lines that produce the issue are the following:
https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/411331f32b286273ed06eb4e4171c62c700e6f76/vpr/src/route/rr_graph_reader.cpp#L748-L777

#### TODO
Track all the places where `PTC` is used for getting the node information.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
