### PR TITLE
Fixed odin memory leak in create_soft_single_port_ram_block func…

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -5329,6 +5329,7 @@ signal_list_t *create_dual_port_ram_block(ast_node_t* block, char *instance_name
 	for (i = 0; i < block_list->num_children; i++)
 		free_signal_list(in_list[i]);
 
+	vtr::free(in_list);
 	dp_memory_list = insert_in_vptr_list(dp_memory_list, block_node);
 	block_node->type = MEMORY;
 


### PR DESCRIPTION
…tion in netlist_creat_from_ast.cpp

#### Description
Fixed memory leak in create_soft_single_port_ram_block funtion in netlist_create_from_ast.cpp where the children of in_list were being freed, but in_list itself was not being freed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
