### PR TITLE
ODIN_II: Fix coverity issue CID 201815

### DIFF
--- a/ODIN_II/SRC/read_blif.cpp
+++ b/ODIN_II/SRC/read_blif.cpp
@@ -658,7 +658,7 @@ void create_hard_block_nodes(hard_block_models *models, FILE *file, Hashtable *o
 void create_internal_node_and_driver(FILE *file, Hashtable *output_nets_hash)
 {
 	/* Storing the names of the input and the final output in array names */
-	char *ptr;
+	char *ptr = NULL;
 	char **names = NULL; // stores the names of the input and the output, last name stored would be of the output
 	int input_count = 0;
 	char buffer[READ_BLIF_BUFFER];
@@ -680,6 +680,11 @@ void create_internal_node_and_driver(FILE *file, Hashtable *output_nets_hash)
 	)
 	{
 		skip_reading_bit_map = true;
+		free_nnode(new_node);
+		for(int i = 0; i < input_count; i++)
+		{
+			vtr::free(names[i]);
+		}
 	}
 	else
 	{
@@ -778,9 +783,9 @@ void create_internal_node_and_driver(FILE *file, Hashtable *output_nets_hash)
 
 		output_nets_hash->add(new_node->name, new_net);
 
-		/* Free the char** names */
-		vtr::free(names);
 	}
+	/* Free the char** names */
+	vtr::free(names);
 }
 
 /*


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 201815. Resource leak due to names not being freed. In the first if block, we can free the contents held by names because they are not assigned to anything, but if the program goes into the else block, the contents are assigned, so we should not free them, just the pointer. 

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
