### PR TITLE
ODIN_II: Leak fix: Do not copy pin, just assign

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -3676,7 +3676,7 @@ void terminate_registered_assignment(ast_node_t *always_node, signal_list_t* ass
 			}
 			nnet_t *net = (nnet_t *)output_nets_sc->data[sc_spot];
 			//looking for dependence according to with the type of statement (non-blocking or blocking)
-			list_dependence_pin[i] = copy_input_npin(pin);
+			list_dependence_pin[i] =(pin);
 			if(pin->node) list_dependence_type[i] = pin->node->related_ast_node->type;
 
 			/* clean up non-blocking */


### PR DESCRIPTION
#### Description
Fixes leak from creating copies of pins unnecessarily. Rather than copying, just assign the pin. 

#### How Has This Been Tested?
Odin pre-commit 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
