### PR TITLE
ODIN II: fix 2D array bug

### DIFF
--- a/ODIN_II/SRC/parse_making_ast.cpp
+++ b/ODIN_II/SRC/parse_making_ast.cpp
@@ -609,7 +609,8 @@ ast_node_t *markAndProcessPortWith(ids top_type, ids port_id, ids net_id, ast_no
 			break;
 
 		case WIRE:
-			if (port->children[5] != NULL)
+			if ((port->num_children == 6 && port->children[5] != NULL)
+				|| (port->num_children == 8 && port->children[7] != NULL))
 			{
 				error_message(NETLIST_ERROR, port->line_number, port->file_number, "%s",
 									"Ports of type net cannot be initialized\n");
@@ -620,7 +621,8 @@ ast_node_t *markAndProcessPortWith(ids top_type, ids port_id, ids net_id, ast_no
 			break;
 
 		default:
-			if (port->children[5] != NULL)
+			if ((port->num_children == 6 && port->children[5] != NULL)
+				|| (port->num_children == 8 && port->children[7] != NULL))
 			{
 				error_message(NETLIST_ERROR, port->line_number, port->file_number, "%s",
 									"Ports with undefined type cannot be initialized\n");
@@ -838,7 +840,8 @@ ast_node_t *markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t *symbo
 					symbol_list->children[i] = markAndProcessPortWith(top_type, id, NO_ID, symbol_list->children[i], is_signed);
 					break;
 				case WIRE:
-					if (symbol_list->children[i]->children[5] != NULL)
+					if ((symbol_list->children[i]->num_children == 6 && symbol_list->children[i]->children[5] != NULL)
+						|| (symbol_list->children[i]->num_children == 8 && symbol_list->children[i]->children[7] != NULL))
 					{
 						error_message(NETLIST_ERROR, symbol_list->children[i]->line_number, symbol_list->children[i]->file_number, "%s",
 								"Nets cannot be initialized\n");
@@ -886,7 +889,8 @@ ast_node_t *markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t *symbo
 					symbol_list->children[i] = markAndProcessPortWith(top_type, id, NO_ID, symbol_list->children[i], is_signed);
 					break;
 				case WIRE:
-					if (symbol_list->children[i]->children[5] != NULL)
+					if ((symbol_list->children[i]->num_children == 6 && symbol_list->children[i]->children[5] != NULL)
+						|| (symbol_list->children[i]->num_children == 8 && symbol_list->children[i]->children[7] != NULL))
 					{
 						error_message(NETLIST_ERROR, symbol_list->children[i]->line_number, symbol_list->children[i]->file_number, "%s",
 								"Nets cannot be initialized\n");


### PR DESCRIPTION
#### Description
Fixed a bug that didn't allow 2D arrays to get through parsing.

#### How Has This Been Tested?
odin pre-commit regression suite

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
