### PR TITLE
vpr: fix memory leak caused by route tree that was not freed.

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -3132,6 +3132,8 @@ static std::vector<int> trace_routed_connection_rr_nodes(const ClusterNetId net_
     //Traced from sink to source, but we want to draw from source to sink
     std::reverse(rr_nodes_on_path.begin(), rr_nodes_on_path.end());
 
+    free_route_tree(rt_root);
+
     if (allocated_route_tree_structs) {
         free_route_tree_timing_structs();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

In the function trace_routed_connection_rr_nodes, I added the route tree to the free list, where it could be correctly freed by the subsequent function call free_route_tree_timing_structs().

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#845 

For this issue, I was unable to replicate the memory leak mentioned above with the latest build of libezgl or the suggested commit of a990b18. 

I built VTR with sanitizers on, and from the vpr folder ran the command:

valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=none --error-exitcode=1 --track-origins=yes ./cmd.sh
where ./cmd.sh was: 
./vpr ~/vtr_baseline/vtr_flow/arch/timing/k6_frac_N10_frac_chain_mem32K_htree0_40nm.xml ~/vtr_baseline/vtr_flow/benchmarks/blif/alu4.blif.

I ran the following command with graphics, and tried different permutations of clicking draw_crit_path, but in the suggested commit there was no report of memory being lost. However, found a heap-buffer-overflow when draw_crit_path was clicked 3-4 times in the routing stage. In the latest build of libezgl I could not replicate the memory leak either, according to @tinayang3024, clicking draw_crit_path 3-4 times would not result in heap-buffer-overflow on the master branch.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It should prevent the memory leak caused by trace_routed_connection_rr_nodes of the graphics module.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Unable to replicate the memory leak**

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
