### PR TITLE
cluster: fix unclustered_list_head_size

### DIFF
--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -870,7 +870,7 @@ static void alloc_and_init_clustering(const t_molecule_stats& max_molecule_stats
 
     /* alloc and load list of molecules to pack */
     unclustered_list_head = (t_molecule_link*)vtr::calloc(max_molecule_stats.num_used_ext_inputs + 1, sizeof(t_molecule_link));
-    unclustered_list_head_size = max_molecule_stats.num_used_ext_inputs;
+    unclustered_list_head_size = max_molecule_stats.num_used_ext_inputs + 1;
 
     for (int i = 0; i <= max_molecule_stats.num_used_ext_inputs; i++) {
         unclustered_list_head[i].next = nullptr;


### PR DESCRIPTION
The `unclustered_list_head` is an array holding heads of lists of unclustered molecules. The array is sorted by number of molecules inputs. Since the `unclustered_list_head_size` was calculated incorrectly, the molecules with the highest input count were not considered while searching for unrelated candidates for a cluster.

This is one of the issues causing #621 
