### PR TITLE
ODIN II: fix segfault from hard adders

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -1129,27 +1129,36 @@ int match_ports(nnode_t *node, nnode_t *next_node, operation_list oper)
 			traverse_operation_node(ast_node_next, component_o, oper, &sign);
 			if (sign != 1)
 			{
+				oassert(component_s[0] && component_o[0] && "missing children on operation");
 				switch (oper)
 				{
 					case ADD:
 					case MULTIPLY:
 					{
 						mark1 = strcmp(component_s[0], component_o[0]);
-						if (mark1 == 0)
-							mark2 = strcmp(component_s[1], component_o[1]);
-						else
+						if (component_s[1] && component_o[1])
 						{
-							oassert(component_s[0] && component_o[1] && component_s[1] && component_o[0]);
-							mark1 = strcmp(component_s[0], component_o[1]);
-							mark2 = strcmp(component_s[1], component_o[0]);
+							if (mark1 == 0)
+							{
+								mark2 = strcmp(component_s[1], component_o[1]);
+							}
+							else
+							{
+								mark1 = strcmp(component_s[0], component_o[1]);
+								mark2 = strcmp(component_s[1], component_o[0]);
+							}
 						}
 					}
 					break;
 
 					case MINUS:
+					{
 						mark1 = strcmp(component_s[0], component_o[0]);
-						if (mark1 == 0)
+						if (mark1 == 0 && component_s[1] && component_o[1])
+						{
 							mark2 = strcmp(component_s[1], component_s[1]);
+						}
+					}							
 					break;
 
 					default:
@@ -1157,7 +1166,9 @@ int match_ports(nnode_t *node, nnode_t *next_node, operation_list oper)
 					break;
 				}
 				if (mark1 == 0 && mark2 == 0)
+				{
 					flag = 1;
+				}
 			}
 		}
 		for(int i = 0; i < ast_node->num_children; i++)
@@ -1166,6 +1177,9 @@ int match_ports(nnode_t *node, nnode_t *next_node, operation_list oper)
 			{
 				vtr::free(component_s[i]);
 			}
+		}
+		for (int i = 0; i < ast_node_next->num_children; i++)
+		{
 			if(ast_node_next->children[i]->type != IDENTIFIERS)
 			{
 				vtr::free(component_o[i]);


### PR DESCRIPTION
#### Description
Fixes seg faults occurring in adders.cpp when using the chain

#### Motivation and Context
nightly regression run was failing because of this seg faults

#### How Has This Been Tested?
odin pre-commit regression suite

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
