### PR TITLE
WIP: Fixed memory leak in add_the_blackbox_for_mults function in multiplie…

### DIFF
--- a/ODIN_II/SRC/multipliers.cpp
+++ b/ODIN_II/SRC/multipliers.cpp
@@ -528,7 +528,9 @@ void add_the_blackbox_for_mults(FILE *out)
 		fprintf(out, ".end\n");
 		fprintf(out, "\n");
 
-		muls = muls->next;
+		t_multiplier *temp = muls->next;
+		vtr::free(muls);
+		muls = temp;
 	}
 }
 


### PR DESCRIPTION
…rs.cpp

#### Description
Fixed memory leak in add_the_blackbox_for_mults function where the t_multiplier pointer was being overwritten before the previous block was being freed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
