### PR TITLE
Odin leak temp localparam list

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -214,6 +214,8 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 							temp_localparam_list = (ast_node_t**) vtr::realloc(temp_localparam_list, sizeof(ast_node_t*)*localparam_num);
 						
 						temp_localparam_list[localparam_num-1] = var_declare;
+						
+						vtr::free(temp_string);
 					}
 				}
 			}

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -214,8 +214,6 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 							temp_localparam_list = (ast_node_t**) vtr::realloc(temp_localparam_list, sizeof(ast_node_t*)*localparam_num);
 						
 						temp_localparam_list[localparam_num-1] = var_declare;
-						
-						vtr::free(temp_string);
 					}
 				}
 			}
@@ -368,6 +366,12 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 		}
 		vtr::free(temp_parameter_list);
 	}
+
+	if(temp_localparam_list)
+	{
+		vtr::free(temp_localparam_list);
+	}
+
 	vtr::free(local_string_cache_list);
 	vtr::free(parent_string_cache_list);
 


### PR DESCRIPTION
#### Description
Fix odin leak from create_param_table_for_module function where the temp_localparam_list was being allocated but not freed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
