### PR TITLE
vpr: added check for null pointer dereference in route_tree_timing.cpp

### DIFF
--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -1426,7 +1426,7 @@ t_rt_node* find_sink_rt_node_recurr(t_rt_node* node, int sink_rr_inode) {
 
     for (t_linked_rt_edge* edge = node->u.child_list; edge != nullptr; edge = edge->next) {
         found_node = find_sink_rt_node_recurr(edge->child, sink_rr_inode); //process each of the children
-
+        VTR_ASSERT(found_node);
         if (found_node->inode == sink_rr_inode) {
             //If the sink has been found downstream in the branch, we would like to immediately exit the search
             return found_node;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
added an assertion to avoid potential null pointer dereference warning.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#871 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

"To keep VTR warning clean during builds (at least with gcc), so that any new warning actually gets looked into."

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Passed basic and strong regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
