### PR TITLE
Odin_II: fix leak appearing when IPO is enabled

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -67,13 +67,10 @@ void init_split_adder(nnode_t *node, nnode_t *ptr, int a, int sizea, int b, int 
  *-------------------------------------------------------------------------*/
 void init_add_distribution()
 {
-	int i, j;
 	oassert(hard_adders != NULL);
-	j = hard_adders->inputs->size + hard_adders->inputs->next->size;
-	adder = (int *)vtr::malloc(sizeof(int) * (j + 1));
-	for (i = 0; i <= j; i++)
-		adder[i] = 0;
-	return;
+
+	int len = hard_adders->inputs->size + hard_adders->inputs->next->size + 1;
+	adder = (int *)vtr::calloc(len, sizeof(int));
 }
 
 /*---------------------------------------------------------------------------
@@ -121,7 +118,7 @@ void report_add_distribution()
 	printf("\n");
 	printf("\nGeometric mean adder/subtractor chain length: %.2f\n", geomean_addsub_length);
 
-	return;
+	vtr::free(adder);
 }
 
 /*---------------------------------------------------------------------------

--- a/ODIN_II/SRC/multipliers.cpp
+++ b/ODIN_II/SRC/multipliers.cpp
@@ -52,6 +52,7 @@ int min_mult = 0;
 int *mults = NULL;
 
 void record_mult_distribution(nnode_t *node);
+void terminate_mult_distribution();
 void init_split_multiplier(nnode_t *node, nnode_t *ptr, int offa, int a, int offb, int b, nnode_t *node_a, nnode_t *node_b);
 void init_multiplier_adder(nnode_t *node, nnode_t *parent, int a, int b);
 void split_multiplier_a(nnode_t *node, int a0, int a1, int b);
@@ -275,14 +276,9 @@ void instantiate_simple_soft_multiplier(nnode_t *node, short mark, netlist_t *ne
  *-------------------------------------------------------------------------*/
 void init_mult_distribution()
 {
-	int i, j;
-
 	oassert(hard_multipliers != NULL);
-	mults = (int *)vtr::malloc(sizeof(int) * (hard_multipliers->inputs->size + 1) * (1 + hard_multipliers->inputs->next->size));
-	for (i = 0; i <= hard_multipliers->inputs->size; i++)
-		for (j = 0; j <= hard_multipliers->inputs->next->size; j++)
-			mults[i * hard_multipliers->inputs->size + j] = 0;
-	return;
+	int len = ( 1 + hard_multipliers->inputs->size ) * ( 1 + hard_multipliers->inputs->next->size );
+	mults = (int *)vtr::calloc(len, sizeof(int));
 }
 
 /*---------------------------------------------------------------------------
@@ -327,7 +323,7 @@ void report_mult_distribution()
 	}
 	printf("\n");
 	printf("\nTotal # of multipliers = %ld\n", num_total);
-	return;
+	vtr::free(mults);
 }
 
 /*---------------------------------------------------------------------------


### PR DESCRIPTION
the leak is introduced from IPO flag by making some global variable appear as unreachable by the program exit.

#### Related Issue
valgrind operator failing on master

#### Motivation and Context
fix regression test

#### How Has This Been Tested?
pre_commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
