### PR TITLE
vpr: fixed memory leak in load_rr_indexed_data_T_values

### DIFF
--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -423,5 +423,6 @@ static void load_rr_indexed_data_T_values(int index_start,
     free(R_total);
     free(switch_R_total);
     free(switch_T_total);
+    free(switch_Cinternal_total);
     free(switches_buffered);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Freed the pointer switch_Cinternal_total in load_rr_indexed_data_T_values.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#889 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
"Memory leaks should be avoided."
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running vtr_reg_valgrind_small after my change no longer reported the memory leak from load_rr_indexed_data_T_values function.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
