### PR TITLE
Track non-configurable edge usage to enable pruning.

### DIFF
--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -812,8 +812,6 @@ class StubFinder {
 //
 //We treat any configurable stubs as an error.
 void check_net_for_stubs(ClusterNetId net) {
-    auto& route_ctx = g_vpr_ctx.mutable_routing();
-
     StubFinder stub_finder;
 
     bool any_stubs = stub_finder.CheckNet(net);

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -14,6 +14,8 @@ using namespace std;
 #include "rr_graph.h"
 #include "check_rr_graph.h"
 #include "read_xml_arch_file.h"
+#include "route_tree_type.h"
+#include "route_tree_timing.h"
 
 /******************** Subroutines local to this module **********************/
 static void check_node_and_range(int inode, enum e_route_type route_type);
@@ -27,6 +29,7 @@ static void check_locally_used_clb_opins(const t_clb_opins_used& clb_opins_used_
                                          enum e_route_type route_type);
 
 static bool check_non_configurable_edges(ClusterNetId net, const t_non_configurable_rr_sets& non_configurable_rr_sets);
+static void check_net_for_stubs(ClusterNetId net);
 
 /************************ Subroutine definitions ****************************/
 
@@ -155,6 +158,8 @@ void check_route(enum e_route_type route_type) {
         }
 
         check_non_configurable_edges(net_id, non_configurable_rr_sets);
+
+        check_net_for_stubs(net_id);
 
         reset_flags(net_id, connected_to_route);
 
@@ -776,4 +781,91 @@ static bool check_non_configurable_edges(ClusterNetId net, const t_non_configura
     }
 
     return true;
+}
+
+// StubFinder traverses a net definition and find ensures that all nodes that
+// are children of a configurable node have at least one sink.
+class StubFinder {
+  public:
+    // Checks specified net for stubs, return true if at least one stub is
+    // found.
+    bool CheckNet(ClusterNetId net);
+
+    // Returns set of stub nodes.
+    const std::set<int>& stub_nodes() {
+        return stub_nodes_;
+    }
+
+  private:
+    bool RecurseTree(t_rt_node* rt_root);
+
+    // Set of stub nodes
+    // Note this is an ordered set so that node output is sorted by node
+    // id.
+    std::set<int> stub_nodes_;
+};
+
+//Cheks for stubs in a net's routing.
+//
+//Stubs (routing branches which don't connect to SINKs) serve no purpose, and only chew up wiring unecessarily.
+//The only exception are stubs required by non-configurable switches (e.g. shorts).
+//
+//We treat any configurable stubs as an error.
+void check_net_for_stubs(ClusterNetId net) {
+    auto& route_ctx = g_vpr_ctx.mutable_routing();
+
+    StubFinder stub_finder;
+
+    bool any_stubs = stub_finder.CheckNet(net);
+    if (any_stubs) {
+        auto& cluster_ctx = g_vpr_ctx.clustering();
+        std::string msg = vtr::string_fmt("Route tree for net '%s' (#%zu) contains stub branches rooted at:\n",
+                                          cluster_ctx.clb_nlist.net_name(net).c_str(), size_t(net));
+        for (int inode : stub_finder.stub_nodes()) {
+            msg += vtr::string_fmt("    %s\n", describe_rr_node(inode).c_str());
+        }
+
+        VPR_THROW(VPR_ERROR_ROUTE, msg.c_str());
+    }
+}
+
+bool StubFinder::CheckNet(ClusterNetId net) {
+    stub_nodes_.clear();
+
+    t_rt_node* rt_root = traceback_to_route_tree(net);
+    RecurseTree(rt_root);
+    free_route_tree(rt_root);
+
+    return !stub_nodes_.empty();
+}
+
+// Returns true if this node is a stub.
+bool StubFinder::RecurseTree(t_rt_node* rt_root) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    if (rt_root->u.child_list == nullptr) {
+        //If a leaf of the route tree is not a SINK, then it is a stub
+        if (device_ctx.rr_nodes[rt_root->inode].type() != SINK) {
+            return true; //It is the current root of this stub
+        } else {
+            return false;
+        }
+    } else {
+        bool is_stub = true;
+        for (t_linked_rt_edge* edge = rt_root->u.child_list; edge != nullptr; edge = edge->next) {
+            bool driver_switch_configurable = device_ctx.rr_switch_inf[edge->iswitch].configurable();
+
+            bool child_is_stub = RecurseTree(edge->child);
+            if (!child_is_stub) {
+                // Because the child was not a stub, this node is not a stub.
+                is_stub = false;
+            } else if (driver_switch_configurable) {
+                // This child was stub, and we drove it from a configurable
+                // edge, this is an error.
+                stub_nodes_.insert(edge->child->inode);
+            }
+        }
+
+        return is_stub;
+    }
 }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -163,10 +163,12 @@ void restore_routing(vtr::vector<ClusterNetId, t_trace*>& best_routing,
 
     for (auto net_id : cluster_ctx.clb_nlist.nets()) {
         /* Free any current routing. */
+        pathfinder_update_path_cost(route_ctx.trace[net_id].head, -1, 0.f);
         free_traceback(net_id);
 
         /* Set the current routing to the saved one. */
         route_ctx.trace[net_id].head = best_routing[net_id];
+        pathfinder_update_path_cost(route_ctx.trace[net_id].head, 1, 0.f);
         best_routing[net_id] = nullptr; /* No stored routing. */
     }
 
@@ -736,7 +738,7 @@ float get_rr_cong_cost(int inode) {
     return (cost);
 }
 
-/* Returns the congestion cost of using this rr_node, *ignoring* 
+/* Returns the congestion cost of using this rr_node, *ignoring*
  * non-configurable edges */
 static float get_single_rr_cong_cost(int inode) {
     auto& device_ctx = g_vpr_ctx.device();
@@ -1112,7 +1114,7 @@ t_bb load_net_route_bb(ClusterNetId net_id, int bb_factor) {
      * the FPGA if necessary.  The bounding box returned by this routine
      * are different from the ones used by the placer in that they are
      * clipped to lie within (0,0) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1)
-     * rather than (1,1) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1).                                                            
+     * rather than (1,1) and (device_ctx.grid.width()-1,device_ctx.grid.height()-1).
      */
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& device_ctx = g_vpr_ctx.device();

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -297,6 +297,8 @@ static void generate_route_timing_reports(const t_router_opts& router_opts,
                                           const SetupTimingInfo& timing_info,
                                           const RoutingDelayCalculator& delay_calc);
 
+static void prune_unused_non_configurable_nets(CBRR& connections_inf);
+
 /************************ Subroutine definitions *****************************/
 bool try_timing_driven_route(const t_router_opts& router_opts,
                              const t_analysis_opts& analysis_opts,
@@ -722,8 +724,16 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
         VTR_LOG("Restoring best routing\n");
 
         auto& router_ctx = g_vpr_ctx.mutable_routing();
+
+        /* Restore congestion from best route */
+        for (auto net_id : cluster_ctx.clb_nlist.nets()) {
+            pathfinder_update_path_cost(route_ctx.trace[net_id].head, -1, pres_fac);
+            pathfinder_update_path_cost(best_routing[net_id].head, 1, pres_fac);
+        }
         router_ctx.trace = best_routing;
         router_ctx.clb_opins_used_locally = best_clb_opins_used_locally;
+
+        prune_unused_non_configurable_nets(connections_inf);
 
         if (timing_info) {
             VTR_LOG("Critical path: %g ns\n", 1e9 * best_routing_metrics.critical_path.delay());
@@ -1530,9 +1540,7 @@ static t_rt_node* setup_routing_resources(int itry,
         profiling::net_rebuild_start();
 
         // convert the previous iteration's traceback into a route tree
-        auto& device_ctx = g_vpr_ctx.device();
-        std::vector<int> non_config_node_set_usage(device_ctx.rr_non_config_node_sets.size(), 0);
-        rt_root = traceback_to_route_tree(net_id, &non_config_node_set_usage);
+        rt_root = traceback_to_route_tree(net_id);
 
         //Santiy check that route tree and traceback are equivalent before pruning
         VTR_ASSERT_DEBUG(verify_traceback_route_tree_equivalent(route_ctx.trace[net_id].head, rt_root));
@@ -1542,7 +1550,7 @@ static t_rt_node* setup_routing_resources(int itry,
         VTR_ASSERT_SAFE(should_route_net(net_id, connections_inf, true));
 
         //Prune the branches of the tree that don't legally lead to sinks
-        rt_root = prune_route_tree(rt_root, connections_inf, &non_config_node_set_usage);
+        rt_root = prune_route_tree(rt_root, connections_inf);
 
         //Now that the tree has been pruned, we can free the old traceback
         // NOTE: this must happen *after* pruning since it changes the
@@ -2792,4 +2800,47 @@ static void generate_route_timing_reports(const t_router_opts& router_opts,
     tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph, *timing_ctx.constraints);
 
     timing_reporter.report_timing_setup(router_opts.first_iteration_timing_report_file, *timing_info.setup_analyzer(), analysis_opts.timing_report_npaths);
+}
+
+// If a route is ripped up during routing, non-configurable sets are left
+// behind.  As a result, the final routing may have stubs at
+// non-configurable sets.  This function tracks non-configurable set usage,
+// and if the sets are unused, prunes them.
+static void prune_unused_non_configurable_nets(CBRR& connections_inf) {
+    auto& device_ctx = g_vpr_ctx.device();
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    auto& route_ctx = g_vpr_ctx.routing();
+
+    std::vector<int> non_config_node_set_usage(device_ctx.rr_non_config_node_sets.size(), 0);
+    for (auto net_id : cluster_ctx.clb_nlist.nets()) {
+        connections_inf.prepare_routing_for_net(net_id);
+        connections_inf.clear_force_reroute_for_net();
+
+        std::fill(non_config_node_set_usage.begin(), non_config_node_set_usage.end(), 0);
+        t_rt_node* rt_root = traceback_to_route_tree(net_id, &non_config_node_set_usage);
+        if (rt_root == nullptr) {
+            continue;
+        }
+
+        //Santiy check that route tree and traceback are equivalent before pruning
+        VTR_ASSERT(verify_traceback_route_tree_equivalent(
+            route_ctx.trace[net_id].head, rt_root));
+
+        // check for edge correctness
+        VTR_ASSERT_SAFE(is_valid_skeleton_tree(rt_root));
+
+        //Prune the branches of the tree that don't legally lead to sinks
+        rt_root = prune_route_tree(rt_root, connections_inf,
+                                   &non_config_node_set_usage);
+
+        // Free old traceback.
+        free_traceback(net_id);
+
+        // Update traceback with pruned tree.
+        auto& reached_rt_sinks = connections_inf.get_reached_rt_sinks();
+        traceback_from_route_tree(net_id, rt_root, reached_rt_sinks.size());
+        VTR_ASSERT(verify_traceback_route_tree_equivalent(route_ctx.trace[net_id].head, rt_root));
+
+        free_route_tree(rt_root);
+    }
 }

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1530,7 +1530,9 @@ static t_rt_node* setup_routing_resources(int itry,
         profiling::net_rebuild_start();
 
         // convert the previous iteration's traceback into a route tree
-        rt_root = traceback_to_route_tree(net_id);
+        auto& device_ctx = g_vpr_ctx.device();
+        std::vector<int> non_config_node_set_usage(device_ctx.rr_non_config_node_sets.size(), 0);
+        rt_root = traceback_to_route_tree(net_id, &non_config_node_set_usage);
 
         //Santiy check that route tree and traceback are equivalent before pruning
         VTR_ASSERT_DEBUG(verify_traceback_route_tree_equivalent(route_ctx.trace[net_id].head, rt_root));
@@ -1540,7 +1542,7 @@ static t_rt_node* setup_routing_resources(int itry,
         VTR_ASSERT_SAFE(should_route_net(net_id, connections_inf, true));
 
         //Prune the branches of the tree that don't legally lead to sinks
-        rt_root = prune_route_tree(rt_root, connections_inf);
+        rt_root = prune_route_tree(rt_root, connections_inf, &non_config_node_set_usage);
 
         //Now that the tree has been pruned, we can free the old traceback
         // NOTE: this must happen *after* pruning since it changes the

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -777,7 +777,6 @@ static t_trace* traceback_to_route_tree_branch(t_trace* trace,
             if (node_type == SINK) {
                 // A non-configurable edge to a sink is also a usage of the
                 // set.
-                auto& device_ctx = g_vpr_ctx.device();
                 auto set_itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
                 if (non_config_node_set_usage != nullptr && set_itr != device_ctx.rr_node_to_non_config_node_set.end()) {
                     if (device_ctx.rr_switch_inf[iswitch].configurable()) {

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -774,6 +774,18 @@ static t_trace* traceback_to_route_tree_branch(t_trace* trace,
             else
                 node->re_expand = true;
 
+            if (node_type == SINK) {
+                // A non-configurable edge to a sink is also a usage of the
+                // set.
+                auto& device_ctx = g_vpr_ctx.device();
+                auto set_itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
+                if (non_config_node_set_usage != nullptr && set_itr != device_ctx.rr_node_to_non_config_node_set.end()) {
+                    if (device_ctx.rr_switch_inf[iswitch].configurable()) {
+                        (*non_config_node_set_usage)[set_itr->second] += 1;
+                    }
+                }
+            }
+
             //Save
             rr_node_to_rt[inode] = node;
         } else {
@@ -1042,6 +1054,21 @@ static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf
         }
 
     } else {
+        // If this node is:
+        //   1. Part of a non-configurable node set
+        //   2. The first node in the tree that is part of the non-configurable
+        //      node set
+        //
+        //      -- and --
+        //
+        //   3. The node set is not active
+        //
+        //  Then prune this node.
+        if (node_set != -1 && device_ctx.rr_switch_inf[node->parent_switch].configurable() && (*non_config_node_set_usage)[node_set] == 0) {
+            // This node should be pruned, re-prune edges once more.
+            return prune_route_tree_recurr(node, connections_inf, /*force_prune=*/false, non_config_node_set_usage);
+        }
+
         //An unpruned intermediate node
         VTR_ASSERT(!force_prune);
 

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -972,7 +972,7 @@ static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf
 
             // After removing an edge, check if non_config_node_set_usage
             // needs an update.
-            if (node_set != -1 && device_ctx.rr_switch_inf[old_edge->iswitch].configurable()) {
+            if (non_config_node_set_usage != nullptr && node_set != -1 && device_ctx.rr_switch_inf[old_edge->iswitch].configurable()) {
                 (*non_config_node_set_usage)[node_set] -= 1;
                 VTR_ASSERT((*non_config_node_set_usage)[node_set] >= 0);
             }
@@ -1041,7 +1041,9 @@ static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf
             if (reached_non_configurably) {
                 // Check if this non-configurable node set is in use.
                 VTR_ASSERT(node_set != -1);
-                force_prune = force_prune || (*non_config_node_set_usage)[node_set] == 0;
+                if (non_config_node_set_usage != nullptr && (*non_config_node_set_usage)[node_set] == 0) {
+                    force_prune = true;
+                }
             }
         }
 
@@ -1063,7 +1065,7 @@ static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf
         //   3. The node set is not active
         //
         //  Then prune this node.
-        if (node_set != -1 && device_ctx.rr_switch_inf[node->parent_switch].configurable() && (*non_config_node_set_usage)[node_set] == 0) {
+        if (non_config_node_set_usage != nullptr && node_set != -1 && device_ctx.rr_switch_inf[node->parent_switch].configurable() && (*non_config_node_set_usage)[node_set] == 0) {
             // This node should be pruned, re-prune edges once more.
             return prune_route_tree_recurr(node, connections_inf, /*force_prune=*/false, non_config_node_set_usage);
         }
@@ -1073,6 +1075,10 @@ static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf
 
         return node; //Not pruned
     }
+}
+
+t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf) {
+    return prune_route_tree(rt_root, connections_inf, nullptr);
 }
 
 t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage) {

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -54,9 +54,9 @@ static t_rt_node* update_unbuffered_ancestors_C_downstream(t_rt_node* start_of_n
 
 bool verify_route_tree_recurr(t_rt_node* node, std::set<int>& seen_nodes);
 
-t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool congested);
+static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool congested, std::vector<int>* non_config_node_set_usage);
 
-static t_trace* traceback_to_route_tree_branch(t_trace* trace, std::map<int, t_rt_node*>& rr_node_to_rt);
+static t_trace* traceback_to_route_tree_branch(t_trace* trace, std::map<int, t_rt_node*>& rr_node_to_rt, std::vector<int>* non_config_node_set_usage);
 
 static std::pair<t_trace*, t_trace*> traceback_from_route_tree_recurr(t_trace* head, t_trace* tail, const t_rt_node* node);
 
@@ -500,11 +500,11 @@ update_unbuffered_ancestors_C_downstream(t_rt_node* start_of_new_path_rt_node) {
 
     /* Having set the value of C_downstream_addition, we must check whethere the parent switch
      * is a buffered or unbuffered switch with the if statement below. If the parent switch is
-     * a buffered switch, then the parent node's downsteam capacitance is increased by the 
+     * a buffered switch, then the parent node's downsteam capacitance is increased by the
      * value of the parent switch's internal capacitance in the if statement below.
-     * Correspondingly, the ancestors' downstream capacitance will be updated by the same  
+     * Correspondingly, the ancestors' downstream capacitance will be updated by the same
      * value through the while loop. Otherwise, if the parent switch is unbuffered, then
-     * the if statement will be ignored, and the parent and ancestral nodes' downstream 
+     * the if statement will be ignored, and the parent and ancestral nodes' downstream
      * capacitance will be increased by the sum of the child's downstream capacitance with
      * the internal capacitance of the parent switch in the while loop/.*/
 
@@ -697,12 +697,20 @@ void update_remaining_net_delays_from_route_tree(float* net_delay,
 }
 
 /***************  Conversion between traceback and route tree *******************/
-t_rt_node* traceback_to_route_tree(ClusterNetId inet) {
+t_rt_node* traceback_to_route_tree(ClusterNetId inet, std::vector<int>* non_config_node_set_usage) {
     auto& route_ctx = g_vpr_ctx.routing();
-    return traceback_to_route_tree(route_ctx.trace[inet].head);
+    return traceback_to_route_tree(route_ctx.trace[inet].head, non_config_node_set_usage);
+}
+
+t_rt_node* traceback_to_route_tree(ClusterNetId inet) {
+    return traceback_to_route_tree(inet, nullptr);
 }
 
 t_rt_node* traceback_to_route_tree(t_trace* head) {
+    return traceback_to_route_tree(head, nullptr);
+}
+
+t_rt_node* traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage) {
     /* Builds a skeleton route tree from a traceback
      * does not calculate R_upstream, C_downstream, or Tdel at all (left uninitialized)
      * returns the root of the converted route tree
@@ -718,7 +726,7 @@ t_rt_node* traceback_to_route_tree(t_trace* head) {
 
     t_trace* trace = head;
     while (trace) { //Each branch
-        trace = traceback_to_route_tree_branch(trace, rr_node_to_rt);
+        trace = traceback_to_route_tree_branch(trace, rr_node_to_rt, non_config_node_set_usage);
     }
     // Due to the recursive nature of traceback_to_route_tree_branch,
     // the source node is not properly configured.
@@ -735,7 +743,9 @@ t_rt_node* traceback_to_route_tree(t_trace* head) {
 //Note that R_upstream and C_downstream are initialized to NaN
 //
 //Returns the t_trace defining the start of the next branch
-static t_trace* traceback_to_route_tree_branch(t_trace* trace, std::map<int, t_rt_node*>& rr_node_to_rt) {
+static t_trace* traceback_to_route_tree_branch(t_trace* trace,
+                                               std::map<int, t_rt_node*>& rr_node_to_rt,
+                                               std::vector<int>* non_config_node_set_usage) {
     t_trace* next = nullptr;
 
     if (trace) {
@@ -774,8 +784,21 @@ static t_trace* traceback_to_route_tree_branch(t_trace* trace, std::map<int, t_r
 
         next = trace->next;
         if (iswitch != OPEN) {
+            // Keep track of non-configurable set usage by looking for
+            // configurable edges that extend out of a non-configurable set.
+            //
+            // Each configurable edges from the non-configurable set is a
+            // usage of the set.
+            auto& device_ctx = g_vpr_ctx.device();
+            auto set_itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
+            if (non_config_node_set_usage != nullptr && set_itr != device_ctx.rr_node_to_non_config_node_set.end()) {
+                if (device_ctx.rr_switch_inf[iswitch].configurable()) {
+                    (*non_config_node_set_usage)[set_itr->second] += 1;
+                }
+            }
+
             //Recursively construct the remaining branch
-            next = traceback_to_route_tree_branch(next, rr_node_to_rt);
+            next = traceback_to_route_tree_branch(next, rr_node_to_rt, non_config_node_set_usage);
 
             //Get the created child
             itr = rr_node_to_rt.find(trace->next->index);
@@ -889,7 +912,7 @@ t_trace* traceback_from_route_tree(ClusterNetId inet, const t_rt_node* root, int
 //Prunes a route tree (recursively) based on congestion and the 'force_prune' argument
 //
 //Returns true if the current node was pruned
-t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool force_prune) {
+static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool force_prune, std::vector<int>* non_config_node_set_usage) {
     //Recursively traverse the route tree rooted at node and remove any congested
     //sub-trees
 
@@ -899,6 +922,11 @@ t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool 
     auto& route_ctx = g_vpr_ctx.routing();
 
     bool congested = (route_ctx.rr_node_route_inf[node->inode].occ() > device_ctx.rr_nodes[node->inode].capacity());
+    int node_set = -1;
+    auto itr = device_ctx.rr_node_to_non_config_node_set.find(node->inode);
+    if (itr != device_ctx.rr_node_to_non_config_node_set.end()) {
+        node_set = itr->second;
+    }
 
     if (congested) {
         //This connection is congested -- prune it
@@ -915,7 +943,8 @@ t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool 
     t_linked_rt_edge* prev_edge = nullptr;
     t_linked_rt_edge* edge = node->u.child_list;
     while (edge) {
-        t_rt_node* child = prune_route_tree_recurr(edge->child, connections_inf, force_prune);
+        t_rt_node* child = prune_route_tree_recurr(edge->child,
+                                                   connections_inf, force_prune, non_config_node_set_usage);
 
         if (!child) { //Child was pruned
 
@@ -929,6 +958,13 @@ t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool 
 
             t_linked_rt_edge* old_edge = edge;
             edge = edge->next;
+
+            // After removing an edge, check if non_config_node_set_usage
+            // needs an update.
+            if (node_set != -1 && device_ctx.rr_switch_inf[old_edge->iswitch].configurable()) {
+                (*non_config_node_set_usage)[node_set] -= 1;
+                VTR_ASSERT((*non_config_node_set_usage)[node_set] >= 0);
+            }
 
             free_linked_rt_edge(old_edge);
 
@@ -977,18 +1013,8 @@ t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool 
         // We take the corresponding actions:
         //   1) Prune the node.
         //
-        //   2) Prune the node only if force_prune is set
-        //
-        //      Since the node was reached non-configurably it is illegal to
-        //      remove it independently of any other nodes which are non-
-        //      configurably connected to it.
-        //
-        //      As a result we only remove a non-configurably connected node
-        //      if force_prune is set.
-        //
-        //      Note that if a node upstream of the non-configurably connected
-        //      nodes becomes congested, force_prune will be set and the *entire*
-        //      set of non-configurably connected nodes will be removed.
+        //   2) Prune the node only if the node set is unused or if force_prune
+        //      is set.
         //
         //   3) Prune the node.
         //
@@ -1000,6 +1026,12 @@ t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool 
         bool reached_non_configurably = false;
         if (node->parent_node) {
             reached_non_configurably = !device_ctx.rr_switch_inf[node->parent_switch].configurable();
+
+            if (reached_non_configurably) {
+                // Check if this non-configurable node set is in use.
+                VTR_ASSERT(node_set != -1);
+                force_prune = force_prune || (*non_config_node_set_usage)[node_set] == 0;
+            }
         }
 
         if (reached_non_configurably && !force_prune) {
@@ -1017,7 +1049,7 @@ t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool 
     }
 }
 
-t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf) {
+t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage) {
     /* Prune a skeleton route tree of illegal branches - when there is at least 1 congested node on the path to a sink
      * This is the top level function to be called with the SOURCE node as root.
      * Returns true if the entire tree has been pruned.
@@ -1035,7 +1067,7 @@ t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf) {
     VTR_ASSERT_MSG(route_ctx.rr_node_route_inf[rt_root->inode].occ() <= device_ctx.rr_nodes[rt_root->inode].capacity(),
                    "Route tree root/SOURCE should never be congested");
 
-    return prune_route_tree_recurr(rt_root, connections_inf, false);
+    return prune_route_tree_recurr(rt_root, connections_inf, false, non_config_node_set_usage);
 }
 
 void pathfinder_update_cost_from_route_tree(const t_rt_node* rt_root, int add_or_sub, float pres_fac) {

--- a/vpr/src/route/route_tree_timing.h
+++ b/vpr/src/route/route_tree_timing.h
@@ -49,11 +49,13 @@ void print_route_tree_node(const t_rt_node* rt_root);
 void print_route_tree_inf(const t_rt_node* rt_root);
 void print_route_tree_congestion(const t_rt_node* rt_root);
 
-t_rt_node* traceback_to_route_tree(t_trace* head);
 t_rt_node* traceback_to_route_tree(ClusterNetId inet);
+t_rt_node* traceback_to_route_tree(ClusterNetId inet, std::vector<int>* non_config_node_set_usage);
+t_rt_node* traceback_to_route_tree(t_trace* head);
+t_rt_node* traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage);
 t_trace* traceback_from_route_tree(ClusterNetId inet, const t_rt_node* root, int num_remaining_sinks);
 
-t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf);
+t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage);
 
 void pathfinder_update_cost_from_route_tree(const t_rt_node* rt_root, int add_or_sub, float pres_fac);
 

--- a/vpr/src/route/route_tree_timing.h
+++ b/vpr/src/route/route_tree_timing.h
@@ -55,6 +55,7 @@ t_rt_node* traceback_to_route_tree(t_trace* head);
 t_rt_node* traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage);
 t_trace* traceback_from_route_tree(ClusterNetId inet, const t_rt_node* root, int num_remaining_sinks);
 
+t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf);
 t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage);
 
 void pathfinder_update_cost_from_route_tree(const t_rt_node* rt_root, int add_or_sub, float pres_fac);

--- a/vpr/src/route/route_tree_timing.h
+++ b/vpr/src/route/route_tree_timing.h
@@ -55,7 +55,17 @@ t_rt_node* traceback_to_route_tree(t_trace* head);
 t_rt_node* traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage);
 t_trace* traceback_from_route_tree(ClusterNetId inet, const t_rt_node* root, int num_remaining_sinks);
 
+// Prune route tree
+//
+//  Note that non-configurable node will not be pruned unless the node is
+//  being totally ripped up, or the node is congested.
 t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf);
+
+// Prune route tree
+//
+//  Note that non-configurable nodes will be pruned if
+//  non_config_node_set_usage is provided.  prune_route_tree will update
+//  non_config_node_set_usage after pruning.
 t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage);
 
 void pathfinder_update_cost_from_route_tree(const t_rt_node* rt_root, int add_or_sub, float pres_fac);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -281,8 +281,7 @@ static int pick_best_direct_connect_target_rr_node(const std::vector<t_rr_node>&
                                                    int from_rr,
                                                    const std::vector<int>& candidate_rr_nodes);
 
-static void expand_non_configurable(int inode, std::set<t_node_edge>& edge_set);
-static void process_non_config_sets(const t_non_configurable_rr_sets& non_config_rr_sets);
+static void process_non_config_sets();
 
 static void build_rr_graph(const t_graph_type graph_type,
                            const std::vector<t_physical_tile_type>& types,
@@ -375,8 +374,7 @@ void create_rr_graph(const t_graph_type graph_type,
         }
     }
 
-    auto non_config_rr_sets = identify_non_configurable_rr_sets();
-    process_non_config_sets(non_config_rr_sets);
+    process_non_config_sets();
 
     print_rr_graph_stats();
 
@@ -2201,8 +2199,8 @@ static void load_uniform_connection_block_pattern(vtr::NdMatrix<int, 5>& tracks_
     int num_phys_pins = pin_locations.size();
 
     /* Keep a record of how many times each track is selected at each
-     * (side, dx, dy) of the block. This is used to ensure a diversity of tracks are 
-     * assigned to pins that might be related. For a given (side, dx, dy), the counts will be 
+     * (side, dx, dy) of the block. This is used to ensure a diversity of tracks are
+     * assigned to pins that might be related. For a given (side, dx, dy), the counts will be
      * decremented after all the tracks have been selected at least once, so the
      * counts will not get too big.
      */
@@ -3051,46 +3049,197 @@ static int pick_best_direct_connect_target_rr_node(const std::vector<t_rr_node>&
     return best_rr;
 }
 
-//Collects the sets of connected non-configurable edges in the RR graph
-t_non_configurable_rr_sets identify_non_configurable_rr_sets() {
-    std::set<std::set<t_node_edge>> edge_sets;
+// Class for building a group of connected edges.
+class EdgeGroups {
+  public:
+    EdgeGroups()
+        : node_count_(std::numeric_limits<size_t>::max()) {}
 
+    // set_node_count must be invoked before create_sets with the count of
+    // nodes. Assumption is that from_node/to_node arguments to
+    // add_non_config_edge are less than node_count.
+    void set_node_count(size_t node_count) {
+        node_count_ = node_count;
+    }
+
+    // Adds non-configurable edge to be group.
+    //
+    // Returns true if this is a new edge.
+    bool add_non_config_edge(int from_node, int to_node) {
+        auto result = node_edges_.insert(std::make_pair(from_node, to_node));
+        return result.second;
+    }
+
+    // After add_non_config_edge has been called for all edges, create_sets
+    // will form groups of nodes that are connected via non-configurable
+    // edges.
+    void create_sets() {
+        rr_non_config_node_sets_map_.clear();
+
+        size_t num_groups = 0;
+        std::vector<std::pair<int, int>> merges;
+
+        VTR_ASSERT(node_count_ != std::numeric_limits<size_t>::max());
+        std::vector<int> node_to_node_set(node_count_, OPEN);
+
+        // First nievely make node groups.  When an edge joins two groups,
+        // mark it for cleanup latter.
+        for (const auto& edge : node_edges_) {
+            VTR_ASSERT(edge.first >= 0 && static_cast<size_t>(edge.first) < node_count_);
+            VTR_ASSERT(edge.second >= 0 && static_cast<size_t>(edge.second) < node_count_);
+
+            int& from_set = node_to_node_set[edge.first];
+            int& to_set = node_to_node_set[edge.second];
+
+            if (from_set == OPEN && to_set == OPEN) {
+                from_set = num_groups++;
+                to_set = from_set;
+            } else if (from_set == OPEN && to_set != OPEN) {
+                from_set = to_set;
+            } else if (from_set != OPEN && to_set == OPEN) {
+                to_set = from_set;
+            } else {
+                VTR_ASSERT(from_set != OPEN);
+                VTR_ASSERT(to_set != OPEN);
+
+                if (from_set != to_set) {
+                    merges.push_back(std::make_pair(
+                        std::min(from_set, to_set),
+                        std::max(from_set, to_set)));
+                }
+            }
+        }
+
+        // We are going to always collapse sets to lower ids, so sort
+        // the merge list to ensure that the merge first elements are always
+        // increasing.
+        std::sort(merges.begin(), merges.end(), [](const std::pair<int, int>& a, const std::pair<int, int>& b) {
+            return a.first < a.second;
+        });
+
+        // Update final_set_map with the final merge id for the second element.
+        // The first element will either be the final value, or already have
+        // an entry in the final_set_map (because sorting), so we can depend on
+        // find_target_set(first) returning a stable value.
+        std::unordered_map<int, int> final_set_map;
+        for (const auto& merge : merges) {
+            VTR_ASSERT(merge.first < merge.second);
+            VTR_ASSERT(merge.first != OPEN);
+            VTR_ASSERT(merge.second != OPEN);
+
+            int target_set = find_target_set(final_set_map, merge.first);
+
+            final_set_map.insert(std::make_pair(merge.second, target_set));
+        }
+
+        // Finalize merges between node set ids.
+        for (auto& set : node_to_node_set) {
+            set = find_target_set(final_set_map, set);
+        }
+        final_set_map.clear();
+
+        // Sanity check the node sets.
+        for (const auto& edge : node_edges_) {
+            VTR_ASSERT(node_to_node_set[edge.first] != OPEN);
+            VTR_ASSERT(node_to_node_set[edge.second] != OPEN);
+            VTR_ASSERT(node_to_node_set[edge.first] == node_to_node_set[edge.second]);
+        }
+
+        // Create compact set of sets.
+        for (size_t inode = 0; inode < node_to_node_set.size(); ++inode) {
+            if (node_to_node_set[inode] != OPEN) {
+                rr_non_config_node_sets_map_[node_to_node_set[inode]].push_back(inode);
+            }
+        }
+    }
+
+    // Create t_non_configurable_rr_sets from set data.
+    t_non_configurable_rr_sets output_sets() {
+        t_non_configurable_rr_sets sets;
+        for (auto& item : rr_non_config_node_sets_map_) {
+            std::set<t_node_edge> edge_set;
+            std::set<int> node_set(item.second.begin(), item.second.end());
+
+            for (const auto& edge : node_edges_) {
+                if (node_set.find(edge.first) != node_set.end()) {
+                    edge_set.emplace(t_node_edge(edge.first, edge.second));
+                }
+            }
+
+            sets.node_sets.emplace(std::move(node_set));
+            sets.edge_sets.emplace(std::move(edge_set));
+        }
+
+        return sets;
+    }
+
+    // Set device context structures for non-configurable node sets.
+    void set_device_context() {
+        std::vector<std::vector<int>> rr_non_config_node_sets;
+        for (auto& item : rr_non_config_node_sets_map_) {
+            rr_non_config_node_sets.emplace_back(std::move(item.second));
+        }
+
+        std::unordered_map<int, int> rr_node_to_non_config_node_set;
+        for (size_t set = 0; set < rr_non_config_node_sets.size(); ++set) {
+            for (const auto inode : rr_non_config_node_sets[set]) {
+                rr_node_to_non_config_node_set.insert(
+                    std::make_pair(inode, set));
+            }
+        }
+
+        auto& device_ctx = g_vpr_ctx.mutable_device();
+        device_ctx.rr_non_config_node_sets = std::move(rr_non_config_node_sets);
+        device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_to_non_config_node_set);
+    }
+
+  private:
+    // Final target set for given set id.
+    static int find_target_set(
+        const std::unordered_map<int, int>& final_set_map,
+        int set) {
+        int target_set = set;
+        while (true) {
+            auto iter = final_set_map.find(target_set);
+            if (iter != final_set_map.end()) {
+                target_set = iter->second;
+            } else {
+                break;
+            }
+        }
+
+        return target_set;
+    }
+
+    // Number of nodes.  All elements of node_edges_ should be less than this
+    // value.
+    size_t node_count_;
+
+    // Set of non-configurable edges.
+    std::set<std::pair<int, int>> node_edges_;
+
+    // Compact set of node sets. Map key is arbitrary.
+    std::map<int, std::vector<int>> rr_non_config_node_sets_map_;
+};
+
+static void expand_non_configurable(int inode, EdgeGroups* groups);
+
+//Collects the sets of connected non-configurable edges in the RR graph
+static void create_edge_groups(EdgeGroups* groups) {
     //Walk through the RR graph and recursively expand non-configurable edges
     //to collect the sets of non-configurably connected nodes
     auto& device_ctx = g_vpr_ctx.device();
+    groups->set_node_count(device_ctx.rr_nodes.size());
+
     for (size_t inode = 0; inode < device_ctx.rr_nodes.size(); ++inode) {
-        std::set<t_node_edge> edge_set;
-
-        expand_non_configurable(inode, edge_set);
-
-        if (!edge_set.empty()) {
-            edge_sets.insert(edge_set);
-        }
+        expand_non_configurable(inode, groups);
     }
 
-    std::set<std::set<int>> node_sets;
-    for (auto& edge_set : edge_sets) {
-        std::set<int> node_set;
-
-        for (const auto& edge : edge_set) {
-            node_set.insert(edge.from_node);
-            node_set.insert(edge.to_node);
-        }
-
-        VTR_ASSERT(!node_set.empty());
-
-        node_sets.insert(node_set);
-    }
-
-    t_non_configurable_rr_sets non_configurable_rr_sets;
-    non_configurable_rr_sets.edge_sets = edge_sets;
-    non_configurable_rr_sets.node_sets = node_sets;
-
-    return non_configurable_rr_sets;
+    groups->create_sets();
 }
 
 //Builds a set of non-configurably connected RR graph edges
-static void expand_non_configurable(int inode, std::set<t_node_edge>& edge_set) {
+static void expand_non_configurable(int inode, EdgeGroups* groups) {
     auto& device_ctx = g_vpr_ctx.device();
 
     for (t_edge_size iedge = 0; iedge < device_ctx.rr_nodes[inode].num_edges(); ++iedge) {
@@ -3099,34 +3248,22 @@ static void expand_non_configurable(int inode, std::set<t_node_edge>& edge_set) 
         if (edge_non_configurable) {
             int to_node = device_ctx.rr_nodes[inode].edge_sink_node(iedge);
 
-            t_node_edge edge = {inode, to_node};
-
-            if (edge_set.count(edge)) {
-                continue; //Already seen don't re-expand to avoid loops
+            if (groups->add_non_config_edge(inode, to_node)) {
+                expand_non_configurable(to_node, groups);
             }
-
-            edge_set.emplace(edge);
-
-            expand_non_configurable(to_node, edge_set);
         }
     }
 }
 
-static void process_non_config_sets(const t_non_configurable_rr_sets& non_config_rr_sets) {
-    std::vector<std::vector<int>> non_config_rr_node_sets;
-    std::unordered_map<int, int> rr_node_non_config_node_set;
+t_non_configurable_rr_sets identify_non_configurable_rr_sets() {
+    EdgeGroups groups;
+    create_edge_groups(&groups);
 
-    for (const auto& node_set : non_config_rr_sets.node_sets) {
-        //Convert node sets to vectors
-        non_config_rr_node_sets.push_back(std::vector<int>(node_set.begin(), node_set.end()));
+    return groups.output_sets();
+}
 
-        //Record reverse look-ups
-        for (int inode : node_set) {
-            rr_node_non_config_node_set.emplace(inode, non_config_rr_node_sets.size() - 1);
-        }
-    }
-
-    auto& device_ctx = g_vpr_ctx.mutable_device();
-    device_ctx.rr_non_config_node_sets = std::move(non_config_rr_node_sets);
-    device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_non_config_node_set);
+static void process_non_config_sets() {
+    EdgeGroups groups;
+    create_edge_groups(&groups);
+    groups.set_device_context();
 }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -3114,7 +3114,7 @@ class EdgeGroups {
         // the merge list to ensure that the merge first elements are always
         // increasing.
         std::sort(merges.begin(), merges.end(), [](const std::pair<int, int>& a, const std::pair<int, int>& b) {
-            return a.first < a.second;
+            return a.first < b.first;
         });
 
         // Update final_set_map with the final merge id for the second element.


### PR DESCRIPTION
#### Description

The previous pruning code left non-configurable sets unpruned.  The new code tracks outbound configurable edges from non-configurable sets, and prunes them when the count reaches zero.

Fixes #526

#### Related Issue

- #526

#### Motivation and Context

#### How Has This Been Tested?

 - [x] Check route has been updated to detect stubs
 - [x] Symbiflow designs that were failing with the new check route now do not error
 - [ ] CI is green

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
