### PR TITLE
Correct pointer type in logging macro.

### DIFF
--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -278,8 +278,8 @@ std::unique_ptr<FILE, decltype(&vtr::fclose)> f_move_stats_file(nullptr, vtr::fc
                 t_pl_loc to = affected_blocks.moved_blocks[0].new_loc;                         \
                 ClusterBlockId b_to = place_ctx.grid_blocks[to.x][to.y].blocks[to.z];          \
                                                                                                \
-                t_physical_tile_type_ptr from_type = cluster_ctx.clb_nlist.block_type(b_from); \
-                t_physical_tile_type_ptr to_type = nullptr;                                    \
+                t_logical_block_type_ptr from_type = cluster_ctx.clb_nlist.block_type(b_from); \
+                t_logical_block_type_ptr to_type = nullptr;                                    \
                 if (b_to) {                                                                    \
                     to_type = cluster_ctx.clb_nlist.block_type(b_to);                          \
                 }                                                                              \


### PR DESCRIPTION
#### Description

Appears that pointer type in logging macro was missed during recent logical <-> physical cluster split.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
