### PR TITLE
Use FASM prefix of parent pb_type, not prefix of output pb_type.

### DIFF
--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -57,6 +57,7 @@ void FasmWriterVisitor::visit_clb_impl(ClusterBlockId blk_id, const t_pb* clb) {
     blk_type_ = grid_loc.type;
 
     current_blk_has_prefix_ = true;
+    clb_prefix_map_.clear();
     std::string grid_prefix;
     if(grid_loc.meta != nullptr && grid_loc.meta->has("fasm_prefix")) {
       auto* value = grid_loc.meta->get("fasm_prefix");
@@ -106,7 +107,7 @@ void FasmWriterVisitor::check_interconnect(const t_pb_routes &pb_routes, int ino
 
   auto *interconnect = prev_pin->output_edges[prev_edge]->interconnect;
   if(interconnect->meta.has("fasm_mux")) {
-    auto* value = interconnect->meta.get("fasm_mux"); 
+    auto* value = interconnect->meta.get("fasm_mux");
     VTR_ASSERT(value != nullptr);
     std::string fasm_mux = value->front().as_string();
     output_fasm_mux(fasm_mux, interconnect, prev_pin);
@@ -234,10 +235,11 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
   // Check if this PB is `open` and has to be skipped
   bool is_parent_pb_null = false;
   std::string clb_prefix = build_clb_prefix(pb, pb_graph_node, &is_parent_pb_null);
+  clb_prefix_map_.insert(std::make_pair(pb_graph_node, clb_prefix));
+  clb_prefix_ = clb_prefix;
   if (is_parent_pb_null == true) {
     return;
   }
-  clb_prefix_ = clb_prefix;
 
   t_pb_type *pb_type = pb_graph_node->pb_type;
   auto *mode = &pb_type->modes[pb->mode];
@@ -619,6 +621,20 @@ void FasmWriterVisitor::finish_impl() {
     walk_routing();
 }
 
+void FasmWriterVisitor::find_clb_prefix(const t_pb_graph_node *node,
+        bool *have_prefix, std::string *clb_prefix) const {
+    while(node != nullptr) {
+        auto clb_prefix_itr = clb_prefix_map_.find(node);
+        *have_prefix = clb_prefix_itr != clb_prefix_map_.end();
+        if(*have_prefix) {
+            *clb_prefix = clb_prefix_itr->second;
+            return;
+        }
+
+        node = node->parent_pb_graph_node;
+    }
+}
+
 void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
                                         t_interconnect *interconnect,
                                         t_pb_graph_pin *mux_input_pin) {
@@ -627,6 +643,11 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
     auto *port_name = mux_input_pin->port->name;
     auto pin_index = mux_input_pin->pin_number;
     auto mux_inputs = vtr::split(fasm_mux, "\n");
+
+    bool have_prefix;
+    std::string clb_prefix;
+    find_clb_prefix(mux_input_pin->parent_node, &have_prefix, &clb_prefix);
+
     for(const auto &mux_input : mux_inputs) {
       auto mux_parts = split_fasm_entry(mux_input, "=:", "\t ");
 
@@ -660,12 +681,13 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
 
       auto fasm_features = vtr::join(vtr::split(mux_parts[1], ","), "\n");
 
+
       if(root_level_connection) {
         // This connection is root level.  pb_index selects between
         // pb_type_prefixes_, not on the mux input.
         if(mux_pb_name == pb_name && mux_port_name == port_name && mux_pin_index == pin_index) {
           if(mux_parts[1] != "NULL") {
-            output_fasm_features(fasm_features);
+            output_fasm_features(have_prefix, clb_prefix, fasm_features);
           }
           return;
         }
@@ -674,7 +696,7 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
                 mux_port_name == port_name &&
                 mux_pin_index == pin_index) {
         if(mux_parts[1] != "NULL") {
-          output_fasm_features(fasm_features);
+          output_fasm_features(have_prefix, clb_prefix, fasm_features);
         }
         return;
       }
@@ -686,18 +708,23 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux,
 }
 
 void FasmWriterVisitor::output_fasm_features(std::string features) const {
+  output_fasm_features(current_blk_has_prefix_, clb_prefix_, features);
+}
+
+void FasmWriterVisitor::output_fasm_features(bool have_clb_prefix, std::string clb_prefix, std::string features) const {
   std::stringstream os(features);
 
   while(os) {
     std::string feature;
     os >> feature;
     if(os) {
-      if(current_blk_has_prefix_) {
-        os_ << blk_prefix_ << clb_prefix_;
+      if(have_clb_prefix) {
+        os_ << blk_prefix_ << clb_prefix;
       }
       os_ << feature << std::endl;
     }
   }
+
 }
 
 } // namespace fasm

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -67,6 +67,7 @@ class FasmWriterVisitor : public NetlistVisitor {
 
   private:
       void output_fasm_features(std::string features) const;
+      void output_fasm_features(bool have_clb_prefix, std::string clb_prefix, std::string features) const;
       void check_features(const t_metadata_dict *meta) const;
       void check_interconnect(const t_pb_routes &pb_route, int inode);
       void check_for_lut(const t_pb* atom);
@@ -77,6 +78,10 @@ class FasmWriterVisitor : public NetlistVisitor {
       const LutOutputDefinition* find_lut(const t_pb_graph_node* pb_graph_node);
       void check_for_param(const t_pb *atom);
 
+      // Walk from node to parents and search for a CLB prefix.
+      void find_clb_prefix(const t_pb_graph_node *node,
+        bool *have_prefix, std::string *clb_prefix) const;
+
       std::ostream& os_;
 
       t_pb_graph_node *root_clb_;
@@ -84,6 +89,7 @@ class FasmWriterVisitor : public NetlistVisitor {
       t_physical_tile_type_ptr blk_type_;
       std::string blk_prefix_;
       std::string clb_prefix_;
+      std::map<const t_pb_graph_node *, std::string> clb_prefix_map_;
       ClusterBlockId current_blk_id_;
       std::vector<t_pb_graph_pin**> pb_graph_pin_lookup_from_index_by_type_;
       std::map<const t_pb_type*, std::vector<std::pair<std::string, LutOutputDefinition>>> lut_definitions_;

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -83,6 +83,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     bool found_lut6 = false;
     bool found_mux1 = false;
     bool found_mux2 = false;
+    bool found_mux3 = false;
     while(fasm_string) {
         // Should see something like:
         // CLB.FLE0.N2_LUT5
@@ -103,6 +104,9 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
         }
         if(!found_mux2 && line == "CLB.FLE9.DISABLE_FF") {
             found_mux2 = true;
+        }
+        if(!found_mux3 && line == "CLB.FLE9.IN0") {
+            found_mux3 = true;
         }
 
         if(line.find("CLB") != std::string::npos) {
@@ -150,6 +154,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     CHECK(found_lut6);
     CHECK(found_mux1);
     CHECK(found_mux2);
+    CHECK(found_mux3);
 
     vpr_free_all(arch, vpr_setup);
 }

--- a/utils/fasm/test/test_fasm_arch.xml
+++ b/utils/fasm/test/test_fasm_arch.xml
@@ -150,10 +150,12 @@
                   <!-- LUT to output is faster than FF to output on a Stratix IV -->
                   <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>
                   <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>
-                  <meta name="fasm_mux">
-                    ff.Q : OUT_MUX.FFQ
-                    lut5.out : OUT_MUX.LUT,DISABLE_FF
-                  </meta>
+                  <metadata>
+                    <meta name="fasm_mux">
+                      ff.Q : OUT_MUX.FFQ
+                      lut5.out : OUT_MUX.LUT,DISABLE_FF
+                    </meta>
+                  </metadata>
                 </mux>
               </interconnect>
               <metadata>
@@ -189,6 +191,19 @@
             <input name="in" num_pins="6"/>
             <output name="out" num_pins="1"/>
             <clock name="clk" num_pins="1"/>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              <metadata>
+                <meta name="fasm_prefix">
+                  ALUT
+                </meta>
+              </metadata>
+            </pb_type>
             <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
               <input name="in" num_pins="6" port_class="lut_in"/>
               <output name="out" num_pins="1" port_class="lut_out"/>
@@ -205,18 +220,24 @@
                 <meta name="fasm_lut">
                   LUT6[63:0]
                 </meta>
+                <meta name="fasm_prefix">
+                  ALUT
+                </meta>
               </metadata>
             </pb_type>
-            <!-- Define flip-flop -->
-            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
-              <input name="D" num_pins="1" port_class="D"/>
-              <output name="Q" num_pins="1" port_class="Q"/>
-              <clock name="clk" num_pins="1" port_class="clock"/>
-              <T_setup value="66e-12" port="ff.D" clock="clk"/>
-              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
-            </pb_type>
             <interconnect>
-              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in">
+                <metadata>
+                  <meta name="fasm_mux">
+                    ble6.in[0] : IN0
+                    ble6.in[1] : IN1
+                    ble6.in[2] : IN2
+                    ble6.in[3] : IN3
+                    ble6.in[4] : IN4
+                    ble6.in[5] : IN5
+                  </meta>
+                </metadata>
+              </direct>
               <direct name="direct2" input="lut6.out" output="ff.D">
                 <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
               </direct>


### PR DESCRIPTION
#### Description

The previous code used the clb prefix of the current block, but the
`interconnect`/`fasm_mux` logic operates on the parent pb_type of the
current block, not the current block itself.  As a result, if the output
of a `fasm_mux` has a prefix, it was getting lumped into the FASM mux
declaration.

#### Motivation and Context

The intention of `fasm_prefix` was to apply to metadata at the current level and deeper.  This bug caused a `fasm_prefix` to leak one level higher than intended.

#### How Has This Been Tested?

1. Integration tests on Symbiflow
2. New unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
