### PR TITLE
odin: accept files with .sv extension

### DIFF
--- a/ODIN_II/SRC/enum_str.cpp
+++ b/ODIN_II/SRC/enum_str.cpp
@@ -2,7 +2,8 @@
 
 const char *file_extension_supported_STR[] =
 {
-	".v"
+	".v",
+	".sv"
 };
 
 const char *edge_type_e_STR[] =

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -162,6 +162,7 @@ extern const char *ids_STR [];
 enum file_extension_supported
 {
 	VERILOG,
+	SYSTEM_VERILOG,
 	file_extension_supported_END
 };
 


### PR DESCRIPTION
This change is needed to make Odin_II accept SystemVerilog files.

#### Motivation and Context
Using Odin_II with SystemVerilog to potentially see what is there and what is missing.

#### How Has This Been Tested?
By getting Odin to use a file with the `.sv` extension.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

Not all tests pass on my machine, but they don't pass without this patch either and I don't think they should be affected by this change so I'll just let the CI verify it.