### PR TITLE
Avoid global routing messing up FASM generation

### DIFF
--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -605,6 +605,7 @@ void FasmWriterVisitor::walk_routing() {
 
     for(const auto &trace : route_ctx.trace) {
       t_trace *head = trace.head;
+      if (!head) continue;
       t_rt_node* root = traceback_to_route_tree(head);
       walk_route_tree(root);
       free_route_tree(root);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a null-pointer test in the main loop of the `FasmWriterVisitor::walk_routing()` method, so an empty trace won't cause segment fault during FASM generation.

#### Description
When calling the `genfasm` util with routing results containing global routes (for example a clock), an empty trace will appear in the `g_vpr_ctx.mutable_routing().trace` vector. The head of such trace is a null pointer, and the `FasmWriterVisitor::walk_routing()` method does not check this before walking the route tree converted from it, eventually causing a segment fault.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
