### PR TITLE
odin Fixed memory leak in create_single_port_ram_block function in netlist…

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -5514,6 +5514,8 @@ signal_list_t *create_single_port_ram_block(ast_node_t* block, char *instance_na
 		free_signal_list(in_list[i]);
 	}
 
+	vtr::free(in_list);
+
 	sp_memory_list = insert_in_vptr_list(sp_memory_list, block_node);
 	block_node->type = MEMORY;
 	block->net_node = block_node;


### PR DESCRIPTION
…_create_from_ast.cpp

#### Description
Freed the signal_list_t in_list. The objects held by in_list were being freed, but in_list itself was not. This has been fixed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x ] All new and existing tests passed
