### PR TITLE
Add flat accessors to NdMatrix.

### DIFF
--- a/libs/libvtrutil/src/vtr_ndmatrix.h
+++ b/libs/libvtrutil/src/vtr_ndmatrix.h
@@ -181,6 +181,17 @@ class NdMatrixBase {
         return dim_sizes_[i];
     }
 
+    // Flat accessors of NdMatrix
+    const T& get(size_t i) const {
+        VTR_ASSERT_SAFE(i < size_);
+        return data_[i];
+    }
+
+    T& get(size_t i) {
+        VTR_ASSERT_SAFE(i < size_);
+        return data_[i];
+    }
+
   public: //Mutators
     //Set all elements to 'value'
     void fill(T value) {


### PR DESCRIPTION
Flat accessors are useful for serialization (see #707).