### PR TITLE
Fix rrgraph reload check when loading rrgraphs from disk.

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -194,6 +194,10 @@ struct DeviceContext : public Context {
      * Clock Network
      ********************************************************************/
     t_clock_arch* clock_arch;
+
+    // Name of rrgraph file read (if any).
+    // Used to determine when reading rrgraph if file is already loaded.
+    std::string read_rr_graph_filename;
 };
 
 //State relating to power analysis

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -327,23 +327,27 @@ void create_rr_graph(const t_graph_type graph_type,
                      const int num_directs,
                      int* Warnings) {
     const auto& device_ctx = g_vpr_ctx.device();
-    if (channel_widths_unchanged(device_ctx.chan_width, nodes_per_chan) && !device_ctx.rr_nodes.empty()) {
-        //No change in channel width, so skip re-building RR graph
-        VTR_LOG("RR graph channel widths unchanged, skipping RR graph rebuild\n");
-        return;
-    }
-
-    free_rr_graph();
 
     if (!det_routing_arch->read_rr_graph_filename.empty()) {
-        load_rr_file(graph_type,
-                     grid,
-                     nodes_per_chan,
-                     segment_inf,
-                     base_cost_type,
-                     &det_routing_arch->wire_to_rr_ipin_switch,
-                     det_routing_arch->read_rr_graph_filename.c_str());
+        if (device_ctx.read_rr_graph_filename != det_routing_arch->read_rr_graph_filename) {
+            free_rr_graph();
+
+            load_rr_file(graph_type,
+                         grid,
+                         segment_inf,
+                         base_cost_type,
+                         &det_routing_arch->wire_to_rr_ipin_switch,
+                         det_routing_arch->read_rr_graph_filename.c_str());
+        }
     } else {
+        if (channel_widths_unchanged(device_ctx.chan_width, nodes_per_chan) && !device_ctx.rr_nodes.empty()) {
+            //No change in channel width, so skip re-building RR graph
+            VTR_LOG("RR graph channel widths unchanged, skipping RR graph rebuild\n");
+            return;
+        }
+
+        free_rr_graph();
+
         build_rr_graph(graph_type,
                        num_block_types,
                        block_types,
@@ -1369,6 +1373,8 @@ void free_rr_graph() {
     /* Before adding any more free calls here, be sure the data is NOT chunk *
      * allocated, as ALL the chunk allocated data is already free!           */
     auto& device_ctx = g_vpr_ctx.mutable_device();
+
+    device_ctx.read_rr_graph_filename.clear();
 
     device_ctx.rr_node_indices.clear();
 

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -57,7 +57,7 @@ void process_blocks(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void verify_grid(pugi::xml_node parent, const pugiutil::loc_data& loc_data, const DeviceGrid& grid);
 void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_edges(pugi::xml_node parent, const pugiutil::loc_data& loc_data, int* wire_to_rr_ipin_switch, const int num_rr_switches);
-void process_channels(t_chan_width& chan_width, pugi::xml_node parent, const pugiutil::loc_data& loc_data);
+void process_channels(t_chan_width& chan_width, const DeviceGrid& grid, pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void process_rr_node_indices(const DeviceGrid& grid);
 void process_seg_id(pugi::xml_node parent, const pugiutil::loc_data& loc_data);
 void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data, const bool is_global_graph, const int num_seg_types);
@@ -69,7 +69,6 @@ void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data,
  * structures as well*/
 void load_rr_file(const t_graph_type graph_type,
                   const DeviceGrid& grid,
-                  t_chan_width nodes_per_chan,
                   const std::vector<t_segment_inf>& segment_inf,
                   const enum e_base_cost_type base_cost_type,
                   int* wire_to_rr_ipin_switch,
@@ -131,7 +130,8 @@ void load_rr_file(const t_graph_type graph_type,
         VTR_LOG("Starting build routing resource graph...\n");
 
         next_component = get_first_child(rr_graph, "channels", loc_data);
-        process_channels(nodes_per_chan, next_component, loc_data);
+        t_chan_width nodes_per_chan;
+        process_channels(nodes_per_chan, grid, next_component, loc_data);
 
         /* Decode the graph_type */
         bool is_global_graph = (GRAPH_GLOBAL == graph_type ? true : false);
@@ -177,6 +177,7 @@ void load_rr_file(const t_graph_type graph_type,
         process_seg_id(next_component, loc_data);
 
         device_ctx.chan_width = nodes_per_chan;
+        device_ctx.read_rr_graph_filename = std::string(read_rr_graph_name);
 
         check_rr_graph(graph_type, grid, device_ctx.block_types);
 
@@ -481,7 +482,7 @@ void process_edges(pugi::xml_node parent, const pugiutil::loc_data& loc_data, in
 }
 
 /* All channel info is read in and loaded into device_ctx.chan_width*/
-void process_channels(t_chan_width& chan_width, pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
+void process_channels(t_chan_width& chan_width, const DeviceGrid& grid, pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
     pugi::xml_node channel, channelLists;
 
     channel = get_first_child(parent, "channel", loc_data);
@@ -491,6 +492,8 @@ void process_channels(t_chan_width& chan_width, pugi::xml_node parent, const pug
     chan_width.y_min = get_attribute(channel, "y_min", loc_data).as_uint();
     chan_width.x_max = get_attribute(channel, "x_max", loc_data).as_uint();
     chan_width.y_max = get_attribute(channel, "y_max", loc_data).as_uint();
+    chan_width.x_list.resize(grid.height());
+    chan_width.y_list.resize(grid.width());
 
     channelLists = get_first_child(parent, "x_list", loc_data);
     while (channelLists) {

--- a/vpr/src/route/rr_graph_reader.h
+++ b/vpr/src/route/rr_graph_reader.h
@@ -6,7 +6,6 @@
 
 void load_rr_file(const t_graph_type graph_type,
                   const DeviceGrid& grid,
-                  t_chan_width nodes_per_chan,
                   const std::vector<t_segment_inf>& segment_inf,
                   const enum e_base_cost_type base_cost_type,
                   int* wire_to_rr_ipin_switch,


### PR DESCRIPTION
#### Description

When ``--read_rr_graph`` is used, every time ``create_rr_graph``is called it will reload the rrgraph.  The intention of ``create_rr_graph`` is to only reload the rrgraph if needed (e.g. [channel width check](https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/master/vpr/src/route/rr_graph.cpp#L330)), however this check doesn't work if the channel width is fixed by the rr graph being read.

This PR changes how ``create_rr_graph`` checks if ``load_rr_graph`` needs to be called.

#### Related Issue

#707 

#### Motivation and Context

Avoids reloading rrgraph when loading the rrgraph from a file.

#### How Has This Been Tested?

- [ ] CI green
- [ ] Tested with symbiflow to see that placement doesn't double load the rrgraph.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
