### PR TITLE
ODIN_II: Fix coverity issue CID 201694

### DIFF
--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -4219,7 +4219,8 @@ static char *get_mif_filename(nnode_t *node)
 {
 	char buffer[BUFFER_MAX_SIZE];
 	buffer[0] = 0;
-	strcat(buffer, node->name);
+	if(strlen(node->name) < BUFFER_MAX_SIZE)
+		strcat(buffer, node->name);
 
 	char *filename = strrchr(buffer, '+');
 	if (filename) filename += 1;


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201694. Check the length of node->name before appending to buffer

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
