### PR TITLE
ODIN II: handle 2D arrays, replication of zero, ternary op in AST elaboration

### DIFF
--- a/ODIN_II/SRC/ast_loop_unroll.cpp
+++ b/ODIN_II/SRC/ast_loop_unroll.cpp
@@ -74,6 +74,7 @@ void update_module_instantiations(ast_node_t *ast_module, ast_node_t ****new_ins
 
 				long sc_spot = sc_add_string(module_names_to_idx, new_instance_name);
 				oassert(sc_spot != -1);
+				module_names_to_idx->data[sc_spot] = (*new_instances)[i][j];
 
 				vtr::free(new_instance_name);
 			}		
@@ -99,6 +100,7 @@ void update_module_instantiations(ast_node_t *ast_module, ast_node_t ****new_ins
 
 				long sc_spot = sc_add_string(module_names_to_idx, new_instance_name);
 				oassert(sc_spot != -1);
+				module_names_to_idx->data[sc_spot] = (*new_instances)[i][j];
 
 				vtr::free(new_instance_name);
 			}

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1465,15 +1465,16 @@ ast_node_t * fold_conditional(ast_node_t **node)
 /*---------------------------------------------------------------------------------------------
  * (function: node_is_constant)
  *-------------------------------------------------------------------------------------------*/
-ast_node_t *node_is_constant(ast_node_t *node){
+bool node_is_constant(ast_node_t *node)
+{
 	if (node && 
 		node->type == NUMBERS && 
 		node->types.vnumber != nullptr &&
 		!(node->types.vnumber->is_dont_care_string()))
 	{
-		return node;
+		return true;
 	}
-	return NULL;
+	return false;
 }
 
 /*---------------------------------------------------------------------------

--- a/ODIN_II/SRC/include/ast_util.h
+++ b/ODIN_II/SRC/include/ast_util.h
@@ -18,6 +18,7 @@ void initial_node(ast_node_t *node, ids id, int line_number, int file_number, in
 void allocate_children_to_node(ast_node_t* node, std::vector<ast_node_t *> children_list);
 void add_child_to_node(ast_node_t* node, ast_node_t *child);
 void add_child_at_the_beginning_of_the_node(ast_node_t* node, ast_node_t *child);
+void remove_child_from_node(ast_node_t* node, int index);
 ast_node_t **expand_node_list_at(ast_node_t **list, long old_size, long to_add, long start_idx);
 void move_ast_node(ast_node_t *src, ast_node_t *dest, ast_node_t *node);
 ast_node_t *ast_node_deep_copy(ast_node_t *node);

--- a/ODIN_II/SRC/include/ast_util.h
+++ b/ODIN_II/SRC/include/ast_util.h
@@ -41,7 +41,7 @@ char_list_t *get_name_of_pins(ast_node_t *var_node, char *instance_name_prefix, 
 char_list_t *get_name_of_pins_with_prefix(ast_node_t *var_node, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list);
 long get_size_of_variable(ast_node_t *node, STRING_CACHE_LIST *local_string_cache_list);
 
-ast_node_t *node_is_constant(ast_node_t *node);
+bool node_is_constant(ast_node_t *node);
 ast_node_t *fold_binary(ast_node_t **node);
 ast_node_t *fold_unary(ast_node_t **node);
 ast_node_t * fold_conditional(ast_node_t **node);

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -350,6 +350,7 @@ struct typ
 		short is_reg;
 		short is_integer;
 		short is_genvar;
+		short is_memory;
 		short is_signed;
 		short is_initialized; // should the variable be initialized with some value?
 		long initial_value;

--- a/ODIN_II/SRC/include/string_cache.h
+++ b/ODIN_II/SRC/include/string_cache.h
@@ -42,6 +42,8 @@ struct STRING_CACHE_LIST{
 	struct ast_node_t **function_local_symbol_table;
 	int num_local_symbol_table;
 	int function_num_local_symbol_table;
+
+	char *instance_name_prefix;
 };
 
 /* creates the hash where it is indexed by a string and the void ** holds the data */

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -90,7 +90,7 @@ void create_all_driver_nets_in_this_function(char *instance_name_prefix, STRING_
 
 void create_top_driver_nets(ast_node_t* module, char *instance_name_prefix);
 void create_top_output_nodes(ast_node_t* module, char *instance_name_prefix);
-nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list);
+nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_prefix);
 nnet_t* define_nodes_and_nets_with_driver(ast_node_t* var_declare, char *instance_name_prefix);
 
 void connect_hard_block_and_alias(ast_node_t* hb_instance, char *instance_name_prefix, int outport_size, STRING_CACHE_LIST *local_string_cache_list);
@@ -136,10 +136,6 @@ signal_list_t *create_soft_single_port_ram_block(ast_node_t* block, char *instan
 signal_list_t *create_soft_dual_port_ram_block(ast_node_t* block, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list);
 
 void look_for_clocks(netlist_t *netlist);
-
-void convert_multi_to_single_dimentional_array(ast_node_t *node, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list);
-char *make_chunk_size_name(char *instance_name_prefix, char *array_name);
-ast_node_t *get_chunk_size_node(char *instance_name_prefix, char *array_name, STRING_CACHE_LIST *local_string_cache_list);
 
 /*----------------------------------------------------------------------------
  * (function: create_param_table_for_module)
@@ -411,6 +407,7 @@ void create_netlist()
 	verilog_netlist = allocate_netlist();
 
 	STRING_CACHE_LIST *top_sc_list = (STRING_CACHE_LIST*)vtr::calloc(1, sizeof(STRING_CACHE_LIST));
+	top_sc_list->instance_name_prefix = vtr::strdup(top_module->children[0]->types.identifier);
 
 	/* create the parameter table for the top module */
 	top_sc_list->local_param_table_sc = create_param_table_for_module(NULL, top_module->children[2], top_string, NULL);
@@ -435,6 +432,7 @@ void create_netlist()
 	top_sc_list->local_symbol_table_sc = sc_free_string_cache(top_sc_list->local_symbol_table_sc);
 	top_sc_list->num_local_symbol_table = 0;
 	top_sc_list->local_symbol_table = (ast_node_t **)vtr::free(top_sc_list->local_symbol_table);
+	top_sc_list->instance_name_prefix = (char *)vtr::free(top_sc_list->instance_name_prefix);
 
 	vtr::free(top_sc_list);
 
@@ -653,7 +651,8 @@ void convert_ast_to_netlist_recursing_via_modules(ast_node_t** current_module, c
 				((ast_node_t*)module_names_to_idx->data[sc_spot])->children[2],
 				temp_instance_name, local_param_table_sc);
 
-			STRING_CACHE_LIST *module_string_cache_list = (STRING_CACHE_LIST*)calloc(1, sizeof(STRING_CACHE_LIST));
+			STRING_CACHE_LIST *module_string_cache_list = (STRING_CACHE_LIST*)vtr::calloc(1, sizeof(STRING_CACHE_LIST));
+			module_string_cache_list->instance_name_prefix = vtr::strdup(temp_instance_name);
 			module_string_cache_list->local_param_table_sc = module_param_table_sc;
 
 			// create the symbol table for the instantiated module
@@ -675,7 +674,8 @@ void convert_ast_to_netlist_recursing_via_modules(ast_node_t** current_module, c
 			module_string_cache_list->local_symbol_table_sc = sc_free_string_cache(module_string_cache_list->local_symbol_table_sc);
 			module_string_cache_list->num_local_symbol_table = 0;
 			module_string_cache_list->local_symbol_table = (ast_node_t **)vtr::free(module_string_cache_list->local_symbol_table);
-			
+			module_string_cache_list->instance_name_prefix = (char *)vtr::free(module_string_cache_list->instance_name_prefix);
+
 			vtr::free(module_string_cache_list);
 		}
         for (k = 0; k < (*current_module)->types.function.size_function_instantiations; k++)
@@ -705,7 +705,8 @@ void convert_ast_to_netlist_recursing_via_modules(ast_node_t** current_module, c
 				((ast_node_t*)module_names_to_idx->data[sc_spot])->children[2],
 				temp_instance_name, local_param_table_sc);
 
-			STRING_CACHE_LIST *function_string_cache_list = (STRING_CACHE_LIST*)calloc(1, sizeof(STRING_CACHE_LIST));
+			STRING_CACHE_LIST *function_string_cache_list = (STRING_CACHE_LIST*)vtr::calloc(1, sizeof(STRING_CACHE_LIST));
+			function_string_cache_list->instance_name_prefix = vtr::strdup(temp_instance_name);
 			function_string_cache_list->local_param_table_sc = function_param_table_sc;
 
 			// create the symbol table for the instantiated function
@@ -727,6 +728,7 @@ void convert_ast_to_netlist_recursing_via_modules(ast_node_t** current_module, c
 			function_string_cache_list->function_local_symbol_table_sc = sc_free_string_cache(function_string_cache_list->function_local_symbol_table_sc);
 			function_string_cache_list->num_local_symbol_table = 0;
 			function_string_cache_list->function_local_symbol_table = (ast_node_t **)vtr::free(function_string_cache_list->function_local_symbol_table);
+			function_string_cache_list->instance_name_prefix = (char *)vtr::free(function_string_cache_list->instance_name_prefix);
 
 			vtr::free(function_string_cache_list);
 		}
@@ -1187,7 +1189,7 @@ void create_all_driver_nets_in_this_module(char *instance_name_prefix, STRING_CA
 		   )
 		{
 			/* create nets based on this driver as the name */
-			define_nets_with_driver(local_symbol_table[i], instance_name_prefix, local_string_cache_list);
+			define_nets_with_driver(local_symbol_table[i], instance_name_prefix);
 		}
 
 	}
@@ -1228,7 +1230,7 @@ void create_all_driver_nets_in_this_function(char *instance_name_prefix, STRING_
 		   )
 		{
 			/* create nets based on this driver as the name */
-			define_nets_with_driver(function_local_symbol_table[i], instance_name_prefix, local_string_cache_list);
+			define_nets_with_driver(function_local_symbol_table[i], instance_name_prefix);
 		}
 
 	}
@@ -1488,80 +1490,14 @@ void create_top_output_nodes(ast_node_t* module, char *instance_name_prefix)
  * (function: define_nets_with_driver)
  * Given a register declaration, this function defines it as a driver.
  *-------------------------------------------------------------------------------------------*/
-nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list)
+nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_prefix)
 {
 	int i;
 	char *temp_string = NULL;
 	long sc_spot;
 	nnet_t *new_net = NULL;
 
-	// pack 2d array into 1d
-	if (var_declare->num_children == 8 
-	&& var_declare->children[5] 
-	&& var_declare->children[6])
-	{
-		ast_node_t *node_max2  = var_declare->children[3];
-		ast_node_t *node_min2  = var_declare->children[4];
-
-		ast_node_t *node_max3  = var_declare->children[5];
-		ast_node_t *node_min3  = var_declare->children[6];
-
-		oassert(node_min2->type == NUMBERS && node_max2->type == NUMBERS);		
-		oassert(node_min3->type == NUMBERS && node_max3->type == NUMBERS);
-
-		long addr_min = node_min2->types.vnumber->get_value();
-		long addr_max = node_max2->types.vnumber->get_value();
-
-		long addr_min1= node_min3->types.vnumber->get_value();
-		long addr_max1= node_max3->types.vnumber->get_value();
-
-		if((addr_min > addr_max) || (addr_min1 > addr_max1))
-		{
-			error_message(NETLIST_ERROR, var_declare->children[0]->line_number, var_declare->children[0]->file_number, "%s",
-					"Odin doesn't support arrays declared [m:n] where m is less than n.");
-		}	
-		else if((addr_min < 0 || addr_max < 0) || (addr_min1 < 0 || addr_max1 < 0))
-		{
-			error_message(NETLIST_ERROR, var_declare->children[0]->line_number, var_declare->children[0]->file_number, "%s",
-					"Odin doesn't support negative number in index.");
-		}
-
-		char *name = var_declare->children[0]->types.identifier;
-
-		if (addr_min != 0 || addr_min1 != 0)
-			error_message(NETLIST_ERROR, var_declare->children[0]->line_number, var_declare->children[0]->file_number,
-					"%s: right memory address index must be zero\n", name);
-
-		long addr_chunk_size = (addr_max1 - addr_min1 + 1);
-		ast_node_t *new_node = create_tree_node_number(addr_chunk_size, var_declare->children[0]->line_number, var_declare->children[0]->file_number);
-
-		STRING_CACHE *local_param_table_sc = local_string_cache_list->local_param_table_sc;
-
-		temp_string = make_chunk_size_name(instance_name_prefix, name);
-
-		if ((sc_spot = sc_add_string(local_param_table_sc, temp_string)) == -1)
-			error_message(NETLIST_ERROR, var_declare->children[0]->line_number, var_declare->children[0]->file_number,
-					"%s: name conflicts with Odin internal reference\n", temp_string);
-
-		vtr::free(temp_string);
-		temp_string = NULL;
-
-		local_param_table_sc->data[sc_spot] = (void *)new_node;
-
-		long new_address_max = (addr_max - addr_min + 1)*addr_chunk_size -1;
-
-		change_to_number_node(var_declare->children[3], new_address_max);
-		change_to_number_node(var_declare->children[4], 0);
-
-		var_declare->children[5] = free_whole_tree(var_declare->children[5]);
-		var_declare->children[6] = free_whole_tree(var_declare->children[6]);
-
-		var_declare->children[5] = var_declare->children[7];
-		var_declare->children[7] = NULL; 
-
-		var_declare->num_children -= 2;
-	}
-
+	
 	if (var_declare->children[1] == NULL || var_declare->type == BLOCKING_STATEMENT)
 	{
 		/* FOR single driver signal since spots 1, 2, 3, 4 are NULL */
@@ -1649,7 +1585,7 @@ nnet_t* define_nets_with_driver(ast_node_t* var_declare, char *instance_name_pre
 		}
 	}
 	/* Implicit memory */
-	else if (var_declare->children[3] != NULL)
+	else if (var_declare->children[3] != NULL && var_declare->types.variable.is_memory)
 	{
 		ast_node_t *node_max1  = var_declare->children[1];
 		ast_node_t *node_min1  = var_declare->children[2];
@@ -1827,7 +1763,7 @@ nnet_t* define_nodes_and_nets_with_driver(ast_node_t* var_declare, char *instanc
 			verilog_netlist->num_top_input_nodes++;
 		}
 	}
-	else if (var_declare->children[3] != NULL)
+	else if (var_declare->types.variable.is_memory)
 	{
 		/* Implicit memory */
 		error_message(NETLIST_ERROR, var_declare->children[3]->line_number, var_declare->children[3]->file_number, "%s\n", "Unhandled implicit memory in define_nodes_and_nets_with_driver");
@@ -3291,11 +3227,6 @@ signal_list_t *assignment_alias(ast_node_t* assignment, char *instance_name_pref
 			error_message(NETLIST_ERROR, assignment->line_number, assignment->file_number,
 							"Invalid addressing mode for implicit memory %s.\n", right_memory->name);
 
-		if(right->num_children > 2 && right->children[2] != NULL)
-		{
-			convert_multi_to_single_dimentional_array(right, instance_name_prefix, local_string_cache_list);
-		}
-
 		signal_list_t* address = netlist_expand_ast_of_module(&(right->children[1]), instance_name_prefix, local_string_cache_list);
 		// Pad/shrink the address to the depth of the memory.
 		
@@ -3391,11 +3322,6 @@ signal_list_t *assignment_alias(ast_node_t* assignment, char *instance_name_pref
 		}
 		else
 		{
-			if(left->num_children > 2 && left->children[2] != NULL)
-			{
-				convert_multi_to_single_dimentional_array(left, instance_name_prefix, local_string_cache_list);
-			}
-
 			// Make sure the memory is addressed.
 			signal_list_t* address = netlist_expand_ast_of_module(&(left->children[1]), instance_name_prefix, local_string_cache_list);
 
@@ -6044,73 +5970,4 @@ signal_list_t *create_hard_block(ast_node_t* block, char *instance_name_prefix, 
 		add_list = insert_in_vptr_list(add_list, block_node);
 
 	return return_list;
-}
-
-void convert_multi_to_single_dimentional_array(ast_node_t *node, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list)
-{
-	char *array_name = NULL;
-	ast_node_t *array_row = NULL;
-	ast_node_t *array_col = NULL;
-	ast_node_t *array_size = NULL;
-
-	ast_node_t *new_node_1 = NULL;
-	ast_node_t *new_node_2 = NULL;
-
-	array_name = make_full_ref_name(NULL, NULL, NULL, node->children[0]->types.identifier, -1);
-	array_size = get_chunk_size_node(instance_name_prefix, array_name, local_string_cache_list);
-	array_row = node->children[1];
-	array_col = node->children[2];
-
-	// build the new AST
-	new_node_1 = newBinaryOperation(MULTIPLY, array_row, array_size, node->children[0]->line_number);
-	new_node_2 = newBinaryOperation(ADD, new_node_1, array_col, node->children[0]->line_number);
-
-	vtr::free(array_name);
-
-	node->children[1] = new_node_2;
-	node->children[2] = NULL;
-	node->num_children -= 1;
-
-	return;
-}
-
-/*--------------------------------------------------------------------------
- * (function: make_chunk_size_name)
- * 	This function creates a string to reference a 2D array chunk size for
- * 	1D array indexing.
- *------------------------------------------------------------------------*/
-char *make_chunk_size_name(char *instance_name_prefix, char *array_name)
-{
-	std::string to_return(instance_name_prefix);
-	to_return += "__";
-	to_return += array_name;
-	to_return += "_____CHUNK_SIZE_DEFINE";
-	return vtr::strdup(to_return.c_str());
-}
-
-/*--------------------------------------------------------------------------
- * (function: get_chunk_size_node)
- * 	This function gets the chunk size node for a 2D array, to be used for
- *	1D array indexing.
- *------------------------------------------------------------------------*/
-ast_node_t *get_chunk_size_node(char *instance_name_prefix, char *array_name, STRING_CACHE_LIST *local_string_cache_list)
-{
-	ast_node_t *array_size = NULL;
-	long sc_spot;
-	STRING_CACHE *local_param_table_sc = local_string_cache_list->local_param_table_sc;
-	char *temp_string = NULL;
-
-	temp_string = make_chunk_size_name(instance_name_prefix, array_name);
-
-	// look up chunk size
-	sc_spot = sc_lookup_string(local_param_table_sc, temp_string);
-	oassert(sc_spot != -1);
-	if (sc_spot != -1)
-	{
-		array_size = ast_node_deep_copy((ast_node_t *)local_param_table_sc->data[sc_spot]);
-	}
-
-	vtr::free(temp_string);
-
-	return array_size;
 }

--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -104,7 +104,7 @@ int yylex(void);
 %type <node> module_connection always statement function_statement blocking_assignment
 %type <node> non_blocking_assignment conditional_statement case_statement case_item_list case_items seq_block
 %type <node> stmt_list delay_control event_expression_list event_expression loop_statement
-%type <node> expression primary probable_expression_list expression_list module_parameter
+%type <node> expression primary expression_list module_parameter
 %type <node> list_of_module_parameters localparam_declaration
 %type <node> specify_block list_of_specify_items specify_item specparam_declaration
 %type <node> specify_pal_connect_declaration c_function_expression_list c_function
@@ -574,72 +574,66 @@ event_expression:
 	;
 
 expression:
-	primary										{$$ = $1;}
-	| '+' expression %prec UADD					{$$ = newUnaryOperation(ADD, $2, yylineno);}
-	| '-' expression %prec UMINUS				{$$ = newUnaryOperation(MINUS, $2, yylineno);}
-	| '~' expression %prec UNOT					{$$ = newUnaryOperation(BITWISE_NOT, $2, yylineno);}
-	| '&' expression %prec UAND					{$$ = newUnaryOperation(BITWISE_AND, $2, yylineno);}
-	| '|' expression %prec UOR					{$$ = newUnaryOperation(BITWISE_OR, $2, yylineno);}
-	| voNAND expression %prec UNAND				{$$ = newUnaryOperation(BITWISE_NAND, $2, yylineno);}
-	| voNOR expression %prec UNOR				{$$ = newUnaryOperation(BITWISE_NOR, $2, yylineno);}
-	| voXNOR  expression %prec UXNOR			{$$ = newUnaryOperation(BITWISE_XNOR, $2, yylineno);}
-	| '!' expression %prec ULNOT				{$$ = newUnaryOperation(LOGICAL_NOT, $2, yylineno);}
-	| '^' expression %prec UXOR					{$$ = newUnaryOperation(BITWISE_XOR, $2, yylineno);}
-	| vCLOG2 '(' expression ')'					{$$ = newUnaryOperation(CLOG2, $3, yylineno);}
-	| voUNSIGNED '(' expression ')'				{$$ = newUnaryOperation(UNSIGNED, $3, yylineno);}
-	| voSIGNED '(' expression ')'				{$$ = newUnaryOperation(SIGNED, $3, yylineno);}
-	| expression '^' expression					{$$ = newBinaryOperation(BITWISE_XOR, $1, $3, yylineno);}
-	| expression voPOWER expression				{$$ = newBinaryOperation(POWER,$1, $3, yylineno);}
-	| expression '*' expression					{$$ = newBinaryOperation(MULTIPLY, $1, $3, yylineno);}
-	| expression '/' expression					{$$ = newBinaryOperation(DIVIDE, $1, $3, yylineno);}
-	| expression '%' expression					{$$ = newBinaryOperation(MODULO, $1, $3, yylineno);}
-	| expression '+' expression					{$$ = newBinaryOperation(ADD, $1, $3, yylineno);}
-	| expression '-' expression					{$$ = newBinaryOperation(MINUS, $1, $3, yylineno);}
-	| expression '&' expression					{$$ = newBinaryOperation(BITWISE_AND, $1, $3, yylineno);}
-	| expression '|' expression					{$$ = newBinaryOperation(BITWISE_OR, $1, $3, yylineno);}
-	| expression voNAND expression				{$$ = newBinaryOperation(BITWISE_NAND, $1, $3, yylineno);}
-	| expression voNOR expression				{$$ = newBinaryOperation(BITWISE_NOR, $1, $3, yylineno);}
-	| expression voXNOR expression				{$$ = newBinaryOperation(BITWISE_XNOR, $1, $3, yylineno);}
-	| expression '<' expression					{$$ = newBinaryOperation(LT, $1, $3, yylineno);}
-	| expression '>' expression					{$$ = newBinaryOperation(GT, $1, $3, yylineno);}
-	| expression voSRIGHT expression			{$$ = newBinaryOperation(SR, $1, $3, yylineno);}
-	| expression voASRIGHT expression			{$$ = newBinaryOperation(ASR, $1, $3, yylineno);}
-	| expression voSLEFT expression				{$$ = newBinaryOperation(SL, $1, $3, yylineno);}
-	| expression voEQUAL expression				{$$ = newBinaryOperation(LOGICAL_EQUAL, $1, $3, yylineno);}
-	| expression voNOTEQUAL expression			{$$ = newBinaryOperation(NOT_EQUAL, $1, $3, yylineno);}
-	| expression voLTE expression				{$$ = newBinaryOperation(LTE, $1, $3, yylineno);}
-	| expression voGTE expression				{$$ = newBinaryOperation(GTE, $1, $3, yylineno);}
-	| expression voCASEEQUAL expression			{$$ = newBinaryOperation(CASE_EQUAL, $1, $3, yylineno);}
-	| expression voCASENOTEQUAL expression		{$$ = newBinaryOperation(CASE_NOT_EQUAL, $1, $3, yylineno);}
-	| expression voOROR expression				{$$ = newBinaryOperation(LOGICAL_OR, $1, $3, yylineno);}
-	| expression voANDAND expression			{$$ = newBinaryOperation(LOGICAL_AND, $1, $3, yylineno);}
-	| expression '?' expression ':' expression	{$$ = newIfQuestion($1, $3, $5, yylineno);}
-	| function_instantiation					{$$ = $1;}
-	| '(' expression ')'						{$$ = $2;}
-	| '{' expression '{' probable_expression_list '}' '}'	{$$ = newListReplicate( $2, $4 ); }
-	| c_function								{$$ = $1;}
+	primary												{$$ = $1;}
+	| '+' expression %prec UADD						{$$ = newUnaryOperation(ADD, $2, yylineno);}
+	| '-' expression %prec UMINUS					{$$ = newUnaryOperation(MINUS, $2, yylineno);}
+	| '~' expression %prec UNOT						{$$ = newUnaryOperation(BITWISE_NOT, $2, yylineno);}
+	| '&' expression %prec UAND						{$$ = newUnaryOperation(BITWISE_AND, $2, yylineno);}
+	| '|' expression %prec UOR						{$$ = newUnaryOperation(BITWISE_OR, $2, yylineno);}
+	| voNAND expression %prec UNAND					{$$ = newUnaryOperation(BITWISE_NAND, $2, yylineno);}
+	| voNOR expression %prec UNOR					{$$ = newUnaryOperation(BITWISE_NOR, $2, yylineno);}
+	| voXNOR  expression %prec UXNOR				{$$ = newUnaryOperation(BITWISE_XNOR, $2, yylineno);}
+	| '!' expression %prec ULNOT					{$$ = newUnaryOperation(LOGICAL_NOT, $2, yylineno);}
+	| '^' expression %prec UXOR						{$$ = newUnaryOperation(BITWISE_XOR, $2, yylineno);}
+	| vCLOG2 '(' expression ')'						{$$ = newUnaryOperation(CLOG2, $3, yylineno);}
+	| voUNSIGNED '(' expression ')'					{$$ = newUnaryOperation(UNSIGNED, $3, yylineno);}
+	| voSIGNED '(' expression ')'					{$$ = newUnaryOperation(SIGNED, $3, yylineno);}
+	| expression '^' expression						{$$ = newBinaryOperation(BITWISE_XOR, $1, $3, yylineno);}
+	| expression voPOWER expression					{$$ = newBinaryOperation(POWER,$1, $3, yylineno);}
+	| expression '*' expression						{$$ = newBinaryOperation(MULTIPLY, $1, $3, yylineno);}
+	| expression '/' expression						{$$ = newBinaryOperation(DIVIDE, $1, $3, yylineno);}
+	| expression '%' expression						{$$ = newBinaryOperation(MODULO, $1, $3, yylineno);}
+	| expression '+' expression						{$$ = newBinaryOperation(ADD, $1, $3, yylineno);}
+	| expression '-' expression						{$$ = newBinaryOperation(MINUS, $1, $3, yylineno);}
+	| expression '&' expression						{$$ = newBinaryOperation(BITWISE_AND, $1, $3, yylineno);}
+	| expression '|' expression						{$$ = newBinaryOperation(BITWISE_OR, $1, $3, yylineno);}
+	| expression voNAND expression					{$$ = newBinaryOperation(BITWISE_NAND, $1, $3, yylineno);}
+	| expression voNOR expression					{$$ = newBinaryOperation(BITWISE_NOR, $1, $3, yylineno);}
+	| expression voXNOR expression					{$$ = newBinaryOperation(BITWISE_XNOR, $1, $3, yylineno);}
+	| expression '<' expression						{$$ = newBinaryOperation(LT, $1, $3, yylineno);}
+	| expression '>' expression						{$$ = newBinaryOperation(GT, $1, $3, yylineno);}
+	| expression voSRIGHT expression				{$$ = newBinaryOperation(SR, $1, $3, yylineno);}
+	| expression voASRIGHT expression				{$$ = newBinaryOperation(ASR, $1, $3, yylineno);}
+	| expression voSLEFT expression					{$$ = newBinaryOperation(SL, $1, $3, yylineno);}
+	| expression voEQUAL expression					{$$ = newBinaryOperation(LOGICAL_EQUAL, $1, $3, yylineno);}
+	| expression voNOTEQUAL expression				{$$ = newBinaryOperation(NOT_EQUAL, $1, $3, yylineno);}
+	| expression voLTE expression					{$$ = newBinaryOperation(LTE, $1, $3, yylineno);}
+	| expression voGTE expression					{$$ = newBinaryOperation(GTE, $1, $3, yylineno);}
+	| expression voCASEEQUAL expression				{$$ = newBinaryOperation(CASE_EQUAL, $1, $3, yylineno);}
+	| expression voCASENOTEQUAL expression			{$$ = newBinaryOperation(CASE_NOT_EQUAL, $1, $3, yylineno);}
+	| expression voOROR expression					{$$ = newBinaryOperation(LOGICAL_OR, $1, $3, yylineno);}
+	| expression voANDAND expression				{$$ = newBinaryOperation(LOGICAL_AND, $1, $3, yylineno);}
+	| expression '?' expression ':' expression		{$$ = newIfQuestion($1, $3, $5, yylineno);}
+	| function_instantiation						{$$ = $1;}
+	| '(' expression ')'							{$$ = $2;}
+	| '{' expression '{' expression_list '}' '}'	{$$ = newListReplicate( $2, $4 ); }
+	| c_function									{$$ = $1;}
 	;
 
 primary:
-	vNUMBER										{$$ = newNumberNode($1, yylineno);}
-	| vSYMBOL_ID										{$$ = newSymbolNode($1, yylineno);}
-	| vSYMBOL_ID '[' expression ']'								{$$ = newArrayRef($1, $3, yylineno);}
-	| vSYMBOL_ID '[' expression ']' '[' expression ']'					{$$ = newArrayRef2D($1, $3, $6, yylineno);}
-	| vSYMBOL_ID '[' expression vPLUS_COLON expression ']'					{$$ = newPlusColonRangeRef($1, $3, $5, yylineno);}
-	| vSYMBOL_ID '[' expression vMINUS_COLON expression ']'					{$$ = newMinusColonRangeRef($1, $3, $5, yylineno);}
-	| vSYMBOL_ID '[' expression ':' expression ']'						{$$ = newRangeRef($1, $3, $5, yylineno);}
+	vNUMBER													{$$ = newNumberNode($1, yylineno);}
+	| vSYMBOL_ID											{$$ = newSymbolNode($1, yylineno);}
+	| vSYMBOL_ID '[' expression ']'							{$$ = newArrayRef($1, $3, yylineno);}
+	| vSYMBOL_ID '[' expression ']' '[' expression ']'		{$$ = newArrayRef2D($1, $3, $6, yylineno);}
+	| vSYMBOL_ID '[' expression vPLUS_COLON expression ']'	{$$ = newPlusColonRangeRef($1, $3, $5, yylineno);}
+	| vSYMBOL_ID '[' expression vMINUS_COLON expression ']'	{$$ = newMinusColonRangeRef($1, $3, $5, yylineno);}
+	| vSYMBOL_ID '[' expression ':' expression ']'			{$$ = newRangeRef($1, $3, $5, yylineno);}
 	| vSYMBOL_ID '[' expression ':' expression ']' '[' expression ':' expression ']'	{$$ = newRangeRef2D($1, $3, $5, $8, $10, yylineno);}
-	| '{' probable_expression_list '}'							{$$ = $2; ($2)->types.concat.num_bit_strings = -1;}
+	| '{' expression_list '}'								{$$ = $2; ($2)->types.concat.num_bit_strings = -1;}
 	;
-
-probable_expression_list:
-	expression				{$$ = $1;}
-	| expression_list ',' expression	{$$ = newList_entry($1, $3); /* note this will be in order lsb = greatest to msb = 0 in the node child list */}
-	;
-
 expression_list:
 	expression_list ',' expression	{$$ = newList_entry($1, $3); /* note this will be in order lsb = greatest to msb = 0 in the node child list */}
-	| expression			{$$ = newList(CONCATENATE, $1);}
+	| expression					{$$ = newList(CONCATENATE, $1);}
 	;
 
  c_function:


### PR DESCRIPTION
#### Description
- Expanded reduce_expressions to unpack 2D arrays and fold constant ternary operations
- Fixed replications of zero so that they are permitted in concatenations that contain other valid bitstrings, but not permitted anywhere else, per the Verilog 2005 standard
- Implicit fallthrough warning was solved via the reorganization of replication
- Bug from unrolled module instances in module_names_to_idx was resolved

#### Related Issue
closes 828

#### How Has This Been Tested?
odin pre-commit regression suite

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
