### PR TITLE
Remove assumption about rr node order when reading XML.

### DIFF
--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -864,8 +864,9 @@ void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data,
     /*Go through each rr_node and use the segment ids to set CHANX and CHANY cost index*/
     rr_node = get_first_child(parent, "node", loc_data);
 
-    for (size_t i = 0; i < device_ctx.rr_nodes.size(); i++) {
-        auto& node = device_ctx.rr_nodes[i];
+    while (rr_node) {
+        int inode = get_attribute(rr_node, "id", loc_data).as_int();
+        auto& node = device_ctx.rr_nodes[inode];
 
         /*CHANX and CHANY cost index is dependent on the segment id*/
 
@@ -876,9 +877,9 @@ void set_cost_indices(pugi::xml_node parent, const pugiutil::loc_data& loc_data,
                 int seg_id = get_attribute(segmentSubnode, "segment_id", loc_data).as_int(0);
                 if (is_global_graph) {
                     node.set_cost_index(0);
-                } else if (device_ctx.rr_nodes[i].type() == CHANX) {
+                } else if (node.type() == CHANX) {
                     node.set_cost_index(CHANX_COST_INDEX_START + seg_id);
-                } else if (device_ctx.rr_nodes[i].type() == CHANY) {
+                } else if (node.type() == CHANY) {
                     node.set_cost_index(CHANX_COST_INDEX_START + num_seg_types + seg_id);
                 }
             }


### PR DESCRIPTION
#### Description

Previous code assumed that rr nodes appeared in id order, rather than rely on the id field of the XML.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

Some experimentation with rr graph reordering based on geometry re-assigns rr node ids based on various criteria.  This requires that the rr graph reader not assume that node ids are in order when being read.

#### How Has This Been Tested?

CI is green and some manual functional testing.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
