### PR TITLE
ODIN_II: Fix coverity issue CID 201850

### DIFF
--- a/ODIN_II/SRC/read_blif.cpp
+++ b/ODIN_II/SRC/read_blif.cpp
@@ -787,9 +787,9 @@ operation_list read_bit_map_find_unknown_gate(int input_count, nnode_t *node, FI
 		fsetpos(file,&pos);
 
 		char *ptr = vtr::strtok(buffer,"\t\n", file, buffer);
-		if      (!strcmp(ptr," 0")) return GND_NODE;
+		if      (!ptr) 				return GND_NODE;
 		else if (!strcmp(ptr," 1")) return VCC_NODE;
-		else if (!ptr)              return GND_NODE;
+		else if (!strcmp(ptr," 0")) return GND_NODE;
 		else                        return VCC_NODE;
 	}
 


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201850. Check for ptr should be done before strcmp otherwise, NULL pointer could be de-referenced

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
