### PR TITLE
ODIN_II: Fix coverity issue CID 202093

### DIFF
--- a/ODIN_II/SRC/soft_logic_def_parser.cpp
+++ b/ODIN_II/SRC/soft_logic_def_parser.cpp
@@ -130,6 +130,7 @@ void read_soft_def_file(t_model *hard_adder_models)
 				|| (soft_hard != "hard" && soft_hard != "soft"))
 				{
 					error =1;
+					vtr::free(line_dup);
 					break;
 				}
 				else


### PR DESCRIPTION
#### Description
Should resolve coverity issue CID 202093. line_dup going out of scope before being freed.

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
