### PR TITLE
VTR_FLOW: do not run valgrind on perl scripts for run_vtr_flow.pl

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -507,6 +507,10 @@ if (    $starting_stage <= $stage_idx_abc
 	and $ending_stage >= $stage_idx_abc
 	and !$error_code )
 {
+	#added so that valgrind will not run on abc and perl because of existing memory errors
+	my $skip_valgrind = $valgrind;
+	$valgrind = 0;
+
 	my @clock_list;
 
 	if ( $flow_type )
@@ -672,10 +676,6 @@ if (    $starting_stage <= $stage_idx_abc
 
 		if ($abc_quote_addition) {$abc_commands = "'" . $abc_commands . "'";}
 
-		#added so that valgrind will not run on abc because of existing memory errors
-		my $skip_valgrind = $valgrind;
-		$valgrind = 0;
-
 		$q = &system_with_timeout( $abc_path, "abc".$domain_itter.".out", $timeout, $temp_dir, "-c",
 			$abc_commands);
 
@@ -689,9 +689,6 @@ if (    $starting_stage <= $stage_idx_abc
 			$error_code = 1;
 			last ABC_OPTIMIZATION;
 		}
-
-		#restore the current valgrind flag
-		$valgrind = $skip_valgrind;
 
 		if ( $flow_type != 3 and exists  $clock_list[$domain_itter] )
 		{
@@ -750,6 +747,9 @@ if (    $starting_stage <= $stage_idx_abc
 		system "rm -f ${temp_dir}*.v";
 		system "rm -f ${temp_dir}*.rc";
 	}
+
+	#restore the current valgrind flag
+	$valgrind = $skip_valgrind;
 }
 
 #################################################################################
@@ -822,9 +822,16 @@ if (    $starting_stage <= $stage_idx_ace
 
 		if ( -e $ace_raw_output_blif_path and $q eq "success") {
 
+			#added so that valgrind will not run on perl because of existing memory errors
+			my $skip_valgrind = $valgrind;
+			$valgrind = 0;
+
             # Restore Multi-Clock Latch Information from ODIN II that was striped out by ACE
             $q = &system_with_timeout($restore_multiclock_info_script, "restore_multiclock_latch_information.ace.out", $timeout, $temp_dir,
                     $odin_output_file_name, $ace_raw_output_blif_name, $ace_output_blif_name);
+
+			#restore the current valgrind flag
+			$valgrind = $skip_valgrind;
 
             if ($q ne "success") {
                 $error_status = "failed: to restore multi-clock latch info";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
disable valgrind when running perl scripts to catch valgrind leaks only on internal components

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/622#issuecomment-513857413_

This should now give a clean valgrind error list, vtr_reg_valgrind_small should now report 0 errors

#### Motivation and Context
Allows to catch only important valgrind leaks

#### How Has This Been Tested?
vtr_reg_valgrind_small

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
