### PR TITLE
ODIN_II: Fix coverity issue CID 200771: Resource leak

### DIFF
--- a/ODIN_II/SRC/netlist_visualizer.cpp
+++ b/ODIN_II/SRC/netlist_visualizer.cpp
@@ -306,6 +306,11 @@ void forward_traversal_net_graph_display(FILE *fp, short marker_value, nnode_t *
 		/* process next element in net */
 		index_in_stack ++;
 	}
+	for(int i = 0; i < num_stack_of_nodes; i++)
+	{
+		free_nnode(stack_of_nodes[i]);
+	}
+	vtr::free(stack_of_nodes);
 }
 
 /*---------------------------------------------------------------------------------------------

--- a/ODIN_II/SRC/netlist_visualizer.cpp
+++ b/ODIN_II/SRC/netlist_visualizer.cpp
@@ -306,6 +306,7 @@ void forward_traversal_net_graph_display(FILE *fp, short marker_value, nnode_t *
 		/* process next element in net */
 		index_in_stack ++;
 	}
+	
 	for(int i = 0; i < num_stack_of_nodes; i++)
 	{
 		free_nnode(stack_of_nodes[i]);


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 200771. Resource leak. Very similiar to PR #811. Need to free stack_of_nodes and it's contents before returning.

#### How Has This Been Tested?
ODIN pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
