### PR TITLE
vpr: check the costs of node to be expanded before adding to the heap

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1903,8 +1903,24 @@ static void timing_driven_add_to_heap(const t_conn_cost_params cost_params,
                               router_lookahead,
                               next, from_node, to_node, iconn, target_node);
 
-    add_to_heap(next);
-    ++router_stats.heap_pushes;
+    auto& route_ctx = g_vpr_ctx.routing();
+
+    float old_next_total_cost = route_ctx.rr_node_route_inf[to_node].path_cost;
+    float old_next_back_cost = route_ctx.rr_node_route_inf[to_node].backward_path_cost;
+
+    float new_next_total_cost = next->cost;
+    float new_next_back_cost = next->backward_path_cost;
+
+    if (old_next_total_cost > new_next_total_cost && old_next_back_cost > new_next_back_cost) {
+        //Add node to the heap only if the current cost is less than its historic cost, since
+        //there is no point in for the router to expand more expensive paths.
+        add_to_heap(next);
+        ++router_stats.heap_pushes;
+    }
+
+    else {
+        free_heap_data(next);
+    }
 }
 
 //Updates current (path step and costs) to account for the step taken to reach to_node


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Added a condition checking both the total_cost and backwards_cost in reaching the node must be less than any previously recorded value of total_cost and backwards_cost, before adding the node to the heap. This action is also referred to as "prepruning".

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This change is required as an improvement to VPR's runtime.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Here are the results of Titan23 benchmarks being run on the StratixIV Titan architecture.

These results are a comparison of the code with the check added vs. master branch.

Both codebases ran only the routing stage, and used the same net and place files to isolate only the effect of the router.

https://docs.google.com/spreadsheets/d/1f8zz_17xW7yyd9VYHUvNfsq8xoqpjj1B1918oFWb83Q/edit?usp=sharing


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
