### PR TITLE
Fixed odin memory leak in get_name_of_pins function in ast_util.cpp

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1008,14 +1008,6 @@ ast_node_t *resolve_node(STRING_CACHE *local_param_table_sc, char *module_name, 
 			
 			node = newNode;
 		}
-		else
-		{
-			if(newNode)
-			{
-				vtr::free(newNode->children);
-				vtr::free(newNode);
-			}
-		}
 
 		vtr::free(node_copy->children);
 		vtr::free(node_copy);


### PR DESCRIPTION
#### Description
Fixed memory leak in get_name_of_pins function in ast_util.cpp where sym_node and it's contents were not being freed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
