### PR TITLE
ODIN_II: Fix coverity issue CID 200780 - Double free

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -149,8 +149,11 @@ void free_assignement_of_node_keep_tree(ast_node_t *node)
 
 			case CONCATENATE:
 				for(i=0; i<node->types.concat.num_bit_strings; i++){
-					vtr::free(node->types.concat.bit_strings);
+					if(node->types.concat.bit_strings[i])
+						vtr::free(node->types.concat.bit_strings[i]);
 				}
+				vtr::free(node->types.concat.bit_strings);
+				
 
 			default:
 				break;


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 200780. 
node->types.concat.bit_strings was being freed inside a for loop rather than freeing it's contents.
Would also probably fix some memory leaks

#### How Has This Been Tested?
ODIN pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
