### PR TITLE
ODIN_II: Fix coverity issue CID 200634

### DIFF
--- a/ODIN_II/SRC/odin_error.cpp
+++ b/ODIN_II/SRC/odin_error.cpp
@@ -98,10 +98,12 @@ void _log_message(odin_error error_type, long line_number, long file, bool soft_
 		va_start(ap, message);
 		vfprintf(stderr,message, ap);
 		va_end(ap);
+
+		if (message[strlen(message)-1] != '\n') 
+			fprintf(stderr,"\n");
 	}
 
-	if (message[strlen(message)-1] != '\n') 
-		fprintf(stderr,"\n");
+
 
 	print_culprit_line(line_number, file);
 


### PR DESCRIPTION
#### Description
Fixes Coverity issue CID200634. Ensures that a possible NULL pointer will not be de-referenced.

#### How Has This Been Tested?
ODIN pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
