### PR TITLE
ODIN_II: Remove any var_declare nodes in the symbol table from the ast

### DIFF
--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1431,6 +1431,7 @@ void initial_node(ast_node_t *new_node, ids id, int line_number, int file_number
 	new_node->net_node = 0;
 	new_node->types.vnumber = nullptr;
 	new_node->types.identifier = NULL;
+	new_node->chunk_size = 1;
 }
 
 /*---------------------------------------------------------------------------

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -397,6 +397,7 @@ struct ast_node_t
 
 	void *hb_port;
 	void *net_node;
+	long chunk_size;
 
 };
 

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -1122,7 +1122,7 @@ void create_all_driver_nets_in_this_function(char *instance_name_prefix, STRING_
 void create_top_driver_nets(ast_node_t* module, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list)
 {
 	/* with the top module we need to visit the entire ast tree */
-	long i, j;
+	long i;
 	long sc_spot;
 	ast_node_t **local_symbol_table = local_string_cache_list->local_symbol_table;
 	long num_local_symbol_table = local_string_cache_list->num_local_symbol_table;
@@ -1132,7 +1132,7 @@ void create_top_driver_nets(ast_node_t* module, char *instance_name_prefix, STRI
 	oassert(module_items->type == MODULE_ITEMS);
 
 	/* search the symbol table for inputs to make drivers */
-	if (module_items->children > 0 || local_symbol_table && num_local_symbol_table > 0)
+	if (local_symbol_table && num_local_symbol_table > 0)
 	{
 		for (i = 0; i < num_local_symbol_table; i++)
 		{
@@ -1227,7 +1227,7 @@ void create_top_driver_nets(ast_node_t* module, char *instance_name_prefix, STRI
 void create_top_output_nodes(ast_node_t* module, char *instance_name_prefix, STRING_CACHE_LIST *local_string_cache_list)
 {
 	/* with the top module we need to visit the entire ast tree */
-	long i, j;
+	long i;
 	int k;
 	long sc_spot;
 	long num_local_symbol_table = local_string_cache_list->num_local_symbol_table;

--- a/ODIN_II/SRC/parse_making_ast.cpp
+++ b/ODIN_II/SRC/parse_making_ast.cpp
@@ -394,17 +394,17 @@ ast_node_t *resolve_ports(ids top_type, ast_node_t *symbol_list)
 				/* range */
 				if (symbol_list->children[j]->children[1] == NULL)
 				{
-					symbol_list->children[j]->children[1] = this_port->children[1];
-					symbol_list->children[j]->children[2] = this_port->children[2];
-					symbol_list->children[j]->children[3] = this_port->children[3];
-					symbol_list->children[j]->children[4] = this_port->children[4];
+					symbol_list->children[j]->children[1] = ast_node_deep_copy(this_port->children[1]);
+					symbol_list->children[j]->children[2] = ast_node_deep_copy(this_port->children[2]);
+					symbol_list->children[j]->children[3] = ast_node_deep_copy(this_port->children[3]);
+					symbol_list->children[j]->children[4] = ast_node_deep_copy(this_port->children[4]);
 
 					if (this_port->num_children == 8)
 					{
 						symbol_list->children[j]->children = (ast_node_t**) realloc(symbol_list->children[j]->children, sizeof(ast_node_t*)*8);
-						symbol_list->children[j]->children[7] = symbol_list->children[j]->children[5];
-						symbol_list->children[j]->children[5] = this_port->children[5];
-						symbol_list->children[j]->children[6] = this_port->children[6];
+						symbol_list->children[j]->children[7] = ast_node_deep_copy(symbol_list->children[j]->children[5]);
+						symbol_list->children[j]->children[5] = ast_node_deep_copy(this_port->children[5]);
+						symbol_list->children[j]->children[6] = ast_node_deep_copy(this_port->children[6]);
 					}
 				}
 
@@ -760,8 +760,8 @@ ast_node_t *markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t *symbo
 
 			if ((symbol_list->children[i]->children[1] == NULL) && (symbol_list->children[i]->children[2] == NULL))
 			{
-				symbol_list->children[i]->children[1] = range_max;
-				symbol_list->children[i]->children[2] = range_min;
+				symbol_list->children[i]->children[1] = ast_node_deep_copy(range_max);
+				symbol_list->children[i]->children[2] = ast_node_deep_copy(range_min);
 			}
 			
 			if(top_type == MODULE) {


### PR DESCRIPTION
#### Description
When building the symbol table, the nodes are no longer copied over, but put directly in the symbol table and then removed completely from the AST, so that these nodes will no longer exist in multiple places. This prevents having to do multiple passes in the code to update the copies, and prevents nodes from being lost when updating both copies to be put in string caches.

This PR should take care of any remaining valgrind leaks from the full benchmarks.

#### How Has This Been Tested?
Odin pre-commit

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
