### PR TITLE
Fix get_name_of_pin_at_bit() ODIN_II compile warnings

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -592,7 +592,7 @@ char *get_name_of_pin_at_bit(ast_node_t *var_node, int bit, char *instance_name_
 	else if (var_node->type == IDENTIFIERS)
 	{
 		long sc_spot;
-		int pin_index;
+		int pin_index = 0;
 
 		if ((sc_spot = sc_lookup_string(local_symbol_table_sc, var_node->types.identifier)) == -1)
 		{


### PR DESCRIPTION
This commit removes several compile warnings related to
ast_util.cpp's get_name_of_pin_at_bit() in ODIN_II.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

#### Description
Changed code to fix compile warnings coming from the get_name_of_pin_at_bit() function. The warnings are about an uninitialized variable being used.

#### Motivation and Context
This change simply removes some ODIN_II compile warnings.

#### How Has This Been Tested?
The pre-commit test was run.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
