### PR TITLE
ODIN_II: Fix leak caused by temp_string

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -149,7 +149,7 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 {
 	/* with the top module we need to visit the entire ast tree */
 	long i, j;
-	char *temp_string;
+	char *temp_string = NULL;
 	char **temp_parameter_list = NULL;
 	ast_node_t **temp_localparam_list = NULL;
 	long sc_spot;
@@ -199,6 +199,7 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 							temp_parameter_list = (char**) vtr::realloc(temp_parameter_list, sizeof(char*)*parameter_num);
 						
 						temp_parameter_list[parameter_num-1] = temp_string;
+						temp_string = NULL;
 					}
 					else if (var_declare->types.variable.is_localparam)
 					{
@@ -211,6 +212,10 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 							temp_localparam_list = (ast_node_t**) vtr::realloc(temp_localparam_list, sizeof(ast_node_t*)*localparam_num);
 						
 						temp_localparam_list[localparam_num-1] = var_declare;
+					}
+					if(temp_string)
+					{
+						vtr::free(temp_string);
 					}
 				}
 			}
@@ -314,10 +319,14 @@ STRING_CACHE *create_param_table_for_module(ast_node_t* parent_parameter_list, a
 		sc_spot = sc_add_string(local_param_table_sc, temp_string);
 		local_param_table_sc->data[sc_spot] = (void *)temp_localparam_list[i]->children[5];
 
+		if(temp_string)
+		{
+			vtr::free(temp_string);
+		}
 		/* add to temp param list */
-		parameter_num++;
-		temp_parameter_list = (char**) vtr::realloc(temp_parameter_list, sizeof(char*)*parameter_num);
-		temp_parameter_list[parameter_num-1] = temp_string;
+		// parameter_num++;
+		// temp_parameter_list = (char**) vtr::realloc(temp_parameter_list, sizeof(char*)*parameter_num);
+		// temp_parameter_list[parameter_num-1] = temp_string;
 	}
 
 	/* clean up */


### PR DESCRIPTION
#### Description
Fixes memory leak caused by temp_string never being freed unless it gets assigned to temp_parameter_list. Commented out some seemingly unnecessary code

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
