### PR TITLE
Add tile filtering option for placer delay matrix sampling.

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -486,6 +486,8 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
 
     PlacerOpts->write_placement_delay_lookup = Options.write_placement_delay_lookup;
     PlacerOpts->read_placement_delay_lookup = Options.read_placement_delay_lookup;
+
+    PlacerOpts->allowed_tiles_for_delay_model = Options.allowed_tiles_for_delay_model;
 }
 
 static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysis_opts) {

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1384,6 +1384,14 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    place_timing_grp.add_argument(args.allowed_tiles_for_delay_model, "--allowed_tiles_for_delay_model")
+        .help(
+            "Names of allowed tile types that can be sampled during delay "
+            "modelling.  Default is to allow all tiles. Can be used to "
+            "exclude specialized tiles from placer delay sampling.")
+        .default_value("")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& route_grp = parser.add_argument_group("routing options");
 
     route_grp.add_argument(args.max_router_iterations, "--max_router_iterations")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -115,6 +115,7 @@ struct t_options {
     argparse::ArgValue<std::string> post_place_timing_report_file;
     argparse::ArgValue<PlaceDelayModelType> place_delay_model;
     argparse::ArgValue<e_reducer> place_delay_model_reducer;
+    argparse::ArgValue<std::string> allowed_tiles_for_delay_model;
 
     /* Router Options */
     argparse::ArgValue<int> max_router_iterations;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -808,6 +808,12 @@ struct t_placer_opts {
 
     std::string write_placement_delay_lookup;
     std::string read_placement_delay_lookup;
+
+    // Tile types that should be used during delay sampling.
+    //
+    // Useful for excluding tiles that have abnormal delay behavior, e.g.
+    // clock tree elements like PLL's, global/local clock buffers, etc.
+    std::string allowed_tiles_for_delay_model;
 };
 
 /* All the parameters controlling the router's operation are in this        *


### PR DESCRIPTION
#### Description

This is useful if the placer delay sampling method tries to sample clock
network tiles (e.g. PLLs, global/local clock buffers) which will result
in a poor delay matrix which is unsuitable for LUTs/FFs/RAMs.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

If the delay matrix sampling algorithm chooses a specialized tile (e.g. PLL, global/local clock buffers) it effectively builds the delay matrix for the specialized network, instead of the general routing fabric.  This option prevents this from being possible.

#### How Has This Been Tested?

Need to finish testing with variant, but a simpler version of this PR was tested with Symbiflow.

Testing remaining to be done:
- [ ] Make sure CI is green
- [ ] Add test for new flag


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
