### PR TITLE
Always initialize cost indexed data on orthagonal segments (if possible).

### DIFF
--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -115,12 +115,22 @@ void alloc_and_load_rr_indexed_data(const std::vector<t_segment_inf>& segment_in
     load_rr_indexed_data_T_values((CHANX_COST_INDEX_START + num_segment),
                                   num_segment, CHANY, nodes_per_chan, L_rr_node_indices);
 
+    // Scan CHANX/CHANY indexed data and search for uninitialized costs.
+    //
+    // This would occur if a segment ends up only being used as CHANX or a
+    // CHANY, but not both.  If this occurs, then copying the orthogonal
+    // pair's cost data is likely a better choice than leaving it as -1.
+    //
+    // The primary reason for this fixup is to avoid propagating negative
+    // values in cost functions.
     for (int cost_index = CHANX_COST_INDEX_START;
          cost_index < CHANX_COST_INDEX_START + 2 * num_segment; cost_index++) {
         int ortho_cost_index = device_ctx.rr_indexed_data[cost_index].ortho_cost_index;
-        /* If segments doesn't have data (e.g. doesn't exists), check if ortho 
-         * segment does exist. If so, copy that data. */
+
+        // Check if this data is uninitialized, but the orthogonal data is
+        // initialized.
         if (device_ctx.rr_indexed_data[cost_index].T_linear == OPEN && device_ctx.rr_indexed_data[ortho_cost_index].T_linear != OPEN) {
+            // Copy orthogonal data over.
             device_ctx.rr_indexed_data[cost_index].T_linear = device_ctx.rr_indexed_data[ortho_cost_index].T_linear;
             device_ctx.rr_indexed_data[cost_index].T_quadratic = device_ctx.rr_indexed_data[ortho_cost_index].T_quadratic;
             device_ctx.rr_indexed_data[cost_index].C_load = device_ctx.rr_indexed_data[ortho_cost_index].C_load;

--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -115,6 +115,18 @@ void alloc_and_load_rr_indexed_data(const std::vector<t_segment_inf>& segment_in
     load_rr_indexed_data_T_values((CHANX_COST_INDEX_START + num_segment),
                                   num_segment, CHANY, nodes_per_chan, L_rr_node_indices);
 
+    for (int cost_index = CHANX_COST_INDEX_START;
+         cost_index < CHANX_COST_INDEX_START + 2 * num_segment; cost_index++) {
+        int ortho_cost_index = device_ctx.rr_indexed_data[cost_index].ortho_cost_index;
+        /* If segments doesn't have data (e.g. doesn't exists), check if ortho 
+         * segment does exist. If so, copy that data. */
+        if (device_ctx.rr_indexed_data[cost_index].T_linear == OPEN && device_ctx.rr_indexed_data[ortho_cost_index].T_linear != OPEN) {
+            device_ctx.rr_indexed_data[cost_index].T_linear = device_ctx.rr_indexed_data[ortho_cost_index].T_linear;
+            device_ctx.rr_indexed_data[cost_index].T_quadratic = device_ctx.rr_indexed_data[ortho_cost_index].T_quadratic;
+            device_ctx.rr_indexed_data[cost_index].C_load = device_ctx.rr_indexed_data[ortho_cost_index].C_load;
+        }
+    }
+
     load_rr_indexed_data_base_costs(nodes_per_chan, L_rr_node_indices,
                                     base_cost_type);
 }


### PR DESCRIPTION
#### Description

The current cost indexing code will leave segment costs as "OPEN" (e.g. -1.f) if none of that segment is present.  This data may get used in the classic cost function here (https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/master/vpr/src/route/router_lookahead.cpp#L50), and as a result a negative lookahead cost may be generated.

The specific circumstances that can result in this is if a segment is only used in the X or Y direction, resulting in none of the opposite type being present.  In this case, it is probably better to use the ortho cost values rather than leave them as "OPEN" (e.g. -1.f).

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?


Green CI, and some symbiflow integration tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
