### PR TITLE
ODIN_II: Leak fix caused by expand_power

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1103,7 +1103,7 @@ static void expand_power(ast_node_t **node)
 		} 
 		else 
 		{
-			new_node = expression1;
+			new_node = ast_node_deep_copy(expression1);
 			for (int i=1; i < len; i++)
 			{
 				ast_node_t *temp_node = create_node_w_type(BINARY_OPERATION, (*node)->line_number, (*node)->file_number);
@@ -1114,7 +1114,7 @@ static void expand_power(ast_node_t **node)
 			}
 		}
 	}
-	//free_whole_tree(*node);
+	free_whole_tree(*node);
 	*node = new_node;
 }
 
@@ -1286,7 +1286,7 @@ ast_node_t *fold_unary(ast_node_t **node)
 /*---------------------------------------------------------------------------------------------
  * (function: calculate_binary)
  *-------------------------------------------------------------------------------------------*/
-ast_node_t * fold_binary(ast_node_t **node)
+ast_node_t *fold_binary(ast_node_t **node)
 {
 	if(!node || !(*node))
 		return NULL;

--- a/ODIN_II/regression_test/benchmark/task/valgrind_operators/task.conf
+++ b/ODIN_II/regression_test/benchmark/task/valgrind_operators/task.conf
@@ -47,17 +47,13 @@ circuit_list_add=binary_shift_left.v
 circuit_list_add=twobits_logical_greater_equal_than.v
 circuit_list_add=binary_shift_right.v
 circuit_list_add=binary_nand.v
-
-####################################
-# currently leaking
-####################################
-# circuit_list_add=asr_8_4.v
-# circuit_list_add=asr_16_7.v
-# circuit_list_add=asr_8_7.v
-# circuit_list_add=specifyBlock.v
-# circuit_list_add=asr_8_6.v
-# circuit_list_add=asr_8_1.v
-# circuit_list_add=asr_8_2.v
-# circuit_list_add=asr_8_5.v
-# circuit_list_add=asr_8_3.v
-# circuit_list_add=eightbit_arithmetic_power.v
+circuit_list_add=asr_8_4.v
+circuit_list_add=asr_16_7.v
+circuit_list_add=asr_8_7.v
+circuit_list_add=specifyBlock.v
+circuit_list_add=asr_8_6.v
+circuit_list_add=asr_8_1.v
+circuit_list_add=asr_8_2.v
+circuit_list_add=asr_8_5.v
+circuit_list_add=asr_8_3.v
+circuit_list_add=eightbit_arithmetic_power.v


### PR DESCRIPTION
#### Description
Fix leak caused by expand_power and re-enable all verilog test files in valgrind_operators, as they should not be causing any leaks after this PR, PR #872, and PR #865 are all merged. The valgrind_operators will fail without all of these being merged, so the other two should be merged first.

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
