### PR TITLE
[WIP] Add ODIN_II parser support for unsynthesizable C macros

### DIFF
--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -66,7 +66,7 @@ int yylex(void);
 %token vOUTPUT vPARAMETER vLOCALPARAM vPOSEDGE vREG vWIRE vXNOR vXOR vDEFPARAM voANDAND vNAND vNEGEDGE vNOR vNOT vOR vFOR
 %token voOROR voLTE voGTE voPAL voSLEFT voSRIGHT vo ASRIGHT voEQUAL voNOTEQUAL voCASEEQUAL
 %token voCASENOTEQUAL voXNOR voNAND voNOR vWHILE vINTEGER vCLOG2 vGENVAR
-%token vPLUS_COLON vMINUS_COLON vSPECPARAM
+%token vPLUS_COLON vMINUS_COLON vSPECPARAM vCFUNC vC_FUNCTION_EXPRESSION
 %token '?' ':' '|' '^' '&' '<' '>' '+' '-' '*' '/' '%' '(' ')' '{' '}' '[' ']' '~' '!' ';' '#' ',' '.' '@' '='
 %token vNOT_SUPPORT 
 
@@ -116,7 +116,7 @@ int yylex(void);
 %type <node> list_of_module_parameters
 %type <node> specify_block list_of_specify_items specify_item specparam_declaration
 %type <node> specify_pal_connect_declaration
-%type <node> initial_block parallel_connection list_of_blocking_assignment
+%type <node> initial_block parallel_connection list_of_blocking_assignment c_function c_function_expression_list c_function_expression
 
 %%
 
@@ -198,6 +198,7 @@ module_item:
 	| always		{$$ = $1;}
 	| defparam_declaration	{$$ = $1;}
 	| specify_block		{$$ = $1;}
+	| c_function		{$$ = $1;}
 	;
 
 function_declaration:
@@ -418,6 +419,7 @@ generate_for:
 
 statement:
 	seq_block										{$$ = $1;}
+	| c_function											{$$ = $1;}
 	| blocking_assignment ';'								{$$ = $1;}
 	| non_blocking_assignment ';'								{$$ = $1;}
 	| vIF '(' expression ')' statement %prec LOWER_THAN_ELSE				{$$ = newIf($3, $5, NULL, yylineno);}
@@ -571,6 +573,20 @@ probable_expression_list:
 expression_list:
 	expression_list ',' expression	{$$ = newList_entry($1, $3); /* note this will be in order lsb = greatest to msb = 0 in the node child list */}
 	| expression			{$$ = newList(CONCATENATE, $1);}
+	;
+
+c_function_expression:
+	vC_FUNCTION_EXPRESSION		{$$ = NULL;}
+	| expression	{$$ = free_whole_tree($1);}
+	;
+
+c_function_expression_list:
+	c_function_expression_list ',' c_function_expression	{$$ = $1;}
+	| c_function_expression			{$$ = $1;}
+	;
+
+c_function:
+	vCFUNC '(' c_function_expression_list ')'';'	{$$ = NULL;}
 	;
 
 %%

--- a/ODIN_II/SRC/verilog_flex.l
+++ b/ODIN_II/SRC/verilog_flex.l
@@ -56,6 +56,7 @@ vDEC [Dd][_]*[[:digit:]][[:digit:]_]*
 vHEX [Hh][_]*[ZzXx[:xdigit:]][ZzXx[:xdigit:]_]*
 vINT [_]*[[:digit:]][[:digit:]_]*
 vWORD [[:alpha:]_][[:alnum:]_]*
+vCPARAM_STRING ["][[:print:]]*["]
 
 	/**
 	* add \" to vPUNCT when support is added for strings
@@ -206,6 +207,7 @@ vDISCARD [\"]
 
 	/*	C functions	*/
 <INITIAL>"$clog2"			{MP; return vCLOG2;}
+<INITIAL>[\$]{vWORD}			{MP; return vCFUNC;}
 
 	/*	signed numbers	*/
 <INITIAL>[[:digit:]]+'[sS]{vBIN}	{ MP; yylval.num_value = vtr::strdup(yytext); return vSIGNED_BINARY; }
@@ -236,6 +238,9 @@ vDISCARD [\"]
 
 	/* return operators */
 <INITIAL>{vPUNCT}					{ MP; return yytext[0]; }
+
+	/* string parameters to c functions */
+<INITIAL>{vCPARAM_STRING}					{ MP; yylval.id_name = vtr::strdup(yytext); return vC_FUNCTION_EXPRESSION; }
 
 	/* general stuff */
 [[:space:]]+						/* ignore spaces */


### PR DESCRIPTION
[WIP] Add ODIN_II parser support for unsynthesizable C macros

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

#### Description
These changes are meant to enable proper parsing of unsynthesizable/unsupported c macros in the future (this code cannot be integrated right away).

#### How Has This Been Tested?
This has been tested with a .v file modified to include a call to fopen(). No other testing has been performed yet.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
