### PR TITLE
vpr: optional noisy log warning file

### DIFF
--- a/libs/libvtrutil/src/vtr_log.cpp
+++ b/libs/libvtrutil/src/vtr_log.cpp
@@ -23,11 +23,11 @@ void add_warnings_to_suppress(std::string function_name) {
     warnings_to_suppress.insert(function_name);
 }
 
-void set_noisy_warn_log_file(const char* log_file_name) {
+void set_noisy_warn_log_file(std::string log_file_name) {
     std::ofstream log;
     log.open(log_file_name, std::ifstream::out | std::ifstream::trunc);
     log.close();
-    noisy_warn_log_file = std::string(log_file_name);
+    noisy_warn_log_file = log_file_name;
 }
 
 void print_or_suppress_warning(const char* pszFileName, unsigned int lineNum, const char* pszFuncName, const char* pszMessage, ...) {
@@ -41,7 +41,7 @@ void print_or_suppress_warning(const char* pszFileName, unsigned int lineNum, co
     auto result = warnings_to_suppress.find(function_name);
     if (result == warnings_to_suppress.end()) {
         vtr::printf_warning(pszFileName, lineNum, msg.data());
-    } else {
+    } else if (!noisy_warn_log_file.empty()) {
         std::ofstream log;
         log.open(noisy_warn_log_file.data(), std::ios_base::app);
         log << "Warning:\n\tfile: " << pszFileName << "\n\tline: " << lineNum << "\n\tmessage: " << msg << std::endl;

--- a/libs/libvtrutil/src/vtr_log.h
+++ b/libs/libvtrutil/src/vtr_log.h
@@ -141,7 +141,7 @@ void set_log_file(const char* filename);
 } // namespace vtr
 
 // The following data structure and functions allow to suppress noisy warnings
-// and direct them into an external file.
+// and direct them into an external file, if specified.
 static std::unordered_set<std::string> warnings_to_suppress;
 static std::string noisy_warn_log_file;
 
@@ -149,7 +149,7 @@ void add_warnings_to_suppress(std::string function_name);
 
 // This function creates a new log file to hold the suppressed warnings.
 // If the file already exists, it is cleared out first.
-void set_noisy_warn_log_file(const char* log_file_name);
+void set_noisy_warn_log_file(std::string log_file_name);
 
 // This function checks whether the function from which the warning has been called
 // is in the set of warnings_to_suppress. If so, the warning is printed on the

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -942,7 +942,9 @@ static argparse::ArgumentParser create_arg_parser(std::string prog_name, t_optio
         .help(
             "Parses a list of functions for which the warnings will be suppressed on stdout.\n"
             "The first element of the list is the name of the output log file with the suppressed warnings.\n"
-            "The file name and the list of functions is separated by `,`\n"
+            "The output log file can be omitted to completely suppress warnings.\n"
+            "The file name and the list of functions is separated by `,`. If no output log file is specified,\n"
+            "the comma is not needed.\n"
             "Each function in the list is delimited by `:`\n"
             "This option should be only used for development purposes.")
         .default_value("");

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -227,14 +227,20 @@ void vpr_init(const int argc, const char** argv, t_options* options, t_vpr_setup
      * warnings are being suppressed
      */
     std::vector<std::string> split_warning_option = vtr::split(options->suppress_warnings, std::string(","));
+    std::string warn_log_file;
+    std::string warn_functions;
+    // If no log file name is provided, the specified warning
+    // to suppress are not output anywhere.
+    if (split_warning_option.size() == 1) {
+        warn_functions = split_warning_option[0];
+    } else if (split_warning_option.size() == 2) {
+        warn_log_file = split_warning_option[0];
+        warn_functions = split_warning_option[1];
+    }
 
-    // If the file or the list of functions is not provided
-    // no warning is suppressed
-    if (split_warning_option.size() == 2) {
-        set_noisy_warn_log_file(split_warning_option[0].data());
-        for (std::string func_name : vtr::split(split_warning_option[1], std::string(":"))) {
-            add_warnings_to_suppress(func_name);
-        }
+    set_noisy_warn_log_file(warn_log_file);
+    for (std::string func_name : vtr::split(warn_functions, std::string(":"))) {
+        add_warnings_to_suppress(func_name);
     }
 
     /* Read in arch and circuit */


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR is to make optional the noisy warning output file optional (given that it could slow down run-time if VPR is launched on a HDD-provided machine). This is a PR related to the already merged https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/672 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Outputting the suppressed warning on dedicated file could slow down run-time for machine mounting HDDs instead of SSDs.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
