### PR TITLE
Do not use unordered_map over flat rr node vector lookup.

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -147,7 +147,7 @@ struct DeviceContext : public Context {
     std::vector<std::vector<int>> rr_non_config_node_sets;
 
     //Reverse look-up from RR node to non-configurably connected node set (index into rr_nonconf_node_sets)
-    std::unordered_map<int, int> rr_node_to_non_config_node_set;
+    std::vector<int> rr_node_to_non_config_node_set;
 
     //The indicies of rr nodes of a given type at a specific x,y grid location
     t_rr_node_indices rr_node_indices; //[0..NUM_RR_TYPES-1][0..grid.width()-1][0..grid.width()-1][0..size-1]

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -725,9 +725,9 @@ float get_rr_cong_cost(int inode) {
 
     float cost = get_single_rr_cong_cost(inode);
 
-    auto itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
-    if (itr != device_ctx.rr_node_to_non_config_node_set.end()) {
-        for (int node : device_ctx.rr_non_config_node_sets[itr->second]) {
+    int node_set = device_ctx.rr_node_to_non_config_node_set[inode];
+    if (node_set != -1) {
+        for (int node : device_ctx.rr_non_config_node_sets[node_set]) {
             if (node != inode) {
                 continue; //Already included above
             }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -3095,8 +3095,11 @@ static void expand_non_configurable(int inode, std::set<t_node_edge>& edge_set) 
 }
 
 static void process_non_config_sets(const t_non_configurable_rr_sets& non_config_rr_sets) {
-    std::vector<std::vector<int>> non_config_rr_node_sets;
-    std::unordered_map<int, int> rr_node_non_config_node_set;
+    auto& device_ctx = g_vpr_ctx.mutable_device();
+
+    std::vector<std::vector<int>>& non_config_rr_node_sets = device_ctx.rr_non_config_node_sets;
+    std::vector<int>& rr_node_non_config_node_set = device_ctx.rr_node_to_non_config_node_set;
+    rr_node_non_config_node_set.resize(device_ctx.rr_nodes.size(), -1);
 
     for (const auto& node_set : non_config_rr_sets.node_sets) {
         //Convert node sets to vectors
@@ -3104,11 +3107,7 @@ static void process_non_config_sets(const t_non_configurable_rr_sets& non_config
 
         //Record reverse look-ups
         for (int inode : node_set) {
-            rr_node_non_config_node_set.emplace(inode, non_config_rr_node_sets.size() - 1);
+            rr_node_non_config_node_set[inode] = non_config_rr_node_sets.size() - 1;
         }
     }
-
-    auto& device_ctx = g_vpr_ctx.mutable_device();
-    device_ctx.rr_non_config_node_sets = std::move(non_config_rr_node_sets);
-    device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_non_config_node_set);
 }


### PR DESCRIPTION
#### Description

Use of unordered_map consumes ~10% of routing time on designs with
non-configurable edges.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

Profiled design with non-configurable edges, and found unordered_map lookahead was taking ~10% of time.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
