### PR TITLE
vtr_flow: fixed qor_compare issue

### DIFF
--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -8,6 +8,7 @@ from openpyxl.worksheet.cell_range import CellRange
 from openpyxl.cell.cell import TYPE_NUMERIC
 import os
 import pandas as pd
+import re
 
 DEFAULT_METRICS = [
     #ABC QoR Metrics
@@ -323,13 +324,22 @@ def dataframe_to_sheet(wb, df, sheet_name):
 
 def safe_sheet_title(raw_title):
 
+    #Keep only file name and drop file path
     safe_title = raw_title.split('/')[-1]
-
-    #Removing all leading zeros from title name
-    safe_title = safe_title.lstrip('0')
 
     if (len(safe_title) > 31):
         safe_title = safe_title[-31:]
+
+    #Remove all non-alphanumerical characters
+    regex = re.compile(r"^\W+")
+    safe_title = regex.sub("", safe_title)
+
+    #Remove bad characters from title
+    for bad_char in ['-']:
+        safe_title = safe_title.replace(bad_char, '_')
+
+    #Remove all leading zeros from title name
+    safe_title = safe_title.lstrip('0')
 
     return safe_title
 

--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import openpyxl #Excel spreadsheet manipulation library
 from openpyxl.utils.dataframe import dataframe_to_rows
 from openpyxl.worksheet.cell_range import CellRange
+from openpyxl.cell.cell import TYPE_NUMERIC
 import os
 import pandas as pd
 
@@ -260,7 +261,7 @@ def fill_ratio(ws, raw_sheet, ref_sheet, dest_row, dest_col, keys, metrics):
                 assert ref_cell.value == raw_cell.value, "Key value must match"
 
                 dest_cell.value = "={}".format(value_ref(ref_cell))
-            elif ref_header.value in metrics and ref_cell.data_type == ref_cell.TYPE_NUMERIC:
+            elif ref_header.value in metrics and ref_cell.data_type == TYPE_NUMERIC:
                 dest_cell.value = "={}".format(safe_ratio_ref(raw_cell, ref_cell))
             else:
                 pass
@@ -322,10 +323,10 @@ def dataframe_to_sheet(wb, df, sheet_name):
 
 def safe_sheet_title(raw_title):
 
-    safe_title = raw_title
+    safe_title = raw_title.split('/')[-1]
 
-    for bad_char in ['/']:
-        safe_title = safe_title.replace(bad_char, '_')
+    #Removing all leading zeros from title name
+    safe_title = safe_title.lstrip('0')
 
     if (len(safe_title) > 31):
         safe_title = safe_title[-31:]


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR solves an issue in the `qor_compare.py` script, for which, if there is a `parse_result` file which name starts with '0', the references in the `ratios` stylesheet are not computed correctly (as the starting 0 gets chopped-off, at least using LibreOffice when opening the `xlsx`).

Another thing is that now, if the input `parse_result` files are located in a different folder, the style sheet names will not contain the whole path, but only the filenames. 

It also solves an issue related to the TYPE_NUMERIC macro which is not found, hence ending in a fatal error.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/652

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is a need of manually changing the script (for the TYPE_NUMERIC issue) or be aware of the name of the parsed results files, which could be avoided with these changes.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
