### PR TITLE
Update lower bound delays during router iterations.

### DIFF
--- a/vpr/src/route/connection_based_routing.h
+++ b/vpr/src/route/connection_based_routing.h
@@ -86,6 +86,7 @@ class Connection_based_routing_resources {
   public:
     // after timing analysis of 1st iteration, can set a lower bound on connection delay
     void set_lower_bound_connection_delays(vtr::vector<ClusterNetId, float*>& net_delay);
+    void update_lower_bound_connection_delays(vtr::vector<ClusterNetId, float*>& net_delay);
 
     // initialize routing resources at the start of routing to a new net
     void prepare_routing_for_net(ClusterNetId inet) {

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -671,6 +671,7 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
                 //                }
 
             } else {
+                connections_inf.update_lower_bound_connection_delays(net_delay);
                 bool stable_routing_configuration = true;
 
                 /*
@@ -2269,6 +2270,23 @@ void Connection_based_routing_resources::set_lower_bound_connection_delays(vtr::
 
         for (unsigned int ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net_id).size(); ++ipin) {
             net_lower_bound_connection_delay.push_back(net_delay[net_id][ipin]);
+        }
+    }
+}
+
+void Connection_based_routing_resources::update_lower_bound_connection_delays(vtr::vector<ClusterNetId, float*>& net_delay) {
+    /* Update lower bound connection delays if a lower net delay is
+     * discovered. */
+
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    for (auto net_id : cluster_ctx.clb_nlist.nets()) {
+        auto& net_lower_bound_connection_delay = lower_bound_connection_delay[net_id];
+
+        for (unsigned int ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net_id).size(); ++ipin) {
+            net_lower_bound_connection_delay[ipin - 1] = std::min(
+                net_lower_bound_connection_delay[ipin - 1],
+                net_delay[net_id][ipin]);
         }
     }
 }


### PR DESCRIPTION
#### Description

Even under ideal circumstances, the router may discover better paths and/or spanning
trees during convergence.  The first iteration is only the lower bound
net delay in the case where nets have no fanout, and the bounding box is
ideal.  Neither of these assumptions always hold.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- [ ] CI is green
- [ ] Titan QoR

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
