### PR TITLE
ODIN_II: Leak fix: free contents of local_param_table_sc

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -428,6 +428,10 @@ void create_netlist()
 	free_implicit_memory_index_and_finalize_memories();
 	create_top_output_nodes(top_module, top_string);
 
+	for(i = 0; i < top_sc_list->local_param_table_sc->size; i++)
+	{
+		free_whole_tree((ast_node_t *)top_sc_list->local_param_table_sc->data[i]);
+	}
 	top_sc_list->local_param_table_sc = sc_free_string_cache(top_sc_list->local_param_table_sc);
 	top_sc_list->local_symbol_table_sc = sc_free_string_cache(top_sc_list->local_symbol_table_sc);
 	top_sc_list->num_local_symbol_table = 0;


### PR DESCRIPTION
#### Description
Fixes memory leaks caused by never freeing the ast nodes held by the local_param_table_sc

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
