### PR TITLE
Cleaned up leaks caused by resolve_node

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -340,6 +340,12 @@ void make_concat_into_list_of_strings(ast_node_t *concat_top, char *instance_nam
 	int j;
 	ast_node_t *rnode[3];
 
+	//initialize these to NULL
+	for(i = 0; i < 3; i++)
+	{
+		rnode[i] = NULL;
+	}
+
 	concat_top->types.concat.num_bit_strings = 0;
 	concat_top->types.concat.bit_strings = NULL;
 
@@ -388,6 +394,16 @@ void make_concat_into_list_of_strings(ast_node_t *concat_top, char *instance_nam
 						concat_top->types.concat.bit_strings = (char**)vtr::realloc(concat_top->types.concat.bit_strings, sizeof(char*)*(concat_top->types.concat.num_bit_strings));
 						concat_top->types.concat.bit_strings[concat_top->types.concat.num_bit_strings-1] = get_name_of_pin_at_bit(concat_top->children[i], j, instance_name_prefix);
 					}
+
+					if(rnode[1] != ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->children[1])
+					{
+						rnode[1] = free_whole_tree(rnode[1]);
+					}
+					if(rnode[2] != ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->children[2])
+					{
+						rnode[2] = free_whole_tree(rnode[2]);
+					}
+
 				}
 				else if (((ast_node_t*)local_symbol_table_sc->data[sc_spot])->children[3] != NULL)
 				{
@@ -419,6 +435,16 @@ void make_concat_into_list_of_strings(ast_node_t *concat_top, char *instance_nam
 				concat_top->types.concat.bit_strings[concat_top->types.concat.num_bit_strings-1] =
 					get_name_of_pin_at_bit(concat_top->children[i], ((rnode[1]->types.vnumber->get_value() - rnode[2]->types.vnumber->get_value()))-j, instance_name_prefix);
 			}
+
+			if(rnode[1] != concat_top->children[i]->children[1])
+			{
+				rnode[1] = free_whole_tree(rnode[1]);
+			}
+			if(rnode[2] != concat_top->children[i]->children[2])
+			{
+				rnode[2] = free_whole_tree(rnode[2]);
+			}
+
 		}
 		else if (concat_top->children[i]->type == NUMBERS)
 		{
@@ -512,6 +538,12 @@ char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_
 	char *return_string = NULL;
 	ast_node_t *rnode[3];
 
+	// initialize these to NULL;
+	for(int i = 0; i < 3; i++)
+	{
+		rnode[i] = NULL;
+	}
+
 	if (var_node->type == ARRAY_REF)
 	{
 		var_node->children[1] = resolve_node(NULL, instance_name_prefix, var_node->children[1], NULL, 0);
@@ -531,6 +563,16 @@ char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_
 		oassert(rnode[1]->types.vnumber->get_value() >= rnode[2]->types.vnumber->get_value()+bit);
 
 		return_string = make_full_ref_name(NULL, NULL, NULL, var_node->children[0]->types.identifier, rnode[2]->types.vnumber->get_value()+bit);
+
+		if(rnode[1] != var_node->children[1])
+		{
+			rnode[1] = free_whole_tree(rnode[1]);
+		}
+		if(rnode[2] != var_node->children[2])
+		{
+			rnode[2] = free_whole_tree(rnode[2]);
+		}
+	
 	}
 	else if ((var_node->type == IDENTIFIERS) && (bit == -1))
 	{
@@ -573,6 +615,7 @@ char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_
 		}
 		else
 		{
+			ast_node_t *temp = var_node;
 			if (var_node->types.concat.num_bit_strings == -1)
 			{
 				/* If this hasn't been made into a string list then do it */
@@ -582,6 +625,11 @@ char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_
 
 			return_string = (char*)vtr::malloc(sizeof(char)*strlen(var_node->types.concat.bit_strings[bit])+1);
 			odin_sprintf(return_string, "%s", var_node->types.concat.bit_strings[bit]);
+		
+			if(var_node != temp)
+			{
+				var_node = free_whole_tree(var_node);
+			}
 		}
 	}
 	else
@@ -643,6 +691,12 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 
 	int i;
 	int width = 0;
+	//initialize these to NULL
+	for(i = 0; i < 3; i++)
+	{
+		rnode[i] = NULL;
+	}
+	i = 0;
 
 	if (var_node->type == ARRAY_REF)
 	{
@@ -652,6 +706,12 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 		oassert(rnode[1] && rnode[1]->type == NUMBERS);
 		oassert(var_node->children[0]->type == IDENTIFIERS);
 		return_string[0] = make_full_ref_name(NULL, NULL, NULL, var_node->children[0]->types.identifier, rnode[1]->types.vnumber->get_value());
+
+		if(rnode[1] != var_node->children[1])
+		{
+			rnode[1] = free_whole_tree(rnode[1]);
+		}
+	
 	}
 	else if (var_node->type == RANGE_REF)
 	{
@@ -671,6 +731,20 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 			oassert(rnode[0]->type == NUMBERS);
 			return_string = get_name_of_pins_number(rnode[0], rnode[2]->types.vnumber->get_value(), width);
 		}
+
+		if(rnode[0] != var_node->children[0])
+		{
+			rnode[0] = free_whole_tree(rnode[0]);
+		}
+		if(rnode[1] != var_node->children[1])
+		{
+			rnode[1] = free_whole_tree(rnode[1]);
+		}
+		if(rnode[2] != var_node->children[2])
+		{
+			rnode[2] = free_whole_tree(rnode[2]);
+		}
+
 	}
 	else if (var_node->type == IDENTIFIERS)
 	{
@@ -722,7 +796,11 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 				}
 				if(rnode[1] != sym_node->children[1])
 				{
-					free_whole_tree(rnode[1]);
+					rnode[1] = free_whole_tree(rnode[1]);
+				}
+				if(rnode[2] != sym_node->children[2])
+				{
+					rnode[2] = free_whole_tree(rnode[2]);
 				}
 			}
 
@@ -753,6 +831,7 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 		}
 		else
 		{
+			ast_node_t *temp = var_node;
 			if (var_node->types.concat.num_bit_strings == -1)
 			{
 				/* If this hasn't been made into a string list then do it */
@@ -766,6 +845,10 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 			{
 				return_string[i] = (char*)vtr::malloc(sizeof(char)*strlen(var_node->types.concat.bit_strings[var_node->types.concat.num_bit_strings-i-1])+1);
 				odin_sprintf(return_string[i], "%s", var_node->types.concat.bit_strings[var_node->types.concat.num_bit_strings-i-1]);
+			}
+			if(var_node != temp)
+			{
+				var_node = free_whole_tree(var_node);
 			}
 		}
 	}
@@ -880,6 +963,14 @@ long get_size_of_variable(ast_node_t *node, char *instance_name_prefix, STRING_C
 		long range_min = node_min->types.vnumber->get_value();
 
 		assignment_size = (range_max - range_min) + 1;
+		if(node_max != var_declare->children[1])
+		{
+			node_max = free_whole_tree(node_max);
+		}
+		if(node_min != var_declare->children[2])
+		{
+			node_min = free_whole_tree(node_min);
+		}
 	}
 
 	oassert(assignment_size != 0);

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -338,13 +338,8 @@ void make_concat_into_list_of_strings(ast_node_t *concat_top, char *instance_nam
 {
 	long i;
 	int j;
-	ast_node_t *rnode[3];
+	ast_node_t *rnode[3] = { 0 };
 
-	//initialize these to NULL
-	for(i = 0; i < 3; i++)
-	{
-		rnode[i] = NULL;
-	}
 
 	concat_top->types.concat.num_bit_strings = 0;
 	concat_top->types.concat.bit_strings = NULL;
@@ -536,13 +531,7 @@ char *get_name_of_var_declare_at_bit(ast_node_t *var_declare, int bit)
 char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_prefix)
 {
 	char *return_string = NULL;
-	ast_node_t *rnode[3];
-
-	// initialize these to NULL;
-	for(int i = 0; i < 3; i++)
-	{
-		rnode[i] = NULL;
-	}
+	ast_node_t *rnode[3] = { 0 };
 
 	if (var_node->type == ARRAY_REF)
 	{
@@ -687,16 +676,9 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix)
 { 
 	char **return_string = NULL;
 	char_list_t *return_list = (char_list_t*)vtr::malloc(sizeof(char_list_t));
-	ast_node_t *rnode[3];
-
+	ast_node_t *rnode[3] = { 0 };
 	int i;
 	int width = 0;
-	//initialize these to NULL
-	for(i = 0; i < 3; i++)
-	{
-		rnode[i] = NULL;
-	}
-	i = 0;
 
 	if (var_node->type == ARRAY_REF)
 	{

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -346,13 +346,24 @@ void create_param_table_for_module(ast_node_t* parent_parameter_list, ast_node_t
 		}
 		ast_node_t *node = (ast_node_t *)local_param_table_sc->data[sc_spot];
 		oassert(node);
+		ast_node_t *temp1 = node;
+		ast_node_t *temp2 = NULL;
 		node = resolve_node(NULL, module_name, node, NULL, 0);
+		if(node != temp1);
+		{
+			temp2 = node;
+		}
 		if (node->type != NUMBERS) 
 		{
 			node = resolve_node(NULL, parent_module, node, NULL, 0); // may contain parameters from parent
 		}
 		oassert(node->type == NUMBERS);
 		local_param_table_sc->data[sc_spot] = (void *)node;
+		if(temp2 && temp2 != node)
+		{
+			free_whole_tree(temp2);
+		}
+
 	}
 
 	/* clean up */
@@ -1405,6 +1416,15 @@ void create_top_output_nodes(ast_node_t* module, char *instance_name_prefix)
 							long max_value = node_max->types.vnumber->get_value();
 							long min_value = node_min->types.vnumber->get_value();
 							
+							if(node_max != var_declare->children[1])
+							{
+								node_max = free_whole_tree(node_max);
+							}
+							if(node_min != var_declare->children[2])
+							{
+								node_min = free_whole_tree(node_min);
+							}
+
 							if(min_value > max_value)
 							{
 								error_message(NETLIST_ERROR, var_declare->children[0]->line_number, var_declare->children[0]->file_number, "%s",
@@ -1499,6 +1519,23 @@ nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_pre
 
 		long addr_min1= node_min3->types.vnumber->get_value();
 		long addr_max1= node_max3->types.vnumber->get_value();
+
+		if(node_max2 != var_declare->children[3])
+		{
+			node_max2 = free_whole_tree(node_max2);
+		}
+		if(node_min2 != var_declare->children[4])
+		{
+			node_min2 = free_whole_tree(node_min2);
+		}
+		if(node_max3 != var_declare->children[5])
+		{
+			node_max3 = free_whole_tree(node_max3);
+		}
+		if(node_min3 != var_declare->children[6])
+		{
+			node_min3 = free_whole_tree(node_min3);
+		}
 
 		if((addr_min > addr_max) || (addr_min1 > addr_max1))
 		{
@@ -1670,6 +1707,24 @@ nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_pre
 		long addr_min = node_min2->types.vnumber->get_value();
 		long addr_max = node_max2->types.vnumber->get_value();
 
+		if(node_max1 != var_declare->children[1])
+		{
+			node_max1 = free_whole_tree(node_max1);
+		}
+		if(node_min1 != var_declare->children[2])
+		{
+			node_min1 = free_whole_tree(node_min1);
+		}
+
+		if(node_max2 != var_declare->children[3])
+		{
+			node_max2 = free_whole_tree(node_max2);
+		}
+		if(node_min2 != var_declare->children[4])
+		{
+			node_min2 = free_whole_tree(node_min2);
+		}
+
 		if(addr_min > addr_max)
 		{
 			error_message(NETLIST_ERROR, var_declare->children[0]->line_number, var_declare->children[0]->file_number, "%s",
@@ -1763,10 +1818,19 @@ nnet_t* define_nodes_and_nets_with_driver(ast_node_t* var_declare, char *instanc
 		/* FOR array driver  since sport 3 and 4 are NULL */
 		ast_node_t *node_max = resolve_node(NULL, instance_name_prefix, var_declare->children[1], NULL, 0);
 		ast_node_t *node_min = resolve_node(NULL, instance_name_prefix, var_declare->children[2], NULL, 0);
-		
+
 		oassert(node_min->type == NUMBERS && node_max->type == NUMBERS);
 		long min_value = node_min->types.vnumber->get_value();
 		long max_value = node_max->types.vnumber->get_value();
+
+		if(node_max != var_declare->children[1])
+		{
+			node_max = free_whole_tree(node_max);
+		}
+		if(node_min != var_declare->children[2])
+		{
+			node_min = free_whole_tree(node_min);
+		}
 
 		if(min_value > max_value)
 		{
@@ -2082,6 +2146,10 @@ int check_for_initial_reg_value(char * module_name, ast_node_t* var_declare, lon
 			warning_message(NETLIST_ERROR, var_declare->line_number, var_declare->file_number, 
 				"%s", "Could not resolve initial assignement to a constant value, skipping\n");
 		}
+	}
+	if(resolved_number != number_node)
+	{
+		resolved_number = free_whole_tree(resolved_number);
 	}
 	return FALSE;
 }
@@ -2490,6 +2558,16 @@ void connect_module_instantiation_and_alias(short PASS, ast_node_t* module_insta
 			/* assume all arrays declared [largest:smallest] */
 			oassert(node2->types.vnumber->get_value() <= node1->types.vnumber->get_value());
 			port_size = node1->types.vnumber->get_value() - node2->types.vnumber->get_value() + 1;
+		
+			if(node1 != module_var_node->children[1])
+			{
+				node1 = free_whole_tree(node1);
+			}
+			if(node2 != module_var_node->children[2])
+			{
+				node2 = free_whole_tree(node2);
+			}
+
 		}
 		else if (module_var_node->children[5] == NULL)
 		{
@@ -2509,6 +2587,24 @@ void connect_module_instantiation_and_alias(short PASS, ast_node_t* module_insta
 			oassert(node2->types.vnumber->get_value() <= node1->types.vnumber->get_value());
 			oassert(node4->types.vnumber->get_value() <= node3->types.vnumber->get_value());
 			port_size = node1->types.vnumber->get_value() * node3->types.vnumber->get_value() - 1;
+		
+			if(node1 != module_var_node->children[1])
+			{
+				node1 = free_whole_tree(node1);
+			}
+			if(node2 != module_var_node->children[2])
+			{
+				node2 = free_whole_tree(node2);
+			}
+			if(node3 != module_var_node->children[3])
+			{
+				node3 = free_whole_tree(node3);
+			}
+			if(node4 != module_var_node->children[4])
+			{
+				node4 = free_whole_tree(node4);
+			}
+
 		}
 
 		//---------------------------------------------------------------------------
@@ -2822,6 +2918,15 @@ signal_list_t *connect_function_instantiation_and_alias(short PASS, ast_node_t* 
 			oassert(node2->types.vnumber->get_value() <= node1->types.vnumber->get_value());
 			port_size = node1->types.vnumber->get_value() - node2->types.vnumber->get_value() + 1;
 
+			if(node1 != module_var_node->children[1])
+			{
+				node1 = free_whole_tree(node1);
+			}
+			if(node2 != module_var_node->children[2])
+			{
+				node2 = free_whole_tree(node2);
+			}
+		
 		}
 		else if (module_var_node->children[5] == NULL)
 		{
@@ -2842,6 +2947,23 @@ signal_list_t *connect_function_instantiation_and_alias(short PASS, ast_node_t* 
 			oassert(node2->types.vnumber->get_value() <= node1->types.vnumber->get_value());
 			oassert(node4->types.vnumber->get_value() <= node3->types.vnumber->get_value());
 			port_size = node1->types.vnumber->get_value() * node3->types.vnumber->get_value() - 1;
+
+			if(node1 != module_var_node->children[1])
+			{
+				node1 = free_whole_tree(node1);
+			}
+			if(node2 != module_var_node->children[2])
+			{
+				node2 = free_whole_tree(node2);
+			}
+			if(node3 != module_var_node->children[3])
+			{
+				node3 = free_whole_tree(node3);
+			}
+			if(node4 != module_var_node->children[4])
+			{
+				node4 = free_whole_tree(node4);
+			}
 
 		}
 
@@ -4213,6 +4335,11 @@ signal_list_t *create_operation_node(ast_node_t *op, signal_list_t **input_lists
 			if (second->type != NUMBERS)
 				error_message(NETLIST_ERROR, op->line_number, op->file_number, "%s", "Odin only supports constant shifts at present\n");
 			oassert(second->type == NUMBERS);
+
+			if(second != op->children[1])
+			{
+				free_whole_tree(second);
+			}
 
 			/* for shift left or right, it's actually a one port operation. The 2nd port is constant */
 			if (i == 0)
@@ -6039,7 +6166,12 @@ void convert_multi_to_single_dimentional_array(ast_node_t *node, char *instance_
 	// see if this operation can be resolved
 	if (new_node_2->type != NUMBERS)
 	{
+		ast_node_t *temp = new_node_2;
 		new_node_2 = resolve_node(NULL, instance_name_prefix, new_node_2, NULL, 0);
+		if(new_node_2 != temp)
+		{
+			free_whole_tree(new_node_2);
+		}
 	}
 
 	return;


### PR DESCRIPTION
#### Description
Cleaned up memory leaks in ast_util.cpp and netlist_create_from_ast.cpp caused by calls to resolve_node.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
