### PR TITLE
ODIN_II: Fix coverity issue CID 201611

### DIFF
--- a/ODIN_II/SRC/read_blif.cpp
+++ b/ODIN_II/SRC/read_blif.cpp
@@ -312,14 +312,11 @@ void create_latch_node_and_driver(FILE *file, Hashtable *output_nets_hash)
 		/* supported added for the ABC .latch output without control */
 		if(input_token_count == 3)
 		{
-			char *clock_name = search_clock_name(file);
 			input_token_count = 5;
 			names = (char**)vtr::realloc(names, sizeof(char*) * input_token_count);
 
-			if(clock_name) names[3] = vtr::strdup(clock_name);
-			else           names[3] = NULL;
-
-			names[4] = vtr::strdup(names[2]);
+			names[3] = search_clock_name(file);
+			names[4] = names[2];
 			names[2] = vtr::strdup("re");
 		}
 		else


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201611. Resource leak due to clock_name not being freed. Since the function search_clock_name will malloc a new string anyway, just assign to names[3] and don't use another variable or do strdup. No need to duplicate strings everywhere if they're not being used again

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
