### PR TITLE
Correct NULL deref path.

### DIFF
--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -779,8 +779,10 @@ t_logical_block_type_ptr find_most_common_block_type(const DeviceGrid& grid) {
 
     if (max_type == nullptr) {
         VTR_LOG_WARN("Unable to determine most common block type (perhaps the device grid was empty?)\n");
+        return nullptr;
+    } else {
+        return logical_block_type(max_type);
     }
-    return logical_block_type(max_type);
 }
 
 InstPort parse_inst_port(std::string str) {


### PR DESCRIPTION
#### Description

Previous code would warn on nullptr, but then derefence anyways.

#### Related Issue

Discovered by coverity in #945

#### Motivation and Context

NULL deref's are bad.

#### How Has This Been Tested?

CI.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
