### PR TITLE
ODIN_II: Fixes leak caused by free_op_node

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -1087,7 +1087,7 @@ void match_node(t_linked_vptr *place, operation_list oper)
 					if (mark == 1)
 					{
 						merge_nodes(node, next_node);
-						remove_list_node(pre, next);
+						remove_list_node(pre, next);	
 					}
 				}
 			}
@@ -1301,6 +1301,10 @@ void reallocate_pins(nnode_t *node, nnode_t *next_node)
 				pin = input_node->input_pins[pin_idx];
 				add_fanout_pin_to_net(net, pin);
 			}
+			else
+			{
+				free_npin(next_node->output_pins[i]->net->fanout_pins[j]);
+			}
 
 		}
 	}
@@ -1311,12 +1315,12 @@ void reallocate_pins(nnode_t *node, nnode_t *next_node)
  *-------------------------------------------------------------------------*/
 void free_op_nodes(nnode_t *node)
 {
-	int i;
-	for (i = 0; i < node->num_output_pins; i++)
+	for (int i = 0; i < node->num_output_pins; i++)
 	{
 		if (node->output_pins[i]->net != NULL)
-			vtr::free(node->output_pins[i]->net->fanout_pins);
-		vtr::free(node->output_pins[i]->net);
+		{
+			free_nnet(node->output_pins[i]->net);
+		}
 	}
 	free_nnode(node);
 


### PR DESCRIPTION
#### Description
Fixes leaks when running raygentop.v with k6_frac_N10_frac_chain_mem32k_40nm.xml, caused by not freeing the net name, or any unused pins before deleting the pointers

#### Related Issue
#622 

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
