### PR TITLE
vpr: added optional disable errors and suppress warnings

### DIFF
--- a/libs/libvtrutil/src/vtr_log.cpp
+++ b/libs/libvtrutil/src/vtr_log.cpp
@@ -1,5 +1,9 @@
-#include "vtr_log.h"
+#include <string>
+#include <fstream>
+#include <cstdarg>
 
+#include "vtr_util.h"
+#include "vtr_log.h"
 #include "log.h"
 
 namespace vtr {
@@ -14,3 +18,33 @@ void set_log_file(const char* filename) {
 }
 
 } // namespace vtr
+
+void add_warnings_to_suppress(std::string function_name) {
+    warnings_to_suppress.insert(function_name);
+}
+
+void set_noisy_warn_log_file(const char* log_file_name) {
+    std::ofstream log;
+    log.open(log_file_name, std::ifstream::out | std::ifstream::trunc);
+    log.close();
+    noisy_warn_log_file = std::string(log_file_name);
+}
+
+void print_or_suppress_warning(const char* pszFileName, unsigned int lineNum, const char* pszFuncName, const char* pszMessage, ...) {
+    std::string function_name(pszFuncName);
+
+    va_list va_args;
+    va_start(va_args, pszMessage);
+    std::string msg = vtr::vstring_fmt(pszMessage, va_args);
+    va_end(va_args);
+
+    auto result = warnings_to_suppress.find(function_name);
+    if (result == warnings_to_suppress.end()) {
+        vtr::printf_warning(pszFileName, lineNum, msg.data());
+    } else {
+        std::ofstream log;
+        log.open(noisy_warn_log_file.data(), std::ios_base::app);
+        log << "Warning:\n\tfile: " << pszFileName << "\n\tline: " << lineNum << "\n\tmessage: " << msg << std::endl;
+        log.close();
+    }
+}

--- a/libs/libvtrutil/src/vtr_log.h
+++ b/libs/libvtrutil/src/vtr_log.h
@@ -1,6 +1,8 @@
 #ifndef VTR_LOG_H
 #define VTR_LOG_H
 #include <tuple>
+#include <unordered_set>
+#include <string>
 
 /*
  * This header defines useful logging macros for VTR projects.
@@ -71,20 +73,29 @@
 #define VTR_LOGF_ERROR(file, line, ...) VTR_LOGVF_ERROR(true, file, line, __VA_ARGS__)
 #define VTR_LOGF_NOP(file, line, ...) VTR_LOGVF_NOP(true, file, line, __VA_ARGS__)
 
+//Custom file-line-func location logging macros
+#define VTR_LOGFF_WARN(file, line, func, ...) VTR_LOGVFF_WARN(true, file, line, func, __VA_ARGS__)
+
 //Conditional logging and custom file-line location macros
 #define VTR_LOGVF(expr, file, line, ...)    \
     do {                                    \
         if (expr) vtr::printf(__VA_ARGS__); \
     } while (false)
 
-#define VTR_LOGVF_WARN(expr, file, line, ...)                   \
-    do {                                                        \
-        if (expr) vtr::printf_warning(file, line, __VA_ARGS__); \
+#define VTR_LOGVF_WARN(expr, file, line, ...)                                   \
+    do {                                                                        \
+        if (expr) print_or_suppress_warning(file, line, __func__, __VA_ARGS__); \
     } while (false)
 
 #define VTR_LOGVF_ERROR(expr, file, line, ...)                \
     do {                                                      \
         if (expr) vtr::printf_error(file, line, __VA_ARGS__); \
+    } while (false)
+
+// Conditional logging and custom file-line-func location macros
+#define VTR_LOGVFF_WARN(expr, file, line, func, ...)                        \
+    do {                                                                    \
+        if (expr) print_or_suppress_warning(file, line, func, __VA_ARGS__); \
     } while (false)
 
 //No-op version of logging macro which avoids unused parameter warnings.
@@ -128,5 +139,21 @@ extern PrintHandlerDirect printf_direct;
 void set_log_file(const char* filename);
 
 } // namespace vtr
+
+// The following data structure and functions allow to suppress noisy warnings
+// and direct them into an external file.
+static std::unordered_set<std::string> warnings_to_suppress;
+static std::string noisy_warn_log_file;
+
+void add_warnings_to_suppress(std::string function_name);
+
+// This function creates a new log file to hold the suppressed warnings.
+// If the file already exists, it is cleared out first.
+void set_noisy_warn_log_file(const char* log_file_name);
+
+// This function checks whether the function from which the warning has been called
+// is in the set of warnings_to_suppress. If so, the warning is printed on the
+// noisy_warn_log_file, otherwise it is printed on stdout (or the regular log file)
+void print_or_suppress_warning(const char* pszFileName, unsigned int lineNum, const char* pszFuncName, const char* pszMessage, ...);
 
 #endif

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -931,6 +931,22 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    gen_grp.add_argument<std::string>(args.disable_errors, "--disable_errors")
+        .help(
+            "Parses a list of functions for which the errors are going to be treated as warnings.\n"
+            "Each function in the list is delimited by `:`\n"
+            "This option should be only used for development purposes.")
+        .default_value("");
+
+    gen_grp.add_argument<std::string>(args.suppress_warnings, "--suppress_warnings")
+        .help(
+            "Parses a list of functions for which the warnings will be suppressed on stdout.\n"
+            "The first element of the list is the name of the output log file with the suppressed warnings.\n"
+            "The file name and the list of functions is separated by `,`\n"
+            "Each function in the list is delimited by `:`\n"
+            "This option should be only used for development purposes.")
+        .default_value("");
+
     auto& file_grp = parser.add_argument_group("file options");
 
     file_grp.add_argument(args.BlifFile, "--circuit_file")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -50,6 +50,8 @@ struct t_options {
     argparse::ArgValue<e_clock_modeling> clock_modeling;
     argparse::ArgValue<bool> exit_before_pack;
     argparse::ArgValue<bool> strict_checks;
+    argparse::ArgValue<std::string> disable_errors;
+    argparse::ArgValue<std::string> suppress_warnings;
 
     /* Atom netlist options */
     argparse::ArgValue<bool> absorb_buffer_luts;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -214,6 +214,29 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
     /* Determine whether echo is on or off */
     setEchoEnabled(options->CreateEchoFile);
 
+    /*
+     * Initialize the functions names for which VPR_THROWs
+     * are demoted to VTR_LOG_WARNs
+     */
+    for (std::string func_name : vtr::split(options->disable_errors, std::string(":"))) {
+        map_error_activation_status(func_name);
+    }
+
+    /*
+     * Initialize the functions names for which
+     * warnings are being suppressed
+     */
+    std::vector<std::string> split_warning_option = vtr::split(options->suppress_warnings, std::string(","));
+
+    // If the file or the list of functions is not provided
+    // no warning is suppressed
+    if (split_warning_option.size() == 2) {
+        set_noisy_warn_log_file(split_warning_option[0].data());
+        for (std::string func_name : vtr::split(split_warning_option[1], std::string(":"))) {
+            add_warnings_to_suppress(func_name);
+        }
+    }
+
     /* Read in arch and circuit */
     SetupVPR(options,
              vpr_setup->TimingEnabled,

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -963,11 +963,7 @@ static void recompute_costs_from_scratch(const t_placer_opts& placer_opts, const
     if (fabs(new_bb_cost - costs->bb_cost) > costs->bb_cost * ERROR_TOL) {
         std::string msg = vtr::string_fmt("in recompute_costs_from_scratch: new_bb_cost = %g, old bb_cost = %g\n",
                                           new_bb_cost, costs->bb_cost);
-        if (placer_opts.strict_checks) {
-            vpr_throw(VPR_ERROR_PLACE, __FILE__, __LINE__, msg.c_str());
-        } else {
-            VTR_LOG_WARN(msg.c_str());
-        }
+        VPR_THROW(VPR_ERROR_PLACE, msg.c_str());
     }
     costs->bb_cost = new_bb_cost;
 
@@ -977,11 +973,7 @@ static void recompute_costs_from_scratch(const t_placer_opts& placer_opts, const
         if (fabs(new_timing_cost - costs->timing_cost) > costs->timing_cost * ERROR_TOL) {
             std::string msg = vtr::string_fmt("in recompute_costs_from_scratch: new_timing_cost = %g, old timing_cost = %g, ERROR_TOL = %g\n",
                                               new_timing_cost, costs->timing_cost, ERROR_TOL);
-            if (placer_opts.strict_checks) {
-                vpr_throw(VPR_ERROR_PLACE, __FILE__, __LINE__, msg.c_str());
-            } else {
-                VTR_LOG_WARN(msg.c_str());
-            }
+            VPR_THROW(VPR_ERROR_PLACE, msg.c_str());
         }
         costs->timing_cost = new_timing_cost;
     } else {

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -118,7 +118,7 @@ void check_route(enum e_route_type route_type) {
             } else { //Continuing along existing branch
                 connects = check_adjacent(prev_node, inode);
                 if (!connects) {
-                    vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+                    VPR_THROW(VPR_ERROR_ROUTE,
                               "in check_route: found non-adjacent segments in traceback while checking net %d:\n"
                               "  %s\n"
                               "  %s\n",

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -502,7 +502,7 @@ static void check_unbuffered_edges(int from_node) {
         }
 
         if (trans_matched == false) {
-            vpr_throw(VPR_ERROR_ROUTE, __FILE__, __LINE__,
+            VPR_THROW(VPR_ERROR_ROUTE,
                       "in check_unbuffered_edges:\n"
                       "connection from node %d to node %d uses an unbuffered switch (switch type %d '%s')\n"
                       "but there is no corresponding unbuffered switch edge in the other direction.\n",

--- a/vpr/src/util/vpr_error.cpp
+++ b/vpr/src/util/vpr_error.cpp
@@ -1,6 +1,8 @@
 #include <cstdarg>
+#include <string>
 
 #include "vtr_util.h"
+#include "vtr_log.h"
 #include "vpr_error.h"
 
 /* Date:June 15th, 2013
@@ -11,6 +13,10 @@
  *			anything but throw an exception which will be caught
  *			main.c.
  */
+void map_error_activation_status(std::string function_name) {
+    functions_to_demote.insert(function_name);
+}
+
 void vpr_throw(enum e_vpr_error type,
                const char* psz_file_name,
                unsigned int line_num,
@@ -40,4 +46,39 @@ void vvpr_throw(enum e_vpr_error type,
     std::string msg = vtr::vstring_fmt(psz_message, va_args);
 
     throw VprError(type, msg, psz_file_name, line_num);
+}
+
+void vpr_throw_msg(enum e_vpr_error type,
+                   const char* psz_file_name,
+                   unsigned int line_num,
+                   std::string msg) {
+    throw VprError(type, msg, psz_file_name, line_num);
+}
+
+void vpr_throw_opt(enum e_vpr_error type,
+                   const char* psz_func_name,
+                   const char* psz_file_name,
+                   unsigned int line_num,
+                   const char* psz_message,
+                   ...) {
+    std::string func_name(psz_func_name);
+
+    // Make a variable argument list
+    va_list va_args;
+
+    // Initialize variable argument list
+    va_start(va_args, psz_message);
+
+    //Format the message
+    std::string msg = vtr::vstring_fmt(psz_message, va_args);
+
+    auto result = functions_to_demote.find(func_name);
+    if (result != functions_to_demote.end()) {
+        VTR_LOGFF_WARN(psz_file_name, line_num, psz_func_name, msg.data());
+    } else {
+        vpr_throw_msg(type, psz_file_name, line_num, msg);
+    }
+
+    // Reset variable argument list
+    va_end(va_args);
 }

--- a/vpr/src/util/vpr_error.h
+++ b/vpr/src/util/vpr_error.h
@@ -1,8 +1,11 @@
 #ifndef VPR_ERROR_H
 #define VPR_ERROR_H
 
-#include "vtr_error.h"
 #include <cstdarg>
+#include <string>
+#include <unordered_set>
+
+#include "vtr_error.h"
 
 enum e_vpr_error {
     VPR_ERROR_UNKNOWN = 0,
@@ -45,6 +48,15 @@ class VprError : public vtr::VtrError {
     t_vpr_error_type type_;
 };
 
+// Set of function names for which the VPR_THROW errors are treated
+// as VTR_LOG_WARN
+static std::unordered_set<std::string> functions_to_demote;
+
+// This function is used to save into the functions_to_demote set
+// all the function names which contain VPR_THROW errors that are
+// going to be demoted to be VTR_LOG_WARN
+void map_error_activation_status(std::string function_name);
+
 //VPR error reporting routines
 //
 //Note that we mark these functions with the C++11 attribute 'noreturn'
@@ -52,14 +64,17 @@ class VprError : public vtr::VtrError {
 //reduce false-positive compiler warnings
 [[noreturn]] void vpr_throw(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, const char* psz_message, ...);
 [[noreturn]] void vvpr_throw(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, const char* psz_message, va_list args);
+[[noreturn]] void vpr_throw_msg(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, std::string msg);
+
+void vpr_throw_opt(enum e_vpr_error type, const char* psz_func_name, const char* psz_file_name, unsigned int line_num, const char* psz_message, ...);
 
 /*
  * Macro wrapper around vpr_throw() which automatically
  * specifies file and line number of call site.
  */
-#define VPR_THROW(type, ...)                              \
-    do {                                                  \
-        vpr_throw(type, __FILE__, __LINE__, __VA_ARGS__); \
+#define VPR_THROW(type, ...)                                            \
+    do {                                                                \
+        vpr_throw_opt(type, __func__, __FILE__, __LINE__, __VA_ARGS__); \
     } while (false)
 
 #endif

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1,6 +1,8 @@
 #include <cstring>
 #include <unordered_set>
 #include <regex>
+#include <algorithm>
+
 using namespace std;
 
 #include "vtr_assert.h"
@@ -18,7 +20,6 @@ using namespace std;
 #include "string.h"
 #include "pack_types.h"
 #include "device_grid.h"
-#include <algorithm>
 
 /* This module contains subroutines that are used in several unrelated parts *
  * of VPR.  They are VPR-specific utility routines.                          */

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -2,7 +2,9 @@
 #define VPR_UTILS_H
 
 #include <vector>
+#include <string>
 #include <regex>
+
 #include "vpr_types.h"
 #include "atom_netlist.h"
 #include "clustered_netlist.h"


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds the functionality to do the following:
- Disable errors by demoting them to warnings;
- Suppress noisy warnings and redirect them to a custom file.

To enable this feature there are two new command line options:
- Warning suppression:
```
--suppress_warnings <output_filename>,<func1>:<func2>:<func3>
```
If the `<output_filename>` is not provided the warnings will be output on stdout as usual.

- Error disabling:
```
--disable_errors <func1>:<func2>:<func3>
```

`<funcN>` is the name of the function for which the warning/error will be suppressed/disabled, therefore, if a function name is specified in the list, all its warnings/errors are going to be disabled.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There are two different reasons why this PR is needed:

1. There are some errors (`VPR_THROWs`) which prevent development from going further and, instead of changing the `VPR_THROW` into a `VTR_LOG_WARN`, it would be very handy to have a mechanism as the one proposed in this PR;
2. It often happens that some warnings are repeated thousands of times and are related to the same issue. This results in having a hard time reading the output logs to find possible bugs.

A note is that these command line options should be used only if the reason behind the disabling/suppression of an error/warning is clear to the developer.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
