### PR TITLE
Provide structure for Router lookahead and placement delay lookup SerDes

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1202,6 +1202,10 @@ struct t_segment_inf {
     //float Cmetal_per_m; /* Wire capacitance (per meter) */
 };
 
+inline bool operator==(const t_segment_inf& a, const t_segment_inf& b) {
+    return a.name == b.name && a.frequency == b.frequency && a.length == b.length && a.arch_wire_switch == b.arch_wire_switch && a.arch_opin_switch == b.arch_opin_switch && a.frac_cb == b.frac_cb && a.frac_sb == b.frac_sb && a.longline == b.longline && a.Rmetal == b.Rmetal && a.Cmetal == b.Cmetal && a.directionality == b.directionality && a.cb == b.cb && a.sb == b.sb;
+}
+
 enum class SwitchType {
     MUX = 0,   //A configurable (buffered) mux (single-driver)
     TRISTATE,  //A configurable tristate-able buffer (multi-driver)

--- a/libs/libvtrutil/src/vtr_cache.h
+++ b/libs/libvtrutil/src/vtr_cache.h
@@ -1,0 +1,44 @@
+#ifndef VTR_CACHE_H_
+#define VTR_CACHE_H_
+
+#include <memory>
+
+namespace vtr {
+
+// Simple cache
+template<typename CacheKey, typename CacheValue>
+class Cache {
+  public:
+    // Clear cache.
+    void clear() {
+        key_ = CacheKey();
+        value_.reset();
+    }
+
+    // Check if the cache is valid, and return the cached value if present and valid.
+    //
+    // Returns nullptr if the cache is invalid.
+    const CacheValue* get(const CacheKey& key) const {
+        if (key == key_ && value_) {
+            return value_.get();
+        } else {
+            return nullptr;
+        }
+    }
+
+    // Update the cache.
+    const CacheValue* set(const CacheKey& key, std::unique_ptr<CacheValue> value) {
+        key_ = key;
+        value_ = std::move(value);
+
+        return value_.get();
+    }
+
+  private:
+    CacheKey key_;
+    std::unique_ptr<CacheValue> value_;
+};
+
+} // namespace vtr
+
+#endif

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -350,8 +350,8 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
 
     RouterOpts->strict_checks = Options.strict_checks;
 
-    RouterOpts->write_lookahead = Options.write_lookahead;
-    RouterOpts->read_lookahead = Options.read_lookahead;
+    RouterOpts->write_router_lookahead = Options.write_router_lookahead;
+    RouterOpts->read_router_lookahead = Options.read_router_lookahead;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -480,6 +480,9 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
     PlacerOpts->rlim_escape_fraction = Options.place_rlim_escape_fraction;
 
     PlacerOpts->strict_checks = Options.strict_checks;
+
+    PlacerOpts->write_placement_delay_lookup = Options.write_placement_delay_lookup;
+    PlacerOpts->read_placement_delay_lookup = Options.read_placement_delay_lookup;
 }
 
 static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysis_opts) {

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -349,6 +349,9 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->first_iteration_timing_report_file = Options.router_first_iteration_timing_report_file;
 
     RouterOpts->strict_checks = Options.strict_checks;
+
+    RouterOpts->write_lookahead = Options.write_lookahead;
+    RouterOpts->read_lookahead = Options.read_lookahead;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -351,7 +351,6 @@ int binary_search_place_and_route(t_placer_opts placer_opts,
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     arch->Directs, arch->num_directs,
                     &warnings);
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1006,12 +1006,12 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .metavar("RR_GRAPH_FILE")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    file_grp.add_argument(args.read_lookahead, "--read_lookahead")
+    file_grp.add_argument(args.read_router_lookahead, "--read_router_lookahead")
         .help(
             "Reads the lookahead data from the specified file instead of computing it.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    file_grp.add_argument(args.write_lookahead, "--write_lookahead")
+    file_grp.add_argument(args.write_router_lookahead, "--write_router_lookahead")
         .help("Writes the lookahead data to the specified file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1006,21 +1006,21 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .metavar("RR_GRAPH_FILE")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    file_grp.add_argument(args.read_rr_graph_file, "--read_lookahead")
+    file_grp.add_argument(args.read_lookahead, "--read_lookahead")
         .help(
             "Reads the lookahead data from the specified file instead of computing it.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    file_grp.add_argument(args.write_rr_graph_file, "--write_lookahead")
+    file_grp.add_argument(args.write_lookahead, "--write_lookahead")
         .help("Writes the lookahead data to the specified file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    file_grp.add_argument(args.read_rr_graph_file, "--read_placement_delay_lookup")
+    file_grp.add_argument(args.read_placement_delay_lookup, "--read_placement_delay_lookup")
         .help(
             "Reads the placement delay lookup from the specified file instead of computing it.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    file_grp.add_argument(args.write_rr_graph_file, "--write_placement_delay_lookup")
+    file_grp.add_argument(args.write_placement_delay_lookup, "--write_placement_delay_lookup")
         .help("Writes the placement delay lookup to the specified file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1006,6 +1006,15 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .metavar("RR_GRAPH_FILE")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    file_grp.add_argument(args.read_rr_graph_file, "--read_lookahead")
+        .help(
+            "Reads the lookahead data to the specified file instead of computing it.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.write_rr_graph_file, "--write_lookahead")
+        .help("Writes the lookahead data to the specified file.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     file_grp.add_argument(args.out_file_prefix, "--outfile_prefix")
         .help("Prefix for output files")
         .show_in(argparse::ShowIn::HELP_ONLY);

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1008,11 +1008,20 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     file_grp.add_argument(args.read_rr_graph_file, "--read_lookahead")
         .help(
-            "Reads the lookahead data to the specified file instead of computing it.")
+            "Reads the lookahead data from the specified file instead of computing it.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     file_grp.add_argument(args.write_rr_graph_file, "--write_lookahead")
         .help("Writes the lookahead data to the specified file.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.read_rr_graph_file, "--read_placement_delay_lookup")
+        .help(
+            "Reads the placement delay lookup from the specified file instead of computing it.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    file_grp.add_argument(args.write_rr_graph_file, "--write_placement_delay_lookup")
+        .help("Writes the placement delay lookup to the specified file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     file_grp.add_argument(args.out_file_prefix, "--outfile_prefix")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -30,8 +30,8 @@ struct t_options {
     argparse::ArgValue<std::string> write_placement_delay_lookup;
     argparse::ArgValue<std::string> read_placement_delay_lookup;
 
-    argparse::ArgValue<std::string> write_lookahead;
-    argparse::ArgValue<std::string> read_lookahead;
+    argparse::ArgValue<std::string> write_router_lookahead;
+    argparse::ArgValue<std::string> read_router_lookahead;
 
     /* Stage Options */
     argparse::ArgValue<bool> do_packing;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -27,6 +27,9 @@ struct t_options {
     argparse::ArgValue<std::string> write_rr_graph_file;
     argparse::ArgValue<std::string> read_rr_graph_file;
 
+    argparse::ArgValue<std::string> write_placement_delay_lookup;
+    argparse::ArgValue<std::string> read_placement_delay_lookup;
+
     argparse::ArgValue<std::string> write_lookahead;
     argparse::ArgValue<std::string> read_lookahead;
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -27,6 +27,9 @@ struct t_options {
     argparse::ArgValue<std::string> write_rr_graph_file;
     argparse::ArgValue<std::string> read_rr_graph_file;
 
+    argparse::ArgValue<std::string> write_lookahead;
+    argparse::ArgValue<std::string> read_lookahead;
+
     /* Stage Options */
     argparse::ArgValue<bool> do_packing;
     argparse::ArgValue<bool> do_placement;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -826,7 +826,6 @@ void vpr_create_rr_graph(t_vpr_setup& vpr_setup, const t_arch& arch, int chan_wi
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     arch.Directs, arch.num_directs,
                     &warnings);
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -720,6 +720,16 @@ RouteStatus vpr_route_fixed_W(t_vpr_setup& vpr_setup,
                               std::shared_ptr<SetupHoldTimingInfo> timing_info,
                               std::shared_ptr<RoutingDelayCalculator> delay_calc,
                               vtr::vector<ClusterNetId, float*>& net_delay) {
+    if (router_needs_lookahead(vpr_setup.RouterOpts.router_algorithm)) {
+        // Prime lookahead cache to avoid adding lookahead computation cost to
+        // the routing timer.
+        get_cached_router_lookahead(
+            vpr_setup.RouterOpts.lookahead_type,
+            vpr_setup.RouterOpts.write_router_lookahead,
+            vpr_setup.RouterOpts.read_router_lookahead,
+            vpr_setup.Segments);
+    }
+
     vtr::ScopedStartFinishTimer timer("Routing");
 
     if (NO_FIXED_CHANNEL_WIDTH == fixed_channel_width || fixed_channel_width <= 0) {
@@ -746,6 +756,9 @@ RouteStatus vpr_route_min_W(t_vpr_setup& vpr_setup,
                             std::shared_ptr<SetupHoldTimingInfo> timing_info,
                             std::shared_ptr<RoutingDelayCalculator> delay_calc,
                             vtr::vector<ClusterNetId, float*>& net_delay) {
+    // Note that lookahead cache is not primed here because
+    // binary_search_place_and_route will change the channel width, and result
+    // in the lookahead cache being recomputed.
     vtr::ScopedStartFinishTimer timer("Routing");
 
     auto& router_opts = vpr_setup.RouterOpts;
@@ -1181,9 +1194,9 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
 }
 
 /* This function performs power estimation. It relies on the
- * placement/routing results, as well as the critical path. 
+ * placement/routing results, as well as the critical path.
  * Power estimation can be performed as part of a full or
- * partial flow. More information on the power estimation functions of 
+ * partial flow. More information on the power estimation functions of
  * VPR can be found here:
  *   http://docs.verilogtorouting.org/en/latest/vtr/power_estimation/
  */

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -19,6 +19,7 @@
 #include "clock_network_builders.h"
 #include "clock_connection_builders.h"
 #include "route_traceback.h"
+#include "router_lookahead.h"
 #include "place_macro.h"
 
 //A Context is collection of state relating to a particular part of VPR
@@ -271,6 +272,14 @@ struct RoutingContext : public Context {
 
     //SHA256 digest of the .route file (used for unique identification and consistency checking)
     std::string routing_id;
+
+    // Cache of router lookahead object.
+    std::unique_ptr<RouterLookahead> cached_router_lookahead_;
+
+    // Parameters used for cached router lookahead object.
+    e_router_lookahead cached_router_lookahead_type_;
+    std::string cached_lookahead_file_;
+    std::vector<t_segment_inf> cached_segment_inf_;
 };
 
 //This object encapsulates VPR's state. There is typically a single instance which is

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -274,12 +274,11 @@ struct RoutingContext : public Context {
     std::string routing_id;
 
     // Cache of router lookahead object.
-    std::unique_ptr<RouterLookahead> cached_router_lookahead_;
-
-    // Parameters used for cached router lookahead object.
-    e_router_lookahead cached_router_lookahead_type_;
-    std::string cached_lookahead_file_;
-    std::vector<t_segment_inf> cached_segment_inf_;
+    //
+    // Cache key: (lookahead type, read lookahead (if any), segment definitions).
+    vtr::Cache<std::tuple<e_router_lookahead, std::string, std::vector<t_segment_inf>>,
+               RouterLookahead>
+        cached_router_lookahead_;
 };
 
 //This object encapsulates VPR's state. There is typically a single instance which is

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -955,8 +955,8 @@ struct t_router_opts {
     std::string first_iteration_timing_report_file;
     bool strict_checks;
 
-    std::string write_lookahead;
-    std::string read_lookahead;
+    std::string write_router_lookahead;
+    std::string read_router_lookahead;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -38,6 +38,7 @@
 #include "vtr_vector.h"
 #include "vtr_util.h"
 #include "vtr_flat_map.h"
+#include "vtr_cache.h"
 
 /*******************************************************************************
  * Global data types and constants

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -951,6 +951,9 @@ struct t_router_opts {
     float reconvergence_cpd_threshold;
     std::string first_iteration_timing_report_file;
     bool strict_checks;
+
+    std::string write_lookahead;
+    std::string read_lookahead;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -820,6 +820,9 @@ struct t_placer_opts {
     std::string post_place_timing_report_file;
 
     bool strict_checks;
+
+    std::string write_placement_delay_lookup;
+    std::string read_placement_delay_lookup;
 };
 
 /* All the parameters controlling the router's operation are in this        *

--- a/vpr/src/place/place_delay_model.h
+++ b/vpr/src/place/place_delay_model.h
@@ -11,44 +11,57 @@ class PlaceDelayModel {
   public:
     virtual ~PlaceDelayModel() = default;
 
+    // Computes place delay model.
     virtual void compute(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
-        int longest_length) = 0;
+        const RouterDelayProfile& router,
+        const t_placer_opts& placer_opts,
+        const t_router_opts& router_opts,
+        int longest_length)
+        = 0;
 
     //Returns the delay estimate between the specified block pins
+    //
+    // Either compute or read methods must be invoked before invoking
+    // delay.
     virtual float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const = 0;
 
     //Dumps the delay model to an echo file
     virtual void dump_echo(std::string filename) const = 0;
 
-    virtual void write(const std::string &file) const = 0;
-    virtual void read(const std::string &file) = 0;
+    // Write place delay model to specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void write(const std::string& file) const = 0;
+
+    // Read place delay model to specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void read(const std::string& file) = 0;
 };
 
 //A simple delay model based on the distance (delta) between block locations
 class DeltaDelayModel : public PlaceDelayModel {
   public:
-    DeltaDelayModel() {};
+    DeltaDelayModel(){};
     DeltaDelayModel(vtr::Matrix<float> delta_delays, t_router_opts router_opts)
         : delays_(std::move(delta_delays))
         , router_opts_(router_opts) {}
 
     void compute(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        const RouterDelayProfile& router,
+        const t_placer_opts& placer_opts,
+        const t_router_opts& router_opts,
         int longest_length) override;
     float delay(int from_x, int from_y, int /*from_pin*/, int to_x, int to_y, int /*to_pin*/) const override;
     void dump_echo(std::string filepath) const override;
 
-    void read(const std::string &file) override {
+    void read(const std::string& file) override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "DeltaDelayModel::read unimplemented");
     }
-    void write(const std::string &file) const override {
+    void write(const std::string& file) const override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "DeltaDelayModel::write unimplemented");
     }
+
   private:
     vtr::Matrix<float> delays_;
     t_router_opts router_opts_;
@@ -57,27 +70,28 @@ class DeltaDelayModel : public PlaceDelayModel {
 class OverrideDelayModel : public PlaceDelayModel {
   public:
     void compute(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        const RouterDelayProfile& router,
+        const t_placer_opts& placer_opts,
+        const t_router_opts& router_opts,
         int longest_length) override;
     float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const override;
     void dump_echo(std::string filepath) const override;
 
-    void read(const std::string &file) override {
+    void read(const std::string& file) override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "OverrideDelayModel::read unimplemented");
     }
-    void write(const std::string &file) const override {
+    void write(const std::string& file) const override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "OverrideDelayModel::write unimplemented");
     }
-  public: //Mutators
 
+  public: //Mutators
   private:
     std::unique_ptr<PlaceDelayModel> base_delay_model_;
 
     void set_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y, float delay);
-    void compute_override_delay_model(const RouterDelayProfile & router);
+    void compute_override_delay_model(const RouterDelayProfile& router);
 
     struct t_override {
         short from_type;

--- a/vpr/src/place/place_delay_model.h
+++ b/vpr/src/place/place_delay_model.h
@@ -13,7 +13,7 @@ class PlaceDelayModel {
 
     // Computes place delay model.
     virtual void compute(
-        const RouterDelayProfile& router,
+        const RouterDelayProfiler& route_profiler,
         const t_placer_opts& placer_opts,
         const t_router_opts& router_opts,
         int longest_length)
@@ -40,25 +40,23 @@ class PlaceDelayModel {
 //A simple delay model based on the distance (delta) between block locations
 class DeltaDelayModel : public PlaceDelayModel {
   public:
-    DeltaDelayModel(){};
+    DeltaDelayModel() {}
     DeltaDelayModel(vtr::Matrix<float> delta_delays, t_router_opts router_opts)
         : delays_(std::move(delta_delays))
         , router_opts_(router_opts) {}
 
     void compute(
-        const RouterDelayProfile& router,
+        const RouterDelayProfiler& router,
         const t_placer_opts& placer_opts,
         const t_router_opts& router_opts,
         int longest_length) override;
     float delay(int from_x, int from_y, int /*from_pin*/, int to_x, int to_y, int /*to_pin*/) const override;
     void dump_echo(std::string filepath) const override;
 
-    void read(const std::string& file) override {
-        (void)file;
+    void read(const std::string& /*file*/) override {
         VPR_THROW(VPR_ERROR_ROUTE, "DeltaDelayModel::read unimplemented");
     }
-    void write(const std::string& file) const override {
-        (void)file;
+    void write(const std::string& /*file*/) const override {
         VPR_THROW(VPR_ERROR_ROUTE, "DeltaDelayModel::write unimplemented");
     }
 
@@ -70,19 +68,17 @@ class DeltaDelayModel : public PlaceDelayModel {
 class OverrideDelayModel : public PlaceDelayModel {
   public:
     void compute(
-        const RouterDelayProfile& router,
+        const RouterDelayProfiler& route_profiler,
         const t_placer_opts& placer_opts,
         const t_router_opts& router_opts,
         int longest_length) override;
     float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const override;
     void dump_echo(std::string filepath) const override;
 
-    void read(const std::string& file) override {
-        (void)file;
+    void read(const std::string& /*file*/) override {
         VPR_THROW(VPR_ERROR_ROUTE, "OverrideDelayModel::read unimplemented");
     }
-    void write(const std::string& file) const override {
-        (void)file;
+    void write(const std::string& /*file*/) const override {
         VPR_THROW(VPR_ERROR_ROUTE, "OverrideDelayModel::write unimplemented");
     }
 
@@ -91,7 +87,7 @@ class OverrideDelayModel : public PlaceDelayModel {
     std::unique_ptr<PlaceDelayModel> base_delay_model_;
 
     void set_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y, float delay);
-    void compute_override_delay_model(const RouterDelayProfile& router);
+    void compute_override_delay_model(const RouterDelayProfiler& router);
 
     struct t_override {
         short from_type;

--- a/vpr/src/place/place_delay_model.h
+++ b/vpr/src/place/place_delay_model.h
@@ -32,7 +32,7 @@ class PlaceDelayModel {
     // May be unimplemented, in which case method should throw an exception.
     virtual void write(const std::string& file) const = 0;
 
-    // Read place delay model to specified file.
+    // Read place delay model from specified file.
     // May be unimplemented, in which case method should throw an exception.
     virtual void read(const std::string& file) = 0;
 };

--- a/vpr/src/place/place_delay_model.h
+++ b/vpr/src/place/place_delay_model.h
@@ -4,30 +4,51 @@
 #include "vtr_ndmatrix.h"
 #include "vtr_flat_map.h"
 #include "vpr_types.h"
-#include "router_lookahead_map.h"
+#include "router_delay_profiling.h"
 
 //Abstract interface to a placement delay model
 class PlaceDelayModel {
   public:
     virtual ~PlaceDelayModel() = default;
 
+    virtual void compute(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        int longest_length) = 0;
+
     //Returns the delay estimate between the specified block pins
     virtual float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const = 0;
 
     //Dumps the delay model to an echo file
     virtual void dump_echo(std::string filename) const = 0;
+
+    virtual void write(const std::string &file) const = 0;
+    virtual void read(const std::string &file) = 0;
 };
 
 //A simple delay model based on the distance (delta) between block locations
 class DeltaDelayModel : public PlaceDelayModel {
   public:
+    DeltaDelayModel() {};
     DeltaDelayModel(vtr::Matrix<float> delta_delays, t_router_opts router_opts)
         : delays_(std::move(delta_delays))
         , router_opts_(router_opts) {}
 
+    void compute(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        int longest_length) override;
     float delay(int from_x, int from_y, int /*from_pin*/, int to_x, int to_y, int /*to_pin*/) const override;
     void dump_echo(std::string filepath) const override;
 
+    void read(const std::string &file) override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "DeltaDelayModel::read unimplemented");
+    }
+    void write(const std::string &file) const override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "DeltaDelayModel::write unimplemented");
+    }
   private:
     vtr::Matrix<float> delays_;
     t_router_opts router_opts_;
@@ -35,18 +56,28 @@ class DeltaDelayModel : public PlaceDelayModel {
 
 class OverrideDelayModel : public PlaceDelayModel {
   public:
-    OverrideDelayModel(std::unique_ptr<PlaceDelayModel> base_delay_model, t_router_opts router_opts)
-        : base_delay_model_(std::move(base_delay_model))
-        , router_opts_(router_opts) {}
-
+    void compute(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        int longest_length) override;
     float delay(int from_x, int from_y, int from_pin, int to_x, int to_y, int to_pin) const override;
     void dump_echo(std::string filepath) const override;
 
+    void read(const std::string &file) override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "OverrideDelayModel::read unimplemented");
+    }
+    void write(const std::string &file) const override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "OverrideDelayModel::write unimplemented");
+    }
   public: //Mutators
-    void set_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y, float delay);
 
   private:
     std::unique_ptr<PlaceDelayModel> base_delay_model_;
+
+    void set_delay_override(int from_type, int from_class, int to_type, int to_class, int delta_x, int delta_y, float delay);
+    void compute_override_delay_model(const RouterDelayProfile & router);
 
     struct t_override {
         short from_type;

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -143,11 +143,12 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
     alloc_routing_structs(chan_width, router_opts, det_routing_arch, segment_inf,
                           directs, num_directs);
 
-    RouterDelayProfiler route_profiler(
+    const RouterLookahead* router_lookahead = get_cached_router_lookahead(
         router_opts.lookahead_type,
         router_opts.write_router_lookahead,
         router_opts.read_router_lookahead,
         segment_inf);
+    RouterDelayProfiler route_profiler(router_lookahead);
 
     int longest_length = get_longest_segment_length(segment_inf);
 

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -69,9 +69,14 @@ struct t_profile_info {
 static t_chan_width setup_chan_width(const t_router_opts& router_opts,
                                      t_chan_width_dist chan_width_dist);
 
-static float route_connection_delay(int source_x_loc, int source_y_loc, int sink_x_loc, int sink_y_loc, const t_router_opts& router_opts, bool measure_directconnect);
+static float route_connection_delay(
+        const RouterDelayProfile & router, int source_x_loc, int source_y_loc,
+        int sink_x_loc, int sink_y_loc, const t_router_opts &router_opts,
+        bool measure_directconnect);
 
-static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
+static void generic_compute_matrix(
+                                   const RouterDelayProfile & router,
+                                   vtr::Matrix<std::vector<float>>& matrix,
                                    int source_x,
                                    int source_y,
                                    int start_x,
@@ -81,11 +86,15 @@ static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
                                    const t_router_opts& router_opts,
                                    bool measure_directconnect);
 
-static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& palcer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length);
+static vtr::Matrix<float> compute_delta_delays(
+        const RouterDelayProfile & router,
+        const t_placer_opts& palcer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length);
 
 float delay_reduce(std::vector<float>& delays, e_reducer reducer);
 
-static vtr::Matrix<float> compute_delta_delay_model(const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, int longest_length);
+static vtr::Matrix<float> compute_delta_delay_model(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, int longest_length);
 
 static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
                                                  t_type_ptr from_type,
@@ -97,7 +106,9 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
                                                  int* src_rr,
                                                  int* sink_rr);
 
-static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model);
+static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(
+        const RouterDelayProfile & router,
+        const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model);
 
 static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays);
 
@@ -126,6 +137,12 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
     alloc_routing_structs(chan_width, router_opts, det_routing_arch, segment_inf,
                           directs, num_directs);
 
+    RouterDelayProfile router(
+            router_opts.lookahead_type,
+            router_opts.write_lookahead,
+            router_opts.read_lookahead,
+            segment_inf);
+
     int longest_length = get_longest_segment_length(segment_inf);
 
     /*now setup and compute the actual arrays */
@@ -134,7 +151,7 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
         || placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
         bool measure_directconnect = (placer_opts.delay_model_type != PlaceDelayModelType::DELTA_OVERRIDE);
 
-        auto delta_delays = compute_delta_delay_model(placer_opts, router_opts, measure_directconnect, longest_length);
+        auto delta_delays = compute_delta_delay_model(router, placer_opts, router_opts, measure_directconnect, longest_length);
         place_delay_model = std::make_unique<DeltaDelayModel>(std::move(delta_delays), router_opts);
 
     } else {
@@ -143,7 +160,7 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
 
     if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
         //Override direct-connect delays
-        place_delay_model = compute_override_delay_model(router_opts, std::move(place_delay_model));
+        place_delay_model = compute_override_delay_model(router, router_opts, std::move(place_delay_model));
     }
 
     /*free all data structures that are no longer needed */
@@ -229,7 +246,10 @@ static t_chan_width setup_chan_width(const t_router_opts& router_opts,
     return init_chan(width_fac, chan_width_dist);
 }
 
-static float route_connection_delay(int source_x, int source_y, int sink_x, int sink_y, const t_router_opts& router_opts, bool measure_directconnect) {
+static float route_connection_delay(
+        const RouterDelayProfile & router, int source_x, int source_y,
+        int sink_x, int sink_y, const t_router_opts &router_opts,
+        bool measure_directconnect) {
     //Routes between the source and sink locations and calculates the delay
 
     float net_delay_value = IMPOSSIBLE_DELTA; /*set to known value for debug purposes */
@@ -261,9 +281,11 @@ static float route_connection_delay(int source_x, int source_y, int sink_x, int 
                 continue;
             }
 
-            successfully_routed = calculate_delay(source_rr_node, sink_rr_node,
-                                                  router_opts,
-                                                  &net_delay_value);
+            {
+                successfully_routed = router.calculate_delay(source_rr_node, sink_rr_node,
+                                                      router_opts,
+                                                      &net_delay_value);
+            }
 
             if (successfully_routed) break;
         }
@@ -278,7 +300,9 @@ static float route_connection_delay(int source_x, int source_y, int sink_x, int 
     return (net_delay_value);
 }
 
-static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
+static void generic_compute_matrix(
+                                   const RouterDelayProfile & router,
+                                   vtr::Matrix<std::vector<float>>& matrix,
                                    int source_x,
                                    int source_y,
                                    int start_x,
@@ -318,7 +342,7 @@ static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
             } else {
                 //Valid start/end
 
-                float delay = route_connection_delay(source_x, source_y, sink_x, sink_y, router_opts, measure_directconnect);
+                float delay = route_connection_delay(router, source_x, source_y, sink_x, sink_y, router_opts, measure_directconnect);
 
 #ifdef VERBOSE
                 VTR_LOG("Computed delay: %12g delta: %d,%d (src: %d,%d sink: %d,%d)\n",
@@ -339,7 +363,9 @@ static void generic_compute_matrix(vtr::Matrix<std::vector<float>>& matrix,
     }
 }
 
-static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length) {
+static vtr::Matrix<float> compute_delta_delays(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length) {
     //To avoid edge effects we place the source at least 'longest_length' away
     //from the device edge
     //and route from there for all possible delta values < dimension
@@ -405,7 +431,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from lower left edge (%d,%d):\n", x, y);
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(router, sampled_delta_delays,
                            x, y,
                            x, y,
                            grid.width() - 1, grid.height() - 1,
@@ -431,7 +457,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from left bottom edge (%d,%d):\n", x, y);
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(router, sampled_delta_delays,
                            x, y,
                            x, y,
                            grid.width() - 1, grid.height() - 1,
@@ -443,7 +469,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from low/low:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(router, sampled_delta_delays,
                            low_x, low_y,
                            low_x, low_y,
                            grid.width() - 1, grid.height() - 1,
@@ -455,7 +481,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from high/high:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(router, sampled_delta_delays,
                            high_x, high_y,
                            0, 0,
                            high_x, high_y,
@@ -467,7 +493,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from high/low:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(router, sampled_delta_delays,
                            high_x, low_y,
                            0, low_y,
                            high_x, grid.height() - 1,
@@ -479,7 +505,7 @@ static vtr::Matrix<float> compute_delta_delays(const t_placer_opts& placer_opts,
 #ifdef VERBOSE
     VTR_LOG("Computing from low/high:\n");
 #endif
-    generic_compute_matrix(sampled_delta_delays,
+    generic_compute_matrix(router, sampled_delta_delays,
                            low_x, high_y,
                            low_x, 0,
                            grid.width() - 1, high_y,
@@ -626,9 +652,13 @@ static void fill_impossible_coordinates(vtr::Matrix<float>& delta_delays) {
     }
 }
 
-static vtr::Matrix<float> compute_delta_delay_model(const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, int longest_length) {
+static vtr::Matrix<float> compute_delta_delay_model(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        bool measure_directconnect, int longest_length) {
     vtr::ScopedStartFinishTimer timer("Computing delta delays");
-    vtr::Matrix<float> delta_delays = compute_delta_delays(placer_opts, router_opts, measure_directconnect, longest_length);
+    vtr::Matrix<float> delta_delays = compute_delta_delays(router,
+            placer_opts, router_opts, measure_directconnect, longest_length);
 
     fix_uninitialized_coordinates(delta_delays);
 
@@ -761,7 +791,9 @@ static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays) {
     return true;
 }
 
-static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model) {
+static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(
+        const RouterDelayProfile & router,
+        const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model) {
     auto delay_model = std::make_unique<OverrideDelayModel>(std::move(base_model), router_opts);
 
     t_router_opts router_opts2 = router_opts;
@@ -824,7 +856,7 @@ static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(const t_
             VTR_ASSERT(sink_rr != OPEN);
 
             float direct_connect_delay = std::numeric_limits<float>::quiet_NaN();
-            bool found_routing_path = calculate_delay(src_rr, sink_rr, router_opts2, &direct_connect_delay);
+            bool found_routing_path = router.calculate_delay(src_rr, sink_rr, router_opts2, &direct_connect_delay);
 
             if (found_routing_path) {
                 delay_model->set_delay_override(from_type->index, from_pin_class, to_type->index, to_pin_class, direct->x_offset, direct->y_offset, direct_connect_delay);

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -106,10 +106,6 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
                                                  int* src_rr,
                                                  int* sink_rr);
 
-static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(
-        const RouterDelayProfile & router,
-        const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model);
-
 static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays);
 
 static int get_longest_segment_length(std::vector<t_segment_inf>& segment_inf);
@@ -147,26 +143,54 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
 
     /*now setup and compute the actual arrays */
     std::unique_ptr<PlaceDelayModel> place_delay_model;
-    if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA
-        || placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
-        bool measure_directconnect = (placer_opts.delay_model_type != PlaceDelayModelType::DELTA_OVERRIDE);
-
-        auto delta_delays = compute_delta_delay_model(router, placer_opts, router_opts, measure_directconnect, longest_length);
-        place_delay_model = std::make_unique<DeltaDelayModel>(std::move(delta_delays), router_opts);
-
+    if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA) {
+        place_delay_model = std::make_unique<DeltaDelayModel>();
+    } else if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
+        place_delay_model = std::make_unique<OverrideDelayModel>();
     } else {
         VTR_ASSERT_MSG(false, "Invalid placer delay model");
     }
 
-    if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {
-        //Override direct-connect delays
-        place_delay_model = compute_override_delay_model(router, router_opts, std::move(place_delay_model));
+    if(placer_opts.read_placement_delay_lookup.empty()) {
+        place_delay_model->compute(router, placer_opts, router_opts, longest_length);
+    } else {
+        place_delay_model->read(placer_opts.read_placement_delay_lookup);
+    }
+
+    if(!placer_opts.write_placement_delay_lookup.empty()) {
+        place_delay_model->write(placer_opts.write_placement_delay_lookup);
     }
 
     /*free all data structures that are no longer needed */
     free_routing_structs();
 
     return place_delay_model;
+}
+
+void DeltaDelayModel::compute(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        int longest_length) {
+    router_opts_ = router_opts;
+    delays_ = compute_delta_delay_model(
+        router,
+        placer_opts, router_opts, /*measure_directconnect=*/true,
+        longest_length);
+}
+
+void OverrideDelayModel::compute(
+        const RouterDelayProfile & router,
+        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
+        int longest_length) {
+    router_opts_ = router_opts;
+    auto delays = compute_delta_delay_model(
+        router,
+        placer_opts, router_opts, /*measure_directconnect=*/false,
+        longest_length);
+
+    base_delay_model_ = std::make_unique<DeltaDelayModel>(delays, router_opts);
+
+    compute_override_delay_model(router);
 }
 
 /******* File Accessible Functions **********/
@@ -791,12 +815,8 @@ static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays) {
     return true;
 }
 
-static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(
-        const RouterDelayProfile & router,
-        const t_router_opts& router_opts, std::unique_ptr<PlaceDelayModel> base_model) {
-    auto delay_model = std::make_unique<OverrideDelayModel>(std::move(base_model), router_opts);
-
-    t_router_opts router_opts2 = router_opts;
+void OverrideDelayModel::compute_override_delay_model(const RouterDelayProfile & router) {
+    t_router_opts router_opts2 = router_opts_;
     router_opts2.astar_fac = 0.;
 
     //Look at all the direct connections that exist, and add overrides to delay model
@@ -859,7 +879,7 @@ static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(
             bool found_routing_path = router.calculate_delay(src_rr, sink_rr, router_opts2, &direct_connect_delay);
 
             if (found_routing_path) {
-                delay_model->set_delay_override(from_type->index, from_pin_class, to_type->index, to_pin_class, direct->x_offset, direct->y_offset, direct_connect_delay);
+                set_delay_override(from_type->index, from_pin_class, to_type->index, to_pin_class, direct->x_offset, direct->y_offset, direct_connect_delay);
             } else {
                 ++missing_paths;
             }
@@ -871,8 +891,6 @@ static std::unique_ptr<OverrideDelayModel> compute_override_delay_model(
         VTR_LOGV_WARN(missing_instances > 0, "Found no delta delay for %d bits of inter-block direct connect '%s' (no instances of this direct found)\n", missing_instances, direct->name);
         VTR_LOGV_WARN(missing_paths > 0, "Found no delta delay for %d bits of inter-block direct connect '%s' (no routing path found)\n", missing_paths, direct->name);
     }
-
-    return delay_model;
 }
 
 bool directconnect_exists(int src_rr_node, int sink_rr_node) {

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -70,31 +70,41 @@ static t_chan_width setup_chan_width(const t_router_opts& router_opts,
                                      t_chan_width_dist chan_width_dist);
 
 static float route_connection_delay(
-        const RouterDelayProfile & router, int source_x_loc, int source_y_loc,
-        int sink_x_loc, int sink_y_loc, const t_router_opts &router_opts,
-        bool measure_directconnect);
+    const RouterDelayProfile& router,
+    int source_x_loc,
+    int source_y_loc,
+    int sink_x_loc,
+    int sink_y_loc,
+    const t_router_opts &router_opts,
+    bool measure_directconnect);
 
 static void generic_compute_matrix(
-                                   const RouterDelayProfile & router,
-                                   vtr::Matrix<std::vector<float>>& matrix,
-                                   int source_x,
-                                   int source_y,
-                                   int start_x,
-                                   int start_y,
-                                   int end_x,
-                                   int end_y,
-                                   const t_router_opts& router_opts,
-                                   bool measure_directconnect);
+    const RouterDelayProfile& router,
+    vtr::Matrix<std::vector<float>>& matrix,
+    int source_x,
+    int source_y,
+    int start_x,
+    int start_y,
+    int end_x,
+    int end_y,
+    const t_router_opts &router_opts,
+    bool measure_directconnect);
 
 static vtr::Matrix<float> compute_delta_delays(
-        const RouterDelayProfile & router,
-        const t_placer_opts& palcer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length);
+    const RouterDelayProfile& router,
+    const t_placer_opts& palcer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    size_t longest_length);
 
 float delay_reduce(std::vector<float>& delays, e_reducer reducer);
 
 static vtr::Matrix<float> compute_delta_delay_model(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, int longest_length);
+    const RouterDelayProfile& router,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    int longest_length);
 
 static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
                                                  t_type_ptr from_type,
@@ -134,10 +144,10 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
                           directs, num_directs);
 
     RouterDelayProfile router(
-            router_opts.lookahead_type,
-            router_opts.write_lookahead,
-            router_opts.read_lookahead,
-            segment_inf);
+        router_opts.lookahead_type,
+        router_opts.write_lookahead,
+        router_opts.read_lookahead,
+        segment_inf);
 
     int longest_length = get_longest_segment_length(segment_inf);
 
@@ -151,13 +161,13 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
         VTR_ASSERT_MSG(false, "Invalid placer delay model");
     }
 
-    if(placer_opts.read_placement_delay_lookup.empty()) {
+    if (placer_opts.read_placement_delay_lookup.empty()) {
         place_delay_model->compute(router, placer_opts, router_opts, longest_length);
     } else {
         place_delay_model->read(placer_opts.read_placement_delay_lookup);
     }
 
-    if(!placer_opts.write_placement_delay_lookup.empty()) {
+    if (!placer_opts.write_placement_delay_lookup.empty()) {
         place_delay_model->write(placer_opts.write_placement_delay_lookup);
     }
 
@@ -168,9 +178,10 @@ std::unique_ptr<PlaceDelayModel> compute_place_delay_model(const t_placer_opts& 
 }
 
 void DeltaDelayModel::compute(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
-        int longest_length) {
+    const RouterDelayProfile& router,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    int longest_length) {
     router_opts_ = router_opts;
     delays_ = compute_delta_delay_model(
         router,
@@ -179,9 +190,10 @@ void DeltaDelayModel::compute(
 }
 
 void OverrideDelayModel::compute(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
-        int longest_length) {
+    const RouterDelayProfile& router,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    int longest_length) {
     router_opts_ = router_opts;
     auto delays = compute_delta_delay_model(
         router,
@@ -271,9 +283,13 @@ static t_chan_width setup_chan_width(const t_router_opts& router_opts,
 }
 
 static float route_connection_delay(
-        const RouterDelayProfile & router, int source_x, int source_y,
-        int sink_x, int sink_y, const t_router_opts &router_opts,
-        bool measure_directconnect) {
+    const RouterDelayProfile& router,
+    int source_x,
+    int source_y,
+    int sink_x,
+    int sink_y,
+    const t_router_opts &router_opts,
+    bool measure_directconnect) {
     //Routes between the source and sink locations and calculates the delay
 
     float net_delay_value = IMPOSSIBLE_DELTA; /*set to known value for debug purposes */
@@ -307,8 +323,8 @@ static float route_connection_delay(
 
             {
                 successfully_routed = router.calculate_delay(source_rr_node, sink_rr_node,
-                                                      router_opts,
-                                                      &net_delay_value);
+                                                             router_opts,
+                                                             &net_delay_value);
             }
 
             if (successfully_routed) break;
@@ -325,16 +341,16 @@ static float route_connection_delay(
 }
 
 static void generic_compute_matrix(
-                                   const RouterDelayProfile & router,
-                                   vtr::Matrix<std::vector<float>>& matrix,
-                                   int source_x,
-                                   int source_y,
-                                   int start_x,
-                                   int start_y,
-                                   int end_x,
-                                   int end_y,
-                                   const t_router_opts& router_opts,
-                                   bool measure_directconnect) {
+    const RouterDelayProfile& router,
+    vtr::Matrix<std::vector<float>>& matrix,
+    int source_x,
+    int source_y,
+    int start_x,
+    int start_y,
+    int end_x,
+    int end_y,
+    const t_router_opts &router_opts,
+    bool measure_directconnect) {
     int delta_x, delta_y;
     int sink_x, sink_y;
 
@@ -388,8 +404,11 @@ static void generic_compute_matrix(
 }
 
 static vtr::Matrix<float> compute_delta_delays(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts, bool measure_directconnect, size_t longest_length) {
+    const RouterDelayProfile& router,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    size_t longest_length) {
     //To avoid edge effects we place the source at least 'longest_length' away
     //from the device edge
     //and route from there for all possible delta values < dimension
@@ -677,12 +696,14 @@ static void fill_impossible_coordinates(vtr::Matrix<float>& delta_delays) {
 }
 
 static vtr::Matrix<float> compute_delta_delay_model(
-        const RouterDelayProfile & router,
-        const t_placer_opts& placer_opts, const t_router_opts& router_opts,
-        bool measure_directconnect, int longest_length) {
+    const RouterDelayProfile& router,
+    const t_placer_opts& placer_opts,
+    const t_router_opts& router_opts,
+    bool measure_directconnect,
+    int longest_length) {
     vtr::ScopedStartFinishTimer timer("Computing delta delays");
     vtr::Matrix<float> delta_delays = compute_delta_delays(router,
-            placer_opts, router_opts, measure_directconnect, longest_length);
+                                                           placer_opts, router_opts, measure_directconnect, longest_length);
 
     fix_uninitialized_coordinates(delta_delays);
 
@@ -815,7 +836,7 @@ static bool verify_delta_delays(const vtr::Matrix<float>& delta_delays) {
     return true;
 }
 
-void OverrideDelayModel::compute_override_delay_model(const RouterDelayProfile & router) {
+void OverrideDelayModel::compute_override_delay_model(const RouterDelayProfile& router) {
     t_router_opts router_opts2 = router_opts_;
     router_opts2.astar_fac = 0.;
 

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -318,6 +318,7 @@ bool try_route(int width_fac,
 
         success = try_timing_driven_route(router_opts,
                                           analysis_opts,
+                                          segment_inf,
                                           net_delay,
                                           netlist_pin_lookup,
                                           timing_info,

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -737,7 +737,7 @@ float get_rr_cong_cost(int inode) {
     return (cost);
 }
 
-/* Returns the congestion cost of using this rr_node, *ignoring* 
+/* Returns the congestion cost of using this rr_node, *ignoring*
  * non-configurable edges */
 static float get_single_rr_cong_cost(int inode) {
     auto& device_ctx = g_vpr_ctx.device();
@@ -1116,7 +1116,7 @@ t_bb load_net_route_bb(ClusterNetId net_id, int bb_factor) {
      * the FPGA if necessary.  The bounding box returned by this routine
      * are different from the ones used by the placer in that they are
      * clipped to lie within (0,0) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1)
-     * rather than (1,1) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1).                                                            
+     * rather than (1,1) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1).
      */
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& device_ctx = g_vpr_ctx.device();
@@ -1902,4 +1902,21 @@ static bool validate_trace_nodes(t_trace* head, const std::unordered_set<int>& t
     }
 
     return true;
+}
+
+// True if router will use a lookahead.
+//
+// This controls whether the router lookahead cache will be primed outside of
+// the router ScopedStartFinishTimer.
+bool router_needs_lookahead(enum e_router_algorithm router_algorithm) {
+    switch (router_algorithm) {
+        case BREADTH_FIRST:
+        case NO_TIMING:
+            return false;
+        case TIMING_DRIVEN:
+            return true;
+        default:
+            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Unknown routing algorithm %d",
+                            router_algorithm);
+    }
 }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -237,7 +237,6 @@ void try_graph(int width_fac, const t_router_opts& router_opts, t_det_routing_ar
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     directs, num_directs,
                     &warning_count);
 }
@@ -289,7 +288,6 @@ bool try_route(int width_fac,
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     directs, num_directs,
                     &warning_count);
 

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -126,3 +126,5 @@ void print_invalid_routing_info();
 
 t_trace* alloc_trace_data();
 void free_trace_data(t_trace* trace);
+
+bool router_needs_lookahead(enum e_router_algorithm router_algorithm);

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -355,7 +355,7 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
 
     route_budgets budgeting_inf;
 
-    auto router_lookahead = make_router_lookahead(
+    const auto* router_lookahead = get_cached_router_lookahead(
         router_opts.lookahead_type,
         router_opts.write_router_lookahead,
         router_opts.read_router_lookahead,

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -357,8 +357,8 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
 
     auto router_lookahead = make_router_lookahead(
         router_opts.lookahead_type,
-        router_opts.write_lookahead,
-        router_opts.read_lookahead,
+        router_opts.write_router_lookahead,
+        router_opts.read_router_lookahead,
         segment_inf);
 
     /*
@@ -1372,7 +1372,9 @@ std::vector<t_heap> timing_driven_find_all_shortest_paths_from_route_tree(t_rt_n
                                                                           RouterStats& router_stats) {
     //Add the route tree to the heap with no specific target node
     int target_node = OPEN;
-    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP, "", "", {});
+    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP,
+                                                  /*write_lookahead=*/"", /*read_lookahead=*/"",
+                                                  /*segment_inf=*/{});
     add_route_tree_to_heap(rt_root, target_node, cost_params, *router_lookahead, router_stats);
     heap_::build_heap(); // via sifting down everything
 
@@ -1392,7 +1394,9 @@ static std::vector<t_heap> timing_driven_find_all_shortest_paths_from_heap(const
                                                                            t_bb bounding_box,
                                                                            std::vector<int>& modified_rr_node_inf,
                                                                            RouterStats& router_stats) {
-    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP, "", "", {});
+    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP,
+                                                  /*write_lookahead=*/"", /*read_lookahead=*/"",
+                                                  /*segment_inf=*/{});
 
     auto& device_ctx = g_vpr_ctx.device();
     std::vector<t_heap> cheapest_paths(device_ctx.rr_nodes.size());

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -356,10 +356,10 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
     route_budgets budgeting_inf;
 
     auto router_lookahead = make_router_lookahead(
-            router_opts.lookahead_type,
-            router_opts.write_lookahead,
-            router_opts.read_lookahead,
-            segment_inf);
+        router_opts.lookahead_type,
+        router_opts.write_lookahead,
+        router_opts.read_lookahead,
+        segment_inf);
 
     /*
      * Routing parameters

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -300,6 +300,7 @@ static void generate_route_timing_reports(const t_router_opts& router_opts,
 /************************ Subroutine definitions *****************************/
 bool try_timing_driven_route(const t_router_opts& router_opts,
                              const t_analysis_opts& analysis_opts,
+                             const std::vector<t_segment_inf>& segment_inf,
                              vtr::vector<ClusterNetId, float*>& net_delay,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                              std::shared_ptr<SetupHoldTimingInfo> timing_info,
@@ -354,7 +355,11 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
 
     route_budgets budgeting_inf;
 
-    auto router_lookahead = make_router_lookahead(router_opts.lookahead_type);
+    auto router_lookahead = make_router_lookahead(
+            router_opts.lookahead_type,
+            router_opts.write_lookahead,
+            router_opts.read_lookahead,
+            segment_inf);
 
     /*
      * Routing parameters
@@ -1367,7 +1372,7 @@ std::vector<t_heap> timing_driven_find_all_shortest_paths_from_route_tree(t_rt_n
                                                                           RouterStats& router_stats) {
     //Add the route tree to the heap with no specific target node
     int target_node = OPEN;
-    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP);
+    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP, "", "", {});
     add_route_tree_to_heap(rt_root, target_node, cost_params, *router_lookahead, router_stats);
     heap_::build_heap(); // via sifting down everything
 
@@ -1387,7 +1392,7 @@ static std::vector<t_heap> timing_driven_find_all_shortest_paths_from_heap(const
                                                                            t_bb bounding_box,
                                                                            std::vector<int>& modified_rr_node_inf,
                                                                            RouterStats& router_stats) {
-    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP);
+    auto router_lookahead = make_router_lookahead(e_router_lookahead::NO_OP, "", "", {});
 
     auto& device_ctx = g_vpr_ctx.device();
     std::vector<t_heap> cheapest_paths(device_ctx.rr_nodes.size());

--- a/vpr/src/route/route_timing.h
+++ b/vpr/src/route/route_timing.h
@@ -15,6 +15,7 @@ int get_max_pins_per_net();
 
 bool try_timing_driven_route(const t_router_opts& router_opts,
                              const t_analysis_opts& analysis_opts,
+                             const std::vector<t_segment_inf>& segment_inf,
                              vtr::vector<ClusterNetId, float*>& net_delay,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                              std::shared_ptr<SetupHoldTimingInfo> timing_info,

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -10,17 +10,16 @@
 static t_rt_node* setup_routing_resources_no_net(int source_node);
 
 RouterDelayProfile::RouterDelayProfile(
-        e_router_lookahead router_lookahead_type,
-        std::string write_lookahead,
-        std::string read_lookahead,
-        const std::vector<t_segment_inf>& segment_inf) {
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf) {
     router_lookahead_ = make_router_lookahead(
-            router_lookahead_type,
-            write_lookahead, read_lookahead, segment_inf);
+        router_lookahead_type,
+        write_lookahead, read_lookahead, segment_inf);
 }
 
-bool RouterDelayProfile::calculate_delay(int source_node, int sink_node,
-        const t_router_opts& router_opts, float* net_delay) const {
+bool RouterDelayProfile::calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const {
     /* Returns true as long as found some way to hook up this net, even if that *
      * way resulted in overuse of resources (congestion).  If there is no way   *
      * to route this net, even ignoring congestion, it returns false.  In this  *
@@ -53,8 +52,8 @@ bool RouterDelayProfile::calculate_delay(int source_node, int sink_node,
     std::vector<int> modified_rr_node_inf;
     RouterStats router_stats;
     t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root,
-            sink_node, cost_params, bounding_box, *router_lookahead_,
-            modified_rr_node_inf, router_stats);
+                                                                      sink_node, cost_params, bounding_box, *router_lookahead_,
+                                                                      modified_rr_node_inf, router_stats);
 
     bool found_path = (cheapest != nullptr);
     if (found_path) {

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -9,7 +9,7 @@
 
 static t_rt_node* setup_routing_resources_no_net(int source_node);
 
-RouterDelayProfile::RouterDelayProfile(
+RouterDelayProfiler::RouterDelayProfiler(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
     std::string read_lookahead,
@@ -19,7 +19,7 @@ RouterDelayProfile::RouterDelayProfile(
         write_lookahead, read_lookahead, segment_inf);
 }
 
-bool RouterDelayProfile::calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const {
+bool RouterDelayProfiler::calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const {
     /* Returns true as long as found some way to hook up this net, even if that *
      * way resulted in overuse of resources (congestion).  If there is no way   *
      * to route this net, even ignoring congestion, it returns false.  In this  *

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -10,14 +10,8 @@
 static t_rt_node* setup_routing_resources_no_net(int source_node);
 
 RouterDelayProfiler::RouterDelayProfiler(
-    e_router_lookahead router_lookahead_type,
-    std::string write_lookahead,
-    std::string read_lookahead,
-    const std::vector<t_segment_inf>& segment_inf) {
-    router_lookahead_ = make_router_lookahead(
-        router_lookahead_type,
-        write_lookahead, read_lookahead, segment_inf);
-}
+    const RouterLookahead* lookahead)
+    : router_lookahead_(lookahead) {}
 
 bool RouterDelayProfiler::calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const {
     /* Returns true as long as found some way to hook up this net, even if that *

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -196,7 +196,6 @@ void alloc_routing_structs(t_chan_width chan_width,
                     router_opts.trim_empty_channels,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
-                    router_opts.lookahead_type,
                     directs, num_directs,
                     &warnings);
 

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -1,8 +1,19 @@
 #include "vpr_types.h"
+#include "router_lookahead.h"
 
 #include <vector>
 
-bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay);
+class RouterDelayProfile {
+public:
+    RouterDelayProfile(
+        e_router_lookahead router_lookahead_type,
+        std::string write_lookahead,
+        std::string read_lookahead,
+        const std::vector<t_segment_inf>& segment_inf);
+    bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const;
+private:
+    std::unique_ptr<RouterLookahead> router_lookahead_;
+};
 
 std::vector<float> calculate_all_path_delays_from_rr_node(int src_rr_node, const t_router_opts& router_opts);
 

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -7,14 +7,15 @@
 #include <vector>
 
 class RouterDelayProfile {
-public:
+  public:
     RouterDelayProfile(
         e_router_lookahead router_lookahead_type,
         std::string write_lookahead,
         std::string read_lookahead,
         const std::vector<t_segment_inf>& segment_inf);
     bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const;
-private:
+
+  private:
     std::unique_ptr<RouterLookahead> router_lookahead_;
 };
 

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -1,3 +1,6 @@
+#ifndef ROUTER_DELAY_PROFILING_H_
+#define ROUTER_DELAY_PROFILING_H_
+
 #include "vpr_types.h"
 #include "router_lookahead.h"
 
@@ -25,3 +28,5 @@ void alloc_routing_structs(t_chan_width chan_width,
                            const int num_directs);
 
 void free_routing_structs();
+
+#endif /* ROUTER_DELAY_PROFILING_H_ */

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -8,15 +8,11 @@
 
 class RouterDelayProfiler {
   public:
-    RouterDelayProfiler(
-        e_router_lookahead router_lookahead_type,
-        std::string write_lookahead,
-        std::string read_lookahead,
-        const std::vector<t_segment_inf>& segment_inf);
+    RouterDelayProfiler(const RouterLookahead* lookahead);
     bool calculate_delay(int source_node, int sink_node, const t_router_opts& router_opts, float* net_delay) const;
 
   private:
-    std::unique_ptr<RouterLookahead> router_lookahead_;
+    const RouterLookahead* router_lookahead_;
 };
 
 std::vector<float> calculate_all_path_delays_from_rr_node(int src_rr_node, const t_router_opts& router_opts);

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -6,9 +6,9 @@
 
 #include <vector>
 
-class RouterDelayProfile {
+class RouterDelayProfiler {
   public:
-    RouterDelayProfile(
+    RouterDelayProfiler(
         e_router_lookahead router_lookahead_type,
         std::string write_lookahead,
         std::string read_lookahead,

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -22,22 +22,21 @@ static std::unique_ptr<RouterLookahead> make_router_lookahead_object(e_router_lo
 }
 
 std::unique_ptr<RouterLookahead> make_router_lookahead(
-        e_router_lookahead router_lookahead_type,
-        std::string write_lookahead,
-        std::string read_lookahead,
-        const std::vector<t_segment_inf>& segment_inf) {
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf) {
     std::unique_ptr<RouterLookahead> router_lookahead = make_router_lookahead_object(router_lookahead_type);
 
-    if(read_lookahead.empty()) {
+    if (read_lookahead.empty()) {
         router_lookahead->compute(segment_inf);
     } else {
         router_lookahead->read(read_lookahead);
     }
 
-    if(!write_lookahead.empty()) {
+    if (!write_lookahead.empty()) {
         router_lookahead->write(write_lookahead);
     }
-
 
     return std::move(router_lookahead);
 }

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -37,16 +37,13 @@ std::unique_ptr<RouterLookahead> make_router_lookahead(
 class ClassicLookahead : public RouterLookahead {
   public:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    void compute(const std::vector<t_segment_inf>& segment_inf) override {
-        (void)segment_inf;
+    void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
     }
 
-    void read(const std::string& file) override {
-        (void)file;
+    void read(const std::string& /*file*/) override {
         VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::read unimplemented");
     }
-    void write(const std::string& file) const override {
-        (void)file;
+    void write(const std::string& /*file*/) const override {
         VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::write unimplemented");
     }
 
@@ -58,12 +55,10 @@ class MapLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
     void compute(const std::vector<t_segment_inf>& segment_inf) override;
-    void read(const std::string& file) override {
-        (void)file;
+    void read(const std::string& /*file*/) override {
         VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read unimplemented");
     }
-    void write(const std::string& file) const override {
-        (void)file;
+    void write(const std::string& /*file*/) const override {
         VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write unimplemented");
     }
 };
@@ -71,14 +66,13 @@ class MapLookahead : public RouterLookahead {
 class NoOpLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    void compute(const std::vector<t_segment_inf>& segment_inf) override {
-        (void)segment_inf;
+    void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
     }
-    void read(const std::string& file) override {
-        (void)file;
+    void read(const std::string& /*file*/) override {
+        VPR_THROW(VPR_ERROR_ROUTE, "Read not supported for NoOpLookahead");
     }
-    void write(const std::string& file) const override {
-        (void)file;
+    void write(const std::string& /*file*/) const override {
+        VPR_THROW(VPR_ERROR_ROUTE, "Write not supported for NoOpLookahead");
     }
 };
 

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -2,21 +2,41 @@
 #define VPR_ROUTER_LOOKAHEAD_H
 #include <memory>
 #include "vpr_types.h"
+#include "vpr_error.h"
 
 struct t_conn_cost_params; //Forward declaration
 
 class RouterLookahead {
   public:
     virtual float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
+    virtual void compute(const std::vector<t_segment_inf>& segment_inf) = 0;
+    virtual void read(const std::string &file) = 0;
+    virtual void write(const std::string &file) const = 0;
 
     virtual ~RouterLookahead() {}
 };
 
-std::unique_ptr<RouterLookahead> make_router_lookahead(e_router_lookahead router_lookahead_type);
+std::unique_ptr<RouterLookahead> make_router_lookahead(
+        e_router_lookahead router_lookahead_type,
+        std::string write_lookahead,
+        std::string read_lookahead,
+        const std::vector<t_segment_inf>& segment_inf);
 
 class ClassicLookahead : public RouterLookahead {
   public:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& segment_inf) override {
+        (void)segment_inf;
+    }
+
+    void read(const std::string &file) override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::read unimplemented");
+    }
+    void write(const std::string &file) const override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::write unimplemented");
+    }
 
   private:
     float classic_wire_lookahead_cost(int node, int target_node, float criticality, float R_upstream) const;
@@ -25,11 +45,29 @@ class ClassicLookahead : public RouterLookahead {
 class MapLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+    void read(const std::string &file) override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read unimplemented");
+    }
+    void write(const std::string &file) const override {
+        (void)file;
+        VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write unimplemented");
+    }
 };
 
 class NoOpLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    void compute(const std::vector<t_segment_inf>& segment_inf) override {
+        (void)segment_inf;
+    }
+    void read(const std::string &file) override {
+        (void)file;
+    }
+    void write(const std::string &file) const override {
+        (void)file;
+    }
 };
 
 #endif

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -28,7 +28,24 @@ class RouterLookahead {
     virtual ~RouterLookahead() {}
 };
 
+// Force creation of lookahead object.
+//
+// This may involve recomputing the lookahead, so only use if lookahead cache
+// cannot be used.
 std::unique_ptr<RouterLookahead> make_router_lookahead(
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf);
+
+// Clear router lookahead cache (e.g. when changing or free rrgraph).
+void invalidate_router_lookahead_cache();
+
+// Returns lookahead for given rr graph.
+//
+// Object is cached in RouterContext, but access to cached object should
+// performed via this function.
+const RouterLookahead* get_cached_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
     std::string read_lookahead,

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -8,19 +8,31 @@ struct t_conn_cost_params; //Forward declaration
 
 class RouterLookahead {
   public:
+    // Get expected cost from node to target_node.
+    //
+    // Either compute or read methods must be invoked before invoking
+    // get_expected_cost.
     virtual float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
+
+    // Compute router lookahead (if needed).
     virtual void compute(const std::vector<t_segment_inf>& segment_inf) = 0;
-    virtual void read(const std::string &file) = 0;
-    virtual void write(const std::string &file) const = 0;
+
+    // Read router lookahead data (if any) from specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void read(const std::string& file) = 0;
+
+    // Write router lookahead data (if any) to specified file.
+    // May be unimplemented, in which case method should throw an exception.
+    virtual void write(const std::string& file) const = 0;
 
     virtual ~RouterLookahead() {}
 };
 
 std::unique_ptr<RouterLookahead> make_router_lookahead(
-        e_router_lookahead router_lookahead_type,
-        std::string write_lookahead,
-        std::string read_lookahead,
-        const std::vector<t_segment_inf>& segment_inf);
+    e_router_lookahead router_lookahead_type,
+    std::string write_lookahead,
+    std::string read_lookahead,
+    const std::vector<t_segment_inf>& segment_inf);
 
 class ClassicLookahead : public RouterLookahead {
   public:
@@ -29,11 +41,11 @@ class ClassicLookahead : public RouterLookahead {
         (void)segment_inf;
     }
 
-    void read(const std::string &file) override {
+    void read(const std::string& file) override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::read unimplemented");
     }
-    void write(const std::string &file) const override {
+    void write(const std::string& file) const override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "ClassicLookahead::write unimplemented");
     }
@@ -46,11 +58,11 @@ class MapLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
     void compute(const std::vector<t_segment_inf>& segment_inf) override;
-    void read(const std::string &file) override {
+    void read(const std::string& file) override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read unimplemented");
     }
-    void write(const std::string &file) const override {
+    void write(const std::string& file) const override {
         (void)file;
         VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write unimplemented");
     }
@@ -62,10 +74,10 @@ class NoOpLookahead : public RouterLookahead {
     void compute(const std::vector<t_segment_inf>& segment_inf) override {
         (void)segment_inf;
     }
-    void read(const std::string &file) override {
+    void read(const std::string& file) override {
         (void)file;
     }
-    void write(const std::string &file) const override {
+    void write(const std::string& file) const override {
         (void)file;
     }
 };

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -380,10 +380,6 @@ void create_rr_graph(const t_graph_type graph_type,
 
     print_rr_graph_stats();
 
-    if (router_lookahead_type == e_router_lookahead::MAP) {
-        compute_router_lookahead(segment_inf.size());
-    }
-
     //Write out rr graph file if needed
     if (!det_routing_arch->write_rr_graph_filename.empty()) {
         write_rr_graph(det_routing_arch->write_rr_graph_filename.c_str(), segment_inf);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1381,6 +1381,8 @@ void free_rr_graph() {
     device_ctx.rr_node_metadata.clear();
 
     device_ctx.rr_edge_metadata.clear();
+
+    invalidate_router_lookahead_cache();
 }
 
 static void build_rr_sinks_sources(const int i,

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -322,7 +322,6 @@ void create_rr_graph(const t_graph_type graph_type,
                      const bool trim_empty_channels,
                      const bool trim_obs_channels,
                      const enum e_clock_modeling clock_modeling,
-                     const e_router_lookahead router_lookahead_type,
                      const t_direct_inf* directs,
                      const int num_directs,
                      int* Warnings) {

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -37,7 +37,6 @@ void create_rr_graph(const t_graph_type graph_type,
                      const bool trim_empty_channels,
                      const bool trim_obs_channels,
                      const enum e_clock_modeling clock_modeling,
-                     const e_router_lookahead router_lookahead_type,
                      const t_direct_inf* directs,
                      const int num_directs,
                      int* Warnings);


### PR DESCRIPTION
#### Description

This PR restructures the router lookahead and placement delay objects to enable several goals:
 - Properly encapsulate existing functionality behind virtual interfaces
 - Provide command line arguments and virtual methods to read and write the router lookahead and placement delay objects
 - Avoid reconstruction of the router lookahead object during placement delay lookup

Once this PR is merged, a followup PR will be submitted to implement the read/write methods with a proposed serialization format.

#### Related Issue


#### Motivation and Context

The router lookahead computation and placement delay matrix computations can take a fairly significant amount of time.  For example (take from one of the titan bench marks, ``stratixiv_arch.timing.xml/gsm_switch_stratixiv_arch_timing.blif``):

```
## Computing router lookahead map
## Computing router lookahead map took 862.39 seconds (max_rss 7998.8 MiB, delta_rss +0.0 MiB)
# Create Device took 1146.56 seconds (max_rss 7998.8 MiB, delta_rss +1742.6 MiB)

# Placement
## Computing placement delta delay look-up
RR graph channel widths unchanged, skipping RR graph rebuild
### Computing delta delays
### Computing delta delays took 5395.12 seconds (max_rss 17405.8 MiB, delta_rss +9407.0 MiB)
## Computing placement delta delay look-up took 5396.87 seconds (max_rss 17405.8 MiB, delta_rss +9407.0 MiB)

...

VPR suceeded
The entire flow of VPR took 16719.29 seconds (max_rss 19437.3 MiB)
```

In this example, the router lookahead map computation took ~5% of the total runtime, and the delay matrix lookup took ~33% of the total runtime.  In terms of wall clock time, taking ~2 hrs before starting placement is less than ideal, especially if parameter tuning is being attempted.

#### How Has This Been Tested?

In theory this change is simply a refactor, so existing tests should pass with zero or minimal runtime impact.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
