### PR TITLE
ODIN II: fix hard block instantiation bug

### DIFF
--- a/ODIN_II/SRC/adders.cpp
+++ b/ODIN_II/SRC/adders.cpp
@@ -1500,3 +1500,34 @@ void instantiate_add_w_carry_block(int *width, nnode_t *node, short mark, netlis
 		connect_output_pin_to_node(width, i, 0, node, current_adder, subtraction);
 	}
 }
+
+bool is_ast_adder(ast_node_t *node)
+{
+	bool is_adder;
+	ast_node_t *instance = node->children[1];
+	is_adder = 	(!strcmp(node->children[0]->types.identifier, "adder")) 
+				 && (instance->children[1]->num_children == 5);
+
+	ast_node_t *connect_list = instance->children[1];
+	if (is_adder && connect_list->children[0]->children[0])
+	{
+		/* port connections were passed by name; verify port names */
+		for (int i = 0; i < connect_list->num_children && is_adder; i++)
+		{
+			char *id = connect_list->children[i]->children[0]->types.identifier; 
+
+			if ((strcmp(id, "a") != 0) &&
+				(strcmp(id, "b") != 0) &&
+				(strcmp(id, "cin") != 0) &&
+				(strcmp(id, "cout") != 0) &&
+				(strcmp(id, "sumout") != 0)
+			)
+			{
+				is_adder = false;
+				break;
+			}
+		}
+	}
+
+	return is_adder;
+}

--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -27,9 +27,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <stdlib.h>
 #include <math.h>
 #include "odin_types.h"
+#include "adders.h"
 #include "ast_util.h"
 #include "ast_elaborate.h"
 #include "ast_loop_unroll.h"
+#include "hard_blocks.h"
+#include "memories.h"
+#include "multipliers.h"
 #include "parse_making_ast.h"
 #include "verilog_bison.h"
 #include "netlist_create_from_ast.h"
@@ -101,19 +105,25 @@ OTHER DEALINGS IN THE SOFTWARE.
 // bool check_mult_bracket(std::vector<int> list);
 
 void update_string_caches(STRING_CACHE_LIST *local_string_cache_list);
+
 void convert_2D_to_1D_array(ast_node_t **var_declare, STRING_CACHE_LIST *local_string_cache_list);
 void convert_2D_to_1D_array_ref(ast_node_t **node, STRING_CACHE_LIST *local_string_cache_list);
 char *make_chunk_size_name(char *instance_name_prefix, char *array_name);
 ast_node_t *get_chunk_size_node(char *instance_name_prefix, char *array_name, STRING_CACHE_LIST *local_string_cache_list);
+
 bool verify_terminal(ast_node_t *top, ast_node_t *iterator);
 void verify_genvars(ast_node_t *node, STRING_CACHE_LIST *local_string_cache_list, char ***other_genvars, int num_genvars);
+
+ast_node_t *look_for_matching_hard_block(ast_node_t *node, char *hard_block_name);
+ast_node_t *look_for_matching_soft_logic(ast_node_t *node, char *hard_block_name);
+
 
 int simplify_ast_module(ast_node_t **ast_module, STRING_CACHE_LIST *local_string_cache_list)
 {
 	/* resolve constant expressions */
+	update_string_caches(local_string_cache_list);
 	bool is_module = (*ast_module)->type == MODULE ? true : false;
 	*ast_module = reduce_expressions(*ast_module, NULL, local_string_cache_list, NULL, 0, is_module);
-	update_string_caches(local_string_cache_list);
 
 	return 1;
 }
@@ -145,6 +155,112 @@ ast_node_t *reduce_expressions(ast_node_t *node, ast_node_t *parent, STRING_CACH
 			case FUNCTION:
 			{
 				skip_children = true;
+				break;
+			}
+			case FUNCTION_INSTANCE:
+			{
+				// check ports
+				ast_node_t *connect_list = node->children[1]->children[1];
+				bool is_ordered_list;
+				if (connect_list->children[1]->children[0]) // skip first connection
+				{
+					is_ordered_list = false; // name was specified
+				}
+				else
+				{
+					is_ordered_list = true;
+				}
+
+				for (int i = 1; i < connect_list->num_children; i++)
+				{
+					if ((connect_list->children[i]->children[0] && is_ordered_list)
+						|| (!connect_list->children[i]->children[0] && !is_ordered_list))
+					{
+						error_message(PARSE_ERROR, node->line_number, node->file_number, 
+								"%s", "Cannot mix port connections by name and port connections by ordered list\n");
+					}
+				}
+
+				skip_children = true;
+
+				break;
+			}
+			case MODULE_ITEMS:
+			{
+				/* look in the string cache for in-line continuous assignments */
+				ast_node_t **local_symbol_table = local_string_cache_list->local_symbol_table;
+				int num_local_symbol_table = local_string_cache_list->num_local_symbol_table;
+
+				for (int i = 0; i < num_local_symbol_table; i++)
+				{
+					ast_node_t *var_declare = local_symbol_table[i];
+					if (var_declare->types.variable.is_wire && var_declare->children[5] != NULL)
+					{
+						/* in-line assignment; split into its own continuous assignment */
+						ast_node_t *id = ast_node_copy(var_declare->children[0]);
+						ast_node_t *val = var_declare->children[5];
+						var_declare->children[5] = NULL;
+
+						ast_node_t *blocking_node = newBlocking(id, val, var_declare->line_number);
+						ast_node_t *assign_node = newList(ASSIGN, blocking_node);
+
+						add_child_to_node(node, assign_node);
+					}
+				}
+
+				break;
+			}
+			case MODULE_INSTANCE:
+			{
+				/* flip hard blocks */
+
+				if (node->num_children == 1)
+				{
+					// check ports
+					ast_node_t *connect_list = node->children[0]->children[1]->children[1];
+					bool is_ordered_list;
+					if (connect_list->children[0]->children[0])
+					{
+						is_ordered_list = false; // name was specified
+					}
+					else
+					{
+						is_ordered_list = true;
+					}
+
+					for (int i = 1; i < connect_list->num_children; i++)
+					{
+						if ((connect_list->children[i]->children[0] && is_ordered_list)
+							|| (!connect_list->children[i]->children[0] && !is_ordered_list))
+						{
+							error_message(PARSE_ERROR, node->line_number, node->file_number, 
+									"%s", "Cannot mix port connections by name and port connections by ordered list\n");
+						}
+					}
+
+					char *module_ref_name = node->children[0]->children[0]->types.identifier;
+					long sc_spot = sc_lookup_string(hard_block_names, module_ref_name);
+
+					/* TODO: strcmp on "multiply", "adder" for soft logic implementation? */
+					if
+					(
+						sc_spot != -1
+						|| !strcmp(module_ref_name, SINGLE_PORT_RAM_string)
+						|| !strcmp(module_ref_name, DUAL_PORT_RAM_string)
+					)
+					{
+						ast_node_t *hb_node = look_for_matching_hard_block(node->children[0], module_ref_name);
+						if (hb_node != node->children[0])
+						{
+							free_whole_tree(node);
+							node = hb_node;
+
+							child_skip_list = (short *)vtr::realloc(child_skip_list, sizeof(short)*node->num_children);
+							child_skip_list[1] = false;
+							break;
+						}
+					}
+				}
 				break;
 			}
 			case VAR_DECLARE:
@@ -330,9 +446,8 @@ ast_node_t *reduce_expressions(ast_node_t *node, ast_node_t *parent, STRING_CACH
 					}
 					
 					assignment_size = 0;
+					skip_children = true;
 				}
-
-				skip_children = true;
 				break;
 			}
 			case BINARY_OPERATION:
@@ -491,9 +606,6 @@ ast_node_t *reduce_expressions(ast_node_t *node, ast_node_t *parent, STRING_CACH
 			case RANGE_REF:
 			case ARRAY_REF:
 				break;
-			case MODULE_INSTANCE:
-				// flip hard blocks
-				break;
 			case ALWAYS: // fallthrough
 			case INITIALS:
 			{
@@ -555,8 +667,6 @@ ast_node_t *reduce_expressions(ast_node_t *node, ast_node_t *parent, STRING_CACH
 			{
 				/* this should be encountered once generate constructs are resolved, so we don't have
 					stray instances that never get instantiated */
-
-				/* TODO: handle hard block instantiation here! */
 
 				if (node->num_children == 2)
 				{
@@ -1113,6 +1223,144 @@ void verify_genvars(ast_node_t *node, STRING_CACHE_LIST *local_string_cache_list
 				verify_genvars(node->children[i], local_string_cache_list, other_genvars, num_genvars);
 			}
 		}
+	}
+}
+
+ast_node_t *look_for_matching_hard_block(ast_node_t *node, char *hard_block_name)
+{
+	t_model *hb_model = find_hard_block(hard_block_name);
+	bool is_hb = true;
+
+	if (!hb_model)
+	{
+		/* check for soft logic RAM */
+		return look_for_matching_soft_logic(node, hard_block_name);
+	}
+	else
+	{
+	
+		t_model_ports *hb_input_ports = hb_model->inputs;
+		t_model_ports *hb_output_ports = hb_model->outputs;
+
+		int num_hb_inputs = 0;
+		int num_hb_outputs = 0;
+
+		while (hb_input_ports != NULL)
+		{
+			num_hb_inputs++;
+			hb_input_ports = hb_input_ports->next;
+		}
+
+		while (hb_output_ports != NULL)
+		{
+			num_hb_outputs++;
+			hb_output_ports = hb_output_ports->next;
+		}
+
+		ast_node_t *connect_list = node->children[1]->children[1];
+
+		/* first check if the number of ports match up */
+		if (connect_list->num_children != (num_hb_inputs + num_hb_outputs))
+		{
+			is_hb = false;
+		}
+		
+		if (is_hb && connect_list->children[0]->children[0] != NULL)
+		{
+			/* if all port names match up, this is a hard block */
+			for (int i = 0; i < connect_list->num_children && is_hb; i++)
+			{
+				oassert(connect_list->children[i]->children[0]);
+				char *id = connect_list->children[i]->children[0]->types.identifier;
+				hb_input_ports = hb_model->inputs;
+				hb_output_ports = hb_model->outputs;
+
+				while ((hb_input_ports != NULL) && (strcmp(hb_input_ports->name, id) != 0))
+				{
+					hb_input_ports = hb_input_ports->next;
+				}
+
+				if (hb_input_ports == NULL)
+				{
+					while ((hb_output_ports != NULL) && (strcmp(hb_output_ports->name, id) != 0))
+					{
+						hb_output_ports = hb_output_ports->next;
+					}
+				}
+				else
+				{
+					continue; // matching input was found
+				}
+
+				if (hb_output_ports == NULL)
+				{
+					is_hb = false; // ports don't match up
+				}
+				else
+				{
+					continue; // matching output was found
+				}
+			}
+		}
+		else if (is_hb)
+		{
+			/* number of ports match, so default to a hard block */
+			warning_message(NETLIST_ERROR, connect_list->line_number, connect_list->file_number, 
+				"Converting this instance to a hard block (%s) - unnamed port connections will be matched according to hard block specification\n", hard_block_name);
+
+			hb_input_ports = hb_model->inputs;
+			hb_output_ports = hb_model->outputs;
+			int i = 0;
+
+			while (hb_output_ports)
+			{
+				oassert(connect_list->children[i] && !connect_list->children[i]->children[0]);
+				connect_list->children[i]->children[0] = newSymbolNode(vtr::strdup(hb_output_ports->name), connect_list->line_number);
+				hb_output_ports = hb_output_ports->next;
+				i++;
+			}
+			
+			while (hb_input_ports)
+			{
+				oassert(connect_list->children[i] && !connect_list->children[i]->children[0]);
+				connect_list->children[i]->children[0] = newSymbolNode(vtr::strdup(hb_input_ports->name), connect_list->line_number);
+				hb_input_ports = hb_input_ports->next;
+				i++;
+			}
+		}
+	}
+
+	if (is_hb)
+	{
+		ast_node_t *instance = ast_node_deep_copy(node->children[1]);
+		char *new_hard_block_name = vtr::strdup(hard_block_name);
+		
+		return newHardBlockInstance(new_hard_block_name, instance, instance->line_number);
+	}
+	else
+	{
+		return look_for_matching_soft_logic(node, hard_block_name);
+	}
+}
+
+ast_node_t *look_for_matching_soft_logic(ast_node_t *node, char *hard_block_name)
+{
+	bool is_hb = true;
+
+	if (!is_ast_sp_ram(node) && !is_ast_dp_ram(node) && !is_ast_adder(node) && !is_ast_multiplier(node))
+	{
+		is_hb = false;
+	}
+
+	if (is_hb)
+	{
+		ast_node_t *instance = ast_node_deep_copy(node->children[1]);
+		char *new_hard_block_name = vtr::strdup(hard_block_name);
+		return newHardBlockInstance(new_hard_block_name, instance, instance->line_number);
+	}
+	else
+	{
+		return node;
 	}
 }
 

--- a/ODIN_II/SRC/include/adders.h
+++ b/ODIN_II/SRC/include/adders.h
@@ -77,6 +77,6 @@ void free_op_nodes(nnode_t *node);
 int match_pins(nnode_t *node, nnode_t *next_node);
 
 void instantiate_add_w_carry_block(int *width, nnode_t *node, short mark, netlist_t *netlist, short subtraction);
-
+bool is_ast_adder(ast_node_t *node);
 
 #endif // ADDERS_H

--- a/ODIN_II/SRC/include/memories.h
+++ b/ODIN_II/SRC/include/memories.h
@@ -82,11 +82,11 @@ void free_sp_ram_signals(sp_ram_signals *signalsvar);
 dp_ram_signals *get_dp_ram_signals(nnode_t *node);
 void free_dp_ram_signals(dp_ram_signals *signalsvar);
 
-char is_sp_ram(nnode_t *node);
-char is_dp_ram(nnode_t *node);
+bool is_sp_ram(nnode_t *node);
+bool is_dp_ram(nnode_t *node);
 
-char is_ast_sp_ram(ast_node_t *node);
-char is_ast_dp_ram(ast_node_t *node);
+bool is_ast_sp_ram(ast_node_t *node);
+bool is_ast_dp_ram(ast_node_t *node);
 
 void init_memory_distribution();
 void check_memories_and_report_distribution();

--- a/ODIN_II/SRC/include/multipliers.h
+++ b/ODIN_II/SRC/include/multipliers.h
@@ -47,6 +47,7 @@ extern void add_the_blackbox_for_mults(FILE *out);
 extern void define_mult_function(nnode_t *node, FILE *out);
 extern void split_multiplier(nnode_t *node, int a0, int b0, int a1, int b1, netlist_t *netlist);
 extern void iterate_multipliers(netlist_t *netlist);
+extern bool is_ast_multiplier(ast_node_t *node);
 extern void clean_multipliers();
 extern void free_multipliers();
 

--- a/ODIN_II/SRC/include/parse_making_ast.h
+++ b/ODIN_II/SRC/include/parse_making_ast.h
@@ -60,6 +60,7 @@ ast_node_t *newModuleNamedInstance(char* unique_name, ast_node_t *module_connect
 ast_node_t *newFunctionNamedInstance(ast_node_t *module_connect_list, ast_node_t *module_parameter_list, int line_number);
 ast_node_t *newModuleInstance(char* module_ref_name, ast_node_t *module_named_instance, int line_number);
 ast_node_t *newFunctionInstance(char* function_ref_name, ast_node_t *function_named_instance, int line_number);
+ast_node_t *newHardBlockInstance(char* module_ref_name, ast_node_t *module_named_instance, int line_number);
 ast_node_t *newModuleParameter(char* id, ast_node_t *expression, int line_number);
 
 /* FUNCTION INSTANCES FUNCTIONS */

--- a/ODIN_II/SRC/memories.cpp
+++ b/ODIN_II/SRC/memories.cpp
@@ -1336,28 +1336,84 @@ void pad_memory_input_port(nnode_t *node, netlist_t *netlist, t_model *model, co
 	}
 }
 
-char is_sp_ram(nnode_t *node)
+bool is_sp_ram(nnode_t *node)
 {
 	oassert(node != NULL);
 	oassert(node->type == MEMORY);
-	return is_ast_sp_ram(node->related_ast_node);
+	return !strcmp(node->related_ast_node->children[0]->types.identifier, SINGLE_PORT_RAM_string);
 }
 
-char is_dp_ram(nnode_t *node)
+bool is_dp_ram(nnode_t *node)
 {
 	oassert(node != NULL);
 	oassert(node->type == MEMORY);
-	return is_ast_dp_ram(node->related_ast_node);
+	return !strcmp(node->related_ast_node->children[0]->types.identifier, DUAL_PORT_RAM_string);
 }
 
-char is_ast_sp_ram(ast_node_t *node)
+bool is_ast_sp_ram(ast_node_t *node)
 {
-	return (!strcmp(node->children[0]->types.identifier, SINGLE_PORT_RAM_string));
+	bool is_ram;
+	ast_node_t *instance = node->children[1];
+	is_ram = 	(!strcmp(node->children[0]->types.identifier, SINGLE_PORT_RAM_string)) 
+				 && (instance->children[1]->num_children == 5);
+
+	ast_node_t *connect_list = instance->children[1];
+	if (is_ram && connect_list->children[0]->children[0])
+	{
+		/* port connections were passed by name; verify port names */
+		for (int i = 0; i < connect_list->num_children && is_ram; i++)
+		{
+			char *id = connect_list->children[i]->children[0]->types.identifier; 
+
+			if ((strcmp(id, "we") != 0) &&
+				(strcmp(id, "clk") != 0) &&
+				(strcmp(id, "addr") != 0) &&
+				(strcmp(id, "data") != 0) &&
+				(strcmp(id, "out") != 0)
+			)
+			{
+				is_ram = false;
+				break;
+			}
+		}
+	}
+
+	return is_ram;
 }
 
-char is_ast_dp_ram(ast_node_t *node)
+bool is_ast_dp_ram(ast_node_t *node)
 {
-	return (!strcmp(node->children[0]->types.identifier, DUAL_PORT_RAM_string));
+	bool is_ram;
+	ast_node_t *instance = node->children[1];
+	is_ram = 	(!strcmp(node->children[0]->types.identifier, DUAL_PORT_RAM_string)) 
+				 && (instance->children[1]->num_children == 9);
+
+	ast_node_t *connect_list = instance->children[1];
+	if (is_ram && connect_list->children[0]->children[0])
+	{
+		/* port connections were passed by name; verify port names */
+		for (int i = 0; i < connect_list->num_children && is_ram; i++)
+		{
+			char *id = connect_list->children[i]->children[0]->types.identifier; 
+
+			if ((strcmp(id, "clk") != 0) &&
+				(strcmp(id, "we1") != 0) &&
+				(strcmp(id, "we2") != 0) &&
+				(strcmp(id, "addr1") != 0) &&
+				(strcmp(id, "addr2") != 0) &&
+				(strcmp(id, "data1") != 0) &&
+				(strcmp(id, "data2") != 0) &&
+				(strcmp(id, "out1") != 0) &&
+				(strcmp(id, "out2") != 0)
+			)
+			{
+				is_ram = false;
+				break;
+			}
+		}
+	}
+
+	return is_ram;
 }
 
 sp_ram_signals *get_sp_ram_signals(nnode_t *node)

--- a/ODIN_II/SRC/multipliers.cpp
+++ b/ODIN_II/SRC/multipliers.cpp
@@ -1419,6 +1419,35 @@ void split_soft_multiplier(nnode_t *node, netlist_t *netlist) {
 	vtr::free(node);
 }
 
+bool is_ast_multiplier(ast_node_t *node)
+{
+	bool is_mult;
+	ast_node_t *instance = node->children[1];
+	is_mult = 	(!strcmp(node->children[0]->types.identifier, "multiply")) 
+				 && (instance->children[1]->num_children == 3);
+
+	ast_node_t *connect_list = instance->children[1];
+	if (is_mult && connect_list->children[0]->children[0])
+	{
+		/* port connections were passed by name; verify port names */
+		for (int i = 0; i < connect_list->num_children && is_mult; i++)
+		{
+			char *id = connect_list->children[i]->children[0]->types.identifier; 
+
+			if ((strcmp(id, "a") != 0) &&
+				(strcmp(id, "b") != 0) &&
+				(strcmp(id, "out") != 0)
+			)
+			{
+				is_mult = false;
+				break;
+			}
+		}
+	}
+
+	return is_mult;
+}
+
 /*-------------------------------------------------------------------------
  * (function: clean_multipliers)
  *

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -5616,6 +5616,8 @@ signal_list_t *create_hard_block(ast_node_t* block, char *instance_name_prefix, 
 			return create_soft_dual_port_ram_block(block, instance_name_prefix, local_string_cache_list);
 	}
 
+	/* TODO: create_soft_adder_block()/create_soft_multiplier_block()??? */
+
 	if (!hb_model)
 	{
 		error_message(NETLIST_ERROR, block->line_number, block->file_number,
@@ -5784,6 +5786,8 @@ signal_list_t *create_hard_block(ast_node_t* block, char *instance_name_prefix, 
 			}
 		}
 	}
+
+	hb_ports = hb_model->outputs;
 
 	/* IF a multiplier - need to process the output pins now */
 	/* Size of the output is estimated to be size of the inputs added */

--- a/ODIN_II/regression_test/benchmark/task/rs_decoder/task.conf
+++ b/ODIN_II/regression_test/benchmark/task/rs_decoder/task.conf
@@ -10,8 +10,8 @@ script_simulation_params=--time_limit 3600s
 arch_dir=../vtr_flow/arch/timing
 
 arch_list_add=k6_N10_40nm.xml
-# arch_list_add=k6_N10_mem32K_40nm.xml
-#arch_list_add=k6_frac_N10_frac_chain_mem32K_40nm.xml
+arch_list_add=k6_N10_mem32K_40nm.xml
+arch_list_add=k6_frac_N10_frac_chain_mem32K_40nm.xml
 
 # setup the circuits
 circuit_dir=regression_test/benchmark/verilog/syntax


### PR DESCRIPTION
### Description
Fixed a bug with module/hard block name collisions. Odin will now convert module instantiations to hard blocks or soft logic where appropriate (i.e., when port connections match), regardless of whether a custom module was written. 

#### How Has This Been Tested?
Odin pre-commit regression suite

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
