### PR TITLE
ODIN_II: Fixes leak in instantiate_arithmetic_shift_right

### DIFF
--- a/ODIN_II/SRC/include/netlist_utils.h
+++ b/ODIN_II/SRC/include/netlist_utils.h
@@ -38,7 +38,6 @@ void join_nets(nnet_t *net, nnet_t* input_net);
 
 void remap_pin_to_new_net(npin_t *pin, nnet_t *new_net);
 void remap_pin_to_new_node(npin_t *pin, nnode_t *new_node, int pin_idx);
-void remap_pin_to_new_node_range(npin_t *pin, nnode_t *new_node, int pin_range_start, int pin_range_end);
 
 
 signal_list_t *init_signal_list();

--- a/ODIN_II/SRC/netlist_utils.cpp
+++ b/ODIN_II/SRC/netlist_utils.cpp
@@ -527,33 +527,6 @@ void remap_pin_to_new_node(npin_t *pin, nnode_t *new_node, int pin_idx)
 	}
 }
 
-/*-------------------------------------------------------------------------
- * (function: remap_pin_to_new_nodes)
- *-----------------------------------------------------------------------*/
-void remap_pin_to_new_node_range(npin_t *pin, nnode_t *new_node, int pin_range_start, int pin_range_end)
-{
-	if (pin->type == INPUT)
-    {
-		/* clean out the entry in the old net */
-        pin->node->input_pins[pin->pin_node_idx] = NULL;
-		/* do the new additions */
-		for(int i = pin_range_start; i>=pin_range_end; i--)
-		{
-			add_input_pin_to_node(new_node, pin, i);
-		}
-	}
-	else if (pin->type == OUTPUT)
-    {
-		/* clean out the entry in the old net */
-        pin->node->output_pins[pin->pin_node_idx] = NULL;
-		/* do the new additions */
-		for(int i = pin_range_start; i>=pin_range_end; i--)
-		{
-			add_output_pin_to_node(new_node, pin, i);
-		}
-	}
-}
-
 /*------------------------------------------------------------------------
  * (function: connect_nodes)
  * 	Connect one output node to the inputs of the input node

--- a/ODIN_II/SRC/output_blif.cpp
+++ b/ODIN_II/SRC/output_blif.cpp
@@ -297,7 +297,7 @@ void depth_traverse_output_blif(nnode_t *node, int traverse_mark_number, FILE *f
 	}
 }
 /*-------------------------------------------------------------------
- * (function: partial_map_node)
+ * (function: output_node)
  * 	Depending on node type, figures out what to print for this node
  *------------------------------------------------------------------*/
 void output_node(nnode_t *node, short /*traverse_number*/, FILE *fp)


### PR DESCRIPTION
#### Description
Fixes valgrind leak caused by not being able to free the nodes and pins in the function instantiate_arithmetic_shift_right. There should not be any leaks found when running the asr benchmarks in the operators suite with the k6_frac_N10_frac_chain_mem32k_40nm.xml architecture file. 

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
