### PR TITLE
ODIN_II: Fix coverity issue CID 201703

### DIFF
--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -1943,8 +1943,12 @@ static bool compute_and_store_value(nnode_t *node, int cycle)
 					if(prev_value < 0)
 						prev_value = !CLOCK_INITIAL_VALUE;
 
-					signed char cur_value = (cycle % get_clock_ratio(node)) ? prev_value : !prev_value;
-					update_pin_value(node->output_pins[0], cur_value, cycle);
+					int clk_ratio = get_clock_ratio(node);
+					if(clk_ratio != 0)
+					{
+						signed char cur_value = (cycle % clk_ratio) ? prev_value : !prev_value;
+						update_pin_value(node->output_pins[0], cur_value, cycle);
+					}
 				}
 			}
 			else // driven by another node

--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -1944,11 +1944,13 @@ static bool compute_and_store_value(nnode_t *node, int cycle)
 						prev_value = !CLOCK_INITIAL_VALUE;
 
 					int clk_ratio = get_clock_ratio(node);
-					if(clk_ratio != 0)
+					if(clk_ratio == 0)
 					{
-						signed char cur_value = (cycle % clk_ratio) ? prev_value : !prev_value;
-						update_pin_value(node->output_pins[0], cur_value, cycle);
+						error_message(SIMULATION_ERROR,-1,-1,"clock(%s) as a 0 valued ratio", node->name);
 					}
+					
+					signed char cur_value = (cycle % clk_ratio) ? prev_value : !prev_value;
+					update_pin_value(node->output_pins[0], cur_value, cycle);
 				}
 			}
 			else // driven by another node


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201703. Ensures that the return value of get_clock_ratio is not zero before doing the modulo.

#### How Has This Been Tested?
Odin pre-commit.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
