### PR TITLE
vpr: shortened check of max nodes per channel vs. max channel width

### DIFF
--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -478,7 +478,7 @@ static void build_rr_graph(const t_graph_type graph_type,
                                                  max_dim, segment_inf,
                                                  use_full_seg_groups, is_global_graph, directionality,
                                                  &num_seg_details);
-        if ((is_global_graph ? 1 : nodes_per_chan.max) != max_chan_width) {
+        if (nodes_per_chan.max != max_chan_width) {
             nodes_per_chan.max = max_chan_width;
             *Warnings |= RR_GRAPH_WARN_CHAN_WIDTH_CHANGED;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Removed existing dead code in rr_graph.cpp.

#### Description
<!--- Describe your changes in detail -->

Code originally checked for whether if is_global_graph was false, when this boolean was already known to be false, so I removed that condition.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#945 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Keeps coverity clean.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Investigated the blame for that particular section of code, and concluded that the condition had never been evaluated before.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
