### PR TITLE
ODIN_II: Fix coverity issue CID 201117

### DIFF
--- a/ODIN_II/SRC/soft_logic_def_parser.cpp
+++ b/ODIN_II/SRC/soft_logic_def_parser.cpp
@@ -100,7 +100,8 @@ void read_soft_def_file(t_model *hard_adder_models)
 				break;
 			
 			std::vector<std::string> tokens;
-			char *temp_str = strtok(vtr::strdup(line.c_str()),",");
+			char *line_dup = vtr::strdup(line.c_str());
+			char *temp_str = strtok(line_dup,",");
 			while(1)
 			{				
 				if(!temp_str)
@@ -142,6 +143,7 @@ void read_soft_def_file(t_model *hard_adder_models)
 					soft_def_map[key_map] = def;
 				}
 			}
+			vtr::free(line_dup);
 		}
 		fclose(input_file);
 


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201117. Need to store the pointer to the string that was duplicated so that it can later be freed.

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
