### PR TITLE
VTR_BUILD: disable pugixml compact mode with sanitize flags on

### DIFF
--- a/libs/EXTERNAL/libpugixml/CMakeLists.txt
+++ b/libs/EXTERNAL/libpugixml/CMakeLists.txt
@@ -19,7 +19,10 @@ set_target_properties(libpugixml PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 set(PUGIXML_SUPPRESS_FLAGS -w)
 target_compile_options(libpugixml PRIVATE ${PUGIXML_SUPPRESS_FLAGS})
 
-#Enable compact mode which reduces memory usage.
-target_compile_definitions(libpugixml PRIVATE PUGIXML_COMPACT)
+#Do not use compact mode with sanitize flags on as pugi structs are not alligned and causes errors.
+if(NOT VTR_ENABLE_SANITIZE)
+    #Enable compact mode which reduces memory usage.
+    target_compile_definitions(libpugixml PRIVATE PUGIXML_COMPACT)
+endif()
 
 install(TARGETS libpugixml DESTINATION bin)


### PR DESCRIPTION
#### Description
pugixml throws errors in compact mode when sanitize flags are on, 
this PR disables compact mode when sanitize flag are set

#### Related Issue
fixes #813 

#### Motivation and Context
Clean sanitize errors

#### How Has This Been Tested?
built using PR  #815 to verify build is successful
no errors are thrown

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
