### PR TITLE
Fixed leak caused by new_name

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -192,7 +192,7 @@ void declare_hard_adder(nnode_t *node)
  *-------------------------------------------------------------------------*/
 void instantiate_hard_adder(nnode_t *node, short mark, netlist_t * /*netlist*/)
 {
-	char *new_name;
+	char *new_name = NULL;
 	int len, sanity, i;
 
 	declare_hard_adder(node);
@@ -211,6 +211,8 @@ void instantiate_hard_adder(nnode_t *node, short mark, netlist_t * /*netlist*/)
 	if (len <= sanity) /* buffer not large enough */
 		oassert(false);
 
+	if(new_name)
+		vtr::free(new_name);
 	/* Give names to the output pins */
 	for (i = 0; i < node->num_output_pins;  i++)
 	{


### PR DESCRIPTION
#### Description
Fixed leak in adders.cpp caused by new_name not being freed before being reassigned

#### Related Issue
Issue #622

#### Motivation and Context
Fixes leak when ODIN is run with the following file:
##### Arch
vtr_flow/arch/timing/k6_frac_N10_frac_chain_mem32K_40nm.xml
##### Verilog
sha.v

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
