### PR TITLE
VTR_BUILD: -lasan not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,7 @@ if(VTR_ENABLE_SANITIZE)
     #Enable sanitizers
     # -fuse-ld=gold force the gold linker to be used (required for sanitizers, but not enabled by default on some systems)
     set(SANITIZE_FLAGS "-g -fsanitize=address -fsanitize=leak -fsanitize=undefined -fuse-ld=gold")
-    message(STATUS "SANTIIZE_FLAGS: ${SANITIZE_FLAGS}")
-    link_libraries("-static-libasan") #Fixes 'ASan runtime does not come first in initial library list'
+    message(STATUS "SANITIZE_FLAGS: ${SANITIZE_FLAGS}")
 endif()
 
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
with the previous flags, vtr would not build with libasan.
the changes remove linking asan as a static library

#### Related Issue
this fixes #814

#### Motivation and Context
Ability to run with sanitize flags.

#### How Has This Been Tested?
built with gcc 9 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
