### PR TITLE
ODIN_II: Fix coverity issue CID 200833, CID 201053, & CID 201095

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -614,7 +614,7 @@ char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_
 	{
 		return_string = get_name_of_pin_number(var_node, bit);
 	}
-	else if (var_node->type == CONCATENATE)
+	else if (var_node->type == CONCATENATE && bit >= 0)
 	{
 		if (var_node->types.concat.num_bit_strings == 0)
 		{


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 200833, CID 20053, & CID 201095. Should check that bit is not negative before using it to index into array

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
