### PR TITLE
Refactor router heap to use heap approximation.

### DIFF
--- a/vpr/src/route/bucket.cpp
+++ b/vpr/src/route/bucket.cpp
@@ -1,0 +1,152 @@
+#include "bucket.h"
+
+std::vector<t_heap*> BucketItems::heap_items_;
+size_t BucketItems::alloced_items_ = 0;
+int BucketItems::num_heap_allocated_ = 0;
+t_heap* BucketItems::heap_free_head_ = nullptr;
+vtr::t_chunk BucketItems::heap_ch_;
+
+void Bucket::init(const DeviceGrid& grid) {
+    vtr::free(heap_);
+    heap_ = nullptr;
+
+    heap_size_ = (grid.width() - 1) * (grid.height() - 1);
+    heap_ = (t_heap**)vtr::malloc(heap_size_ * sizeof(t_heap*));
+    memset(heap_, 0, heap_size_ * sizeof(t_heap*));
+
+    heap_head_ = std::numeric_limits<size_t>::max();
+    heap_tail_ = 0;
+}
+
+void Bucket::free() {
+    vtr::free(heap_);
+    heap_ = nullptr;
+}
+
+void Bucket::expand(size_t required_number_of_buckets) {
+    auto old_size = heap_size_;
+    heap_size_ = required_number_of_buckets * 2;
+
+    heap_ = (t_heap**)vtr::realloc((void*)(heap_),
+                                   heap_size_ * sizeof(t_heap*));
+    std::fill(heap_ + old_size, heap_ + heap_size_, nullptr);
+}
+
+void Bucket::verify() {
+    for (size_t bucket = heap_head_; bucket <= heap_tail_; ++bucket) {
+        for (t_heap* data = heap_[bucket]; data != nullptr;
+             data = data->next_bucket) {
+            VTR_ASSERT(data->cost > 0 && ((size_t)cost_to_int(data->cost)) == bucket);
+        }
+    }
+}
+
+size_t Bucket::seed_ = 1231;
+t_heap** Bucket::heap_ = nullptr;
+size_t Bucket::heap_size_ = 0;
+size_t Bucket::heap_head_ = std::numeric_limits<size_t>::max();
+size_t Bucket::heap_tail_ = 0;
+
+void Bucket::clear() {
+    if (heap_head_ != std::numeric_limits<size_t>::max()) {
+        std::fill(heap_ + heap_head_, heap_ + heap_tail_ + 1, nullptr);
+    }
+    heap_head_ = std::numeric_limits<size_t>::max();
+    heap_tail_ = 0;
+}
+
+void Bucket::push(t_heap* hptr) {
+    float cost = hptr->cost;
+    if (!std::isfinite(cost)) {
+        return;
+    }
+
+    //heap_::verify_extract_top();
+
+    // Which bucket should this go into?
+    auto int_cost = cost_to_int(cost);
+
+    if (int_cost < 0) {
+        VTR_LOG_WARN("Cost is negative? cost = %g\n", cost);
+        int_cost = 0;
+    }
+
+    size_t uint_cost = int_cost;
+
+    // Is that bucket allocated?
+    if (uint_cost >= heap_size_) {
+        // Not enough buckets!
+        expand(uint_cost);
+    }
+
+    // Insert into bucket
+    auto* prev = heap_[uint_cost];
+    hptr->next_bucket = prev;
+    heap_[uint_cost] = hptr;
+
+    if (uint_cost < heap_head_) {
+        heap_head_ = uint_cost;
+    }
+    if (uint_cost > heap_tail_) {
+        heap_tail_ = uint_cost;
+    }
+
+    //heap_::verify_extract_top();
+}
+
+t_heap* Bucket::pop() {
+    auto heap_head = heap_head_;
+    auto heap_tail = heap_tail_;
+    t_heap** heap = heap_;
+
+    // Check empty
+    if (heap_head == std::numeric_limits<size_t>::max()) {
+        return nullptr;
+    }
+
+    // Find first non-empty bucket
+
+    // Randomly remove element
+    size_t count = fast_rand() % 4;
+
+    t_heap* prev = nullptr;
+    t_heap* next = heap[heap_head];
+    for (size_t i = 0; i < count && next->next_bucket != nullptr; ++i) {
+        prev = next;
+        next = prev->next_bucket;
+    }
+
+    if (prev == nullptr) {
+        heap[heap_head] = next->next_bucket;
+    } else {
+        prev->next_bucket = next->next_bucket;
+    }
+
+    // Update first non-empty bucket if bucket is now empty
+    if (heap[heap_head] == nullptr) {
+        heap_head += 1;
+        while (heap_head <= heap_tail && heap[heap_head] == nullptr) {
+            heap_head += 1;
+        }
+
+        if (heap_head > heap_tail) {
+            heap_head = std::numeric_limits<size_t>::max();
+        }
+
+        heap_head_ = heap_head;
+    }
+
+    return next;
+}
+
+void Bucket::print() {
+    for (size_t i = heap_head_; i < heap_tail_; ++i) {
+        if (heap_[heap_head_] != nullptr) {
+            VTR_LOG("B:%d ", i);
+            for (auto* item = heap_[i]; item != nullptr; item = item->next_bucket) {
+                VTR_LOG(" %e", item->cost);
+            }
+        }
+    }
+    VTR_LOG("\n");
+}

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -1,0 +1,322 @@
+#ifndef _BUCKET_ITEMS_H_
+#define _BUCKET_ITEMS_H_
+
+#include <vector>
+
+#include "netlist_fwd.h"
+#include "physical_types.h"
+#include "vtr_memory.h"
+#include "globals.h"
+
+/* Used by the heap as its fundamental data structure.
+ * Each heap element represents a partial route.
+ *
+ * cost:    The cost used to sort heap.
+ *          For the timing-driven router this is the backward_path_cost +
+ *          expected cost to the target.
+ *          For the breadth-first router it is the node cost to reach this
+ *          point.
+ *
+ * backward_path_cost:  Used only by the timing-driven router.  The "known"
+ *                      cost of the path up to and including this node.
+ *                      In this case, the .cost member contains not only
+ *                      the known backward cost but also an expected cost
+ *                      to the target.
+ *
+ * R_upstream: Used only by the timing-driven router.  Stores the upstream
+ *             resistance to ground from this node, including the
+ *             resistance of the node itself (device_ctx.rr_nodes[index].R).
+ *
+ * index: The RR node index associated with the costs/R_upstream values
+ *
+ * u.prev.node: The previous node used to reach the current 'index' node
+ * u.prev.next: The edge from u.prev.node used to reach the current 'index' node
+ *
+ * u.next:  pointer to the next s_heap structure in the free
+ *          linked list.  Not used when on the heap.
+ *
+ */
+struct t_heap {
+    float cost = 0.;
+    float backward_path_cost = 0.;
+    float R_upstream = 0.;
+
+    int index = OPEN;
+
+    struct t_prev {
+        int node;
+        int edge;
+    };
+
+    union {
+        t_heap* next;
+        t_prev prev;
+    } u;
+
+    // Next pointer for Bucket linked list.
+    t_heap* next_bucket;
+};
+
+// Allocator for t_heap items.
+//
+// Supports fast clearing of the items, under the assumption that when clear
+// is invoked, all outstanding references can be dropped.  This should be true
+// between net routing, and avoids the need to rebuild the free list between
+// nets.
+class BucketItems {
+  public:
+    // Returns all allocated items to be available for allocation.
+    //
+    // This operation is only safe if all outstanding references are discarded.
+    // This is true when the router is starting on a new net, as all outstanding
+    // items should be in the bucket, which is cleared at the start of routing.
+    static void clear() {
+        heap_free_head_ = nullptr;
+        num_heap_allocated_ = 0;
+        alloced_items_ = 0;
+    }
+
+    // Iterators over all items ever allocated.  This is not the list of alive
+    // items, but can be used for fast invalidation if needed.
+    static std::vector<t_heap*>::iterator begin() {
+        return heap_items_.begin();
+    }
+    static std::vector<t_heap*>::iterator end() {
+        return heap_items_.end();
+    }
+
+    // Deallocate all items.  Outstanding references to items will become
+    // invalid.
+    static void free() {
+        // Free each individual heap item.
+        for (auto* item : heap_items_) {
+            vtr::chunk_delete(item, &heap_ch_);
+        }
+        heap_items_.clear();
+
+        /*free the memory chunks that were used by heap and linked f pointer */
+        free_chunk_memory(&heap_ch_);
+    }
+
+    // Allocate an item.  This may cause a dynamic allocation if no previously
+    // allocated items are available.
+    static t_heap* alloc_item() {
+        t_heap* temp_ptr;
+        if (alloced_items_ < heap_items_.size()) {
+            temp_ptr = heap_items_[alloced_items_++];
+        } else {
+            if (heap_free_head_ == nullptr) { /* No elements on the free list */
+                heap_free_head_ = vtr::chunk_new<t_heap>(&heap_ch_);
+                heap_items_.push_back(heap_free_head_);
+                alloced_items_ += 1;
+            }
+
+            temp_ptr = heap_free_head_;
+            heap_free_head_ = heap_free_head_->u.next;
+        }
+
+        num_heap_allocated_++;
+
+        return temp_ptr;
+    }
+
+    // Return a free'd item to be reallocated.
+    static void free_item(t_heap* hptr) {
+        hptr->u.next = heap_free_head_;
+        heap_free_head_ = hptr;
+        num_heap_allocated_--;
+    }
+
+    // Number of outstanding allocations.
+    static int num_heap_allocated() {
+        return num_heap_allocated_;
+    }
+
+  private:
+    /* Vector of all items ever allocated. Used for full item iteration and
+     * for reuse after a `clear` invocation. */
+    static std::vector<t_heap*> heap_items_;
+
+    /* Tracks how many items from heap_items_ are in use. */
+    static size_t alloced_items_;
+
+    /* Number of outstanding allocated items. */
+    static int num_heap_allocated_;
+
+    /* For managing my own list of currently free heap data structures. */
+    static t_heap* heap_free_head_;
+
+    /* For keeping track of the sudo malloc memory for the heap*/
+    static vtr::t_chunk heap_ch_;
+};
+
+inline void free_heap_data(t_heap* hptr) {
+    BucketItems::free_item(hptr);
+}
+
+inline t_heap*
+alloc_heap_data() {
+    //Extract the head
+    t_heap* temp_ptr = BucketItems::alloc_item();
+
+    //Reset
+    temp_ptr->u.next = nullptr;
+    temp_ptr->next_bucket = nullptr;
+    temp_ptr->cost = 0.;
+    temp_ptr->backward_path_cost = 0.;
+    temp_ptr->R_upstream = 0.;
+    temp_ptr->index = OPEN;
+    temp_ptr->u.prev.node = NO_PREVIOUS;
+    temp_ptr->u.prev.edge = NO_PREVIOUS;
+    return (temp_ptr);
+}
+
+// Prority queue approximation using cost buckets and randomization.
+//
+// The Bucket contains linked lists for costs at kConvFactor intervals.  Given
+// that cost is approximately delay, each bucket contains ~1 picosecond (1e12)
+// worth items.
+//
+// Items are pushed into the linked list that matches their cost [0, 1)
+// picosecond.  When popping the Bucket, a random item in the cheapest bucket
+// with items is returned.  This randomization exists to prevent the router
+// from following identical paths when operating with identical costs.
+// Consider two parallel paths to a node.
+class Bucket {
+  public:
+    Bucket() {}
+
+    // Allocate initial buckets for items.
+    static void init(const DeviceGrid& grid);
+
+    // Deallocate memory for buckets.  This does NOT call
+    // BucketItems::free_item on contained items.
+    static void free();
+
+    // Empties all buckets of items.
+    //
+    // This does NOT call BucketItems::free_item on contained items.  The
+    // assumption is that when Bucket::clear is called, BucketItems::clear
+    // is also called.
+    static void clear();
+
+    // Push an item onto a bucket.
+    static void push(t_heap* hptr);
+
+    // Pop an item from the cheapest non-empty bucket.
+    //
+    // Returns nullptr if empty.
+    static t_heap* pop();
+
+    // True if all buckets are empty.
+    static bool empty() {
+        return heap_head_ == std::numeric_limits<size_t>::max();
+    }
+
+    // Sanity check state of buckets (e.g. all items within each bucket have
+    // a cost that matches their bucket index.
+    static void verify();
+
+    // Print items contained in buckets.
+    static void print();
+
+  private:
+    // Factor used to convert cost from float to int.  Should be scaled to
+    // enable sufficent precision in bucketting.
+    static constexpr float kConvFactor = 1e12;
+
+    // Convert cost from float to integer bucket id.
+    static int cost_to_int(float cost) {
+        return (int)(cost * kConvFactor);
+    }
+
+    // Simple fast random function used for randomizing item selection on pop.
+    static size_t fast_rand() {
+        seed_ = (0x234ab32a1 * seed_) ^ (0x12acbade);
+        return seed_;
+    }
+
+    // Expand the number of buckets.
+    //
+    // Only call if insufficient bucets exist.
+    static void expand(size_t required_number_of_buckets);
+
+    static size_t seed_; /* Seed for fast_rand, should be non-zero */
+
+    static t_heap** heap_;    /* Buckets for linked lists*/
+    static size_t heap_size_; /* Number of buckets */
+    static size_t heap_head_; /* First non-empty bucket */
+    static size_t heap_tail_; /* Last non-empty bucket */
+};
+
+inline bool is_empty_heap() {
+    return Bucket::empty();
+}
+
+inline void init_heap(const DeviceGrid& grid) {
+    Bucket::init(grid);
+}
+
+inline void empty_heap() {
+    BucketItems::clear();
+    Bucket::clear();
+}
+
+inline void add_to_heap(t_heap* hptr) {
+    Bucket::push(hptr);
+}
+
+inline t_heap* get_heap_head() {
+    return Bucket::pop();
+}
+
+namespace heap_ {
+
+inline void push_back(t_heap* const hptr) {
+    add_to_heap(hptr);
+}
+
+inline bool is_valid() {
+    return true;
+}
+
+// extract every element and print it
+inline void pop_heap() {
+    while (!is_empty_heap())
+        VTR_LOG("%e ", get_heap_head()->cost);
+    VTR_LOG("\n");
+}
+
+inline void build_heap() {
+}
+
+inline void verify_extract_top() {
+    Bucket::verify();
+}
+
+inline void print_heap() {
+    Bucket::print();
+}
+
+inline void push_back_node(int inode, float total_cost, int prev_node, int prev_edge, float backward_path_cost, float R_upstream) {
+    /* Puts an rr_node on the heap with the same condition as node_to_heap,
+     * but do not fix heap property yet as that is more efficiently done from
+     * bottom up with build_heap    */
+
+    auto& route_ctx = g_vpr_ctx.routing();
+    if (total_cost >= route_ctx.rr_node_route_inf[inode].path_cost)
+        return;
+
+    t_heap* hptr = alloc_heap_data();
+    hptr->index = inode;
+    hptr->cost = total_cost;
+    hptr->u.prev.node = prev_node;
+    hptr->u.prev.edge = prev_edge;
+    hptr->backward_path_cost = backward_path_cost;
+    hptr->R_upstream = R_upstream;
+    push_back(hptr);
+}
+
+} // namespace heap_
+
+#endif /* _BUCKET_ITEMS_H_ */

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -182,6 +182,16 @@ alloc_heap_data() {
 // with items is returned.  This randomization exists to prevent the router
 // from following identical paths when operating with identical costs.
 // Consider two parallel paths to a node.
+//
+// Important node: This approximation makes some assumptions about the
+// structure of costs.
+//
+// Assumptions:
+//  1. 0 is the minimum cost
+//  2. Costs that are different by 0.1 % of the maximum cost are effectively
+//     equivilant
+//  3. The cost function is roughly linear.
+//
 class Bucket {
   public:
     Bucket() {}

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -223,11 +223,11 @@ class Bucket {
   private:
     // Factor used to convert cost from float to int.  Should be scaled to
     // enable sufficent precision in bucketting.
-    static constexpr float kConvFactor = 1e12;
+    static constexpr float kDefaultConvFactor = 1e12;
 
     // Convert cost from float to integer bucket id.
     static int cost_to_int(float cost) {
-        return (int)(cost * kConvFactor);
+        return (int)(cost * conv_factor_);
     }
 
     // Simple fast random function used for randomizing item selection on pop.
@@ -236,6 +236,8 @@ class Bucket {
         return seed_;
     }
 
+    static void check_scaling();
+
     // Expand the number of buckets.
     //
     // Only call if insufficient bucets exist.
@@ -243,10 +245,14 @@ class Bucket {
 
     static size_t seed_; /* Seed for fast_rand, should be non-zero */
 
-    static t_heap** heap_;    /* Buckets for linked lists*/
-    static size_t heap_size_; /* Number of buckets */
-    static size_t heap_head_; /* First non-empty bucket */
-    static size_t heap_tail_; /* Last non-empty bucket */
+    static t_heap** heap_;     /* Buckets for linked lists*/
+    static size_t heap_size_;  /* Number of buckets */
+    static size_t heap_head_;  /* First non-empty bucket */
+    static size_t heap_tail_;  /* Last non-empty bucket */
+    static float conv_factor_; /* Cost bucket scaling factor */
+
+    static float min_cost_; /* Smallest cost seen */
+    static float max_cost_; /* Large cost seen */
 };
 
 inline bool is_empty_heap() {

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -45,22 +45,12 @@ struct t_trace_branch {
 
 /**************** Static variables local to route_common.c ******************/
 
-static t_heap** heap; /* Indexed from [1..heap_size] */
-static int heap_size; /* Number of slots in the heap array */
-static int heap_tail; /* Index of first unused slot in the heap array */
-
-/* For managing my own list of currently free heap data structures.     */
-static t_heap* heap_free_head = nullptr;
-/* For keeping track of the sudo malloc memory for the heap*/
-static vtr::t_chunk heap_ch;
-
 /* For managing my own list of currently free trace data structures.    */
 static t_trace* trace_free_head = nullptr;
 /* For keeping track of the sudo malloc memory for the trace*/
 static vtr::t_chunk trace_ch;
 
 static int num_trace_allocated = 0; /* To watch for memory leaks. */
-static int num_heap_allocated = 0;
 static int num_linked_f_pointer_allocated = 0;
 
 /*  The numbering relation between the channels and clbs is:				*
@@ -467,17 +457,6 @@ void pathfinder_update_cost(float pres_fac, float acc_fac) {
     }
 }
 
-void init_heap(const DeviceGrid& grid) {
-    if (heap != nullptr) {
-        vtr::free(heap + 1);
-        heap = nullptr;
-    }
-    heap_size = (grid.width() - 1) * (grid.height() - 1);
-    heap = (t_heap**)vtr::malloc(heap_size * sizeof(t_heap*));
-    heap--; /* heap stores from [1..heap_size] */
-    heap_tail = 1;
-}
-
 /* Call this before you route any nets.  It frees any old traceback and   *
  * sets the list of rr_nodes touched to empty.                            */
 void init_route_structs(int bb_factor) {
@@ -493,7 +472,7 @@ void init_route_structs(int bb_factor) {
     route_ctx.trace.resize(cluster_ctx.clb_nlist.nets().size());
     route_ctx.trace_nodes.resize(cluster_ctx.clb_nlist.nets().size());
 
-    init_heap(device_ctx.grid);
+    Bucket::init(device_ctx.grid);
 
     //Various look-ups
     route_ctx.net_rr_terminals = load_net_rr_terminals(device_ctx.rr_node_indices);
@@ -505,7 +484,7 @@ void init_route_structs(int bb_factor) {
     /* Check that things that should have been emptied after the last routing *
      * really were.                                                           */
 
-    if (heap_tail != 1) {
+    if (!is_empty_heap()) {
         VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
                         "in init_route_structs. Heap is not empty.\n");
     }
@@ -736,7 +715,7 @@ float get_rr_cong_cost(int inode) {
     return (cost);
 }
 
-/* Returns the congestion cost of using this rr_node, *ignoring* 
+/* Returns the congestion cost of using this rr_node, *ignoring*
  * non-configurable edges */
 static float get_single_rr_cong_cost(int inode) {
     auto& device_ctx = g_vpr_ctx.device();
@@ -928,36 +907,12 @@ void free_route_structs() {
      * final routing result is not freed.                                */
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
-    if (heap != nullptr) {
-        //Free the individiaul heap elements (calls destructors)
-        for (int i = 1; i < num_heap_allocated; i++) {
-            VTR_LOG("Freeing %p\n", heap[i]);
-            vtr::chunk_delete(heap[i], &heap_ch);
-        }
+    BucketItems::free();
+    Bucket::free();
 
-        // coverity[offset_free : Intentional]
-        free(heap + 1);
-
-        heap = nullptr; /* Defensive coding:  crash hard if I use these. */
-    }
-
-    if (heap_free_head != nullptr) {
-        t_heap* curr = heap_free_head;
-        while (curr) {
-            t_heap* tmp = curr;
-            curr = curr->u.next;
-
-            vtr::chunk_delete(tmp, &heap_ch);
-        }
-
-        heap_free_head = nullptr;
-    }
     if (route_ctx.route_bb.size() != 0) {
         route_ctx.route_bb.clear();
     }
-
-    /*free the memory chunks that were used by heap and linked f pointer */
-    free_chunk_memory(&heap_ch);
 }
 
 /* Frees the data structures needed to save a routing.                     */
@@ -1112,7 +1067,7 @@ t_bb load_net_route_bb(ClusterNetId net_id, int bb_factor) {
      * the FPGA if necessary.  The bounding box returned by this routine
      * are different from the ones used by the placer in that they are
      * clipped to lie within (0,0) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1)
-     * rather than (1,1) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1).                                                            
+     * rather than (1,1) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1).
      */
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& device_ctx = g_vpr_ctx.device();
@@ -1177,227 +1132,18 @@ void add_to_mod_list(int inode, std::vector<int>& modified_rr_node_inf) {
     }
 }
 
-namespace heap_ {
-size_t parent(size_t i);
-size_t left(size_t i);
-size_t right(size_t i);
-size_t size();
-void expand_heap_if_full();
-
-size_t parent(size_t i) { return i >> 1; }
-// child indices of a heap
-size_t left(size_t i) { return i << 1; }
-size_t right(size_t i) { return (i << 1) + 1; }
-size_t size() { return static_cast<size_t>(heap_tail - 1); } // heap[0] is not valid element
-
-// make a heap rooted at index i by **sifting down** in O(lgn) time
-void sift_down(size_t hole) {
-    t_heap* head{heap[hole]};
-    size_t child{left(hole)};
-    while ((int)child < heap_tail) {
-        if ((int)child + 1 < heap_tail && heap[child + 1]->cost < heap[child]->cost)
-            ++child;
-        if (heap[child]->cost < head->cost) {
-            heap[hole] = heap[child];
-            hole = child;
-            child = left(child);
-        } else
-            break;
-    }
-    heap[hole] = head;
-}
-
-// runs in O(n) time by sifting down; the least work is done on the most elements: 1 swap for bottom layer, 2 swap for 2nd, ... lgn swap for top
-// 1*(n/2) + 2*(n/4) + 3*(n/8) + ... + lgn*1 = 2n (sum of i/2^i)
-void build_heap() {
-    // second half of heap are leaves
-    for (size_t i = heap_tail >> 1; i != 0; --i)
-        sift_down(i);
-}
-
-// O(lgn) sifting up to maintain heap property after insertion (should sift down when building heap)
-void sift_up(size_t leaf, t_heap* const node) {
-    while ((leaf > 1) && (node->cost < heap[parent(leaf)]->cost)) {
-        // sift hole up
-        heap[leaf] = heap[parent(leaf)];
-        leaf = parent(leaf);
-    }
-    heap[leaf] = node;
-}
-
-void expand_heap_if_full() {
-    if (heap_tail > heap_size) { /* Heap is full */
-        heap_size *= 2;
-        heap = (t_heap**)vtr::realloc((void*)(heap + 1),
-                                      heap_size * sizeof(t_heap*));
-        heap--; /* heap goes from [1..heap_size] */
-    }
-}
-
-// adds an element to the back of heap and expand if necessary, but does not maintain heap property
-void push_back(t_heap* const hptr) {
-    expand_heap_if_full();
-    heap[heap_tail] = hptr;
-    ++heap_tail;
-}
-
-void push_back_node(int inode, float total_cost, int prev_node, int prev_edge, float backward_path_cost, float R_upstream) {
-    /* Puts an rr_node on the heap with the same condition as node_to_heap,
-     * but do not fix heap property yet as that is more efficiently done from
-     * bottom up with build_heap    */
-
-    auto& route_ctx = g_vpr_ctx.routing();
-    if (total_cost >= route_ctx.rr_node_route_inf[inode].path_cost)
-        return;
-
-    t_heap* hptr = alloc_heap_data();
-    hptr->index = inode;
-    hptr->cost = total_cost;
-    hptr->u.prev.node = prev_node;
-    hptr->u.prev.edge = prev_edge;
-    hptr->backward_path_cost = backward_path_cost;
-    hptr->R_upstream = R_upstream;
-    push_back(hptr);
-}
-
-bool is_valid() {
-    for (size_t i = 1; (int)i <= heap_tail >> 1; ++i) {
-        if ((int)left(i) < heap_tail && heap[left(i)]->cost < heap[i]->cost) return false;
-        if ((int)right(i) < heap_tail && heap[right(i)]->cost < heap[i]->cost) return false;
-    }
-    return true;
-}
-// extract every element and print it
-void pop_heap() {
-    while (!is_empty_heap())
-        VTR_LOG("%e ", get_heap_head()->cost);
-    VTR_LOG("\n");
-}
-// print every element; not necessarily in order for minheap
-void print_heap() {
-    for (int i = 1; i<heap_tail>> 1; ++i)
-        VTR_LOG("(%e %e %e) ", heap[i]->cost, heap[left(i)]->cost, heap[right(i)]->cost);
-    VTR_LOG("\n");
-}
-// verify correctness of extract top by making a copy, sorting it, and iterating it at the same time as extraction
-void verify_extract_top() {
-    constexpr float float_epsilon = 1e-20;
-    std::cout << "copying heap\n";
-    std::vector<t_heap*> heap_copy{heap + 1, heap + heap_tail};
-    // sort based on cost with cheapest first
-    VTR_ASSERT(heap_copy.size() == size());
-    std::sort(begin(heap_copy), end(heap_copy),
-              [](const t_heap* a, const t_heap* b) {
-                  return a->cost < b->cost;
-              });
-    std::cout << "starting to compare top elements\n";
-    size_t i = 0;
-    while (!is_empty_heap()) {
-        while (heap_copy[i]->index == OPEN)
-            ++i; // skip the ones that won't be extracted
-        auto top = get_heap_head();
-        if (abs(top->cost - heap_copy[i]->cost) > float_epsilon)
-            std::cout << "mismatch with sorted " << top << '(' << top->cost << ") " << heap_copy[i] << '(' << heap_copy[i]->cost << ")\n";
-        ++i;
-    }
-    if (i != heap_copy.size())
-        std::cout << "did not finish extracting: " << i << " vs " << heap_copy.size() << std::endl;
-    else
-        std::cout << "extract top working as intended\n";
-}
-} // namespace heap_
 // adds to heap and maintains heap quality
-void add_to_heap(t_heap* hptr) {
-    heap_::expand_heap_if_full();
-    // start with undefined hole
-    ++heap_tail;
-    heap_::sift_up(heap_tail - 1, hptr);
-}
-
 /*WMF: peeking accessor :) */
-bool is_empty_heap() {
-    return (bool)(heap_tail == 1);
-}
-
-t_heap*
-get_heap_head() {
-    /* Returns a pointer to the smallest element on the heap, or NULL if the     *
-     * heap is empty.  Invalid (index == OPEN) entries on the heap are never     *
-     * returned -- they are just skipped over.                                   */
-
-    t_heap* cheapest;
-    size_t hole, child;
-
-    do {
-        if (heap_tail == 1) { /* Empty heap. */
-            VTR_LOG_WARN("Empty heap occurred in get_heap_head.\n");
-            return (nullptr);
-        }
-
-        cheapest = heap[1];
-
-        hole = 1;
-        child = 2;
-        --heap_tail;
-        while ((int)child < heap_tail) {
-            if (heap[child + 1]->cost < heap[child]->cost)
-                ++child; // become right child
-            heap[hole] = heap[child];
-            hole = child;
-            child = heap_::left(child);
-        }
-        heap_::sift_up(hole, heap[heap_tail]);
-
-    } while (cheapest->index == OPEN); /* Get another one if invalid entry. */
-
-    return (cheapest);
-}
-
-void empty_heap() {
-    for (int i = 1; i < heap_tail; i++)
-        free_heap_data(heap[i]);
-
-    heap_tail = 1;
-}
-
-t_heap*
-alloc_heap_data() {
-    if (heap_free_head == nullptr) { /* No elements on the free list */
-        heap_free_head = vtr::chunk_new<t_heap>(&heap_ch);
-    }
-
-    //Extract the head
-    t_heap* temp_ptr = heap_free_head;
-    heap_free_head = heap_free_head->u.next;
-
-    num_heap_allocated++;
-
-    //Reset
-    temp_ptr->u.next = nullptr;
-    temp_ptr->cost = 0.;
-    temp_ptr->backward_path_cost = 0.;
-    temp_ptr->R_upstream = 0.;
-    temp_ptr->index = OPEN;
-    temp_ptr->u.prev.node = NO_PREVIOUS;
-    temp_ptr->u.prev.edge = NO_PREVIOUS;
-    return (temp_ptr);
-}
-
-void free_heap_data(t_heap* hptr) {
-    hptr->u.next = heap_free_head;
-    heap_free_head = hptr;
-    num_heap_allocated--;
-}
 
 void invalidate_heap_entries(int sink_node, int ipin_node) {
     /* Marks all the heap entries consisting of sink_node, where it was reached *
      * via ipin_node, as invalid (OPEN).  Used only by the breadth_first router *
      * and even then only in rare circumstances.                                */
 
-    for (int i = 1; i < heap_tail; i++) {
-        if (heap[i]->index == sink_node) {
-            if (heap[i]->u.prev.node == ipin_node) {
-                heap[i]->index = OPEN; /* Invalid. */
+    for (auto* item : vtr::make_range(BucketItems::begin(), BucketItems::end())) {
+        if (item->index == sink_node) {
+            if (item->u.prev.node == ipin_node) {
+                item->index = OPEN; /* Invalid. */
                 break;
             }
         }
@@ -1550,7 +1296,7 @@ void print_route(const char* placement_file, const char* route_file) {
     if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_MEM)) {
         fp = vtr::fopen(getEchoFileName(E_ECHO_MEM), "w");
         fprintf(fp, "\nNum_heap_allocated: %d   Num_trace_allocated: %d\n",
-                num_heap_allocated, num_trace_allocated);
+                BucketItems::num_heap_allocated(), num_trace_allocated);
         fprintf(fp, "Num_linked_f_pointer_allocated: %d\n",
                 num_linked_f_pointer_allocated);
         fclose(fp);
@@ -1560,14 +1306,14 @@ void print_route(const char* placement_file, const char* route_file) {
     route_ctx.routing_id = vtr::secure_digest_file(route_file);
 }
 
-//To ensure the router can only swaps pin which are actually logically equivalent some block output pins must be
+//To ensure the router can only swap pins which are actually logically equivalent, some block output pins must be
 //reserved in certain cases.
 //
 // In the RR graph, output pin equivalence is modelled by a single SRC node connected to (multiple) OPINs, modelling
 // that each of the OPINs is logcially equivalent (i.e. it doesn't matter through which the router routes a signal,
 // so long as it is from the appropriate SRC).
 //
-// This correctly models 'full' equivalence (e.g. if there is a full crossbar between the outputs), but is to
+// This correctly models 'full' equivalence (e.g. if there is a full crossbar between the outputs), but is too
 // optimistic for 'instance' equivalence (which typcially models the pin equivalence possible by swapping sub-block
 // instances like BLEs). In particular, for the 'instance' equivalence case, some of the 'equivalent' block outputs
 // may be used by internal signals which are routed entirely *within* the block (i.e. the signals which never leave
@@ -1614,7 +1360,7 @@ void reserve_locally_used_opins(float pres_fac, float acc_fac, bool rip_up_local
             VTR_ASSERT(type->class_inf[iclass].equivalence == PortEquivalence::INSTANCE);
 
             //From the SRC node we walk through it's out going edges to collect the
-            //OPIN nodes. We then push them onto a heap so the the OPINs with lower
+            //OPIN nodes. We then push them onto a heap so the OPINs with lower
             //congestion cost are popped-off/reserved first. (Intuitively, we want
             //the reserved OPINs to move out of the way of congestion, by preferring
             //to reserve OPINs with lower congestion costs).

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -3,52 +3,7 @@
 #include <vector>
 #include "clustered_netlist.h"
 #include "vtr_vector.h"
-
-/* Used by the heap as its fundamental data structure.
- * Each heap element represents a partial route.
- *
- * cost:    The cost used to sort heap.
- *          For the timing-driven router this is the backward_path_cost +
- *          expected cost to the target.
- *          For the breadth-first router it is the node cost to reach this
- *          point.
- *
- * backward_path_cost:  Used only by the timing-driven router.  The "known"
- *                      cost of the path up to and including this node.
- *                      In this case, the .cost member contains not only
- *                      the known backward cost but also an expected cost
- *                      to the target.
- *
- * R_upstream: Used only by the timing-driven router.  Stores the upstream 
- *             resistance to ground from this node, including the
- *             resistance of the node itself (device_ctx.rr_nodes[index].R).
- *
- * index: The RR node index associated with the costs/R_upstream values
- *
- * u.prev.node: The previous node used to reach the current 'index' node
- * u.prev.next: The edge from u.prev.node used to reach the current 'index' node
- *
- * u.next:  pointer to the next s_heap structure in the free
- *          linked list.  Not used when on the heap.
- *
- */
-struct t_heap {
-    float cost = 0.;
-    float backward_path_cost = 0.;
-    float R_upstream = 0.;
-
-    int index = OPEN;
-
-    struct t_prev {
-        int node;
-        int edge;
-    };
-
-    union {
-        t_heap* next;
-        t_prev prev;
-    } u;
-};
+#include "bucket.h"
 
 /******* Subroutines in route_common used only by other router modules ******/
 
@@ -72,34 +27,12 @@ float get_rr_cong_cost(int inode);
 void mark_ends(ClusterNetId net_id);
 void mark_remaining_ends(const std::vector<int>& remaining_sinks);
 
-void add_to_heap(t_heap* hptr);
-t_heap* alloc_heap_data();
 void node_to_heap(int inode, float cost, int prev_node, int prev_edge, float backward_path_cost, float R_upstream);
-
-bool is_empty_heap();
 
 void free_traceback(ClusterNetId net_id);
 void free_traceback(t_trace* tptr);
 
 void add_to_mod_list(int inode, std::vector<int>& modified_rr_node_inf);
-
-namespace heap_ {
-void build_heap();
-void sift_down(size_t hole);
-void sift_up(size_t tail, t_heap* const hptr);
-void push_back(t_heap* const hptr);
-void push_back_node(int inode, float total_cost, int prev_node, int prev_edge, float backward_path_cost, float R_upstream);
-bool is_valid();
-void pop_heap();
-void print_heap();
-void verify_extract_top();
-} // namespace heap_
-
-t_heap* get_heap_head();
-
-void empty_heap();
-
-void free_heap_data(t_heap* hptr);
 
 void invalidate_heap_entries(int sink_node, int ipin_node);
 
@@ -111,7 +44,6 @@ void reset_rr_node_route_structs();
 
 void free_trace_structs();
 
-void init_heap(const DeviceGrid& grid);
 void reserve_locally_used_opins(float pres_fac, float acc_fac, bool rip_up_local_opins);
 
 void free_chunk_memory_trace();


### PR DESCRIPTION
### Description

The heap approximation doesn't precisely follow the heap property, but
offers an approximation that is sufficient for the router's purpose.
This new data structure is faster to clear, faster during route time,
and results in better router behavior because it provides some
randomness on elements with costs that are same within 1 ps.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

Profiler data showed a significant amount of time being spent managing the heap, especially the heap pop operation.  This refactoring has a couple gains for a couple reasons:
 - The new data structure does not provide an exact heap.  Instead it is an approximation based on grouping of cost.  This cost grouping is currently being done on a [0, 1) picosecond (1e-12) basis.
 - The new data structure provides some randomness on nodes with costs in the same grouping.  For items with identical cost, this avoids sending the router down identical paths, and resolves some congestion without explicitly costing it.
 - The new data structure and memory management clear very quickly by avoiding rebuilding the free list.

In limited functional testing these changes resulted in a 30-40% runtime decrease with a ~3% CPD increase.

#### How Has This Been Tested?

Some smaller functional tests (44k connections) show better convergence properties, and better per iteration runtime, and better overall runtime.

Titan benchmarks are being run now to see if the change holds on a variety of designs (especially larger ones).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
