### PR TITLE
get_value: solve the runtime 64bits_long error

### DIFF
--- a/libs/librtlnumber/src/include/internal_bits.hpp
+++ b/libs/librtlnumber/src/include/internal_bits.hpp
@@ -758,19 +758,30 @@ public:
     }
     
     /***
-     * getters
+     * getters to 64 bit int
      */
     int64_t get_value()
     {
+        using integer_t = int64_t;
+        size_t bit_size = 8*sizeof(integer_t);
+
         assert_Werr( (! this->bitstring.has_unknowns() ) ,
                     "Invalid Number contains dont care values. number: " + this->bitstring.to_string(false)
         );   
 
-        int64_t result = 0;
-        BitSpace::bit_value_t pad = this->get_padding_bit(); // = this->is_negative();
-        for(size_t bit_index = 0; bit_index < this->size(); bit_index++)
+        size_t end = this->size();
+        if(end > bit_size)
         {
-            int64_t current_bit = static_cast<int64_t>(pad);
+            printf(" === Warning: Returning a 64 bit integer from a larger bitstring (%zu). The bitstring will be truncated\n", bit_size);
+            end = bit_size;
+        }
+
+        integer_t result = 0;
+        BitSpace::bit_value_t pad = this->get_padding_bit(); // = this->is_negative();
+
+        for(size_t bit_index = 0; bit_index < end; bit_index++)
+        {
+            integer_t current_bit = static_cast<integer_t>(pad);
             if(bit_index < this->size())
                 current_bit = this->bitstring.get_bit(bit_index);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
change get_value function to solve runtime error of long 64bits for Sanitizer

#### How Has This Been Tested?
compile on make build odin

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
