### PR TITLE
vpr: changed some VPR_THROW to VPR_ERROR

### DIFF
--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -963,7 +963,7 @@ static void recompute_costs_from_scratch(const t_placer_opts& placer_opts, const
     if (fabs(new_bb_cost - costs->bb_cost) > costs->bb_cost * ERROR_TOL) {
         std::string msg = vtr::string_fmt("in recompute_costs_from_scratch: new_bb_cost = %g, old bb_cost = %g\n",
                                           new_bb_cost, costs->bb_cost);
-        VPR_THROW(VPR_ERROR_PLACE, msg.c_str());
+        VPR_ERROR(VPR_ERROR_PLACE, msg.c_str());
     }
     costs->bb_cost = new_bb_cost;
 
@@ -973,7 +973,7 @@ static void recompute_costs_from_scratch(const t_placer_opts& placer_opts, const
         if (fabs(new_timing_cost - costs->timing_cost) > costs->timing_cost * ERROR_TOL) {
             std::string msg = vtr::string_fmt("in recompute_costs_from_scratch: new_timing_cost = %g, old timing_cost = %g, ERROR_TOL = %g\n",
                                               new_timing_cost, costs->timing_cost, ERROR_TOL);
-            VPR_THROW(VPR_ERROR_PLACE, msg.c_str());
+            VPR_ERROR(VPR_ERROR_PLACE, msg.c_str());
         }
         costs->timing_cost = new_timing_cost;
     } else {

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -118,7 +118,7 @@ void check_route(enum e_route_type route_type) {
             } else { //Continuing along existing branch
                 connects = check_adjacent(prev_node, inode);
                 if (!connects) {
-                    VPR_THROW(VPR_ERROR_ROUTE,
+                    VPR_ERROR(VPR_ERROR_ROUTE,
                               "in check_route: found non-adjacent segments in traceback while checking net %d:\n"
                               "  %s\n"
                               "  %s\n",

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -502,7 +502,7 @@ static void check_unbuffered_edges(int from_node) {
         }
 
         if (trans_matched == false) {
-            VPR_THROW(VPR_ERROR_ROUTE,
+            VPR_ERROR(VPR_ERROR_ROUTE,
                       "in check_unbuffered_edges:\n"
                       "connection from node %d to node %d uses an unbuffered switch (switch type %d '%s')\n"
                       "but there is no corresponding unbuffered switch edge in the other direction.\n",

--- a/vpr/src/util/vpr_error.cpp
+++ b/vpr/src/util/vpr_error.cpp
@@ -56,6 +56,7 @@ void vpr_throw_msg(enum e_vpr_error type,
 }
 
 void vpr_throw_opt(enum e_vpr_error type,
+                   const char* psz_func_pretty_name,
                    const char* psz_func_name,
                    const char* psz_file_name,
                    unsigned int line_num,
@@ -77,7 +78,7 @@ void vpr_throw_opt(enum e_vpr_error type,
 
     auto result = functions_to_demote.find(func_name);
     if (result != functions_to_demote.end()) {
-        VTR_LOGFF_WARN(psz_file_name, line_num, psz_func_name, msg.data());
+        VTR_LOGFF_WARN(psz_file_name, line_num, psz_func_pretty_name, msg.data());
     } else {
         vpr_throw_msg(type, psz_file_name, line_num, msg);
     }

--- a/vpr/src/util/vpr_error.h
+++ b/vpr/src/util/vpr_error.h
@@ -66,7 +66,7 @@ void map_error_activation_status(std::string function_name);
 [[noreturn]] void vvpr_throw(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, const char* psz_message, va_list args);
 [[noreturn]] void vpr_throw_msg(enum e_vpr_error type, const char* psz_file_name, unsigned int line_num, std::string msg);
 
-void vpr_throw_opt(enum e_vpr_error type, const char* psz_func_name, const char* psz_file_name, unsigned int line_num, const char* psz_message, ...);
+void vpr_throw_opt(enum e_vpr_error type, const char* psz_func_pretty_name, const char* psz_func_name, const char* psz_file_name, unsigned int line_num, const char* psz_message, ...);
 
 //Figure out what macro to use to get the name of the current function
 // We default to __func__ which is defined in C99
@@ -103,9 +103,9 @@ void vpr_throw_opt(enum e_vpr_error type, const char* psz_func_name, const char*
  * default stops the program, but may be suppressed (i.e. converted to a
  * warning).
  */
-#define VPR_ERROR(type, ...)                                                      \
-    do {                                                                          \
-        vpr_throw_opt(type, VPR_THROW_FUNCTION, __FILE__, __LINE__, __VA_ARGS__); \
+#define VPR_ERROR(type, ...)                                                                \
+    do {                                                                                    \
+        vpr_throw_opt(type, VPR_THROW_FUNCTION, __func__, __FILE__, __LINE__, __VA_ARGS__); \
     } while (false)
 
 #endif


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR follows changes in https://github.com/verilog-to-routing/vtr-verilog-to-routing/commit/93640d35613d989faea6c015c548be12bf76ce93.
It changes some VPR_THROWs to VPR_ERRORs to make them non-fatal and allow their disabling from command line.

An additional change of this PR is related to the usage of `__PRETTY_FUNCTION__`.
It is utilized only when displaying the error (demoted to warning), not for discerning what ERRORs need to be treated as WARNs, as the pretty function adds additional information to the string which, once compared with the function names of the command line option, cannot produce a match (making it impossible to demote errors to warnings from cmd line).

With this change, if g++ version is previous 99, __func__ and __PRETTY_FUNCTION__ in `vpr_throw_opt` function will have the same content, but it is necessary to duplicate them to make it possible to correctly compare the name of the calling function with the function name provided from cmd line.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As some VPR_THROWs can be treated as non-fatal, some of them should now be changed to be VPR_ERRORs instead.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
