### PR TITLE
[WIP]ODIN_II: Fix leak from convert_2D_to_1D_array

### DIFF
--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -912,7 +912,7 @@ void convert_2D_to_1D_array(ast_node_t **var_declare, STRING_CACHE_LIST *local_s
 	ast_node_t *node_max2  = (*var_declare)->children[3];
 	ast_node_t *node_min2  = (*var_declare)->children[4];
 
-	ast_node_t *node_max3  = (*var_dqeclare)->children[5];
+	ast_node_t *node_max3  = (*var_declare)->children[5];
 	ast_node_t *node_min3  = (*var_declare)->children[6];
 
 	oassert(node_min2->type == NUMBERS && node_max2->type == NUMBERS);		


### PR DESCRIPTION
#### Description
Fixes valgrind leak from overwriting an ast_node in convert_2D_to_1D_array. This node gets overwitten when calling this function from update_string_caches

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
