### PR TITLE
Introduce dynamic_bitset and use it avoid rr node lookup.

### DIFF
--- a/utils/route_diag/src/main.cpp
+++ b/utils/route_diag/src/main.cpp
@@ -75,11 +75,8 @@ static void do_one_route(int source_node, int sink_node,
     update_rr_base_costs(1);
 
     //maximum bounding box for placement
-    t_bb bounding_box;
-    bounding_box.xmin = 0;
-    bounding_box.xmax = device_ctx.grid.width() + 1;
-    bounding_box.ymin = 0;
-    bounding_box.ymax = device_ctx.grid.height() + 1;
+    t_bb_cache bounding_box;
+    bounding_box.set_whole_grid();
 
     t_conn_cost_params cost_params;
     cost_params.criticality = 1.;
@@ -93,7 +90,9 @@ static void do_one_route(int source_node, int sink_node,
     std::vector<int> modified_rr_node_inf;
     RouterStats router_stats;
     auto router_lookahead = make_router_lookahead(router_opts.lookahead_type);
-    t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root, sink_node, cost_params, bounding_box, *router_lookahead, modified_rr_node_inf, router_stats);
+    t_heap* cheapest = timing_driven_route_connection_from_route_tree(
+            rt_root, sink_node,
+            cost_params, bounding_box, *router_lookahead, modified_rr_node_inf, router_stats);
 
     bool found_path = (cheapest != nullptr);
     if (found_path) {

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -194,6 +194,9 @@ struct DeviceContext : public Context {
      * Clock Network
      ********************************************************************/
     t_clock_arch* clock_arch;
+
+    // Bit set of IPIN's.
+    dynamic_bitset ipin_nodes;
 };
 
 //State relating to power analysis
@@ -265,7 +268,7 @@ struct RoutingContext : public Context {
     vtr::vector<ClusterNetId, t_net_routing_status> net_status; //[0..cluster_ctx.clb_nlist.nets().size()-1]
 
     //Limits area within which each net must be routed.
-    vtr::vector<ClusterNetId, t_bb> route_bb; /* [0..cluster_ctx.clb_nlist.nets().size()-1]*/
+    vtr::vector<ClusterNetId, t_bb_cache> route_bb; /* [0..cluster_ctx.clb_nlist.nets().size()-1]*/
 
     t_clb_opins_used clb_opins_used_locally; //[0..cluster_ctx.clb_nlist.blocks().size()-1][0..num_class-1]
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1333,4 +1333,65 @@ class RouteStatus {
 
 typedef vtr::vector<ClusterBlockId, std::vector<std::vector<int>>> t_clb_opins_used; //[0..num_blocks-1][0..class-1][0..used_pins-1]
 
+class dynamic_bitset {
+  public:
+    // Bits in underlying storage.
+    static constexpr size_t kWidth = std::numeric_limits<unsigned int>::digits;
+
+    void resize(size_t size) {
+        array_.resize((size + kWidth - 1) / kWidth);
+    }
+    void fill(bool set) {
+        if (set) {
+            std::fill(array_.begin(), array_.end(), std::numeric_limits<unsigned int>::max());
+        } else {
+            std::fill(array_.begin(), array_.end(), 0);
+        }
+    }
+
+    void set(size_t index, bool val) {
+        if (val) {
+            array_[index / kWidth] |= (1 << (index % kWidth));
+        } else {
+            array_[index / kWidth] &= ~(1u << (index % kWidth));
+        }
+    }
+
+    bool get(size_t index) const {
+        return (array_[index / kWidth] & (1u << (index % kWidth))) != 0;
+    }
+
+  private:
+    std::vector<unsigned int> array_;
+};
+
+class t_bb_cache {
+  public:
+    void update_cache(const t_bb bounding_box) {
+        full_grid_ = false;
+        bounding_box_ = bounding_box;
+        build_cache();
+    }
+
+    void set_whole_grid() {
+        full_grid_ = true;
+    }
+
+    const t_bb& bb() const {
+        return bounding_box_;
+    }
+
+    bool inode_in_bb(size_t inode) const {
+        return full_grid_ || rr_node_bitset_.get(inode);
+    }
+
+  private:
+    void build_cache();
+
+    bool full_grid_;
+    t_bb bounding_box_;
+    // Intentionally using vector<bool> override.
+    dynamic_bitset rr_node_bitset_;
+};
+
 #endif

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1220,7 +1220,7 @@ static void draw_routing_bb(ezgl::renderer& g) {
     t_draw_coords* draw_coords = get_draw_coords_vars();
 
     auto net_id = ClusterNetId(draw_state->show_routing_bb);
-    const t_bb* bb = &route_ctx.route_bb[net_id];
+    const t_bb* bb = &route_ctx.route_bb[net_id].bb();
 
     //The router considers an RR node to be 'within' the the bounding box if it
     //is *loosely* greater (i.e. greater than or equal) the left/bottom edges, and

--- a/vpr/src/route/route_breadth_first.cpp
+++ b/vpr/src/route/route_breadth_first.cpp
@@ -362,10 +362,7 @@ static void breadth_first_expand_neighbours(int inode, float pcost, ClusterNetId
     for (iconn = 0; iconn < num_edges; iconn++) {
         to_node = device_ctx.rr_nodes[inode].edge_sink_node(iconn);
 
-        if (device_ctx.rr_nodes[to_node].xhigh() < route_ctx.route_bb[net_id].xmin
-            || device_ctx.rr_nodes[to_node].xlow() > route_ctx.route_bb[net_id].xmax
-            || device_ctx.rr_nodes[to_node].yhigh() < route_ctx.route_bb[net_id].ymin
-            || device_ctx.rr_nodes[to_node].ylow() > route_ctx.route_bb[net_id].ymax)
+        if (!route_ctx.route_bb[net_id].inode_in_bb(to_node))
             continue; /* Node is outside (expanded) bounding box. */
 
         breadth_first_add_to_heap(pcost, bend_cost, inode, to_node, iconn);

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -1092,15 +1092,15 @@ static vtr::vector<ClusterBlockId, std::vector<int>> load_rr_clb_sources(const t
     return rr_blk_source;
 }
 
-vtr::vector<ClusterNetId, t_bb> load_route_bb(int bb_factor) {
-    vtr::vector<ClusterNetId, t_bb> route_bb;
+vtr::vector<ClusterNetId, t_bb_cache> load_route_bb(int bb_factor) {
+    vtr::vector<ClusterNetId, t_bb_cache> route_bb;
 
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
     auto nets = cluster_ctx.clb_nlist.nets();
     route_bb.resize(nets.size());
     for (auto net_id : nets) {
-        route_bb[net_id] = load_net_route_bb(net_id, bb_factor);
+        route_bb[net_id].update_cache(load_net_route_bb(net_id, bb_factor));
     }
     return route_bb;
 }

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -52,7 +52,7 @@ struct t_heap {
 
 /******* Subroutines in route_common used only by other router modules ******/
 
-vtr::vector<ClusterNetId, t_bb> load_route_bb(int bb_factor);
+vtr::vector<ClusterNetId, t_bb_cache> load_route_bb(int bb_factor);
 
 t_bb load_net_route_bb(ClusterNetId net_id, int bb_factor);
 

--- a/vpr/src/route/route_timing.h
+++ b/vpr/src/route/route_timing.h
@@ -81,7 +81,7 @@ struct t_conn_cost_params {
 t_heap* timing_driven_route_connection_from_route_tree(t_rt_node* rt_root,
                                                        int sink_node,
                                                        const t_conn_cost_params cost_params,
-                                                       t_bb bounding_box,
+                                                       const t_bb_cache& bounding_box,
                                                        const RouterLookahead& router_lookahead,
                                                        std::vector<int>& modified_rr_node_inf,
                                                        RouterStats& router_stats);

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -24,11 +24,8 @@ bool calculate_delay(int source_node, int sink_node, const t_router_opts& router
     update_rr_base_costs(1);
 
     //maximum bounding box for placement
-    t_bb bounding_box;
-    bounding_box.xmin = 0;
-    bounding_box.xmax = device_ctx.grid.width() + 1;
-    bounding_box.ymin = 0;
-    bounding_box.ymax = device_ctx.grid.height() + 1;
+    t_bb_cache bb_cache;
+    bb_cache.set_whole_grid();
 
     t_conn_cost_params cost_params;
     cost_params.criticality = 1.;
@@ -42,7 +39,7 @@ bool calculate_delay(int source_node, int sink_node, const t_router_opts& router
     std::vector<int> modified_rr_node_inf;
     RouterStats router_stats;
     auto router_lookahead = make_router_lookahead(router_opts.lookahead_type);
-    t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root, sink_node, cost_params, bounding_box, *router_lookahead, modified_rr_node_inf, router_stats);
+    t_heap* cheapest = timing_driven_route_connection_from_route_tree(rt_root, sink_node, cost_params, bb_cache, *router_lookahead, modified_rr_node_inf, router_stats);
 
     bool found_path = (cheapest != nullptr);
     if (found_path) {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -579,6 +579,7 @@ static void build_rr_graph(const t_graph_type graph_type,
     device_ctx.rr_node_indices = alloc_and_load_rr_node_indices(max_chan_width, grid,
                                                                 &num_rr_nodes, chan_details_x, chan_details_y);
     device_ctx.rr_nodes.resize(num_rr_nodes);
+    device_ctx.ipin_nodes.resize(num_rr_nodes);
 
     /* These are data structures used by the the unidir opin mapping. They are used
      * to spread connections evenly for each segment type among the available
@@ -690,6 +691,10 @@ static void build_rr_graph(const t_graph_type graph_type,
                             &Fc_clipped,
                             directs, num_directs, clb_to_clb_directs,
                             is_global_graph);
+
+    for (size_t i = 0; i < device_ctx.rr_nodes.size(); i++) {
+        device_ctx.ipin_nodes.set(i, device_ctx.rr_nodes[i].type() == IPIN);
+    }
 
     /* Update rr_nodes capacities if global routing */
     if (graph_type == GRAPH_GLOBAL) {

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -146,6 +146,8 @@ void load_rr_file(const t_graph_type graph_type,
         int num_rr_nodes = count_children(next_component, "node", loc_data);
 
         device_ctx.rr_nodes.resize(num_rr_nodes);
+        device_ctx.ipin_nodes.resize(num_rr_nodes);
+        device_ctx.ipin_nodes.fill(false);
         process_nodes(next_component, loc_data);
 
         /* Loads edges, switches, and node look up tables*/
@@ -306,6 +308,7 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
             node.set_type(OPIN);
         } else if (strcmp(node_type, "IPIN") == 0) {
             node.set_type(IPIN);
+            device_ctx.ipin_nodes.set(inode, true);
         } else {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER,
                             "Valid inputs for class types are \"CHANX\", \"CHANY\",\"SOURCE\", \"SINK\",\"OPIN\", and \"IPIN\".");

--- a/vpr/src/route/spatial_route_tree_lookup.cpp
+++ b/vpr/src/route/spatial_route_tree_lookup.cpp
@@ -11,7 +11,7 @@ SpatialRouteTreeLookup build_route_tree_spatial_lookup(ClusterNetId net, t_rt_no
 
     int fanout = cluster_ctx.clb_nlist.net_sinks(net).size();
 
-    t_bb bb = route_ctx.route_bb[net];
+    t_bb bb = route_ctx.route_bb[net].bb();
     float bb_area = (bb.xmax - bb.xmin) * (bb.ymax - bb.ymin);
     float bb_area_per_sink = bb_area / fanout;
     float bin_area = BIN_AREA_PER_SINK_FACTOR * bb_area_per_sink;


### PR DESCRIPTION
#### Description

In the router hotpath, if the rr node vector is larger than the cache,
roughly every memory access has non-trival performance impact.  Avoiding
these accesses has a ~10% route time improvement on large graphs.

Graphs that fix within the CPU cache will likely be negatively impacted
by this change.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

I've been profiling the router, and identifying hotspots.  One of the hotspots that jumps out right now is rr node access.  Before the router would read the rr node bounding box data over and over again to check against the net bb.  This is repeated work, and unneeded memory accesses.

Instead, when bounding boxes are updated (which is initially and then less frequently during routing), all nodes are tested against the net bounding box.  This is more up front computation, but in a linear memory access pattern, which allows for proper prefetch.  The result is a bitset that is sizeof(rr_node)*sizeof(unsigned int) (e.g. 40*64 => 2560) significantly smaller.  Because the bitset is smaller, it has a greater chance of staying in the CPU cache, avoiding the need to go to main memory to read the rr node bounds.

The IPIN bitset is a similar optimization.

It is worth noting that it is expected that on designs where the rr node table fits in the CPU cache, these changes will hurt performance.  However given that each rr node is 40 bytes, a 500k node (with no edges) graph will exceed a 16 MB cache.

#### How Has This Been Tested?

I've run this on two microcontroller class designs.  I'll need to run titan benchmarks to confirm that across a broad spectrum of designs the memory <-> CPU trade off is worth it.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
