### PR TITLE
 Odin_ii: Fix coverity issue CID 134668: Resource leak 

### DIFF
--- a/ODIN_II/SRC/read_blif.cpp
+++ b/ODIN_II/SRC/read_blif.cpp
@@ -418,6 +418,7 @@ char* search_clock_name(FILE* file)
 	fgetpos(file,&pos);
 	rewind(file);
 
+	char *to_return = NULL;
 	char ** input_names = NULL;
 	int input_names_count = 0;
 	int found = 0;
@@ -430,7 +431,7 @@ char* search_clock_name(FILE* file)
 		if(feof(file))
 			break;
 
-		char *ptr;
+		char *ptr = NULL;
 		if((ptr = vtr::strtok(buffer, TOKENS, file, buffer)))
 		{
 			if(!strcmp(ptr,".end"))
@@ -469,8 +470,25 @@ char* search_clock_name(FILE* file)
 	file_line_number = last_line;
 	fsetpos(file,&pos);
 
-	if (found) return input_names[0];
-	else       return vtr::strdup(DEFAULT_CLOCK_NAME);
+	if (found)
+	{
+		to_return = input_names[0];
+	}
+	else
+	{
+		to_return = vtr::strdup(DEFAULT_CLOCK_NAME);
+		for(int i = 0; i < input_names_count; i++)
+		{
+			if(input_names[i])
+			{
+				vtr::free(input_names[i]);
+			}
+		}
+	}  
+			
+	vtr::free(input_names);   
+
+	return to_return; 
 }
 
 


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 134668; resource leak. Need to free input_names and it's contents before returning.

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
