### PR TITLE
Inline and make const ref some args in the inner loop of the router.

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -168,13 +168,13 @@ static std::vector<t_heap> timing_driven_find_all_shortest_paths_from_heap(const
                                                                            std::vector<int>& modified_rr_node_inf,
                                                                            RouterStats& router_stats);
 
-static void timing_driven_expand_cheapest(t_heap* cheapest,
-                                          int target_node,
-                                          const t_conn_cost_params cost_params,
-                                          t_bb bounding_box,
-                                          const RouterLookahead& router_lookahead,
-                                          std::vector<int>& modified_rr_node_inf,
-                                          RouterStats& router_stats);
+static inline void timing_driven_expand_cheapest(t_heap* cheapest,
+                                                 int target_node,
+                                                 const t_conn_cost_params cost_params,
+                                                 t_bb bounding_box,
+                                                 const RouterLookahead& router_lookahead,
+                                                 std::vector<int>& modified_rr_node_inf,
+                                                 RouterStats& router_stats);
 
 static t_rt_node* setup_routing_resources(int itry, ClusterNetId net_id, unsigned num_sinks, float pres_fac, int min_incremental_reroute_fanout, CBRR& incremental_rerouting_res, t_rt_node** rt_node_of_sink);
 
@@ -194,54 +194,54 @@ static t_bb add_high_fanout_route_tree_to_heap(t_rt_node* rt_root,
 
 static t_bb adjust_highfanout_bounding_box(t_bb highfanout_bb);
 
-static void add_route_tree_node_to_heap(t_rt_node* rt_node,
-                                        int target_node,
-                                        const t_conn_cost_params cost_params,
-                                        const RouterLookahead& router_lookahead,
-                                        RouterStats& router_stats);
+static inline void add_route_tree_node_to_heap(t_rt_node* rt_node,
+                                               int target_node,
+                                               const t_conn_cost_params cost_params,
+                                               const RouterLookahead& router_lookahead,
+                                               RouterStats& router_stats);
 
-static void timing_driven_expand_neighbours(t_heap* current,
-                                            const t_conn_cost_params cost_params,
-                                            t_bb bounding_box,
-                                            const RouterLookahead& router_lookahead,
-                                            int target_node,
-                                            RouterStats& router_stats);
+static inline void timing_driven_expand_neighbours(t_heap* current,
+                                                   const t_conn_cost_params cost_params,
+                                                   const t_bb& bounding_box,
+                                                   const RouterLookahead& router_lookahead,
+                                                   int target_node,
+                                                   RouterStats& router_stats);
 
-static void timing_driven_expand_neighbour(t_heap* current,
-                                           const int from_node,
-                                           const t_edge_size from_edge,
-                                           const int to_node,
-                                           const t_conn_cost_params cost_params,
-                                           const t_bb bounding_box,
-                                           const RouterLookahead& router_lookahead,
-                                           int target_node,
-                                           const t_bb target_bb,
-                                           RouterStats& router_stats);
+static inline void timing_driven_expand_neighbour(t_heap* current,
+                                                  const int from_node,
+                                                  const t_edge_size from_edge,
+                                                  const int to_node,
+                                                  const t_conn_cost_params& cost_params,
+                                                  const t_bb& bounding_box,
+                                                  const RouterLookahead& router_lookahead,
+                                                  int target_node,
+                                                  const t_bb& target_bb,
+                                                  RouterStats& router_stats);
 
-static void timing_driven_add_to_heap(const t_conn_cost_params cost_params,
-                                      const RouterLookahead& router_lookahead,
-                                      const t_heap* current,
-                                      const int from_node,
-                                      const int to_node,
-                                      const int iconn,
-                                      const int target_node,
-                                      RouterStats& router_stats);
+static inline void timing_driven_add_to_heap(const t_conn_cost_params& cost_params,
+                                             const RouterLookahead& router_lookahead,
+                                             const t_heap* current,
+                                             const int from_node,
+                                             const int to_node,
+                                             const int iconn,
+                                             const int target_node,
+                                             RouterStats& router_stats);
 
-static void timing_driven_expand_node(const t_conn_cost_params cost_params,
-                                      const RouterLookahead& router_lookahead,
-                                      t_heap* current,
-                                      const int from_node,
-                                      const int to_node,
-                                      const int iconn,
-                                      const int target_node);
+static inline void timing_driven_expand_node(const t_conn_cost_params& cost_params,
+                                             const RouterLookahead& router_lookahead,
+                                             t_heap* current,
+                                             const int from_node,
+                                             const int to_node,
+                                             const int iconn,
+                                             const int target_node);
 
-static void evaluate_timing_driven_node_costs(t_heap* from,
-                                              const t_conn_cost_params cost_params,
-                                              const RouterLookahead& router_lookahead,
-                                              const int from_node,
-                                              const int to_node,
-                                              const int iconn,
-                                              const int target_node);
+static inline void evaluate_timing_driven_node_costs(t_heap* from,
+                                                     const t_conn_cost_params& cost_params,
+                                                     const RouterLookahead& router_lookahead,
+                                                     const int from_node,
+                                                     const int to_node,
+                                                     const int iconn,
+                                                     const int target_node);
 
 static bool timing_driven_check_net_delays(vtr::vector<ClusterNetId, float*>& net_delay);
 
@@ -1788,12 +1788,12 @@ static void add_route_tree_node_to_heap(t_rt_node* rt_node,
     ++router_stats.heap_pushes;
 }
 
-static void timing_driven_expand_neighbours(t_heap* current,
-                                            const t_conn_cost_params cost_params,
-                                            t_bb bounding_box,
-                                            const RouterLookahead& router_lookahead,
-                                            int target_node,
-                                            RouterStats& router_stats) {
+static inline void timing_driven_expand_neighbours(t_heap* current,
+                                                   const t_conn_cost_params cost_params,
+                                                   const t_bb& bounding_box,
+                                                   const RouterLookahead& router_lookahead,
+                                                   int target_node,
+                                                   RouterStats& router_stats) {
     /* Puts all the rr_nodes adjacent to current on the heap.
      */
 
@@ -1825,16 +1825,16 @@ static void timing_driven_expand_neighbours(t_heap* current,
 //Conditionally adds to_node to the router heap (via path from from_node via from_edge).
 //RR nodes outside the expanded bounding box specified in bounding_box are not added
 //to the heap.
-static void timing_driven_expand_neighbour(t_heap* current,
-                                           const int from_node,
-                                           const t_edge_size from_edge,
-                                           const int to_node,
-                                           const t_conn_cost_params cost_params,
-                                           const t_bb bounding_box,
-                                           const RouterLookahead& router_lookahead,
-                                           int target_node,
-                                           const t_bb target_bb,
-                                           RouterStats& router_stats) {
+static inline void timing_driven_expand_neighbour(t_heap* current,
+                                                  const int from_node,
+                                                  const t_edge_size from_edge,
+                                                  const int to_node,
+                                                  const t_conn_cost_params& cost_params,
+                                                  const t_bb& bounding_box,
+                                                  const RouterLookahead& router_lookahead,
+                                                  int target_node,
+                                                  const t_bb& target_bb,
+                                                  RouterStats& router_stats) {
     auto& device_ctx = g_vpr_ctx.device();
 
     int to_xlow = device_ctx.rr_nodes[to_node].xlow();
@@ -1890,14 +1890,14 @@ static void timing_driven_expand_neighbour(t_heap* current,
 }
 
 //Add to_node to the heap, and also add any nodes which are connected by non-configurable edges
-static void timing_driven_add_to_heap(const t_conn_cost_params cost_params,
-                                      const RouterLookahead& router_lookahead,
-                                      const t_heap* current,
-                                      const int from_node,
-                                      const int to_node,
-                                      const int iconn,
-                                      const int target_node,
-                                      RouterStats& router_stats) {
+static inline void timing_driven_add_to_heap(const t_conn_cost_params& cost_params,
+                                             const RouterLookahead& router_lookahead,
+                                             const t_heap* current,
+                                             const int from_node,
+                                             const int to_node,
+                                             const int iconn,
+                                             const int target_node,
+                                             RouterStats& router_stats) {
     t_heap* next = alloc_heap_data();
     next->index = to_node;
 
@@ -1931,7 +1931,7 @@ static void timing_driven_add_to_heap(const t_conn_cost_params cost_params,
 }
 
 //Updates current (path step and costs) to account for the step taken to reach to_node
-static void timing_driven_expand_node(const t_conn_cost_params cost_params,
+static void timing_driven_expand_node(const t_conn_cost_params& cost_params,
                                       const RouterLookahead& router_lookahead,
                                       t_heap* current,
                                       const int from_node,
@@ -1953,7 +1953,7 @@ static void timing_driven_expand_node(const t_conn_cost_params cost_params,
 
 //Calculates the cost of reaching to_node
 static void evaluate_timing_driven_node_costs(t_heap* to,
-                                              const t_conn_cost_params cost_params,
+                                              const t_conn_cost_params& cost_params,
                                               const RouterLookahead& router_lookahead,
                                               const int from_node,
                                               const int to_node,
@@ -2007,8 +2007,10 @@ static void evaluate_timing_driven_node_costs(t_heap* to,
     Tdel += Rdel_adjust * switch_Cinternal;
 
     //Update the backward cost (upstream already included)
-    to->backward_path_cost += (1. - cost_params.criticality) * get_rr_cong_cost(to_node); //Congestion cost
-    to->backward_path_cost += cost_params.criticality * Tdel;                             //Delay cost
+    if (cost_params.criticality != 1.) {
+        to->backward_path_cost += (1. - cost_params.criticality) * get_rr_cong_cost(to_node); //Congestion cost
+    }
+    to->backward_path_cost += cost_params.criticality * Tdel; //Delay cost
     if (cost_params.bend_cost != 0.) {
         t_rr_type from_type = device_ctx.rr_nodes[from_node].type();
         t_rr_type to_type = device_ctx.rr_nodes[to_node].type();

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -2007,6 +2007,16 @@ static void evaluate_timing_driven_node_costs(t_heap* to,
     Tdel += Rdel_adjust * switch_Cinternal;
 
     //Update the backward cost (upstream already included)
+    //
+    // This check is in-place for times when criticality is set exactly to 1.
+    // This is not the general case when doing timing-driven routing, but
+    // when using the router for expansions, criticality will be set to 1
+    // to avoid accounting for congestion.  In these cases it is a win to avoid
+    // getting the congestion cost.
+    //
+    // Because the behavior is always one way during expansion and almost always
+    // the other way during routing, it is expected that the branch predictors
+    // will not mispredict this branch.
     if (cost_params.criticality != 1.) {
         to->backward_path_cost += (1. - cost_params.criticality) * get_rr_cong_cost(to_node); //Congestion cost
     }


### PR DESCRIPTION
#### Description

- Avoid copying cost_parameters structure.
- Request inline of inner loop functions as they are invoked at few (1-3)
  callsites, but get called many many times.
- Don't get congestion if it won't be used.  Useful for accelerating
  pure expansion.

#### Related Issue

#1008 

#### Motivation and Context

When integrating the router for expansions in the placer and lookahead, I noted that a non-trival fraction of profiler CPU samples were being spent on function preambles.  This PR avoids this time via inlining or making const ref some arguments.  The cost is an increased binary size, however the number of callsites for the inlined functions are low (1-3), and the number of function calls is very very high, so this should provide a benefit to both pure expansions and timing driven expansions.

#### How Has This Been Tested?

1. [x] Tested expansions with and without this change
2. [ ] Titan QoR run

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
