### PR TITLE
ODIN_II leak Fix get_chunk_size_node

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -6193,5 +6193,7 @@ ast_node_t *get_chunk_size_node(char *instance_name_prefix, char *array_name, ST
 		array_size = ast_node_deep_copy((ast_node_t *)local_param_table_sc->data[sc_spot]);
 	}
 
+	vtr::free(temp_string);
+
 	return array_size;
 }


### PR DESCRIPTION
#### Description
Fixes leak from temp_string being allocated and going out of scope before being freed.

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
