### PR TITLE
 Fixed memory leak and valgrind errors in add_hard_block_model functio…

### DIFF
--- a/ODIN_II/wrapper_odin.sh
+++ b/ODIN_II/wrapper_odin.sh
@@ -20,7 +20,7 @@ if [ ! -f ${EXEC} ]; then
 fi
 
 TIME_EXEC=$($SHELL -c "which time") 
-VALGRIND_EXEC="valgrind --leak-check=full"
+VALGRIND_EXEC="valgrind --leak-check=full --max-stackframe=128000000"
 PERF_EXEC="perf stat record -a -d -d -d -o"
 GDB_EXEC="gdb --args"
 LOG=""


### PR DESCRIPTION
…n and get_hard_block_model function in read_bliff.cpp

#### Description
Made changes to the add_hard_block_model and get_hard_block_model functions in read_bliff.cpp where certain benchmarks were causing ODIN to segfault due to uninitialized pointers and not checking for NULL pointers before attempting to access the pointers.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
