### PR TITLE
Fix depth_traverse_count() ODIN_II compile warning

### DIFF
--- a/ODIN_II/SRC/netlist_utils.cpp
+++ b/ODIN_II/SRC/netlist_utils.cpp
@@ -815,7 +815,7 @@ void hookup_output_pins_from_signal_list(nnode_t *node, int n_start_idx, signal_
 	}
 }
 
-void depth_traverse_count(nnode_t *node, int *count, int traverse_mark_number);
+void depth_traverse_count(nnode_t *node, int *count, short traverse_mark_number);
 /*---------------------------------------------------------------------------------------------
  * (function: count_nodes_in_netlist)
  *-------------------------------------------------------------------------------------------*/
@@ -842,7 +842,7 @@ int count_nodes_in_netlist(netlist_t *netlist)
 /*---------------------------------------------------------------------------------------------
  * (function: depth_first_traverse)
  *-------------------------------------------------------------------------------------------*/
-void depth_traverse_count(nnode_t *node, int *count, int traverse_mark_number)
+void depth_traverse_count(nnode_t *node, int *count, short traverse_mark_number)
 {
 	int i, j;
 	nnode_t *next_node;


### PR DESCRIPTION
This commit removes a compile warning related to
netlist_utils.cpp's depth_traverse_count() in ODIN_II.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

#### Description
This commit changes the parameters to the depth_traverse_count() function to accept a `short` instead of an `int`. This was done because the parameter was later being assigned to a value in `node`, which is of type short int.

#### Motivation and Context
This removes a warning that comes up during ODIN_II compilation.

#### How Has This Been Tested?
The pre-commit test was run.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
