### PR TITLE
Fix fold_conditional() ODIN_II compile warning

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1455,7 +1455,7 @@ ast_node_t * fold_conditional(ast_node_t **node)
 	if(!node || !(*node))
 		return NULL;
 
-	operation_list op_id = (*node)->types.operation.op;
+	ids op_id = (*node)->type;
 	ast_node_t *to_return = NULL;
 
 	switch (op_id)


### PR DESCRIPTION
This commit removes a compile warning related to
ast_util.cpp's fold_conditional() in ODIN_II.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

#### Description
Changed code to fix compile warnings coming from the fold_conditional() function. The warnings happen because the wrong type of enum is being used in a certain spot.

#### Motivation and Context
This change removes one ODIN_II compile warning.

#### How Has This Been Tested?
The pre-commit test was run.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
