### PR TITLE
docs: add note to usage of parallel workers

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -113,6 +113,8 @@ General Options
 
     If this option is not specified it may be set from the ``VPR_NUM_WORKERS`` environment variable; otherwise the default is used.
 
+    .. note:: To compile VPR to allow the usage of parallel workers, ``libtbb-dev`` must be installed in the system.
+
     **Default:** ``1``
 
 .. option:: --timing_analysis {on | off}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds an additional comment on how to enable the parallel workers.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If `libtbb-dev` is not installed in the system, parallel workers are not enabled. Therefore, a more explicit comment on the docs helps in getting the end-user to set-up the system for parallel workers builds.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs update

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
