### PR TITLE
ODIN_II: Fix coverity issue CID 200827

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -1149,7 +1149,7 @@ int match_ports(nnode_t *node, nnode_t *next_node, operation_list oper)
 					case MINUS:
 						mark1 = strcmp(component_s[0], component_o[0]);
 						if (mark1 == 0)
-							mark2 = strcmp(component_s[1], component_s[1]);
+							mark2 = strcmp(component_s[1], component_o[1]);
 					break;
 
 					default:


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 200827. Typo; string comparison done on component_s[1] against itself, should've been compared against component_o[1]

#### How Has This Been Tested?
ODIN pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
