### PR TITLE
Fix depth_first_traverse_visualize() ODIN_II compile warning

### DIFF
--- a/ODIN_II/SRC/netlist_visualizer.cpp
+++ b/ODIN_II/SRC/netlist_visualizer.cpp
@@ -34,7 +34,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "vtr_util.h"
 #include "vtr_memory.h"
 
-void depth_first_traverse_visualize(nnode_t *node, FILE *fp, int traverse_mark_number);
+void depth_first_traverse_visualize(nnode_t *node, FILE *fp, short traverse_mark_number);
 void depth_first_traversal_graph_display(FILE *out, short marker_value, netlist_t *netllist);
 
 void forward_traversal_net_graph_display(FILE *out, short marker_value, nnode_t *node);
@@ -87,7 +87,7 @@ void depth_first_traversal_graph_display(FILE *out, short marker_value, netlist_
 /*---------------------------------------------------------------------------------------------
  * (function: depth_first_traverse)
  *-------------------------------------------------------------------------------------------*/
-void depth_first_traverse_visualize(nnode_t *node, FILE *fp, int traverse_mark_number)
+void depth_first_traverse_visualize(nnode_t *node, FILE *fp, short traverse_mark_number)
 {
 	int i, j;
 	nnode_t *next_node;


### PR DESCRIPTION
This commit removes a compile warning related to
netlist_visualizer.cpp's depth_first_traverse_visualize()
in ODIN_II.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>

#### Description
This commit changes the parameters to the depth_first_traverse_visualize() function to accept a `short` instead of an `int`. This was done because the parameter was later being assigned to a value in `node`, which is of type short int. The value passed in when this function is called is also a short int.

#### Motivation and Context
This change removes an ODIN_II compile error.

#### How Has This Been Tested?
The pre-commit test was run.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
