### PR TITLE
Odin leak in subtractions.cpp not_node[i]

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -192,7 +192,7 @@ void declare_hard_adder(nnode_t *node)
  *-------------------------------------------------------------------------*/
 void instantiate_hard_adder(nnode_t *node, short mark, netlist_t * /*netlist*/)
 {
-	char *new_name = NULL;
+	char *new_name;
 	int len, sanity, i;
 
 	declare_hard_adder(node);
@@ -211,8 +211,6 @@ void instantiate_hard_adder(nnode_t *node, short mark, netlist_t * /*netlist*/)
 	if (len <= sanity) /* buffer not large enough */
 		oassert(false);
 
-	if(new_name)
-		vtr::free(new_name);
 	/* Give names to the output pins */
 	for (i = 0; i < node->num_output_pins;  i++)
 	{

--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -192,7 +192,7 @@ void declare_hard_adder(nnode_t *node)
  *-------------------------------------------------------------------------*/
 void instantiate_hard_adder(nnode_t *node, short mark, netlist_t * /*netlist*/)
 {
-	char *new_name;
+	char *new_name = NULL;
 	int len, sanity, i;
 
 	declare_hard_adder(node);
@@ -211,6 +211,8 @@ void instantiate_hard_adder(nnode_t *node, short mark, netlist_t * /*netlist*/)
 	if (len <= sanity) /* buffer not large enough */
 		oassert(false);
 
+	if(new_name)
+		vtr::free(new_name);
 	/* Give names to the output pins */
 	for (i = 0; i < node->num_output_pins;  i++)
 	{

--- a/ODIN_II/SRC/subtractions.cpp
+++ b/ODIN_II/SRC/subtractions.cpp
@@ -140,7 +140,7 @@ void instantiate_hard_adder_subtraction(nnode_t *node, short mark, netlist_t * /
 
 	if (len <= sanity) /* buffer not large enough */
 		oassert(false);
-	
+
 	/* Give names to the output pins */
 	for (i = 0; i < node->num_output_pins;  i++)
 	{

--- a/ODIN_II/SRC/subtractions.cpp
+++ b/ODIN_II/SRC/subtractions.cpp
@@ -398,10 +398,12 @@ void split_adder_for_sub(nnode_t *nodeo, int a, int b, int sizea, int sizeb, int
 	for(i = 0; i < b; i++)
 	{
 		not_node[i] = allocate_nnode();
+		nnode_t *temp = not_node[i];
 		if(nodeo->num_input_port_sizes == 2)
 			not_node[i] = make_not_gate_with_input(nodeo->input_pins[a + i], not_node[i], -1);
 		else
 			not_node[i] = make_not_gate_with_input(nodeo->input_pins[i], not_node[i], -1);
+		free_nnode(temp);
 	}
 
 	for(i = 0; i < count; i++)

--- a/ODIN_II/SRC/subtractions.cpp
+++ b/ODIN_II/SRC/subtractions.cpp
@@ -140,7 +140,9 @@ void instantiate_hard_adder_subtraction(nnode_t *node, short mark, netlist_t * /
 
 	if (len <= sanity) /* buffer not large enough */
 		oassert(false);
-
+	
+	if(new_name)
+		vtr::free(new_name);
 	/* Give names to the output pins */
 	for (i = 0; i < node->num_output_pins;  i++)
 	{

--- a/ODIN_II/SRC/subtractions.cpp
+++ b/ODIN_II/SRC/subtractions.cpp
@@ -141,8 +141,6 @@ void instantiate_hard_adder_subtraction(nnode_t *node, short mark, netlist_t * /
 	if (len <= sanity) /* buffer not large enough */
 		oassert(false);
 	
-	if(new_name)
-		vtr::free(new_name);
 	/* Give names to the output pins */
 	for (i = 0; i < node->num_output_pins;  i++)
 	{


### PR DESCRIPTION
#### Description
Fixed memory leak in subtractions.cpp where not_node[i] was allocated and then reassigned without being freed.

#### Related Issue
Issue #622

#### Motivation and Context
Fixes leak when ODIN is run with the following file:

##### Arch
vtr_flow/arch/timing/k6_frac_N10_frac_chain_mem32K_40nm.xml

#####Verilog
sha.v

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
