### PR TITLE
read_blif bug fix

### DIFF
--- a/ODIN_II/SRC/read_blif.cpp
+++ b/ODIN_II/SRC/read_blif.cpp
@@ -1380,7 +1380,7 @@ hard_block_model *read_hard_block_model(char *name_subckt, hard_block_ports *por
 		while (vtr::fgets(buffer, READ_BLIF_BUFFER, file))
 		{
 			char *token = vtr::strtok(buffer,TOKENS, file, buffer);
-			// match .model followed buy the subcircuit name.
+			// match .model followed by the subcircuit name.
 			if (token && !strcmp(token,".model") && !strcmp(vtr::strtok(NULL,TOKENS, file, buffer), name_subckt))
 			{
 				model = (hard_block_model *)vtr::calloc(1, sizeof(hard_block_model));
@@ -1397,27 +1397,30 @@ hard_block_model *read_hard_block_model(char *name_subckt, hard_block_ports *por
 				while (vtr::fgets(buffer, READ_BLIF_BUFFER, file))
 				{
 					char *first_word = vtr::strtok(buffer, TOKENS, file, buffer);
-					if(!strcmp(first_word, ".inputs"))
+					if(first_word)
 					{
-						char *name;
-						while ((name = vtr::strtok(NULL, TOKENS, file, buffer)))
+						if(!strcmp(first_word, ".inputs"))
 						{
-							model->inputs->names = (char **)vtr::realloc(model->inputs->names, sizeof(char *) * (model->inputs->count + 1));
-							model->inputs->names[model->inputs->count++] = vtr::strdup(name);
+							char *name;
+							while ((name = vtr::strtok(NULL, TOKENS, file, buffer)))
+							{
+								model->inputs->names = (char **)vtr::realloc(model->inputs->names, sizeof(char *) * (model->inputs->count + 1));
+								model->inputs->names[model->inputs->count++] = vtr::strdup(name);
+							}
 						}
-					}
-					else if(!strcmp(first_word, ".outputs"))
-					{
-						char *name;
-						while ((name = vtr::strtok(NULL, TOKENS, file, buffer)))
+						else if(!strcmp(first_word, ".outputs"))
 						{
-							model->outputs->names = (char **)vtr::realloc(model->outputs->names, sizeof(char *) * (model->outputs->count + 1));
-							model->outputs->names[model->outputs->count++] = vtr::strdup(name);
+							char *name;
+							while ((name = vtr::strtok(NULL, TOKENS, file, buffer)))
+							{
+								model->outputs->names = (char **)vtr::realloc(model->outputs->names, sizeof(char *) * (model->outputs->count + 1));
+								model->outputs->names[model->outputs->count++] = vtr::strdup(name);
+							}
 						}
-					}
-					else if(!strcmp(first_word, ".end"))
-					{
-						break;
+						else if(!strcmp(first_word, ".end"))
+						{
+							break;
+						}
 					}
 				}
 				break;


### PR DESCRIPTION
When using Odin_II in -b mode, large post-ABC BLIFs cause segfault
Unguarded strtok was passing null pointer to strcmp
Simply guarded the failed strtok, unclear whether this resolves
underlying issue.
Similar issue still happens if large BLIFs used in simulator.
Also fixed typo.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
