### PR TITLE
Odin_II: remove dependency to GNU coreutils realpath

### DIFF
--- a/ODIN_II/regression_test/.library/conf_generate.sh
+++ b/ODIN_II/regression_test/.library/conf_generate.sh
@@ -26,7 +26,7 @@ function echo_bm_conf() {
         else
             path_to_exec=$(find ${_temp_bm_dir} -name ${_reg_exec_name})
             path_to_exec=$(dirname ${path_to_exec})
-            realative_path_from_exec=$(realpath --relative-to=${path_to_exec} ${_input_bm_dir})
+            realative_path_from_exec=$(realapath_from ${_input_bm_dir} ${path_to_exec} )
 
             _bm_name=$(basename ${realative_path_from_exec})
 
@@ -34,7 +34,7 @@ function echo_bm_conf() {
             circuit_list_input=""
             for files in $(find ${_input_bm_dir} -type f -name "*.v")
             do
-                circuit_path=$(realpath --relative-to=${_input_bm_dir} ${files})
+                circuit_path=$(realapath_from ${files} ${_input_bm_dir} )
                 circuit_list_input="\
 circuit_list_add=${circuit_path}
 ${circuit_list_input}"
@@ -42,7 +42,7 @@ ${circuit_list_input}"
 
             for files in $(find ${_input_bm_dir} -type f -name "*.blif")
             do
-                circuit_path=$(realpath --relative-to=${_input_bm_dir} ${files})
+                circuit_path=$(realapath_from ${files} ${_input_bm_dir} )
                 circuit_list_input="\
 circuit_list_add=${circuit_path}
 ${circuit_list_input}"

--- a/ODIN_II/regression_test/.library/helper.sh
+++ b/ODIN_II/regression_test/.library/helper.sh
@@ -42,3 +42,50 @@ function fetch_cursor_position() {
   IFS='[;' read -p $'\e[6n' -d R -a pos -rs || echo "failed with error: $? ; ${pos[*]}"
   echo "${pos[1]}:${pos[2]}"
 }
+
+function realapath_from() {
+	original_path="$1"
+	relative_to="$2"
+
+	reconstructed_path=""
+
+	# we now have the full path of both, 
+	# we trim original_path until it has a common path with relative_to
+	# a: /path/to/dir/a/somewhere
+	# b: /path/to/dir/b/somewhere
+	while [ "_${original_path}" != "_" ] && [ "${original_path}" != "/" ] && [ "_$(echo ${relative_to} | grep ${original_path})" == "_" ]
+	do
+		if [ "_${reconstructed_path}" == "_" ]
+		then
+			reconstructed_path="$( basename ${original_path} )"
+		else
+			reconstructed_path="$( basename ${original_path} )/${reconstructed_path}"
+		fi
+		original_path=$( dirname ${original_path} )
+	done
+
+	# original path now holds the common path to the relative_path
+	# a: /path/to/dir
+	# b: /path/to/dir/b/somewhere
+	# c: a/somewhere
+
+	if [ "_${original_path}" != "_" ] && [ "${original_path}" != "/" ]
+	then 
+		relative_to="$(echo ${relative_to} | sed s+`echo ${original_path}`++g)"
+	fi
+
+	# original path now holds the path above
+	# b: b/somewhere
+	# c: a/somewhere
+
+	while [ "_${relative_to}" != "_" ] && [ "${relative_to}" != "/" ]
+	do
+		reconstructed_path="../${reconstructed_path}"
+		relative_to=$( dirname ${relative_to} )
+	done
+
+	# reconstructed_path is complete
+	# c: ../../a/somewhere
+
+	echo ${reconstructed_path}
+}

--- a/ODIN_II/verify_odin.sh
+++ b/ODIN_II/verify_odin.sh
@@ -157,7 +157,7 @@ function init_temp() {
 
 function create_temp() {
 	if [ ! -d ${NEW_RUN_DIR} ]; then
-		echo "Benchmark result location: $(realpath --relative-to=${PWD} ${NEW_RUN_DIR})"
+		echo "Benchmark result location: ${NEW_RUN_DIR}"
 		mkdir -p ${NEW_RUN_DIR}
 
 		unlink ${REGRESSION_DIR}/latest &> /dev/null || /bin/true
@@ -918,7 +918,7 @@ then
 fi
 
 _TEST=$(readlink -f ${_TEST})
-_TEST=$(realpath --relative-to=${THIS_DIR} ${_TEST})
+_TEST=$(realapath_from  ${_TEST} ${THIS_DIR})
 
 echo "Task: ${_TEST}"
 


### PR DESCRIPTION
travis will not run reg test due to missing realpath command.

#### Description
rolled my own realpath -from_directory in the odin script library

#### Related Issue
N/A

#### Motivation and Context
fix regression test on travis

#### How Has This Been Tested?
pre_commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
