### PR TITLE
WIP: Fixed memory leak in get_name_of_pins function in ast_util.cpp

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -718,6 +718,10 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 						i+rnode[2]->types.vnumber->get_value());
 					index++;
 				}
+				if(rnode[1])
+				{
+					free_single_node(rnode[1]);
+				}
 			}
 			else if (sym_node->children[3] != NULL)
 			{


### PR DESCRIPTION
#### Description
Fixed memory leak in get_name_of_pins function in ast_util.cpp where rnode[1] was being allocated but never freed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
