### PR TITLE
Fix segfault in find_most_common_block_type

### DIFF
--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -779,6 +779,7 @@ t_logical_block_type_ptr find_most_common_block_type(const DeviceGrid& grid) {
 
     if (max_type == nullptr) {
         VTR_LOG_WARN("Unable to determine most common block type (perhaps the device grid was empty?)\n");
+        return nullptr;
     }
     return logical_block_type(max_type);
 }


### PR DESCRIPTION
Recent logical/physical tiles split introduced the regression. If there is no max_type found we should not call the logical_block_type function, but rather return the nullptr immediately  (like we did before the split).