### PR TITLE
ODIN_II: Fix coverity issue 201170

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -3632,6 +3632,7 @@ signal_list_t *assignment_alias(ast_node_t* assignment, char *instance_name_pref
 		if (right_memory)
 		{
 			// Register inputs for later assignment directly to the memory.
+			oassert(right_inputs);
 			int i;
 			for (i = 0; i < right_inputs->count; i++)
 			{


### PR DESCRIPTION
#### Description
Should resolve coverity issue 201170. Check that right_inputs is not NULL before de-referencing

#### How Has This Been Tested?
ODIN pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
