### PR TITLE
Single pass verilog preprocessor and Remove freopen

### DIFF
--- a/ODIN_II/SRC/include/config_t.h
+++ b/ODIN_II/SRC/include/config_t.h
@@ -15,7 +15,7 @@ struct config_t
 	bool output_ast_graphs; // switch that outputs ast graphs per node for use with GRaphViz tools
 	bool output_netlist_graphs; // switch that outputs netlist graphs per node for use with GraphViz tools
 	bool print_parse_tokens; // switch that controls whether or not each token is printed during parsing
-	bool output_preproc_source; // switch that outputs the pre-processed source
+	bool output_preproc_source; // TODO: unused
 	
 	int min_hard_multiplier; // threshold from hard to soft logic
 	int mult_padding; // setting how multipliers are padded to fit fixed size

--- a/ODIN_II/SRC/include/odin_buffer.hpp
+++ b/ODIN_II/SRC/include/odin_buffer.hpp
@@ -1,0 +1,209 @@
+#ifndef ODIN_BUFFER_HPP
+#define ODIN_BUFFER_HPP
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <algorithm>
+
+#include "vtr_memory.h"
+
+#define CHUNK_SIZE 128
+/* General Utility methods ------------------------------------------------- */
+
+class dynamic_buffer_t
+{
+private:
+	char *str = NULL;
+	size_t len = 0;
+public:
+
+
+    void push(char in)
+    {
+        if(this->len % CHUNK_SIZE == 0)
+        {
+            this->str = (char*) vtr::realloc(this->str, sizeof(char) * (this->len + CHUNK_SIZE));
+            memset(&this->str[this->len], 0, CHUNK_SIZE);
+        }
+
+        this->str[this->len] = in;	
+        this->len += 1;
+    }
+
+    char *dump_str()
+    {
+        char *temp = str;
+        str = NULL;
+        return temp;
+    }
+    
+};
+
+
+class buffered_reader_t
+{
+private:
+    FILE *source = NULL;
+
+    bool eof = false;
+    bool multiline_comment = false;
+
+    const char *one_line_comment = "";
+    size_t one_line_comment_len = 0;
+
+    const char *n_line_comment_ST = "";
+    size_t n_line_comment_ST_len = 0;
+
+    const char *n_line_comment_END = "";
+    size_t n_line_comment_END_len = 0;
+
+    size_t buffer_size = 2;
+
+    static bool is_eof(int in)
+    {
+        return (EOF == in);
+    }
+
+    static bool is_nl(int in)
+    {
+        return is_eof(in) || ('\n' == (char)in || '\r' == (char)in);
+    }
+
+    static bool is_whitespace(int in)
+    {
+        return is_nl(in) || ( ' ' == (char)in || '\t' == (char)in);
+    }
+
+    bool is_one_line_comment(const char *in)
+    {
+        return (one_line_comment_len && strncmp (in, one_line_comment, one_line_comment_len) == 0);
+    }
+
+    bool is_n_line_comment_ST(const char *in)
+    {
+        return (n_line_comment_ST_len && strncmp (in, n_line_comment_ST, n_line_comment_ST_len) == 0);
+    }
+
+    bool is_n_line_comment_END(const char *in)
+    {
+        return (n_line_comment_END_len && strncmp (in, n_line_comment_END, n_line_comment_END_len) == 0);
+    }
+
+    buffered_reader_t(){}
+
+public:
+    buffered_reader_t(FILE *_source, const char *_one_line_comment, const char *_n_line_comment_ST, const char *_n_line_comment_END)
+    {
+        this->source = _source;
+
+        if(_one_line_comment)
+        {
+            this->one_line_comment = _one_line_comment;
+            this->one_line_comment_len = strlen(_one_line_comment);
+        }
+        
+        if(_n_line_comment_ST && _n_line_comment_END)
+        {
+            this->n_line_comment_ST = _n_line_comment_ST;
+            this->n_line_comment_END = _n_line_comment_END;
+            
+            this->n_line_comment_ST_len = strlen(_n_line_comment_ST);
+            this->n_line_comment_END_len = strlen(_n_line_comment_END);
+        }
+
+        this->buffer_size = (
+            std::max((size_t)2, // for whitespace duplicate
+            std::max(one_line_comment_len,
+            std::max(n_line_comment_ST_len,
+                    n_line_comment_END_len)))
+        );
+    }
+
+    /*
+    * Reads a line from a file stream character-by-character
+    * to dynamically build a string.
+    * strip duplicate whitespace
+    * skip comments
+    */
+    char* get_line()
+    {
+        char *line = NULL;
+
+        if(!(eof))
+        {
+            dynamic_buffer_t my_line;
+
+            char *buffer = (char*) vtr::calloc(this->buffer_size, sizeof(char));
+
+            bool single_line_comment = false;
+            size_t skip_count = this->buffer_size-1;
+            bool eol = false;
+
+            bool first_write = true;
+
+            // trim head and compress
+            while( !is_nl(buffer[0]) )
+            {
+                int c = '\n';
+                if(!eol && !(eof))
+                    c = fgetc(source);
+
+                for(int i = 1; i < this->buffer_size; i++)
+                {
+                    buffer[i-1] = buffer[i];
+                }
+
+                buffer[this->buffer_size-1] = (char)c;
+
+                eof = (eof || is_eof(c));
+                eol = (eol || is_nl(c));
+
+                if(skip_count)
+                {
+                    skip_count--;
+                }
+                else if( multiline_comment )
+                {
+                    if(is_n_line_comment_END(buffer))
+                    {
+                        multiline_comment = false;
+                        skip_count = strlen(n_line_comment_END);
+                    }
+                }
+                else if( single_line_comment )
+                {
+                    // read until the end
+                }
+                else if(is_one_line_comment(buffer))
+                {
+                    single_line_comment = true;
+                }
+                else if(is_n_line_comment_ST(buffer))
+                {
+                    multiline_comment = true;
+                }
+                else if( ! is_whitespace(buffer[0]) )
+                {
+                    first_write = false;
+                    my_line.push(buffer[0]);	
+                }
+                else if( ! is_whitespace(buffer[1]) )
+                {
+                    if( ! first_write )
+                        my_line.push(' ');	
+                }
+            } 
+
+            vtr::free(buffer);
+
+            my_line.push('\0');	
+
+            line = my_line.dump_str();
+        }
+
+        return line;
+    }
+};
+
+#endif //ODIN_BUFFER_HPP

--- a/ODIN_II/SRC/include/verilog_preprocessor.h
+++ b/ODIN_II/SRC/include/verilog_preprocessor.h
@@ -1,91 +1,10 @@
 #ifndef verilog_preprocessor_h
 #define verilog_preprocessor_h
 
-#define DefaultSize 20
 #include <stdio.h>
 
-//#define BLOCK_EMPTY_DEFINES
-
-/* Structs */
-typedef struct veri_include
-{
-	char *path;
-	struct veri_include *included_from;
-	int	line;
-} veri_include;
-
-typedef struct veri_define
-{
-	char *symbol;
-	char *value;
-	int line;
-	veri_include *defined_in;
-} veri_define;
-
-struct veri_Includes
-{
-	veri_include **included_files;
-	int current_size;
-	int current_index;
-} ;
-
-struct veri_Defines
-{
-	veri_define **defined_constants;
-	int current_size;
-	int current_index;
-} ;
-
-/* Globals */
-extern struct veri_Includes veri_includes;
-extern struct veri_Defines veri_defines;
-
-/* Initalization and Cleanup */
 int init_veri_preproc();
 int cleanup_veri_preproc();
-void clean_veri_define(veri_define *current);
-void clean_veri_include(veri_include *current);
-
-/* Adding/Removing includes or defines */
-int add_veri_define(char *symbol, char *value, int line, veri_include *included_from);
-char* ret_veri_definedval(const char *symbol);
-int veri_is_defined(const char * symbol);
-veri_include* add_veri_include(const char *path, int line, veri_include *included_from);
-
-/* Preprocessor ------------------------------------------------------------- */
 FILE* veri_preproc(FILE *source);
-void veri_preproc_bootstraped(FILE *source, FILE *preproc_producer, veri_include *current_include);
-
-/* ------------------------------------------------------------------------- */
-
-
-/* Stack for tracking conditional branches --------------------------------- */
-typedef struct veri_flag_node
-{
-	int flag;
-	struct veri_flag_node *next;
-} veri_flag_node;
-
-typedef struct
-{
-	veri_flag_node *top;
-} veri_flag_stack;
-
-/* stack methods */
-int top(veri_flag_stack *stack);
-int pop(veri_flag_stack *stack);
-void push(veri_flag_stack *stack, int flag);
-
-/* ------------------------------------------------------------------------- */
-
-
-/* General Utility methods ------------------------------------------------- */
-bool is_whitespace(const char in);
-char *trim(char *input_str);
-char* trim(char *input_string, size_t n);
-char *get_line(char *line, long *size, FILE *source);
-
-/* ------------------------------------------------------------------------- */
-
 
 #endif

--- a/ODIN_II/SRC/odin_ii.cpp
+++ b/ODIN_II/SRC/odin_ii.cpp
@@ -625,7 +625,7 @@ void set_default_config()
 	configuration.output_ast_graphs = 0;
 	configuration.output_netlist_graphs = 0;
 	configuration.print_parse_tokens = 0;
-	configuration.output_preproc_source = 1;
+	configuration.output_preproc_source = 0; // TODO: unused
 	configuration.debug_output_path = std::string(DEFAULT_OUTPUT);
 	configuration.arch_file = NULL;
 

--- a/ODIN_II/SRC/parse_making_ast.cpp
+++ b/ODIN_II/SRC/parse_making_ast.cpp
@@ -77,34 +77,10 @@ short to_view_parse;
 /*
  * File-scope function declarations
  */
-void graphVizOutputPreproc(FILE *yyin);
 ast_node_t *newFunctionAssigning(ast_node_t *expression1, ast_node_t *expression2, int line_number);
 ast_node_t *newHardBlockInstance(char* module_ref_name, ast_node_t *module_named_instance, int line_number);
 ast_node_t *resolve_ports(ids top_type, ast_node_t *symbol_list);
 
-/*
- * Function implementations
- */
-void graphVizOutputPreproc(FILE *yyin)
-{
-	std::string file_out = 	configuration.debug_output_path 
-							+ "/" 
-							+ strip_path_and_ext(configuration.list_of_file_names[current_parse_file]).c_str() 
-							+ "_preproc.v";
-
-	FILE *fp = fopen(file_out.c_str(), "w");
-	oassert(fp);
-
-	char *line = NULL;
-
-	while ((line = get_line(line, NULL, yyin)) != NULL)
-	{
-		fprintf(fp, "%s", line);
-		vtr::free(line);
-	}
-	fclose(fp);
-	rewind(yyin);
-}
 
 static void assert_supported_file_extension(std::string input_file, int file_number)
 {
@@ -160,10 +136,6 @@ void parse_to_ast()
 		}
 
 		yyin = veri_preproc(yyin);
-
-		/* write out the pre-processed file */
-		if (configuration.output_preproc_source)
-			graphVizOutputPreproc(yyin);
 
 		/* reset the line count */
 		yylineno = 0;

--- a/ODIN_II/SRC/read_xml_config_file.cpp
+++ b/ODIN_II/SRC/read_xml_config_file.cpp
@@ -178,12 +178,6 @@ void read_debug_switches(pugi::xml_node a_node, config_t *config, const pugiutil
 		config->print_parse_tokens = atoi(child.child_value());
 	}
 
-	child = get_single_child(a_node, "output_preproc_source", loc_data, OPTIONAL);
-	if (child != NULL)
-	{
-		config->output_preproc_source = atoi(child.child_value());
-	}
-
 	return;
 }
 

--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -67,7 +67,7 @@ int yylex(void);
 %token voOROR voLTE voGTE voPAL voSLEFT voSRIGHT vo ASRIGHT voEQUAL voNOTEQUAL voCASEEQUAL
 %token voCASENOTEQUAL voXNOR voNAND voNOR vWHILE vINTEGER vCLOG2 vGENVAR
 %token vPLUS_COLON vMINUS_COLON vSPECPARAM
-%token '?' ':' '|' '^' '&' '<' '>' '+' '-' '*' '/' '%' '(' ')' '{' '}' '[' ']'
+%token '?' ':' '|' '^' '&' '<' '>' '+' '-' '*' '/' '%' '(' ')' '{' '}' '[' ']' '~' '!' ';' '#' ',' '.' '@' '='
 %token vNOT_SUPPORT 
 
 %right '?' ':'

--- a/ODIN_II/SRC/verilog_flex.l
+++ b/ODIN_II/SRC/verilog_flex.l
@@ -47,8 +47,28 @@ OTHER DEALINGS IN THE SOFTWARE.
 %option noinput
 %option never-interactive
 %option nounistd
+%option nodefault
+%option yylineno
+
+vBIN [Bb][_]*[ZzXx0-1][ZzXx0-1_]*
+vOCT [Oo][_]*[ZzXx0-7][ZzXx0-7_]*
+vDEC [Dd][_]*[[:digit:]][[:digit:]_]*
+vHEX [Hh][_]*[ZzXx[:xdigit:]][ZzXx[:xdigit:]_]*
+vINT [_]*[[:digit:]][[:digit:]_]*
+vWORD [[:alpha:]_][[:alnum:]_]*
+
+	/**
+	* add \" to vPUNCT when support is added for strings
+	* update the bison file also when changing this 
+	*/
+vPUNCT 	[\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
+
+	/* hack to get strings to match as a symbol, this is broken and wrong. */
+vDISCARD [\"]
 
 %%
+
+<INITIAL>`timescale.*$              { MP; continue;}
 
 	/*	Keywords	*/
 <INITIAL>"always"			{ MP; return vALWAYS;}
@@ -57,7 +77,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 <INITIAL>"begin"			{ MP; return vBEGIN;}
 <INITIAL>"case"				{ MP; return vCASE;}
 <INITIAL>"default"			{ MP; return vDEFAULT;}
-<INITIAL>"`define"[^\n]*	{ MP; continue; }
 <INITIAL>"defparam"			{ MP; return vDEFPARAM;}
 <INITIAL>"else"				{ MP; return vELSE;}
 <INITIAL>"end"				{ MP; return vEND;}
@@ -185,53 +204,44 @@ OTHER DEALINGS IN THE SOFTWARE.
 	/*	unsupported Operators	*/
 <INITIAL>"&&&"				{ UNSUPPORTED_TOKEN; return vNOT_SUPPORT;}
 
-
 	/*	C functions	*/
 <INITIAL>"$clog2"			{MP; return vCLOG2;}
 
-	/*	operands	*/
-<INITIAL>`?[a-zA-Z_][a-zA-Z0-9_]*				{ MP; yylval.id_name = vtr::strdup(yytext); return vSYMBOL_ID; }
-
 	/*	signed numbers	*/
-<INITIAL>[0-9]+'[sS][bB][0-1_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_BINARY; }
-<INITIAL>[0-9]+'[sS][hH][a-fA-F0-9_]*				{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_HEXADECIMAL; }
-<INITIAL>[0-9]+'[sS][oO][0-7_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_OCTAL; }
-<INITIAL>[0-9]+'[sS][dD][0-9_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_DECIMAL; }
-<INITIAL>'[sS][bB][0-1_]*							{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_BINARY; }
-<INITIAL>'[sS][hH][a-fA-F0-9_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_HEXADECIMAL; }
-<INITIAL>'[sS][oO][0-7_]*							{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_OCTAL; }
-<INITIAL>'[sS][dD][0-9_]*							{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_DECIMAL; }
-
-<INITIAL>[0-9_]+									{ MP; yylval.num_value = vtr::strdup(yytext); return vINTEGRAL; }
+<INITIAL>[[:digit:]]+'[sS]{vBIN}	{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_BINARY; }
+<INITIAL>[[:digit:]]+'[sS]{vHEX}	{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_HEXADECIMAL; }
+<INITIAL>[[:digit:]]+'[sS]{vOCT}	{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_OCTAL; }
+<INITIAL>[[:digit:]]+'[sS]{vDEC}	{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_DECIMAL; }
+<INITIAL>'[sS]{vBIN}				{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_BINARY; }
+<INITIAL>'[sS]{vHEX}				{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_HEXADECIMAL; }
+<INITIAL>'[sS]{vOCT}				{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_OCTAL; }
+<INITIAL>'[sS]{vDEC}				{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_DECIMAL; }
 
 	/*	unsigned Numbers	*/
-<INITIAL>[0-9]+'[bB][0-1_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_BINARY; }
-<INITIAL>[0-9]+'[hH][a-fA-F0-9_]*				{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_HEXADECIMAL; }
-<INITIAL>[0-9]+'[oO][0-7_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_OCTAL; }
-<INITIAL>[0-9]+'[dD][0-9_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_DECIMAL; }
-<INITIAL>'[bB][0-1_]*							{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_BINARY; }
-<INITIAL>'[hH][a-fA-F0-9_]*						{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_HEXADECIMAL; }
-<INITIAL>'[oO][0-7_]*							{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_OCTAL; }
-<INITIAL>'[dD][0-9_]*							{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_DECIMAL; }
+<INITIAL>[[:digit:]]+'{vBIN}		{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_BINARY; }
+<INITIAL>[[:digit:]]+'{vHEX}		{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_HEXADECIMAL; }
+<INITIAL>[[:digit:]]+'{vOCT}		{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_OCTAL; }
+<INITIAL>[[:digit:]]+'{vDEC}		{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_DECIMAL; }
+<INITIAL>'{vBIN}					{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_BINARY; }
+<INITIAL>'{vHEX}					{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_HEXADECIMAL; }
+<INITIAL>'{vOCT}					{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_OCTAL; }
+<INITIAL>'{vDEC}					{ MP; yylval.num_value = vtr::strdup(yytext); return vUNSIGNED_DECIMAL; }
 
+	/* ints */
+<INITIAL>#{vINT}					{ MP; yylval.num_value = vtr::strdup(yytext+1); return vDELAY_ID; }
+<INITIAL>{vINT}						{ MP; yylval.num_value = vtr::strdup(yytext); return vINTEGRAL; }
 
-<INITIAL>#[0-9]+								{ MP; yylval.num_value = vtr::strdup(yytext+1); return vDELAY_ID; }
+	/*	operands	*/
+<INITIAL>{vWORD}					{ MP; yylval.id_name = vtr::strdup(yytext); return vSYMBOL_ID; }
 
 	/* return operators */
-<INITIAL>[}{;:\[\],()#=.@&!?<>%|^~+*/-]			{ MP; return yytext[0]; }
+<INITIAL>{vPUNCT}					{ MP; return yytext[0]; }
 
 	/* general stuff */
-<INITIAL>[\f\r\t\b ]+				{ continue;}					/* ignore spaces */
-<INITIAL,COMMENT>"\n"				{ yylineno++; continue;}		/* catch lines */
-<INITIAL>`timescale.*$              { MP; continue;}
+[[:space:]]+						/* ignore spaces */
+{vDISCARD}							/* ignore some chars altogether */
 
-	/* Get the comments */
-<INITIAL>"/*"						{ MP; BEGIN COMMENT; continue;} /* begin state where we eat everything for comments*/
-<COMMENT>.							{ continue;}
-<COMMENT>"*/"						{ BEGIN 0; continue;}
-<INITIAL>"//"[^\n]*					{ MP; continue;}
-
-
-<*>.|\n		{ printf("Missing verilog.l rule: Default rule invoked in state %d\nLine %d::\"%s\"\n", YY_START, yylineno, yytext); }
+	/* catch all */
+.									{ UNSUPPORTED_TOKEN; }
 
 %%


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This fixes issue #64 via the removal of the freopen on tempfiles and also use a single pass preprocessor.

getline, trim and whitespace removal in one function to be used by the preprocessor

#### Related Issue
closes issue #64 

#### Motivation and Context
fix issue of freopen on tmpfile

#### How Has This Been Tested?
full regression suite, basic and strong

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
