### PR TITLE
vpr: pass t_placer_opts in binary_search_place_and_route by reference

### DIFF
--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -43,7 +43,7 @@ static float comp_width(t_chan* chan, float x, float separation);
 
 /************************* Subroutine Definitions ****************************/
 
-int binary_search_place_and_route(t_placer_opts placer_opts,
+int binary_search_place_and_route(const t_placer_opts& placer_opts_ref,
                                   const t_annealing_sched& annealing_sched,
                                   const t_router_opts& router_opts,
                                   const t_analysis_opts& analysis_opts,
@@ -75,6 +75,12 @@ int binary_search_place_and_route(t_placer_opts placer_opts,
     int warnings;
 
     t_graph_type graph_type;
+
+    /* We have chosen to pass placer_opts_ref by reference because of its large size. *      
+     * However, since the value is mutated later in the function, we declare a        *
+     * mutable variable called placer_opts equal to placer_opts_ref.                  */
+
+    t_placer_opts placer_opts = placer_opts_ref;
 
     /* Allocate the major routing structures. */
 

--- a/vpr/src/base/place_and_route.h
+++ b/vpr/src/base/place_and_route.h
@@ -21,7 +21,7 @@ struct t_fmap_cell {
     t_fmap_cell* next;
 };
 
-int binary_search_place_and_route(t_placer_opts placer_opts,
+int binary_search_place_and_route(const t_placer_opts& placer_opts_ref,
                                   const t_annealing_sched& annealing_sched,
                                   const t_router_opts& router_opts,
                                   const t_analysis_opts& analysis_opts,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Coverity has reported a defect in the build.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

** CID 202040:  Performance inefficiencies  (PASS_BY_VALUE)
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/vpr/src/base/place_and_route.cpp: 46 in binary_search_place_and_route(t_placer_opts, const t_annealing_sched &, const t_router_opts &, const t_analysis_opts &, const t_file_name_opts &, const t_arch *, bool, int, t_det_routing_arch *, std::vector<t_segment_inf, std::allocator<t_segment_inf>> &, vtr::vector<vtr::StrongId<cluster_net_id_tag, int, (int)-1>, float *> &, std::shared_ptr<SetupHoldTimingInfo>, std::shared_ptr<PostClusterDelayCalculator>)()


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We do not need to pass the entire t_placer_opts into the function, its reference shall suffice.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
