### PR TITLE
ODIN_II: added -Werror when BUILD_TYPE is release_strict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,13 @@ include(SupportCcache)
 
 project("VTR")
 
+#
+# VTR Build Options
+#
+set(VTR_COMPILE_OPTIONS "none" CACHE STRING "Specify whether vpr uses strict compiling options, e.g. -Werror")
+set(CACHE VTR_COMPILE_OPTIONS PROPERTY STRING strict none)
+
+
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
     message("CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
@@ -196,7 +203,7 @@ endforeach()
 
 #Suppress IPO link warnings
 set(IPO_LINK_WARN_SUPRESS_FLAGS " ")
-set(IPO_LINK_WARN_SUPRESS_FLAGS_TO_CHECK 
+set(IPO_LINK_WARN_SUPRESS_FLAGS_TO_CHECK
     "-Wno-null-dereference"
     )
 foreach(flag ${IPO_LINK_WARN_SUPRESS_FLAGS_TO_CHECK})
@@ -301,9 +308,9 @@ enable_testing()
 set(READLINE_FOUND FALSE)
 
 
-# set VPR_USE_EZGL in the root of VTR to decide whether to add 
-# subdirectory of graphics library, which prevents users 
-# without gtk/x11 libraries installed to build. VPR_USE_EZGL is 
+# set VPR_USE_EZGL in the root of VTR to decide whether to add
+# subdirectory of graphics library, which prevents users
+# without gtk/x11 libraries installed to build. VPR_USE_EZGL is
 # being used in both the vpr CMakeLists and libs/EXTERNAL CMakeLists.
 #
 # check if GTK and X11 are installed and turn on/off graphics

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ override CMAKE_PARAMS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -G 'Unix Makefil
 #Are we doing a strict (i.e. warnings as errors) build?
 ifneq (,$(findstring strict,$(BUILD_TYPE)))
 	#Configure for strict build with VPR warning treated as errors
-override CMAKE_PARAMS := -DVPR_COMPILE_OPTIONS=strict ${CMAKE_PARAMS}
+override CMAKE_PARAMS := -DVTR_COMPILE_OPTIONS=strict ${CMAKE_PARAMS}
 endif #Strict build type
 
 # -s : Suppresss makefile output (e.g. entering/leaving directories)

--- a/ODIN_II/CMakeLists.txt
+++ b/ODIN_II/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.9)
 
 project("ODIN_II")
 
+#
+# ODIN_II Build Options
+#
+set(VTR_COMPILE_OPTIONS "none" CACHE STRING "Specify whether ODIN_II uses strict compiling options, e.g. -Werror")
+set(CACHE VTR_COMPILE_OPTIONS PROPERTY STRING strict none)
+
 if(ODIN_DEBUG)
 
     message("*** Compiling with Odin debug flags")
@@ -112,7 +118,7 @@ add_library(libodin_ii STATIC
              ${LIB_HEADERS_H}
              ${LIB_HEADERS_HPP}
              ${LIB_SOURCES}
-             ${FLEX_VerilogLexer_OUTPUTS} 
+             ${FLEX_VerilogLexer_OUTPUTS}
              ${BISON_VerilogParser_OUTPUT_SOURCE})
 
 target_include_directories(libodin_ii PUBLIC ${LIB_INCLUDE_DIRS})
@@ -162,6 +168,21 @@ endif()
 get_target_property(ODIN_USES_IPO odin_II INTERPROCEDURAL_OPTIMIZATION)
 if (ODIN_USES_IPO)
     set_target_properties(odin_II PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+endif()
+
+set(ODIN_COMPILE_OPTIONS_FLAGS
+    #GCC-like
+    "-Werror"
+    )
+
+#add strict odin compiler flags, if set
+if(VTR_COMPILE_OPTIONS STREQUAL "strict")
+    message(STATUS "ODIN_II: building with strict flags")
+    foreach(ODIN_FLAG ${ODIN_COMPILE_OPTIONS_FLAGS})
+        message(STATUS "\tAdding CXX flag: ${ODIN_FLAG}")
+        target_compile_options(libodin_ii PRIVATE ${ODIN_FLAG})
+        target_compile_options(odin_II PRIVATE ${ODIN_FLAG})
+    endforeach()
 endif()
 
 install(TARGETS odin_II libodin_ii DESTINATION bin)

--- a/ODIN_II/CMakeLists.txt
+++ b/ODIN_II/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project("ODIN_II")
 
-#
-# ODIN_II Build Options
-#
-set(VTR_COMPILE_OPTIONS "none" CACHE STRING "Specify whether ODIN_II uses strict compiling options, e.g. -Werror")
-set(CACHE VTR_COMPILE_OPTIONS PROPERTY STRING strict none)
-
 if(ODIN_DEBUG)
 
     message("*** Compiling with Odin debug flags")

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project("vpr")
 
-#
-# VPR Build Options
-#
-set(VTR_COMPILE_OPTIONS "none" CACHE STRING "Specify whether vpr uses strict compiling options, e.g. -Werror")
-set(CACHE VTR_COMPILE_OPTIONS PROPERTY STRING strict none)
-
 set(VPR_EXECUTION_ENGINE "auto" CACHE STRING "Specify the framework for (potential) parallel execution")
 set_property(CACHE VPR_EXECUTION_ENGINE PROPERTY STRINGS auto serial tbb)
 

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -5,8 +5,8 @@ project("vpr")
 #
 # VPR Build Options
 #
-set(VPR_COMPILE_OPTIONS "none" CACHE STRING "Specify whether vpr uses strict compiling options, e.g. -Werror")
-set(CACHE VPR_COMPILE_OPTIONS PROPERTY STRING strict none)
+set(VTR_COMPILE_OPTIONS "none" CACHE STRING "Specify whether vpr uses strict compiling options, e.g. -Werror")
+set(CACHE VTR_COMPILE_OPTIONS PROPERTY STRING strict none)
 
 set(VPR_EXECUTION_ENGINE "auto" CACHE STRING "Specify the framework for (potential) parallel execution")
 set_property(CACHE VPR_EXECUTION_ENGINE PROPERTY STRINGS auto serial tbb)
@@ -68,7 +68,7 @@ target_link_libraries(libvpr
 
 #link graphics library only when graphics set to on
 if (VPR_USE_EZGL STREQUAL "on")
-    target_link_libraries(libvpr 
+    target_link_libraries(libvpr
 			     ezgl)
 
     compile_gresources(
@@ -164,7 +164,7 @@ else()
     message(ERROR "Unsupported VPR_PGO_CONFIG '${VPR_PGO_CONFIG}'")
 endif()
 
-if (VPR_COMPILE_OPTIONS STREQUAL "strict")
+if (VTR_COMPILE_OPTIONS STREQUAL "strict")
     message(STATUS "VPR: building with strict flags")
     foreach(flag ${VPR_COMPILE_OPTIONS_FLAGS})
         message(STATUS "\tAdding CXX flag: ${flag}")


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds the optional `-Werror` flag during ODIN_II compilation to have a warning-free build in Travis CI.

This PR also contains two formatting fixes (trailing space and tab-to-spaces conversion).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Having a consistent warning-free build is necessary to prevent from having possible regressions in the future.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, by inserting useless code producing warnings which have been correctly caught at compile time.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
