### PR TITLE
Odin_II leak - Changed location of free call

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -2131,14 +2131,17 @@ void create_symbol_table_for_function(ast_node_t* function_items, char * module_
 int check_for_initial_reg_value(char * module_name, ast_node_t* var_declare, long *value){
 	oassert(var_declare->type == VAR_DECLARE);
 
-	ast_node_t *number_node = var_declare->children[5];
-	ast_node_t *resolved_number = resolve_node(NULL, module_name, number_node, NULL, 0);
+	ast_node_t *resolved_number = resolve_node(NULL, module_name, var_declare->children[5], NULL, 0);
 	// Initial value is always the last child, if one exists
 	if(resolved_number != NULL)
 	{
 		if(resolved_number->type == NUMBERS)
 		{
 			*value = resolved_number->types.vnumber->get_value();
+			if(resolved_number != var_declare->children[5])
+			{
+				resolved_number = free_whole_tree(resolved_number);
+			}
 			return true;
 		}
 		else
@@ -2146,10 +2149,6 @@ int check_for_initial_reg_value(char * module_name, ast_node_t* var_declare, lon
 			warning_message(NETLIST_ERROR, var_declare->line_number, var_declare->file_number, 
 				"%s", "Could not resolve initial assignement to a constant value, skipping\n");
 		}
-	}
-	if(resolved_number != number_node)
-	{
-		resolved_number = free_whole_tree(resolved_number);
 	}
 	return false;
 }


### PR DESCRIPTION
#### Description
This function was returning before reaching the free call, so the call was moved to be above the return call.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
