### PR TITLE
odin: makefile: fix parallel build

### DIFF
--- a/ODIN_II/Makefile
+++ b/ODIN_II/Makefile
@@ -36,7 +36,7 @@ help:
 		large_test		run the complete battery of test before merging changes\n\
 	"
 
-_init:
+_init: clean
 	mkdir -p $(ODIN_BUILD_DIR)
 
 clean:
@@ -44,11 +44,15 @@ clean:
 	$(RM) -Rf $(BUILD_DIR)/CMakeCache.txt
 	$(RM) -Rf $(BUILD_DIR)/ODIN_II
 
-_build_it:
+define _build_it_gen
+_build_it_$(1): _set_$(1)
 	cd $(BUILD_DIR) &&\
 	$(BUILDER)
 
-$(ODIN_BUILD_DIR)/.%.build: clean _init
+$(1): _build_it_$(1)
+endef
+
+$(ODIN_BUILD_DIR)/.%.build: _init
 	touch $@
 
 _set_build: $(ODIN_BUILD_DIR)/.regular.build
@@ -71,15 +75,8 @@ _set_clang_tidy: $(ODIN_BUILD_DIR)/.tidy.build
 	cd $(BUILD_DIR) &&\
 	cmake  $(CMAKE_GEN_ARGS) $(CMAKE_ARGS) -DODIN_TIDY=on ..
 
-build: _set_build _build_it
-
-debug: _set_debug _build_it
-
-warn: _set_warn _build_it
-
-gcov: _set_gcov _build_it
-
-clang_tidy: _set_clang_tidy _build_it
+BUILD_IT_TARGETS = build debug warn gcov clang_tidy
+$(foreach  t,$(BUILD_IT_TARGETS), $(eval $(call _build_it_gen,$(t))))
 
 scrub:
 	find SRC/ -type f \( -iname \*.gcno -or -iname \*.gcda -or -iname \*.gcov \) -exec rm -f {} \; 


### PR DESCRIPTION
This PR fixes the Makefile for Odin to allow parallel builds (e.g. `make -j$(nproc)`)

#### Description

There were two issues with the way the targets are defined.

1. The `.%.build` target cannot depend on both `clean` and `_init`. It works
fine with a single-core build, but when executing it in parallel, the
`clean` target breaks the `_init` target. To make it work in parallel the
`_init` target now directly depends on the `clean` target.

2. The `_set_<xxx>` targets have to be executed before the `_build_it`
target - they cannot be executed at the same time. This has been
reworked to use a dynamically defined targets to avoid creating an extra
wrapper target for each of them.

#### Motivation and Context
To be able to build Odin using multiple cores.

#### How Has This Been Tested?
Both mutli and single job builds work for Odin.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
