### PR TITLE
[WIP] ODIN_II: Fix coverity issue CID 201282

### DIFF
--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -898,7 +898,7 @@ static void compute_and_store_part(int start, int end, int current_stage, stages
 {
 
 	for (int j = start;j >= 0 && j <= end && j < s->counts[current_stage]; j++)
-		if(s->stages[current_stage][j])
+		if(s->stages[current_stage][j] && is_node_ready(s->stages[current_stage][j], cycle) && !is_node_complete(s->stages[current_stage][j], cycle))
 			compute_and_store_value(s->stages[current_stage][j], cycle);
 
 }
@@ -1307,7 +1307,8 @@ static stages_t *simulate_first_cycle(netlist_t *netlist, int cycle, lines_t *l)
 	{
 		nnode_t *node = queue.front();
 		queue.pop();
-		compute_and_store_value(node, cycle);
+		if(node && is_node_ready(node, cycle) && !is_node_complete(node, cycle))
+			compute_and_store_value(node, cycle);
 		// Match node for items passed via -p and add to lines if there's a match.
 		add_additional_items_to_lines(node, l);
 
@@ -1706,7 +1707,6 @@ static thread_node_distribution *calculate_thread_distribution(stages_t *s)
 static bool compute_and_store_value(nnode_t *node, int cycle)
 {
 	//double computation_time = wall_time();
-	is_node_ready(node,cycle);
 	operation_list type = is_clock_node(node)?CLOCK_NODE:node->type;
 	switch(type)
 	{


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201282. Check if is_node_ready is true before calling the function, as is done everywhere else the function is called. 

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
