### PR TITLE
Add debug logging if there is a non-finite value from the lookahead.

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -2033,6 +2033,11 @@ static void evaluate_timing_driven_node_costs(t_heap* to,
 
     //Update total cost
     float expected_cost = router_lookahead.get_expected_cost(to_node, target_node, cost_params, to->R_upstream);
+    VTR_LOGV_DEBUG(f_router_debug && !std::isfinite(expected_cost),
+                   "        Lookahead from %s (%s) to %s (%s) is non-finite, expected_cost = %f, to->R_upstream = %f\n",
+                   rr_node_arch_name(to_node).c_str(), describe_rr_node(to_node).c_str(),
+                   rr_node_arch_name(target_node).c_str(), describe_rr_node(target_node).c_str(),
+                   expected_cost, to->R_upstream);
     total_cost = to->backward_path_cost + cost_params.astar_fac * expected_cost;
 
     to->cost = total_cost;


### PR DESCRIPTION
#### Description

When debugging lookaheads, a common problem early on is simply the lookahead failing to find valid values (e.g. finite).  This adds a small debug log message if a non-finite lookahead is detected and router debugging is enabled.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context


This is simply a debugging aid.

#### How Has This Been Tested?


Compiled and checked the output on a failure.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
