### PR TITLE
Add argument to add prefix to timing report.

### DIFF
--- a/vpr/src/analysis/timing_reports.cpp
+++ b/vpr/src/analysis/timing_reports.cpp
@@ -12,7 +12,7 @@
 
 #include "VprTimingGraphResolver.h"
 
-void generate_setup_timing_stats(const SetupTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& analysis_opts) {
+void generate_setup_timing_stats(const std::string& prefix, const SetupTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& analysis_opts) {
     auto& timing_ctx = g_vpr_ctx.timing();
     auto& atom_ctx = g_vpr_ctx.atom();
 
@@ -23,16 +23,16 @@ void generate_setup_timing_stats(const SetupTimingInfo& timing_info, const Analy
 
     tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph, *timing_ctx.constraints);
 
-    timing_reporter.report_timing_setup("report_timing.setup.rpt", *timing_info.setup_analyzer(), analysis_opts.timing_report_npaths);
+    timing_reporter.report_timing_setup(prefix + "report_timing.setup.rpt", *timing_info.setup_analyzer(), analysis_opts.timing_report_npaths);
 
     if (analysis_opts.timing_report_skew) {
-        timing_reporter.report_skew_setup("report_skew.setup.rpt", *timing_info.setup_analyzer(), analysis_opts.timing_report_npaths);
+        timing_reporter.report_skew_setup(prefix + "report_skew.setup.rpt", *timing_info.setup_analyzer(), analysis_opts.timing_report_npaths);
     }
 
-    timing_reporter.report_unconstrained_setup("report_unconstrained_timing.setup.rpt", *timing_info.setup_analyzer());
+    timing_reporter.report_unconstrained_setup(prefix + "report_unconstrained_timing.setup.rpt", *timing_info.setup_analyzer());
 }
 
-void generate_hold_timing_stats(const HoldTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& analysis_opts) {
+void generate_hold_timing_stats(const std::string& prefix, const HoldTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& analysis_opts) {
     auto& timing_ctx = g_vpr_ctx.timing();
     auto& atom_ctx = g_vpr_ctx.atom();
 
@@ -43,11 +43,11 @@ void generate_hold_timing_stats(const HoldTimingInfo& timing_info, const Analysi
 
     tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph, *timing_ctx.constraints);
 
-    timing_reporter.report_timing_hold("report_timing.hold.rpt", *timing_info.hold_analyzer(), analysis_opts.timing_report_npaths);
+    timing_reporter.report_timing_hold(prefix + "report_timing.hold.rpt", *timing_info.hold_analyzer(), analysis_opts.timing_report_npaths);
 
     if (analysis_opts.timing_report_skew) {
-        timing_reporter.report_skew_hold("report_skew.hold.rpt", *timing_info.hold_analyzer(), analysis_opts.timing_report_npaths);
+        timing_reporter.report_skew_hold(prefix + "report_skew.hold.rpt", *timing_info.hold_analyzer(), analysis_opts.timing_report_npaths);
     }
 
-    timing_reporter.report_unconstrained_hold("report_unconstrained_timing.hold.rpt", *timing_info.hold_analyzer());
+    timing_reporter.report_unconstrained_hold(prefix + "report_unconstrained_timing.hold.rpt", *timing_info.hold_analyzer());
 }

--- a/vpr/src/analysis/timing_reports.h
+++ b/vpr/src/analysis/timing_reports.h
@@ -5,7 +5,7 @@
 #include "AnalysisDelayCalculator.h"
 #include "vpr_types.h"
 
-void generate_setup_timing_stats(const SetupTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& report_detail);
-void generate_hold_timing_stats(const HoldTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& report_detail);
+void generate_setup_timing_stats(const std::string& prefix, const SetupTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& report_detail);
+void generate_hold_timing_stats(const std::string& prefix, const HoldTimingInfo& timing_info, const AnalysisDelayCalculator& delay_calc, const t_analysis_opts& report_detail);
 
 #endif

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1124,8 +1124,10 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
 
         //Timing stats
         VTR_LOG("\n");
-        generate_hold_timing_stats(*timing_info, *analysis_delay_calc, vpr_setup.AnalysisOpts);
-        generate_setup_timing_stats(*timing_info, *analysis_delay_calc, vpr_setup.AnalysisOpts);
+        generate_hold_timing_stats(/*prefix=*/"", *timing_info,
+                                   *analysis_delay_calc, vpr_setup.AnalysisOpts);
+        generate_setup_timing_stats(/*prefix=*/"", *timing_info,
+                                    *analysis_delay_calc, vpr_setup.AnalysisOpts);
 
         //Write the post-syntesis netlist
         if (vpr_setup.AnalysisOpts.gen_post_synthesis_netlist) {


### PR DESCRIPTION
#### Description

This will be used to add timing report outputs other than the final
post-route report.

#### Related Issue

https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/653

#### Motivation and Context

This allows the report generation functions generate_setup_timing_stats and generate_hold_timing_stats to be invoked by multiple callsites without colliding on the file names.

#### How Has This Been Tested?

Compiles and CI should pass once https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/655 is resolved

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
