### PR TITLE
Remove all use of global data from core route tree timing functions.

### DIFF
--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -630,12 +630,19 @@ void FasmWriterVisitor::walk_route_tree(const t_rt_node *root) {
 void FasmWriterVisitor::walk_routing() {
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
+    bool allocated = alloc_route_tree_timing_structs(/*exists_ok=*/true);
+
+
     for(const auto &trace : route_ctx.trace) {
       t_trace *head = trace.head;
       if (!head) continue;
       t_rt_node* root = traceback_to_route_tree(head);
       walk_route_tree(root);
       free_route_tree(root);
+    }
+
+    if(allocated) {
+        free_route_tree_timing_structs();
     }
 }
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -62,6 +62,7 @@
 #include "check_route.h"
 #include "constant_nets.h"
 #include "atom_netlist_utils.h"
+#include "route_tree_timing.h"
 
 #include "pack_report.h"
 
@@ -1166,6 +1167,8 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
                               *timing_ctx.graph, *timing_ctx.constraints, *analysis_delay_calc, timing_info->analyzer());
         }
 
+        bool allocated = alloc_route_tree_timing_structs(/*exists_ok=*/true);
+
         //Timing stats
         VTR_LOG("\n");
         generate_hold_timing_stats(/*prefix=*/"", *timing_info,
@@ -1185,6 +1188,9 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
 
         //Clean-up the net delays
         free_net_delay(net_delay, &net_delay_ch);
+        if (allocated) {
+            free_route_tree_timing_structs();
+        }
     }
 }
 

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -811,9 +811,16 @@ class StubFinder {
 //
 //We treat any configurable stubs as an error.
 void check_net_for_stubs(ClusterNetId net) {
+    bool allocated = alloc_route_tree_timing_structs(/*exists_ok=*/true);
+
     StubFinder stub_finder;
 
     bool any_stubs = stub_finder.CheckNet(net);
+
+    if (allocated) {
+        free_route_tree_timing_structs();
+    }
+
     if (any_stubs) {
         auto& cluster_ctx = g_vpr_ctx.clustering();
         std::string msg = vtr::string_fmt("Route tree for net '%s' (#%zu) contains stub branches rooted at:\n",

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -14,6 +14,7 @@
 #include "globals.h"
 #include "route_common.h"
 #include "route_tree_timing.h"
+#include "route_tree_timing_obj.h"
 
 /* This module keeps track of the partial routing tree for timing-driven     *
  * routing.  The normal traceback structure doesn't provide enough info      *
@@ -24,42 +25,19 @@
 
 /********************** Variables local to this module ***********************/
 
-/* Array below allows mapping from any rr_node to any rt_node currently in
- * the rt_tree.                                                              */
-
-static std::vector<t_rt_node*> rr_node_to_rt_node; /* [0..device_ctx.rr_nodes.size()-1] */
-
-/* Frees lists for fast addition and deletion of nodes and edges. */
-
-static t_rt_node* rt_node_free_list = nullptr;
-static t_linked_rt_edge* rt_edge_free_list = nullptr;
+static std::unique_ptr<RouteTreeTiming<
+    decltype(DeviceContext::rr_nodes),
+    decltype(DeviceContext::rr_node_to_non_config_node_set),
+    decltype(DeviceContext::rr_switch_inf)>>
+    tree_timing;
 
 /********************** Subroutines local to this module *********************/
 
-static t_rt_node* alloc_rt_node();
-
-static void free_rt_node(t_rt_node* rt_node);
-
-static t_linked_rt_edge* alloc_linked_rt_edge();
-
-static void free_linked_rt_edge(t_linked_rt_edge* rt_edge);
-
-static t_rt_node* add_subtree_to_route_tree(t_heap* hptr,
-                                            t_rt_node** sink_rt_node_ptr);
-
-static t_rt_node* add_non_configurable_to_route_tree(const int rr_node, const bool reached_by_non_configurable_edge, std::unordered_set<int>& visited);
-
-static t_rt_node* update_unbuffered_ancestors_C_downstream(t_rt_node* start_of_new_subtree_rt_node);
-
-bool verify_route_tree_recurr(t_rt_node* node, std::set<int>& seen_nodes);
-
-static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool congested, std::vector<int>* non_config_node_set_usage);
-
-static t_trace* traceback_to_route_tree_branch(t_trace* trace, std::map<int, t_rt_node*>& rr_node_to_rt, std::vector<int>* non_config_node_set_usage);
+static bool verify_route_tree_recurr(t_rt_node* node, std::set<int>& seen_nodes);
 
 static std::pair<t_trace*, t_trace*> traceback_from_route_tree_recurr(t_trace* head, t_trace* tail, const t_rt_node* node);
 
-void collect_route_tree_connections(const t_rt_node* node, std::set<std::tuple<int, int, int>>& connections);
+static void collect_route_tree_connections(const t_rt_node* node, std::set<std::tuple<int, int, int>>& connections);
 
 /************************** Subroutine definitions ***************************/
 
@@ -72,9 +50,9 @@ bool alloc_route_tree_timing_structs(bool exists_ok) {
     /* Allocates any structures needed to build the routing trees. */
 
     auto& device_ctx = g_vpr_ctx.device();
+    auto& route_ctx = g_vpr_ctx.routing();
 
-    bool route_tree_structs_are_allocated = (rr_node_to_rt_node.size() == size_t(device_ctx.rr_nodes.size())
-                                             || rt_node_free_list != nullptr);
+    bool route_tree_structs_are_allocated = bool(tree_timing);
     if (route_tree_structs_are_allocated) {
         if (exists_ok) {
             return false;
@@ -84,7 +62,14 @@ bool alloc_route_tree_timing_structs(bool exists_ok) {
         }
     }
 
-    rr_node_to_rt_node = std::vector<t_rt_node*>(device_ctx.rr_nodes.size(), nullptr);
+    tree_timing = std::make_unique<RouteTreeTiming<
+        decltype(device_ctx.rr_nodes),
+        decltype(device_ctx.rr_node_to_non_config_node_set),
+        decltype(device_ctx.rr_switch_inf)>>(
+        device_ctx.rr_nodes,
+        device_ctx.rr_node_to_non_config_node_set,
+        device_ctx.rr_switch_inf,
+        route_ctx.net_rr_terminals);
 
     return true;
 }
@@ -92,107 +77,13 @@ bool alloc_route_tree_timing_structs(bool exists_ok) {
 void free_route_tree_timing_structs() {
     /* Frees the structures needed to build routing trees, and really frees
      * (i.e. calls free) all the data on the free lists.                         */
-
-    t_rt_node *rt_node, *next_node;
-    t_linked_rt_edge *rt_edge, *next_edge;
-
-    rr_node_to_rt_node.clear();
-
-    rt_node = rt_node_free_list;
-
-    while (rt_node != nullptr) {
-        next_node = rt_node->u.next;
-        free(rt_node);
-        rt_node = next_node;
-    }
-
-    rt_node_free_list = nullptr;
-
-    rt_edge = rt_edge_free_list;
-
-    while (rt_edge != nullptr) {
-        next_edge = rt_edge->next;
-        free(rt_edge);
-        rt_edge = next_edge;
-    }
-
-    rt_edge_free_list = nullptr;
-}
-
-static t_rt_node*
-alloc_rt_node() {
-    /* Allocates a new rt_node, from the free list if possible, from the free
-     * store otherwise.                                                         */
-
-    t_rt_node* rt_node;
-
-    rt_node = rt_node_free_list;
-
-    if (rt_node != nullptr) {
-        rt_node_free_list = rt_node->u.next;
-    } else {
-        rt_node = (t_rt_node*)vtr::malloc(sizeof(t_rt_node));
-    }
-
-    return (rt_node);
-}
-
-static void free_rt_node(t_rt_node* rt_node) {
-    /* Adds rt_node to the proper free list.          */
-
-    rt_node->u.next = rt_node_free_list;
-    rt_node_free_list = rt_node;
-}
-
-static t_linked_rt_edge*
-alloc_linked_rt_edge() {
-    /* Allocates a new linked_rt_edge, from the free list if possible, from the
-     * free store otherwise.                                                     */
-
-    t_linked_rt_edge* linked_rt_edge;
-
-    linked_rt_edge = rt_edge_free_list;
-
-    if (linked_rt_edge != nullptr) {
-        rt_edge_free_list = linked_rt_edge->next;
-    } else {
-        linked_rt_edge = (t_linked_rt_edge*)vtr::malloc(sizeof(t_linked_rt_edge));
-    }
-
-    VTR_ASSERT(linked_rt_edge != nullptr);
-    return (linked_rt_edge);
-}
-
-/* Adds the rt_edge to the rt_edge free list.                       */
-static void free_linked_rt_edge(t_linked_rt_edge* rt_edge) {
-    rt_edge->next = rt_edge_free_list;
-    rt_edge_free_list = rt_edge;
+    tree_timing.reset();
 }
 
 /* Initializes the routing tree to just the net source, and returns the root
  * node of the rt_tree (which is just the net source).                       */
 t_rt_node* init_route_tree_to_source(ClusterNetId inet) {
-    t_rt_node* rt_root;
-    int inode;
-
-    auto& route_ctx = g_vpr_ctx.routing();
-    auto& device_ctx = g_vpr_ctx.device();
-
-    rt_root = alloc_rt_node();
-    rt_root->u.child_list = nullptr;
-    rt_root->parent_node = nullptr;
-    rt_root->parent_switch = OPEN;
-    rt_root->re_expand = true;
-
-    inode = route_ctx.net_rr_terminals[inet][0]; /* Net source */
-
-    rt_root->inode = inode;
-    rt_root->C_downstream = device_ctx.rr_nodes[inode].C();
-    rt_root->R_upstream = device_ctx.rr_nodes[inode].R();
-    rt_root->Tdel = 0.5 * device_ctx.rr_nodes[inode].R() * device_ctx.rr_nodes[inode].C();
-    rr_node_to_rt_node[inode] = rt_root;
-
-    return (rt_root);
+    return tree_timing->init_route_tree_to_source(inet);
 }
 
 /* Adds the most recently finished wire segment to the routing tree, and
@@ -200,409 +91,30 @@ t_rt_node* init_route_tree_to_source(ClusterNetId inet) {
  * is the heap pointer of the SINK that was reached.  This routine returns
  * a pointer to the rt_node of the SINK that it adds to the routing.        */
 t_rt_node* update_route_tree(t_heap* hptr, SpatialRouteTreeLookup* spatial_rt_lookup) {
-    t_rt_node *start_of_new_subtree_rt_node, *sink_rt_node;
-    t_rt_node *unbuffered_subtree_rt_root, *subtree_parent_rt_node;
-    float Tdel_start;
-    short iswitch;
-
-    auto& device_ctx = g_vpr_ctx.device();
-
-    //Create a new subtree from the target in hptr to existing routing
-    start_of_new_subtree_rt_node = add_subtree_to_route_tree(hptr, &sink_rt_node);
-
-    //Propagate R_upstream down into the new subtree
-    load_new_subtree_R_upstream(start_of_new_subtree_rt_node);
-
-    //Propagate C_downstream up from new subtree sinks to subtree root
-    load_new_subtree_C_downstream(start_of_new_subtree_rt_node);
-
-    //Propagate C_downstream up from the subtree root
-    unbuffered_subtree_rt_root = update_unbuffered_ancestors_C_downstream(start_of_new_subtree_rt_node);
-
-    subtree_parent_rt_node = unbuffered_subtree_rt_root->parent_node;
-
-    if (subtree_parent_rt_node != nullptr) { /* Parent exists. */
-        Tdel_start = subtree_parent_rt_node->Tdel;
-        iswitch = unbuffered_subtree_rt_root->parent_switch;
-        Tdel_start += device_ctx.rr_switch_inf[iswitch].R * unbuffered_subtree_rt_root->C_downstream;
-        Tdel_start += device_ctx.rr_switch_inf[iswitch].Tdel;
-    } else { /* Subtree starts at SOURCE */
-        Tdel_start = 0.;
-    }
-
-    load_route_tree_Tdel(unbuffered_subtree_rt_root, Tdel_start);
-
-    if (spatial_rt_lookup) {
-        update_route_tree_spatial_lookup_recur(start_of_new_subtree_rt_node, *spatial_rt_lookup);
-    }
-
-    return (sink_rt_node);
+    auto& route_ctx = g_vpr_ctx.routing();
+    return tree_timing->update_route_tree<decltype(route_ctx.rr_node_route_inf)>(route_ctx.rr_node_route_inf, hptr, spatial_rt_lookup);
 }
 
 void add_route_tree_to_rr_node_lookup(t_rt_node* node) {
-    if (node) {
-        VTR_ASSERT(rr_node_to_rt_node[node->inode] == nullptr || rr_node_to_rt_node[node->inode] == node);
-
-        rr_node_to_rt_node[node->inode] = node;
-
-        for (auto edge = node->u.child_list; edge != nullptr; edge = edge->next) {
-            add_route_tree_to_rr_node_lookup(edge->child);
-        }
-    }
-}
-
-static t_rt_node*
-add_subtree_to_route_tree(t_heap* hptr, t_rt_node** sink_rt_node_ptr) {
-    /* Adds the most recent wire segment, ending at the SINK indicated by hptr,
-     * to the routing tree.  It returns the first (most upstream) new rt_node,
-     * and (via a pointer) the rt_node of the new SINK. Traverses up from SINK  */
-
-    t_rt_node *rt_node, *downstream_rt_node, *sink_rt_node;
-    t_linked_rt_edge* linked_rt_edge;
-
-    auto& device_ctx = g_vpr_ctx.device();
-    auto& route_ctx = g_vpr_ctx.routing();
-
-    int inode = hptr->index;
-
-    //if (device_ctx.rr_nodes[inode].type() != SINK) {
-    //VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
-    //"in add_subtree_to_route_tree. Expected type = SINK (%d).\n"
-    //"Got type = %d.",  SINK, device_ctx.rr_nodes[inode].type());
-    //}
-
-    sink_rt_node = alloc_rt_node();
-    sink_rt_node->u.child_list = nullptr;
-    sink_rt_node->inode = inode;
-    rr_node_to_rt_node[inode] = sink_rt_node;
-
-    /* In the code below I'm marking SINKs and IPINs as not to be re-expanded.
-     * It makes the code more efficient (though not vastly) to prune this way
-     * when there aren't route-throughs or ipin doglegs.                        */
-
-    sink_rt_node->re_expand = false;
-
-    /* Now do it's predecessor. */
-
-    downstream_rt_node = sink_rt_node;
-
-    std::unordered_set<int> main_branch_visited;
-    std::unordered_set<int> all_visited;
-    inode = hptr->u.prev.node;
-    t_edge_size iedge = hptr->u.prev.edge;
-    short iswitch = device_ctx.rr_nodes[inode].edge_switch(iedge);
-
-    /* For all "new" nodes in the main path */
-    // inode is node index of previous node
-    // NO_PREVIOUS tags a previously routed node
-
-    while (rr_node_to_rt_node[inode] == nullptr) { //Not connected to existing routing
-        main_branch_visited.insert(inode);
-        all_visited.insert(inode);
-
-        linked_rt_edge = alloc_linked_rt_edge();
-        linked_rt_edge->child = downstream_rt_node;
-
-        // Also mark downstream_rt_node->inode as visited to prevent
-        // add_non_configurable_to_route_tree from potentially adding
-        // downstream_rt_node to the rt tree twice.
-        all_visited.insert(downstream_rt_node->inode);
-        linked_rt_edge->iswitch = iswitch;
-        linked_rt_edge->next = nullptr;
-
-        rt_node = alloc_rt_node();
-        downstream_rt_node->parent_node = rt_node;
-        downstream_rt_node->parent_switch = iswitch;
-
-        rt_node->u.child_list = linked_rt_edge;
-        rt_node->inode = inode;
-
-        rr_node_to_rt_node[inode] = rt_node;
-
-        if (device_ctx.rr_nodes[inode].type() == IPIN) {
-            rt_node->re_expand = false;
-        } else {
-            rt_node->re_expand = true;
-        }
-
-        downstream_rt_node = rt_node;
-        iedge = route_ctx.rr_node_route_inf[inode].prev_edge;
-        inode = route_ctx.rr_node_route_inf[inode].prev_node;
-        iswitch = device_ctx.rr_nodes[inode].edge_switch(iedge);
-    }
-
-    //Inode is now the branch point to the old routing; do not need
-    //to alloc another node since the old routing has done so already
-    rt_node = rr_node_to_rt_node[inode];
-    VTR_ASSERT_MSG(rt_node, "Previous routing branch should exist");
-
-    linked_rt_edge = alloc_linked_rt_edge();
-    linked_rt_edge->child = downstream_rt_node;
-    linked_rt_edge->iswitch = iswitch;
-    linked_rt_edge->next = rt_node->u.child_list; //Add to head
-    rt_node->u.child_list = linked_rt_edge;
-
-    downstream_rt_node->parent_node = rt_node;
-    downstream_rt_node->parent_switch = iswitch;
-
-    //Expand (recursively) each of the main-branch nodes adding any
-    //non-configurably connected nodes
-    for (int rr_node : main_branch_visited) {
-        add_non_configurable_to_route_tree(rr_node, false, all_visited);
-    }
-
-    *sink_rt_node_ptr = sink_rt_node;
-    return (downstream_rt_node);
-}
-
-static t_rt_node* add_non_configurable_to_route_tree(const int rr_node, const bool reached_by_non_configurable_edge, std::unordered_set<int>& visited) {
-    t_rt_node* rt_node = nullptr;
-
-    if (!visited.count(rr_node) || !reached_by_non_configurable_edge) {
-        visited.insert(rr_node);
-
-        auto& device_ctx = g_vpr_ctx.device();
-
-        rt_node = rr_node_to_rt_node[rr_node];
-
-        if (!reached_by_non_configurable_edge) { //An existing main branch node
-            VTR_ASSERT(rt_node);
-        } else {
-            VTR_ASSERT(reached_by_non_configurable_edge);
-
-            if (!rt_node) {
-                rt_node = alloc_rt_node();
-                rt_node->u.child_list = nullptr;
-                rt_node->inode = rr_node;
-
-                if (device_ctx.rr_nodes[rr_node].type() == IPIN) {
-                    rt_node->re_expand = false;
-                } else {
-                    rt_node->re_expand = true;
-                }
-            } else {
-                VTR_ASSERT(rt_node->inode == rr_node);
-            }
-        }
-
-        for (int iedge : device_ctx.rr_nodes[rr_node].non_configurable_edges()) {
-            //Recursive case: expand children
-            VTR_ASSERT(!device_ctx.rr_nodes[rr_node].edge_is_configurable(iedge));
-
-            int to_rr_node = device_ctx.rr_nodes[rr_node].edge_sink_node(iedge);
-
-            //Recurse
-            t_rt_node* child_rt_node = add_non_configurable_to_route_tree(to_rr_node, true, visited);
-
-            if (!child_rt_node) continue;
-
-            int iswitch = device_ctx.rr_nodes[rr_node].edge_switch(iedge);
-
-            //Create the edge
-            t_linked_rt_edge* linked_rt_edge = alloc_linked_rt_edge();
-            linked_rt_edge->child = child_rt_node;
-            linked_rt_edge->iswitch = iswitch;
-
-            //Add edge at head of parent linked list
-            linked_rt_edge->next = rt_node->u.child_list;
-            rt_node->u.child_list = linked_rt_edge;
-
-            //Update child to parent ref
-            child_rt_node->parent_node = rt_node;
-            child_rt_node->parent_switch = iswitch;
-        }
-        rr_node_to_rt_node[rr_node] = rt_node;
-    }
-
-    return rt_node;
+    tree_timing->add_route_tree_to_rr_node_lookup(node);
 }
 
 void load_new_subtree_R_upstream(t_rt_node* rt_node) {
-    /* Sets the R_upstream values of all the nodes in the new path to the
-     * correct value by traversing down to SINK from the start of the new path. */
-
-    if (!rt_node) {
-        return;
-    }
-
-    auto& device_ctx = g_vpr_ctx.device();
-
-    t_rt_node* parent_rt_node = rt_node->parent_node;
-    int inode = rt_node->inode;
-
-    //Calculate upstream resistance
-    float R_upstream = 0.;
-    if (parent_rt_node) {
-        int iswitch = rt_node->parent_switch;
-        bool switch_buffered = device_ctx.rr_switch_inf[iswitch].buffered();
-
-        if (!switch_buffered) {
-            R_upstream += parent_rt_node->R_upstream; //Parent upstream R
-        }
-        R_upstream += device_ctx.rr_switch_inf[iswitch].R; //Parent switch R
-    }
-    R_upstream += device_ctx.rr_nodes[inode].R(); //Current node R
-
-    rt_node->R_upstream = R_upstream;
-
-    //Update children
-    for (t_linked_rt_edge* edge = rt_node->u.child_list; edge != nullptr; edge = edge->next) {
-        load_new_subtree_R_upstream(edge->child); //Recurse
-    }
+    tree_timing->load_new_subtree_R_upstream(rt_node);
 }
 
 float load_new_subtree_C_downstream(t_rt_node* rt_node) {
-    float C_downstream = 0.;
-
-    if (rt_node) {
-        auto& device_ctx = g_vpr_ctx.device();
-
-        C_downstream += device_ctx.rr_nodes[rt_node->inode].C();
-        for (t_linked_rt_edge* edge = rt_node->u.child_list; edge != nullptr; edge = edge->next) {
-            /*Similar to net_delay.cpp, this for loop traverses a rc subtree, whose edges represent enabled switches.
-             * When switches such as multiplexers and tristate buffers are enabled, their fanout
-             * produces an "internal capacitance". We account for this internal capacitance of the
-             * switch by adding it to the total capacitance of the node.*/
-
-            C_downstream += device_ctx.rr_switch_inf[edge->iswitch].Cinternal;
-
-            float C_downstream_child = load_new_subtree_C_downstream(edge->child);
-
-            if (!device_ctx.rr_switch_inf[edge->iswitch].buffered()) {
-                C_downstream += C_downstream_child;
-            }
-        }
-
-        rt_node->C_downstream = C_downstream;
-    }
-
-    return C_downstream;
-}
-
-static t_rt_node*
-update_unbuffered_ancestors_C_downstream(t_rt_node* start_of_new_path_rt_node) {
-    /* Updates the C_downstream values for the ancestors of the new path.  Once
-     * a buffered switch is found amongst the ancestors, no more ancestors are
-     * affected.  Returns the root of the "unbuffered subtree" whose Tdel
-     * values are affected by the new path's addition.                          */
-
-    t_rt_node *rt_node, *parent_rt_node;
-    short iswitch;
-    float C_downstream_addition;
-
-    auto& device_ctx = g_vpr_ctx.device();
-
-    rt_node = start_of_new_path_rt_node;
-    parent_rt_node = rt_node->parent_node;
-    iswitch = rt_node->parent_switch;
-
-    /* Now that a connection has been made between rt_node and its parent we must also consider
-     * the potential effect of internal capacitance. We will first assume that parent is connected
-     * by an unbuffered switch, so the ancestors downstream capacitance must be equal to the sum
-     * of the child's downstream capacitance with the internal capacitance of the switch.*/
-
-    C_downstream_addition = rt_node->C_downstream + device_ctx.rr_switch_inf[iswitch].Cinternal;
-
-    /* Having set the value of C_downstream_addition, we must check whethere the parent switch
-     * is a buffered or unbuffered switch with the if statement below. If the parent switch is
-     * a buffered switch, then the parent node's downsteam capacitance is increased by the
-     * value of the parent switch's internal capacitance in the if statement below.
-     * Correspondingly, the ancestors' downstream capacitance will be updated by the same
-     * value through the while loop. Otherwise, if the parent switch is unbuffered, then
-     * the if statement will be ignored, and the parent and ancestral nodes' downstream
-     * capacitance will be increased by the sum of the child's downstream capacitance with
-     * the internal capacitance of the parent switch in the while loop/.*/
-
-    if (parent_rt_node != nullptr && device_ctx.rr_switch_inf[iswitch].buffered() == true) {
-        C_downstream_addition = device_ctx.rr_switch_inf[iswitch].Cinternal;
-        rt_node = parent_rt_node;
-        rt_node->C_downstream += C_downstream_addition;
-        parent_rt_node = rt_node->parent_node;
-        iswitch = rt_node->parent_switch;
-    }
-
-    while (parent_rt_node != nullptr && device_ctx.rr_switch_inf[iswitch].buffered() == false) {
-        rt_node = parent_rt_node;
-        rt_node->C_downstream += C_downstream_addition;
-        parent_rt_node = rt_node->parent_node;
-        iswitch = rt_node->parent_switch;
-    }
-    return (rt_node);
+    return tree_timing->load_new_subtree_C_downstream(rt_node);
 }
 
 void load_route_tree_Tdel(t_rt_node* subtree_rt_root, float Tarrival) {
-    /* Updates the Tdel values of the subtree rooted at subtree_rt_root by
-     * by calling itself recursively.  The C_downstream values of all the nodes
-     * must be correct before this routine is called.  Tarrival is the time at
-     * at which the signal arrives at this node's *input*.                      */
-
-    int inode;
-    short iswitch;
-    t_rt_node* child_node;
-    t_linked_rt_edge* linked_rt_edge;
-    float Tdel, Tchild;
-
-    auto& device_ctx = g_vpr_ctx.device();
-
-    inode = subtree_rt_root->inode;
-
-    /* Assuming the downstream connections are, on average, connected halfway
-     * along a wire segment's length.  See discussion in net_delay.c if you want
-     * to change this.                                                           */
-
-    Tdel = Tarrival + 0.5 * subtree_rt_root->C_downstream * device_ctx.rr_nodes[inode].R();
-    subtree_rt_root->Tdel = Tdel;
-
-    /* Now expand the children of this node to load their Tdel values (depth-
-     * first pre-order traversal).                                              */
-
-    linked_rt_edge = subtree_rt_root->u.child_list;
-
-    while (linked_rt_edge != nullptr) {
-        iswitch = linked_rt_edge->iswitch;
-        child_node = linked_rt_edge->child;
-
-        Tchild = Tdel + device_ctx.rr_switch_inf[iswitch].R * child_node->C_downstream;
-        Tchild += device_ctx.rr_switch_inf[iswitch].Tdel; /* Intrinsic switch delay. */
-        load_route_tree_Tdel(child_node, Tchild);
-
-        linked_rt_edge = linked_rt_edge->next;
-    }
+    tree_timing->load_route_tree_Tdel(subtree_rt_root, Tarrival);
 }
 
 void load_route_tree_rr_route_inf(t_rt_node* root) {
-    /* Traverses down a route tree and updates rr_node_inf for all nodes
-     * to reflect that these nodes have already been routed to 			 */
-
-    VTR_ASSERT(root != nullptr);
-
     auto& route_ctx = g_vpr_ctx.mutable_routing();
-
-    t_linked_rt_edge* edge{root->u.child_list};
-
-    for (;;) {
-        int inode = root->inode;
-        route_ctx.rr_node_route_inf[inode].prev_node = NO_PREVIOUS;
-        route_ctx.rr_node_route_inf[inode].prev_edge = NO_PREVIOUS;
-        // path cost should be unset
-        VTR_ASSERT(std::isinf(route_ctx.rr_node_route_inf[inode].path_cost));
-        VTR_ASSERT(std::isinf(route_ctx.rr_node_route_inf[inode].backward_path_cost));
-
-        // reached a sink
-        if (!edge) { return; }
-        // branch point (sibling edges)
-        else if (edge->next) {
-            // recursively update for each of its sibling branches
-            do {
-                load_route_tree_rr_route_inf(edge->child);
-                edge = edge->next;
-            } while (edge);
-            return;
-        }
-
-        root = edge->child;
-        edge = root->u.child_list;
-    }
+    return tree_timing->load_route_tree_rr_route_inf<decltype(route_ctx.rr_node_route_inf)>(
+        &route_ctx.rr_node_route_inf, root);
 }
 
 bool verify_route_tree(t_rt_node* root) {
@@ -610,7 +122,7 @@ bool verify_route_tree(t_rt_node* root) {
     return verify_route_tree_recurr(root, seen_nodes);
 }
 
-bool verify_route_tree_recurr(t_rt_node* node, std::set<int>& seen_nodes) {
+static bool verify_route_tree_recurr(t_rt_node* node, std::set<int>& seen_nodes) {
     if (seen_nodes.count(node->inode)) {
         VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Duplicate route tree nodes found for node %d", node->inode);
     }
@@ -624,59 +136,21 @@ bool verify_route_tree_recurr(t_rt_node* node, std::set<int>& seen_nodes) {
 }
 
 void free_route_tree(t_rt_node* rt_node) {
-    /* Puts the rt_nodes and edges in the tree rooted at rt_node back on the
-     * free lists.  Recursive, depth-first post-order traversal.                */
-
-    t_linked_rt_edge *rt_edge, *next_edge;
-
-    rt_edge = rt_node->u.child_list;
-
-    while (rt_edge != nullptr) { /* For all children */
-        t_rt_node* child_node = rt_edge->child;
-        free_route_tree(child_node);
-        next_edge = rt_edge->next;
-        free_linked_rt_edge(rt_edge);
-        rt_edge = next_edge;
-    }
-
-    if (!rr_node_to_rt_node.empty()) {
-        rr_node_to_rt_node.at(rt_node->inode) = nullptr;
-    }
-
-    free_rt_node(rt_node);
+    tree_timing->free_route_tree(rt_node);
 }
 
 void print_route_tree(const t_rt_node* rt_node) {
-    print_route_tree(rt_node, 0);
+    auto& route_ctx = g_vpr_ctx.routing();
+    return tree_timing->print_route_tree<decltype(route_ctx.rr_node_route_inf)>(
+        route_ctx.rr_node_route_inf,
+        rt_node);
 }
 
 void print_route_tree(const t_rt_node* rt_node, int depth) {
-    std::string indent;
-    for (int i = 0; i < depth; ++i) {
-        indent += "  ";
-    }
-
-    auto& device_ctx = g_vpr_ctx.device();
-    VTR_LOG("%srt_node: %d (%s)", indent.c_str(), rt_node->inode, device_ctx.rr_nodes[rt_node->inode].type_string());
-
-    if (rt_node->parent_switch != OPEN) {
-        bool parent_edge_configurable = device_ctx.rr_switch_inf[rt_node->parent_switch].configurable();
-        if (!parent_edge_configurable) {
-            VTR_LOG("*");
-        }
-    }
-
     auto& route_ctx = g_vpr_ctx.routing();
-
-    if (route_ctx.rr_node_route_inf[rt_node->inode].occ() > device_ctx.rr_nodes[rt_node->inode].capacity()) {
-        VTR_LOG(" x");
-    }
-
-    VTR_LOG("\n");
-
-    for (t_linked_rt_edge* rt_edge = rt_node->u.child_list; rt_edge != nullptr; rt_edge = rt_edge->next) {
-        print_route_tree(rt_edge->child, depth + 1);
-    }
+    return tree_timing->print_route_tree<decltype(route_ctx.rr_node_route_inf)>(
+        route_ctx.rr_node_route_inf,
+        rt_node, depth);
 }
 
 void update_net_delays_from_route_tree(float* net_delay,
@@ -716,131 +190,7 @@ t_rt_node* traceback_to_route_tree(t_trace* head) {
 }
 
 t_rt_node* traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage) {
-    /* Builds a skeleton route tree from a traceback
-     * does not calculate R_upstream, C_downstream, or Tdel at all (left uninitialized)
-     * returns the root of the converted route tree
-     * initially points at the traceback equivalent of root 							  */
-
-    if (head == nullptr) {
-        return nullptr;
-    }
-
-    VTR_ASSERT_DEBUG(validate_traceback(head));
-
-    std::map<int, t_rt_node*> rr_node_to_rt;
-
-    t_trace* trace = head;
-    while (trace) { //Each branch
-        trace = traceback_to_route_tree_branch(trace, rr_node_to_rt, non_config_node_set_usage);
-    }
-    // Due to the recursive nature of traceback_to_route_tree_branch,
-    // the source node is not properly configured.
-    // Here, for the source we set the parent node and switch to be
-    // nullptr and OPEN respectively.
-
-    rr_node_to_rt[head->index]->parent_node = nullptr;
-    rr_node_to_rt[head->index]->parent_switch = OPEN;
-
-    return rr_node_to_rt[head->index];
-}
-
-//Constructs a single branch of a route tree from a traceback
-//Note that R_upstream and C_downstream are initialized to NaN
-//
-//Returns the t_trace defining the start of the next branch
-static t_trace* traceback_to_route_tree_branch(t_trace* trace,
-                                               std::map<int, t_rt_node*>& rr_node_to_rt,
-                                               std::vector<int>* non_config_node_set_usage) {
-    t_trace* next = nullptr;
-
-    if (trace) {
-        t_rt_node* node = nullptr;
-
-        int inode = trace->index;
-        int iswitch = trace->iswitch;
-
-        auto itr = rr_node_to_rt.find(trace->index);
-        if (itr == rr_node_to_rt.end()) {
-            //Create
-
-            //Initialize route tree node
-            node = alloc_rt_node();
-            node->inode = inode;
-            node->u.child_list = nullptr;
-
-            node->R_upstream = std::numeric_limits<float>::quiet_NaN();
-            node->C_downstream = std::numeric_limits<float>::quiet_NaN();
-            node->Tdel = std::numeric_limits<float>::quiet_NaN();
-
-            auto& device_ctx = g_vpr_ctx.device();
-            auto node_type = device_ctx.rr_nodes[inode].type();
-            if (node_type == IPIN || node_type == SINK)
-                node->re_expand = false;
-            else
-                node->re_expand = true;
-
-            if (node_type == SINK) {
-                // A non-configurable edge to a sink is also a usage of the
-                // set.
-                auto set_itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
-                if (non_config_node_set_usage != nullptr && set_itr != device_ctx.rr_node_to_non_config_node_set.end()) {
-                    if (device_ctx.rr_switch_inf[iswitch].configurable()) {
-                        (*non_config_node_set_usage)[set_itr->second] += 1;
-                    }
-                }
-            }
-
-            //Save
-            rr_node_to_rt[inode] = node;
-        } else {
-            //Found
-            node = itr->second;
-        }
-        VTR_ASSERT(node);
-
-        next = trace->next;
-        if (iswitch != OPEN) {
-            // Keep track of non-configurable set usage by looking for
-            // configurable edges that extend out of a non-configurable set.
-            //
-            // Each configurable edges from the non-configurable set is a
-            // usage of the set.
-            auto& device_ctx = g_vpr_ctx.device();
-            auto set_itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
-            if (non_config_node_set_usage != nullptr && set_itr != device_ctx.rr_node_to_non_config_node_set.end()) {
-                if (device_ctx.rr_switch_inf[iswitch].configurable()) {
-                    (*non_config_node_set_usage)[set_itr->second] += 1;
-                }
-            }
-
-            //Recursively construct the remaining branch
-            next = traceback_to_route_tree_branch(next, rr_node_to_rt, non_config_node_set_usage);
-
-            //Get the created child
-            itr = rr_node_to_rt.find(trace->next->index);
-            VTR_ASSERT_MSG(itr != rr_node_to_rt.end(), "Child must exist");
-            t_rt_node* child = itr->second;
-
-            //Create the edge
-            t_linked_rt_edge* edge = alloc_linked_rt_edge();
-            edge->iswitch = trace->iswitch;
-            edge->child = child;
-            edge->next = nullptr;
-
-            //Insert edge at tail of list
-            edge->next = node->u.child_list;
-            node->u.child_list = edge;
-
-            //Set child -> parent ref's
-            child->parent_node = node;
-            child->parent_switch = iswitch;
-
-            //Parent and child should be mutual
-            VTR_ASSERT(node->u.child_list->child == child);
-            VTR_ASSERT(child->parent_node == node);
-        }
-    }
-    return next;
+    return tree_timing->traceback_to_route_tree(head, non_config_node_set_usage);
 }
 
 static std::pair<t_trace*, t_trace*> traceback_from_route_tree_recurr(t_trace* head, t_trace* tail, const t_rt_node* node) {
@@ -925,218 +275,16 @@ t_trace* traceback_from_route_tree(ClusterNetId inet, const t_rt_node* root, int
     return head;
 }
 
-//Prunes a route tree (recursively) based on congestion and the 'force_prune' argument
-//
-//Returns true if the current node was pruned
-static t_rt_node* prune_route_tree_recurr(t_rt_node* node, CBRR& connections_inf, bool force_prune, std::vector<int>* non_config_node_set_usage) {
-    //Recursively traverse the route tree rooted at node and remove any congested
-    //sub-trees
-
-    VTR_ASSERT(node);
-
-    auto& device_ctx = g_vpr_ctx.device();
-    auto& route_ctx = g_vpr_ctx.routing();
-
-    bool congested = (route_ctx.rr_node_route_inf[node->inode].occ() > device_ctx.rr_nodes[node->inode].capacity());
-    int node_set = -1;
-    auto itr = device_ctx.rr_node_to_non_config_node_set.find(node->inode);
-    if (itr != device_ctx.rr_node_to_non_config_node_set.end()) {
-        node_set = itr->second;
-    }
-
-    if (congested) {
-        //This connection is congested -- prune it
-        force_prune = true;
-    }
-
-    if (connections_inf.should_force_reroute_connection(node->inode)) {
-        //Forcibly re-route (e.g. to improve delay)
-        force_prune = true;
-    }
-
-    //Recursively prune children
-    bool all_children_pruned = true;
-    t_linked_rt_edge* prev_edge = nullptr;
-    t_linked_rt_edge* edge = node->u.child_list;
-    while (edge) {
-        t_rt_node* child = prune_route_tree_recurr(edge->child,
-                                                   connections_inf, force_prune, non_config_node_set_usage);
-
-        if (!child) { //Child was pruned
-
-            //Remove the edge
-            if (edge == node->u.child_list) { //Was Head
-                node->u.child_list = edge->next;
-            } else { //Was intermediate
-                VTR_ASSERT(prev_edge);
-                prev_edge->next = edge->next;
-            }
-
-            t_linked_rt_edge* old_edge = edge;
-            edge = edge->next;
-
-            // After removing an edge, check if non_config_node_set_usage
-            // needs an update.
-            if (non_config_node_set_usage != nullptr && node_set != -1 && device_ctx.rr_switch_inf[old_edge->iswitch].configurable()) {
-                (*non_config_node_set_usage)[node_set] -= 1;
-                VTR_ASSERT((*non_config_node_set_usage)[node_set] >= 0);
-            }
-
-            free_linked_rt_edge(old_edge);
-
-            //Note prev_edge is unchanged
-
-        } else { //Child not pruned
-            all_children_pruned = false;
-
-            //Edge not removed
-            prev_edge = edge;
-            edge = edge->next;
-        }
-    }
-
-    if (device_ctx.rr_nodes[node->inode].type() == SINK) {
-        if (!force_prune) {
-            //Valid path to sink
-
-            //Record sink as reachable
-            connections_inf.reached_rt_sink(node);
-
-            return node; //Not pruned
-        } else {
-            VTR_ASSERT(force_prune);
-
-            //Record as not reached
-            connections_inf.toreach_rr_sink(node->inode);
-
-            free_rt_node(node);
-            return nullptr; //Pruned
-        }
-    } else if (all_children_pruned) {
-        //This node has no children
-        //
-        // This can happen in three scenarios:
-        //   1) This node is being pruned. As a result any child nodes
-        //      (subtrees) will have been pruned.
-        //
-        //   2) This node was reached by a non-configurable edge but
-        //      was otherwise unused (forming a 'stub' off the main
-        //      branch).
-        //
-        //   3) This node is uncongested, but all its connected sub-trees
-        //      have been pruned.
-        //
-        // We take the corresponding actions:
-        //   1) Prune the node.
-        //
-        //   2) Prune the node only if the node set is unused or if force_prune
-        //      is set.
-        //
-        //   3) Prune the node.
-        //
-        //      This avoid the creation of unused 'stubs'. (For example if
-        //      we left the stubs in and they were subsequently not used
-        //      they would uselessly consume routing resources).
-        VTR_ASSERT(node->u.child_list == nullptr);
-
-        bool reached_non_configurably = false;
-        if (node->parent_node) {
-            reached_non_configurably = !device_ctx.rr_switch_inf[node->parent_switch].configurable();
-
-            if (reached_non_configurably) {
-                // Check if this non-configurable node set is in use.
-                VTR_ASSERT(node_set != -1);
-                if (non_config_node_set_usage != nullptr && (*non_config_node_set_usage)[node_set] == 0) {
-                    force_prune = true;
-                }
-            }
-        }
-
-        if (reached_non_configurably && !force_prune) {
-            return node; //Not pruned
-        } else {
-            free_rt_node(node);
-            return nullptr; //Pruned
-        }
-
-    } else {
-        // If this node is:
-        //   1. Part of a non-configurable node set
-        //   2. The first node in the tree that is part of the non-configurable
-        //      node set
-        //
-        //      -- and --
-        //
-        //   3. The node set is not active
-        //
-        //  Then prune this node.
-        //
-        if (non_config_node_set_usage != nullptr && node_set != -1 && device_ctx.rr_switch_inf[node->parent_switch].configurable() && (*non_config_node_set_usage)[node_set] == 0) {
-            // This node should be pruned, re-prune edges once more.
-            //
-            // If the following is true:
-            //
-            //  - The node set is unused
-            //    (e.g. (*non_config_node_set_usage)[node_set] == 0)
-            //  - This particular node still had children
-            //    (which is true by virtue of being in this else statement)
-            //
-            // Then that indicates that the node set became unused during the
-            // pruning. One or more of the children of this node will be
-            // pruned if prune_route_tree_recurr is called again, and
-            // eventually the whole node will be prunable.
-            //
-            //  Consider the following graph:
-            //
-            //  1 -> 2
-            //  2 -> 3 [non-configurable]
-            //  2 -> 4 [non-configurable]
-            //  3 -> 5
-            //  4 -> 6
-            //
-            //  Assume that nodes 5 and 6 do not connect to a sink, so they
-            //  will be pruned (as normal). When prune_route_tree_recurr
-            //  visits 2 for the first time, node 3 or 4 will remain. This is
-            //  because when prune_route_tree_recurr visits 3 or 4, it will
-            //  not have visited 4 or 3 (respectively). As a result, either
-            //  node 3 or 4 will not be pruned on the first pass, because the
-            //  node set usage count will be > 0. However after
-            //  prune_route_tree_recurr visits 2, 3 and 4, the node set usage
-            //  will be 0, so everything can be pruned.
-            return prune_route_tree_recurr(node, connections_inf,
-                                           /*force_prune=*/false, non_config_node_set_usage);
-        }
-
-        //An unpruned intermediate node
-        VTR_ASSERT(!force_prune);
-
-        return node; //Not pruned
-    }
-}
-
 t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf) {
-    return prune_route_tree(rt_root, connections_inf, nullptr);
+    auto& route_ctx = g_vpr_ctx.routing();
+    return tree_timing->prune_route_tree<decltype(route_ctx.rr_node_route_inf)>(
+        route_ctx.rr_node_route_inf, rt_root, connections_inf, nullptr);
 }
 
 t_rt_node* prune_route_tree(t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage) {
-    /* Prune a skeleton route tree of illegal branches - when there is at least 1 congested node on the path to a sink
-     * This is the top level function to be called with the SOURCE node as root.
-     * Returns true if the entire tree has been pruned.
-     *
-     * Note: does not update R_upstream/C_downstream
-     */
-
-    VTR_ASSERT(rt_root);
-
-    auto& device_ctx = g_vpr_ctx.device();
     auto& route_ctx = g_vpr_ctx.routing();
-
-    VTR_ASSERT_MSG(device_ctx.rr_nodes[rt_root->inode].type() == SOURCE, "Root of route tree must be SOURCE");
-
-    VTR_ASSERT_MSG(route_ctx.rr_node_route_inf[rt_root->inode].occ() <= device_ctx.rr_nodes[rt_root->inode].capacity(),
-                   "Route tree root/SOURCE should never be congested");
-
-    return prune_route_tree_recurr(rt_root, connections_inf, false, non_config_node_set_usage);
+    return tree_timing->prune_route_tree<decltype(route_ctx.rr_node_route_inf)>(
+        route_ctx.rr_node_route_inf, rt_root, connections_inf, non_config_node_set_usage);
 }
 
 void pathfinder_update_cost_from_route_tree(const t_rt_node* rt_root, int add_or_sub, float pres_fac) {
@@ -1414,25 +562,7 @@ bool is_uncongested_route_tree(const t_rt_node* root) {
 
 t_rt_node*
 init_route_tree_to_source_no_net(int inode) {
-    /* Initializes the routing tree to just the net source, and returns the root
-     * node of the rt_tree (which is just the net source).                       */
-
-    t_rt_node* rt_root;
-
-    auto& device_ctx = g_vpr_ctx.device();
-
-    rt_root = alloc_rt_node();
-    rt_root->u.child_list = nullptr;
-    rt_root->parent_node = nullptr;
-    rt_root->parent_switch = OPEN;
-    rt_root->re_expand = true;
-    rt_root->inode = inode;
-    rt_root->C_downstream = device_ctx.rr_nodes[inode].C();
-    rt_root->R_upstream = device_ctx.rr_nodes[inode].R();
-    rt_root->Tdel = 0.5 * device_ctx.rr_nodes[inode].R() * device_ctx.rr_nodes[inode].C();
-    rr_node_to_rt_node[inode] = rt_root;
-
-    return (rt_root);
+    return tree_timing->init_route_tree_to_source_no_net(inode);
 }
 
 bool verify_traceback_route_tree_equivalent(const t_trace* head, const t_rt_node* rt_root) {
@@ -1478,7 +608,7 @@ bool verify_traceback_route_tree_equivalent(const t_trace* head, const t_rt_node
     return true;
 }
 
-void collect_route_tree_connections(const t_rt_node* node, std::set<std::tuple<int, int, int>>& connections) {
+static void collect_route_tree_connections(const t_rt_node* node, std::set<std::tuple<int, int, int>>& connections) {
     if (node) {
         //Record reaching connection
         int prev_node = OPEN;

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -50,7 +50,6 @@ bool alloc_route_tree_timing_structs(bool exists_ok) {
     /* Allocates any structures needed to build the routing trees. */
 
     auto& device_ctx = g_vpr_ctx.device();
-    auto& route_ctx = g_vpr_ctx.routing();
 
     bool route_tree_structs_are_allocated = bool(tree_timing);
     if (route_tree_structs_are_allocated) {
@@ -68,8 +67,7 @@ bool alloc_route_tree_timing_structs(bool exists_ok) {
         decltype(device_ctx.rr_switch_inf)>>(
         device_ctx.rr_nodes,
         device_ctx.rr_node_to_non_config_node_set,
-        device_ctx.rr_switch_inf,
-        route_ctx.net_rr_terminals);
+        device_ctx.rr_switch_inf);
 
     return true;
 }
@@ -83,7 +81,8 @@ void free_route_tree_timing_structs() {
 /* Initializes the routing tree to just the net source, and returns the root
  * node of the rt_tree (which is just the net source).                       */
 t_rt_node* init_route_tree_to_source(ClusterNetId inet) {
-    return tree_timing->init_route_tree_to_source(inet);
+    auto& route_ctx = g_vpr_ctx.routing();
+    return tree_timing->init_route_tree_to_source(route_ctx.net_rr_terminals, inet);
 }
 
 /* Adds the most recently finished wire segment to the routing tree, and

--- a/vpr/src/route/route_tree_timing_obj.cpp
+++ b/vpr/src/route/route_tree_timing_obj.cpp
@@ -1,0 +1,84 @@
+#include "route_tree_timing_obj.h"
+#include "vtr_memory.h"
+
+RtNodeAllocator::RtNodeAllocator()
+    : rt_node_free_list_(nullptr) {}
+RtNodeAllocator::~RtNodeAllocator() {
+    empty_free_list();
+}
+
+void RtNodeAllocator::empty_free_list() {
+    t_rt_node* rt_node = rt_node_free_list_;
+
+    while (rt_node != nullptr) {
+        t_rt_node* next_node = rt_node->u.next;
+        free(rt_node);
+        rt_node = next_node;
+    }
+
+    rt_node_free_list_ = nullptr;
+}
+
+t_rt_node* RtNodeAllocator::alloc() {
+    /* Allocates a new rt_node, from the free list if possible, from the free
+     * store otherwise.                                                         */
+
+    t_rt_node* rt_node;
+
+    rt_node = rt_node_free_list_;
+
+    if (rt_node != nullptr) {
+        rt_node_free_list_ = rt_node->u.next;
+    } else {
+        rt_node = (t_rt_node*)vtr::malloc(sizeof(t_rt_node));
+    }
+
+    return (rt_node);
+}
+
+void RtNodeAllocator::free(t_rt_node* rt_node) {
+    /* Adds rt_node to the proper free list.          */
+    rt_node->u.next = rt_node_free_list_;
+    rt_node_free_list_ = rt_node;
+}
+
+LinkedRtEdgeAllocator::LinkedRtEdgeAllocator()
+    : rt_edge_free_list_(nullptr) {}
+LinkedRtEdgeAllocator::~LinkedRtEdgeAllocator() {
+    empty_free_list();
+}
+
+t_linked_rt_edge* LinkedRtEdgeAllocator::alloc() {
+    /* Allocates a new linked_rt_edge, from the free list if possible, from the
+     * free store otherwise.                                                     */
+
+    t_linked_rt_edge* linked_rt_edge;
+
+    linked_rt_edge = rt_edge_free_list_;
+
+    if (linked_rt_edge != nullptr) {
+        rt_edge_free_list_ = linked_rt_edge->next;
+    } else {
+        linked_rt_edge = (t_linked_rt_edge*)vtr::malloc(sizeof(t_linked_rt_edge));
+    }
+
+    VTR_ASSERT(linked_rt_edge != nullptr);
+    return (linked_rt_edge);
+}
+
+void LinkedRtEdgeAllocator::free(t_linked_rt_edge* rt_edge) {
+    rt_edge->next = rt_edge_free_list_;
+    rt_edge_free_list_ = rt_edge;
+}
+
+void LinkedRtEdgeAllocator::empty_free_list() {
+    t_linked_rt_edge* rt_edge = rt_edge_free_list_;
+
+    while (rt_edge != nullptr) {
+        t_linked_rt_edge* next_edge = rt_edge->next;
+        free(rt_edge);
+        rt_edge = next_edge;
+    }
+
+    rt_edge_free_list_ = nullptr;
+}

--- a/vpr/src/route/route_tree_timing_obj.h
+++ b/vpr/src/route/route_tree_timing_obj.h
@@ -1,0 +1,145 @@
+#pragma once
+#include <vector>
+#include "route_tree_type.h"
+#include "clustered_netlist_fwd.h"
+#include "spatial_route_tree_lookup.h"
+#include "vtr_vector.h"
+#include "vpr_types.h"
+#include "route_common.h"
+#include "connection_based_routing.h"
+
+class RtNodeAllocator {
+  public:
+    RtNodeAllocator();
+    ~RtNodeAllocator();
+    t_rt_node* alloc();
+    void free(t_rt_node* rt_node);
+    void empty_free_list();
+
+  private:
+    t_rt_node* rt_node_free_list_;
+};
+
+class LinkedRtEdgeAllocator {
+  public:
+    LinkedRtEdgeAllocator();
+    ~LinkedRtEdgeAllocator();
+    t_linked_rt_edge* alloc();
+    void free(t_linked_rt_edge* rt_edge);
+    void empty_free_list();
+
+  private:
+    /* Frees lists for fast addition and deletion of nodes and edges. */
+    t_linked_rt_edge* rt_edge_free_list_;
+};
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+class RouteTreeTiming {
+  public:
+    RouteTreeTiming(
+        const RrNodeInf& node_inf,
+        const RrNodeSetInf& node_set_inf,
+        const SwitchInf& switch_inf,
+        const vtr::vector<ClusterNetId, std::vector<int>>& net_rr_terminals)
+        : node_inf_(node_inf)
+        , node_set_inf_(node_set_inf)
+        , switch_inf_(switch_inf)
+        , net_rr_terminals_(net_rr_terminals) {
+        rr_node_to_rt_node_.resize(node_inf_.size(), nullptr);
+    }
+
+    t_rt_node* init_route_tree_to_source(ClusterNetId inet);
+
+    void free_route_tree(t_rt_node* rt_node);
+
+    template<typename RouteInf>
+    void print_route_tree(const RouteInf& route_inf, const t_rt_node* rt_node) const;
+
+    template<typename RouteInf>
+    void print_route_tree(const RouteInf& route_inf, const t_rt_node* rt_node, int depth) const;
+
+    template<typename RouteInf>
+    t_rt_node* update_route_tree(const RouteInf& route_inf, t_heap* hptr, SpatialRouteTreeLookup* spatial_rt_lookup);
+
+    void load_route_tree_Tdel(t_rt_node* rt_root, float Tarrival) const;
+
+    template<typename RouteInf>
+    void load_route_tree_rr_route_inf(RouteInf* route_inf_ptr, t_rt_node* root) const;
+
+    t_rt_node* init_route_tree_to_source_no_net(int inode);
+
+    void add_route_tree_to_rr_node_lookup(t_rt_node* node);
+
+    t_rt_node* find_sink_rt_node(t_rt_node* rt_root, ClusterNetId net_id, ClusterPinId sink_pin);
+    t_rt_node* find_sink_rt_node_recurr(t_rt_node* node, int sink_inode);
+
+    /********** Incremental reroute ***********/
+    // instead of ripping up a net that has some congestion, cut the branches
+    // that don't legally lead to a sink and start routing with that partial route tree
+
+    void print_edge(const t_linked_rt_edge* edge);
+    void print_route_tree_node(const t_rt_node* rt_root);
+    void print_route_tree_inf(const t_rt_node* rt_root);
+    void print_route_tree_congestion(const t_rt_node* rt_root);
+
+    t_rt_node* traceback_to_route_tree(ClusterNetId inet);
+    t_rt_node* traceback_to_route_tree(ClusterNetId inet, std::vector<int>* non_config_node_set_usage);
+    t_rt_node* traceback_to_route_tree(t_trace* head);
+    t_rt_node* traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage);
+    t_trace* traceback_from_route_tree(ClusterNetId inet, const t_rt_node* root, int num_remaining_sinks);
+
+    // Prune route tree
+    //
+    //  Note that non-configurable node will not be pruned unless the node is
+    //  being totally ripped up, or the node is congested.
+    template<typename RouteInf>
+    t_rt_node* prune_route_tree(const RouteInf& route_inf, t_rt_node* rt_root, CBRR& connections_inf);
+
+    // Prune route tree
+    //
+    //  Note that non-configurable nodes will be pruned if
+    //  non_config_node_set_usage is provided.  prune_route_tree will update
+    //  non_config_node_set_usage after pruning.
+    template<typename RouteInf>
+    t_rt_node* prune_route_tree(const RouteInf& route_inf, t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage);
+
+    void pathfinder_update_cost_from_route_tree(const t_rt_node* rt_root, int add_or_sub, float pres_fac);
+
+    bool is_equivalent_route_tree(const t_rt_node* rt_root, const t_rt_node* cloned_rt_root);
+    bool is_valid_skeleton_tree(const t_rt_node* rt_root);
+    bool is_valid_route_tree(const t_rt_node* rt_root);
+    bool is_uncongested_route_tree(const t_rt_node* root);
+    float load_new_subtree_C_downstream(t_rt_node* rt_node) const;
+    void load_new_subtree_R_upstream(t_rt_node* rt_node) const;
+
+  private:
+    template<typename RouteInf>
+    t_rt_node* add_subtree_to_route_tree(const RouteInf& route_inf, t_heap* hptr, t_rt_node** sink_rt_node_ptr);
+
+    t_rt_node*
+    update_unbuffered_ancestors_C_downstream(t_rt_node* start_of_new_path_rt_node) const;
+
+    bool verify_route_tree_recurr(t_rt_node* node, std::set<int>* seen_nodes) const;
+
+    t_trace* traceback_to_route_tree_branch(t_trace* trace,
+                                            std::map<int, t_rt_node*>* rr_node_to_rt,
+                                            std::vector<int>* non_config_node_set_usage);
+
+    template<typename RouteInf>
+    t_rt_node* prune_route_tree_recurr(const RouteInf& route_inf, t_rt_node* node, CBRR& connections_inf, bool force_prune, std::vector<int>* non_config_node_set_usage);
+
+    t_rt_node* add_non_configurable_to_route_tree(const int rr_node, const bool reached_by_non_configurable_edge, std::unordered_set<int>& visited);
+
+    /* Array below allows mapping from any rr_node to any rt_node currently in
+     * the rt_tree.                                                              */
+    std::vector<t_rt_node*> rr_node_to_rt_node_; /* [0..device_ctx.rr_nodes.size()-1] */
+
+    const RrNodeInf& node_inf_;
+    const RrNodeSetInf& node_set_inf_;
+    const SwitchInf& switch_inf_;
+    RtNodeAllocator rt_nodes_;
+    LinkedRtEdgeAllocator rt_edges_;
+    const vtr::vector<ClusterNetId, std::vector<int>>& net_rr_terminals_;
+};
+
+#include "route_tree_timing_obj.hpp"

--- a/vpr/src/route/route_tree_timing_obj.h
+++ b/vpr/src/route/route_tree_timing_obj.h
@@ -39,16 +39,16 @@ class RouteTreeTiming {
     RouteTreeTiming(
         const RrNodeInf& node_inf,
         const RrNodeSetInf& node_set_inf,
-        const SwitchInf& switch_inf,
-        const vtr::vector<ClusterNetId, std::vector<int>>& net_rr_terminals)
+        const SwitchInf& switch_inf)
         : node_inf_(node_inf)
         , node_set_inf_(node_set_inf)
-        , switch_inf_(switch_inf)
-        , net_rr_terminals_(net_rr_terminals) {
+        , switch_inf_(switch_inf) {
         rr_node_to_rt_node_.resize(node_inf_.size(), nullptr);
     }
 
-    t_rt_node* init_route_tree_to_source(ClusterNetId inet);
+    t_rt_node* init_route_tree_to_source(
+        const vtr::vector<ClusterNetId, std::vector<int>>& net_rr_terminals,
+        ClusterNetId inet);
 
     void free_route_tree(t_rt_node* rt_node);
 
@@ -139,7 +139,6 @@ class RouteTreeTiming {
     const SwitchInf& switch_inf_;
     RtNodeAllocator rt_nodes_;
     LinkedRtEdgeAllocator rt_edges_;
-    const vtr::vector<ClusterNetId, std::vector<int>>& net_rr_terminals_;
 };
 
 #include "route_tree_timing_obj.hpp"

--- a/vpr/src/route/route_tree_timing_obj.hpp
+++ b/vpr/src/route/route_tree_timing_obj.hpp
@@ -1,0 +1,858 @@
+#include "clustered_netlist_fwd.h"
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::init_route_tree_to_source(ClusterNetId inet) {
+    /* Initializes the routing tree to just the net source, and returns the root
+     * node of the rt_tree (which is just the net source).                       */
+
+    t_rt_node* rt_root;
+
+    rt_root = rt_nodes_.alloc();
+    rt_root->u.child_list = nullptr;
+    rt_root->parent_node = nullptr;
+    rt_root->parent_switch = OPEN;
+    rt_root->re_expand = true;
+
+    int inode = net_rr_terminals_[inet][0]; /* Net source */
+
+    rt_root->inode = inode;
+    rt_root->C_downstream = node_inf_[inode].C();
+    rt_root->R_upstream = node_inf_[inode].R();
+    rt_root->Tdel = 0.5 * node_inf_[inode].R() * node_inf_[inode].C();
+    rr_node_to_rt_node_[inode] = rt_root;
+
+    return (rt_root);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::free_route_tree(t_rt_node* rt_node) {
+    /* Puts the rt_nodes and edges in the tree rooted at rt_node back on the
+     * free lists.  Recursive, depth-first post-order traversal.                */
+
+    t_linked_rt_edge *rt_edge, *next_edge;
+
+    rt_edge = rt_node->u.child_list;
+
+    while (rt_edge != nullptr) { /* For all children */
+        t_rt_node* child_node = rt_edge->child;
+        free_route_tree(child_node);
+        next_edge = rt_edge->next;
+        rt_edges_.free(rt_edge);
+        rt_edge = next_edge;
+    }
+
+    if (!rr_node_to_rt_node_.empty()) {
+        rr_node_to_rt_node_.at(rt_node->inode) = nullptr;
+    }
+
+    rt_nodes_.free(rt_node);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::print_route_tree(const RouteInf& route_inf, const t_rt_node* rt_node) const {
+    print_route_tree(route_inf, rt_node, 0);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::print_route_tree(const RouteInf& route_inf, const t_rt_node* rt_node, int depth) const {
+    std::string indent;
+    for (int i = 0; i < depth; ++i) {
+        indent += "  ";
+    }
+
+    VTR_LOG("%srt_node: %d (%s)", indent.c_str(), rt_node->inode, node_inf_[rt_node->inode].type_string());
+
+    if (rt_node->parent_switch != OPEN) {
+        bool parent_edge_configurable = switch_inf_[rt_node->parent_switch].configurable();
+        if (!parent_edge_configurable) {
+            VTR_LOG("*");
+        }
+    }
+
+    if (route_inf[rt_node->inode].occ() > node_inf_[rt_node->inode].capacity()) {
+        VTR_LOG(" x");
+    }
+
+    VTR_LOG("\n");
+
+    for (t_linked_rt_edge* rt_edge = rt_node->u.child_list; rt_edge != nullptr; rt_edge = rt_edge->next) {
+        print_route_tree(route_inf, rt_edge->child, depth + 1);
+    }
+}
+
+/* Adds the most recently finished wire segment to the routing tree, and
+ * updates the Tdel, etc. numbers for the rest of the routing tree.  hptr
+ * is the heap pointer of the SINK that was reached.  This routine returns
+ * a pointer to the rt_node of the SINK that it adds to the routing.        */
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::update_route_tree(const RouteInf& route_inf, t_heap* hptr, SpatialRouteTreeLookup* spatial_rt_lookup) {
+    t_rt_node *start_of_new_subtree_rt_node, *sink_rt_node;
+    t_rt_node *unbuffered_subtree_rt_root, *subtree_parent_rt_node;
+    float Tdel_start;
+    short iswitch;
+
+    //Create a new subtree from the target in hptr to existing routing
+    start_of_new_subtree_rt_node = add_subtree_to_route_tree(route_inf, hptr, &sink_rt_node);
+
+    //Propagate R_upstream down into the new subtree
+    load_new_subtree_R_upstream(start_of_new_subtree_rt_node);
+
+    //Propagate C_downstream up from new subtree sinks to subtree root
+    load_new_subtree_C_downstream(start_of_new_subtree_rt_node);
+
+    //Propagate C_downstream up from the subtree root
+    unbuffered_subtree_rt_root = update_unbuffered_ancestors_C_downstream(start_of_new_subtree_rt_node);
+
+    subtree_parent_rt_node = unbuffered_subtree_rt_root->parent_node;
+
+    if (subtree_parent_rt_node != nullptr) { /* Parent exists. */
+        Tdel_start = subtree_parent_rt_node->Tdel;
+        iswitch = unbuffered_subtree_rt_root->parent_switch;
+        Tdel_start += switch_inf_[iswitch].R * unbuffered_subtree_rt_root->C_downstream;
+        Tdel_start += switch_inf_[iswitch].Tdel;
+    } else { /* Subtree starts at SOURCE */
+        Tdel_start = 0.;
+    }
+
+    load_route_tree_Tdel(unbuffered_subtree_rt_root, Tdel_start);
+
+    if (spatial_rt_lookup) {
+        update_route_tree_spatial_lookup_recur(start_of_new_subtree_rt_node, *spatial_rt_lookup);
+    }
+
+    return (sink_rt_node);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+t_rt_node*
+RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::add_subtree_to_route_tree(const RouteInf& route_inf, t_heap* hptr, t_rt_node** sink_rt_node_ptr) {
+    /* Adds the most recent wire segment, ending at the SINK indicated by hptr,
+     * to the routing tree.  It returns the first (most upstream) new rt_node,
+     * and (via a pointer) the rt_node of the new SINK. Traverses up from SINK  */
+
+    t_rt_node *rt_node, *downstream_rt_node, *sink_rt_node;
+    t_linked_rt_edge* linked_rt_edge;
+
+    int inode = hptr->index;
+
+    sink_rt_node = rt_nodes_.alloc();
+    sink_rt_node->u.child_list = nullptr;
+    sink_rt_node->inode = inode;
+    rr_node_to_rt_node_[inode] = sink_rt_node;
+
+    /* In the code below I'm marking SINKs and IPINs as not to be re-expanded.
+     * It makes the code more efficient (though not vastly) to prune this way
+     * when there aren't route-throughs or ipin doglegs.                        */
+
+    sink_rt_node->re_expand = false;
+
+    /* Now do it's predecessor. */
+
+    downstream_rt_node = sink_rt_node;
+
+    std::unordered_set<int> main_branch_visited;
+    std::unordered_set<int> all_visited;
+    inode = hptr->u.prev.node;
+    t_edge_size iedge = hptr->u.prev.edge;
+    short iswitch = node_inf_[inode].edge_switch(iedge);
+
+    /* For all "new" nodes in the main path */
+    // inode is node index of previous node
+    // NO_PREVIOUS tags a previously routed node
+
+    while (rr_node_to_rt_node_[inode] == nullptr) { //Not connected to existing routing
+        main_branch_visited.insert(inode);
+        all_visited.insert(inode);
+
+        linked_rt_edge = rt_edges_.alloc();
+        linked_rt_edge->child = downstream_rt_node;
+
+        // Also mark downstream_rt_node->inode as visited to prevent
+        // add_non_configurable_to_route_tree from potentially adding
+        // downstream_rt_node to the rt tree twice.
+        all_visited.insert(downstream_rt_node->inode);
+        linked_rt_edge->iswitch = iswitch;
+        linked_rt_edge->next = nullptr;
+
+        rt_node = rt_nodes_.alloc();
+        downstream_rt_node->parent_node = rt_node;
+        downstream_rt_node->parent_switch = iswitch;
+
+        rt_node->u.child_list = linked_rt_edge;
+        rt_node->inode = inode;
+
+        rr_node_to_rt_node_[inode] = rt_node;
+
+        if (node_inf_[inode].type() == IPIN) {
+            rt_node->re_expand = false;
+        } else {
+            rt_node->re_expand = true;
+        }
+
+        downstream_rt_node = rt_node;
+        iedge = route_inf[inode].prev_edge;
+        inode = route_inf[inode].prev_node;
+        iswitch = node_inf_[inode].edge_switch(iedge);
+    }
+
+    //Inode is now the branch point to the old routing; do not need
+    //to alloc another node since the old routing has done so already
+    rt_node = rr_node_to_rt_node_[inode];
+    VTR_ASSERT_MSG(rt_node, "Previous routing branch should exist");
+
+    linked_rt_edge = rt_edges_.alloc();
+    linked_rt_edge->child = downstream_rt_node;
+    linked_rt_edge->iswitch = iswitch;
+    linked_rt_edge->next = rt_node->u.child_list; //Add to head
+    rt_node->u.child_list = linked_rt_edge;
+
+    downstream_rt_node->parent_node = rt_node;
+    downstream_rt_node->parent_switch = iswitch;
+
+    //Expand (recursively) each of the main-branch nodes adding any
+    //non-configurably connected nodes
+    for (int rr_node : main_branch_visited) {
+        add_non_configurable_to_route_tree(rr_node, false, all_visited);
+    }
+
+    *sink_rt_node_ptr = sink_rt_node;
+    return (downstream_rt_node);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::add_non_configurable_to_route_tree(const int rr_node, const bool reached_by_non_configurable_edge, std::unordered_set<int>& visited) {
+    t_rt_node* rt_node = nullptr;
+
+    if (!visited.count(rr_node) || !reached_by_non_configurable_edge) {
+        visited.insert(rr_node);
+
+        auto& device_ctx = g_vpr_ctx.device();
+
+        rt_node = rr_node_to_rt_node_[rr_node];
+
+        if (!reached_by_non_configurable_edge) { //An existing main branch node
+            VTR_ASSERT(rt_node);
+        } else {
+            VTR_ASSERT(reached_by_non_configurable_edge);
+
+            if (!rt_node) {
+                rt_node = rt_nodes_.alloc();
+                rt_node->u.child_list = nullptr;
+                rt_node->inode = rr_node;
+
+                if (device_ctx.rr_nodes[rr_node].type() == IPIN) {
+                    rt_node->re_expand = false;
+                } else {
+                    rt_node->re_expand = true;
+                }
+            } else {
+                VTR_ASSERT(rt_node->inode == rr_node);
+            }
+        }
+
+        for (int iedge : device_ctx.rr_nodes[rr_node].non_configurable_edges()) {
+            //Recursive case: expand children
+            VTR_ASSERT(!device_ctx.rr_nodes[rr_node].edge_is_configurable(iedge));
+
+            int to_rr_node = device_ctx.rr_nodes[rr_node].edge_sink_node(iedge);
+
+            //Recurse
+            t_rt_node* child_rt_node = add_non_configurable_to_route_tree(to_rr_node, true, visited);
+
+            if (!child_rt_node) continue;
+
+            int iswitch = device_ctx.rr_nodes[rr_node].edge_switch(iedge);
+
+            //Create the edge
+            t_linked_rt_edge* linked_rt_edge = rt_edges_.alloc();
+            linked_rt_edge->child = child_rt_node;
+            linked_rt_edge->iswitch = iswitch;
+
+            //Add edge at head of parent linked list
+            linked_rt_edge->next = rt_node->u.child_list;
+            rt_node->u.child_list = linked_rt_edge;
+
+            //Update child to parent ref
+            child_rt_node->parent_node = rt_node;
+            child_rt_node->parent_switch = iswitch;
+        }
+        rr_node_to_rt_node_[rr_node] = rt_node;
+    }
+
+    return rt_node;
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+t_rt_node*
+RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::update_unbuffered_ancestors_C_downstream(t_rt_node* start_of_new_path_rt_node) const {
+    /* Updates the C_downstream values for the ancestors of the new path.  Once
+     * a buffered switch is found amongst the ancestors, no more ancestors are
+     * affected.  Returns the root of the "unbuffered subtree" whose Tdel
+     * values are affected by the new path's addition.                          */
+
+    t_rt_node *rt_node, *parent_rt_node;
+    short iswitch;
+    float C_downstream_addition;
+
+    rt_node = start_of_new_path_rt_node;
+    parent_rt_node = rt_node->parent_node;
+    iswitch = rt_node->parent_switch;
+
+    /* Now that a connection has been made between rt_node and its parent we must also consider
+     * the potential effect of internal capacitance. We will first assume that parent is connected
+     * by an unbuffered switch, so the ancestors downstream capacitance must be equal to the sum
+     * of the child's downstream capacitance with the internal capacitance of the switch.*/
+
+    C_downstream_addition = rt_node->C_downstream + switch_inf_[iswitch].Cinternal;
+
+    /* Having set the value of C_downstream_addition, we must check whethere the parent switch
+     * is a buffered or unbuffered switch with the if statement below. If the parent switch is
+     * a buffered switch, then the parent node's downsteam capacitance is increased by the
+     * value of the parent switch's internal capacitance in the if statement below.
+     * Correspondingly, the ancestors' downstream capacitance will be updated by the same
+     * value through the while loop. Otherwise, if the parent switch is unbuffered, then
+     * the if statement will be ignored, and the parent and ancestral nodes' downstream
+     * capacitance will be increased by the sum of the child's downstream capacitance with
+     * the internal capacitance of the parent switch in the while loop/.*/
+
+    if (parent_rt_node != nullptr && switch_inf_[iswitch].buffered() == true) {
+        C_downstream_addition = switch_inf_[iswitch].Cinternal;
+        rt_node = parent_rt_node;
+        rt_node->C_downstream += C_downstream_addition;
+        parent_rt_node = rt_node->parent_node;
+        iswitch = rt_node->parent_switch;
+    }
+
+    while (parent_rt_node != nullptr && switch_inf_[iswitch].buffered() == false) {
+        rt_node = parent_rt_node;
+        rt_node->C_downstream += C_downstream_addition;
+        parent_rt_node = rt_node->parent_node;
+        iswitch = rt_node->parent_switch;
+    }
+    return (rt_node);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::load_route_tree_Tdel(t_rt_node* subtree_rt_root, float Tarrival) const {
+    /* Updates the Tdel values of the subtree rooted at subtree_rt_root by
+     * by calling itself recursively.  The C_downstream values of all the nodes
+     * must be correct before this routine is called.  Tarrival is the time at
+     * at which the signal arrives at this node's *input*.                      */
+
+    int inode;
+    short iswitch;
+    t_rt_node* child_node;
+    t_linked_rt_edge* linked_rt_edge;
+    float Tdel, Tchild;
+
+    inode = subtree_rt_root->inode;
+
+    /* Assuming the downstream connections are, on average, connected halfway
+     * along a wire segment's length.  See discussion in net_delay.c if you want
+     * to change this.                                                           */
+
+    Tdel = Tarrival + 0.5 * subtree_rt_root->C_downstream * node_inf_[inode].R();
+    subtree_rt_root->Tdel = Tdel;
+
+    /* Now expand the children of this node to load their Tdel values (depth-
+     * first pre-order traversal).                                              */
+
+    linked_rt_edge = subtree_rt_root->u.child_list;
+
+    while (linked_rt_edge != nullptr) {
+        iswitch = linked_rt_edge->iswitch;
+        child_node = linked_rt_edge->child;
+
+        Tchild = Tdel + switch_inf_[iswitch].R * child_node->C_downstream;
+        Tchild += switch_inf_[iswitch].Tdel; /* Intrinsic switch delay. */
+        load_route_tree_Tdel(child_node, Tchild);
+
+        linked_rt_edge = linked_rt_edge->next;
+    }
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::load_route_tree_rr_route_inf(RouteInf* route_inf_ptr, t_rt_node* root) const {
+    /* Traverses down a route tree and updates rr_node_inf for all nodes
+     * to reflect that these nodes have already been routed to 			 */
+
+    VTR_ASSERT(root != nullptr);
+
+    RouteInf& route_inf = *route_inf_ptr;
+
+    t_linked_rt_edge* edge{root->u.child_list};
+
+    for (;;) {
+        int inode = root->inode;
+        route_inf[inode].prev_node = NO_PREVIOUS;
+        route_inf[inode].prev_edge = NO_PREVIOUS;
+        // path cost should be unset
+        VTR_ASSERT(std::isinf(route_inf[inode].path_cost));
+        VTR_ASSERT(std::isinf(route_inf[inode].backward_path_cost));
+
+        // reached a sink
+        if (!edge) { return; }
+        // branch point (sibling edges)
+        else if (edge->next) {
+            // recursively update for each of its sibling branches
+            do {
+                load_route_tree_rr_route_inf(route_inf_ptr, edge->child);
+                edge = edge->next;
+            } while (edge);
+            return;
+        }
+
+        root = edge->child;
+        edge = root->u.child_list;
+    }
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::init_route_tree_to_source_no_net(int inode) {
+    /* Initializes the routing tree to just the net source, and returns the root
+     * node of the rt_tree (which is just the net source).                       */
+
+    t_rt_node* rt_root;
+
+    rt_root = rt_nodes_.alloc();
+    rt_root->u.child_list = nullptr;
+    rt_root->parent_node = nullptr;
+    rt_root->parent_switch = OPEN;
+    rt_root->re_expand = true;
+    rt_root->inode = inode;
+    rt_root->C_downstream = node_inf_[inode].C();
+    rt_root->R_upstream = node_inf_[inode].R();
+    rt_root->Tdel = 0.5 * node_inf_[inode].R() * node_inf_[inode].C();
+    rr_node_to_rt_node_[inode] = rt_root;
+
+    return (rt_root);
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::add_route_tree_to_rr_node_lookup(t_rt_node* node) {
+    if (node) {
+        VTR_ASSERT(rr_node_to_rt_node_[node->inode] == nullptr || rr_node_to_rt_node_[node->inode] == node);
+
+        rr_node_to_rt_node_[node->inode] = node;
+
+        for (auto edge = node->u.child_list; edge != nullptr; edge = edge->next) {
+            add_route_tree_to_rr_node_lookup(edge->child);
+        }
+    }
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::traceback_to_route_tree(t_trace* head, std::vector<int>* non_config_node_set_usage) {
+    /* Builds a skeleton route tree from a traceback
+     * does not calculate R_upstream, C_downstream, or Tdel at all (left uninitialized)
+     * returns the root of the converted route tree
+     * initially points at the traceback equivalent of root 							  */
+
+    if (head == nullptr) {
+        return nullptr;
+    }
+
+    VTR_ASSERT_DEBUG(validate_traceback(head));
+
+    std::map<int, t_rt_node*> rr_node_to_rt;
+
+    t_trace* trace = head;
+    while (trace) { //Each branch
+        trace = traceback_to_route_tree_branch(trace, &rr_node_to_rt, non_config_node_set_usage);
+    }
+    // Due to the recursive nature of traceback_to_route_tree_branch,
+    // the source node is not properly configured.
+    // Here, for the source we set the parent node and switch to be
+    // nullptr and OPEN respectively.
+
+    rr_node_to_rt[head->index]->parent_node = nullptr;
+    rr_node_to_rt[head->index]->parent_switch = OPEN;
+
+    return rr_node_to_rt[head->index];
+}
+
+//Constructs a single branch of a route tree from a traceback
+//Note that R_upstream and C_downstream are initialized to NaN
+//
+//Returns the t_trace defining the start of the next branch
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+t_trace* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::traceback_to_route_tree_branch(t_trace* trace,
+                                                                                             std::map<int, t_rt_node*>* rr_node_to_rt,
+                                                                                             std::vector<int>* non_config_node_set_usage) {
+    t_trace* next = nullptr;
+
+    if (trace) {
+        t_rt_node* node = nullptr;
+
+        int inode = trace->index;
+        int iswitch = trace->iswitch;
+
+        auto itr = rr_node_to_rt->find(trace->index);
+        if (itr == rr_node_to_rt->end()) {
+            //Create
+
+            //Initialize route tree node
+            node = rt_nodes_.alloc();
+            node->inode = inode;
+            node->u.child_list = nullptr;
+
+            node->R_upstream = std::numeric_limits<float>::quiet_NaN();
+            node->C_downstream = std::numeric_limits<float>::quiet_NaN();
+            node->Tdel = std::numeric_limits<float>::quiet_NaN();
+
+            auto node_type = node_inf_[inode].type();
+            if (node_type == IPIN || node_type == SINK)
+                node->re_expand = false;
+            else
+                node->re_expand = true;
+
+            if (node_type == SINK) {
+                // A non-configurable edge to a sink is also a usage of the
+                // set.
+                auto set_itr = node_set_inf_.find(inode);
+                if (non_config_node_set_usage != nullptr && set_itr != node_set_inf_.end()) {
+                    if (switch_inf_[iswitch].configurable()) {
+                        (*non_config_node_set_usage)[set_itr->second] += 1;
+                    }
+                }
+            }
+
+            //Save
+            rr_node_to_rt->insert(std::make_pair(inode, node));
+        } else {
+            //Found
+            node = itr->second;
+        }
+        VTR_ASSERT(node);
+
+        next = trace->next;
+        if (iswitch != OPEN) {
+            // Keep track of non-configurable set usage by looking for
+            // configurable edges that extend out of a non-configurable set.
+            //
+            // Each configurable edges from the non-configurable set is a
+            // usage of the set.
+            auto set_itr = node_set_inf_.find(inode);
+            if (non_config_node_set_usage != nullptr && set_itr != node_set_inf_.end()) {
+                if (switch_inf_[iswitch].configurable()) {
+                    (*non_config_node_set_usage)[set_itr->second] += 1;
+                }
+            }
+
+            //Recursively construct the remaining branch
+            next = traceback_to_route_tree_branch(next, rr_node_to_rt, non_config_node_set_usage);
+
+            //Get the created child
+            itr = rr_node_to_rt->find(trace->next->index);
+            VTR_ASSERT_MSG(itr != rr_node_to_rt->end(), "Child must exist");
+            t_rt_node* child = itr->second;
+
+            //Create the edge
+            t_linked_rt_edge* edge = rt_edges_.alloc();
+            edge->iswitch = trace->iswitch;
+            edge->child = child;
+            edge->next = nullptr;
+
+            //Insert edge at tail of list
+            edge->next = node->u.child_list;
+            node->u.child_list = edge;
+
+            //Set child -> parent ref's
+            child->parent_node = node;
+            child->parent_switch = iswitch;
+
+            //Parent and child should be mutual
+            VTR_ASSERT(node->u.child_list->child == child);
+            VTR_ASSERT(child->parent_node == node);
+        }
+    }
+    return next;
+}
+
+// Prune route tree
+//
+//  Note that non-configurable node will not be pruned unless the node is
+//  being totally ripped up, or the node is congested.
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::prune_route_tree(const RouteInf& route_inf, t_rt_node* rt_root, CBRR& connections_inf) {
+    return prune_route_tree(route_inf, rt_root, connections_inf, nullptr);
+}
+
+// Prune route tree
+//
+//  Note that non-configurable nodes will be pruned if
+//  non_config_node_set_usage is provided.  prune_route_tree will update
+//  non_config_node_set_usage after pruning.
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::prune_route_tree(const RouteInf& route_inf, t_rt_node* rt_root, CBRR& connections_inf, std::vector<int>* non_config_node_set_usage) {
+    /* Prune a skeleton route tree of illegal branches - when there is at least 1 congested node on the path to a sink
+     * This is the top level function to be called with the SOURCE node as root.
+     * Returns true if the entire tree has been pruned.
+     *
+     * Note: does not update R_upstream/C_downstream
+     */
+
+    VTR_ASSERT(rt_root);
+
+    VTR_ASSERT_MSG(node_inf_[rt_root->inode].type() == SOURCE, "Root of route tree must be SOURCE");
+
+    VTR_ASSERT_MSG(route_inf[rt_root->inode].occ() <= node_inf_[rt_root->inode].capacity(),
+                   "Route tree root/SOURCE should never be congested");
+
+    return prune_route_tree_recurr(route_inf, rt_root, connections_inf, false, non_config_node_set_usage);
+}
+
+//Prunes a route tree (recursively) based on congestion and the 'force_prune' argument
+//
+//Returns true if the current node was pruned
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+template<typename RouteInf>
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::prune_route_tree_recurr(const RouteInf& route_inf, t_rt_node* node, CBRR& connections_inf, bool force_prune, std::vector<int>* non_config_node_set_usage) {
+    //Recursively traverse the route tree rooted at node and remove any congested
+    //sub-trees
+
+    VTR_ASSERT(node);
+
+    bool congested = (route_inf[node->inode].occ() > node_inf_[node->inode].capacity());
+    int node_set = -1;
+    auto itr = node_set_inf_.find(node->inode);
+    if (itr != node_set_inf_.end()) {
+        node_set = itr->second;
+    }
+
+    if (congested) {
+        //This connection is congested -- prune it
+        force_prune = true;
+    }
+
+    if (connections_inf.should_force_reroute_connection(node->inode)) {
+        //Forcibly re-route (e.g. to improve delay)
+        force_prune = true;
+    }
+
+    //Recursively prune children
+    bool all_children_pruned = true;
+    t_linked_rt_edge* prev_edge = nullptr;
+    t_linked_rt_edge* edge = node->u.child_list;
+    while (edge) {
+        t_rt_node* child = prune_route_tree_recurr(route_inf, edge->child,
+                                                   connections_inf, force_prune, non_config_node_set_usage);
+
+        if (!child) { //Child was pruned
+
+            //Remove the edge
+            if (edge == node->u.child_list) { //Was Head
+                node->u.child_list = edge->next;
+            } else { //Was intermediate
+                VTR_ASSERT(prev_edge);
+                prev_edge->next = edge->next;
+            }
+
+            t_linked_rt_edge* old_edge = edge;
+            edge = edge->next;
+
+            // After removing an edge, check if non_config_node_set_usage
+            // needs an update.
+            if (non_config_node_set_usage != nullptr && node_set != -1 && switch_inf_[old_edge->iswitch].configurable()) {
+                (*non_config_node_set_usage)[node_set] -= 1;
+                VTR_ASSERT((*non_config_node_set_usage)[node_set] >= 0);
+            }
+
+            rt_edges_.free(old_edge);
+
+            //Note prev_edge is unchanged
+
+        } else { //Child not pruned
+            all_children_pruned = false;
+
+            //Edge not removed
+            prev_edge = edge;
+            edge = edge->next;
+        }
+    }
+
+    if (node_inf_[node->inode].type() == SINK) {
+        if (!force_prune) {
+            //Valid path to sink
+
+            //Record sink as reachable
+            connections_inf.reached_rt_sink(node);
+
+            return node; //Not pruned
+        } else {
+            VTR_ASSERT(force_prune);
+
+            //Record as not reached
+            connections_inf.toreach_rr_sink(node->inode);
+
+            rt_nodes_.free(node);
+            return nullptr; //Pruned
+        }
+    } else if (all_children_pruned) {
+        //This node has no children
+        //
+        // This can happen in three scenarios:
+        //   1) This node is being pruned. As a result any child nodes
+        //      (subtrees) will have been pruned.
+        //
+        //   2) This node was reached by a non-configurable edge but
+        //      was otherwise unused (forming a 'stub' off the main
+        //      branch).
+        //
+        //   3) This node is uncongested, but all its connected sub-trees
+        //      have been pruned.
+        //
+        // We take the corresponding actions:
+        //   1) Prune the node.
+        //
+        //   2) Prune the node only if the node set is unused or if force_prune
+        //      is set.
+        //
+        //   3) Prune the node.
+        //
+        //      This avoid the creation of unused 'stubs'. (For example if
+        //      we left the stubs in and they were subsequently not used
+        //      they would uselessly consume routing resources).
+        VTR_ASSERT(node->u.child_list == nullptr);
+
+        bool reached_non_configurably = false;
+        if (node->parent_node) {
+            reached_non_configurably = !switch_inf_[node->parent_switch].configurable();
+
+            if (reached_non_configurably) {
+                // Check if this non-configurable node set is in use.
+                VTR_ASSERT(node_set != -1);
+                if (non_config_node_set_usage != nullptr && (*non_config_node_set_usage)[node_set] == 0) {
+                    force_prune = true;
+                }
+            }
+        }
+
+        if (reached_non_configurably && !force_prune) {
+            return node; //Not pruned
+        } else {
+            rt_nodes_.free(node);
+            return nullptr; //Pruned
+        }
+
+    } else {
+        // If this node is:
+        //   1. Part of a non-configurable node set
+        //   2. The first node in the tree that is part of the non-configurable
+        //      node set
+        //
+        //      -- and --
+        //
+        //   3. The node set is not active
+        //
+        //  Then prune this node.
+        //
+        if (non_config_node_set_usage != nullptr && node_set != -1 && switch_inf_[node->parent_switch].configurable() && (*non_config_node_set_usage)[node_set] == 0) {
+            // This node should be pruned, re-prune edges once more.
+            //
+            // If the following is true:
+            //
+            //  - The node set is unused
+            //    (e.g. (*non_config_node_set_usage)[node_set] == 0)
+            //  - This particular node still had children
+            //    (which is true by virtue of being in this else statement)
+            //
+            // Then that indicates that the node set became unused during the
+            // pruning. One or more of the children of this node will be
+            // pruned if prune_route_tree_recurr is called again, and
+            // eventually the whole node will be prunable.
+            //
+            //  Consider the following graph:
+            //
+            //  1 -> 2
+            //  2 -> 3 [non-configurable]
+            //  2 -> 4 [non-configurable]
+            //  3 -> 5
+            //  4 -> 6
+            //
+            //  Assume that nodes 5 and 6 do not connect to a sink, so they
+            //  will be pruned (as normal). When prune_route_tree_recurr
+            //  visits 2 for the first time, node 3 or 4 will remain. This is
+            //  because when prune_route_tree_recurr visits 3 or 4, it will
+            //  not have visited 4 or 3 (respectively). As a result, either
+            //  node 3 or 4 will not be pruned on the first pass, because the
+            //  node set usage count will be > 0. However after
+            //  prune_route_tree_recurr visits 2, 3 and 4, the node set usage
+            //  will be 0, so everything can be pruned.
+            return prune_route_tree_recurr(route_inf, node, connections_inf,
+                                           /*force_prune=*/false, non_config_node_set_usage);
+        }
+
+        //An unpruned intermediate node
+        VTR_ASSERT(!force_prune);
+
+        return node; //Not pruned
+    }
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+float RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::load_new_subtree_C_downstream(t_rt_node* rt_node) const {
+    float C_downstream = 0.;
+
+    if (rt_node) {
+        C_downstream += node_inf_[rt_node->inode].C();
+        for (t_linked_rt_edge* edge = rt_node->u.child_list; edge != nullptr; edge = edge->next) {
+            /*Similar to net_delay.cpp, this for loop traverses a rc subtree, whose edges represent enabled switches.
+             * When switches such as multiplexers and tristate buffers are enabled, their fanout
+             * produces an "internal capacitance". We account for this internal capacitance of the
+             * switch by adding it to the total capacitance of the node.*/
+
+            C_downstream += switch_inf_[edge->iswitch].Cinternal;
+
+            float C_downstream_child = load_new_subtree_C_downstream(edge->child);
+
+            if (!switch_inf_[edge->iswitch].buffered()) {
+                C_downstream += C_downstream_child;
+            }
+        }
+
+        rt_node->C_downstream = C_downstream;
+    }
+
+    return C_downstream;
+}
+
+template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
+void RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::load_new_subtree_R_upstream(t_rt_node* rt_node) const {
+    /* Sets the R_upstream values of all the nodes in the new path to the
+     * correct value by traversing down to SINK from the start of the new path. */
+
+    if (!rt_node) {
+        return;
+    }
+
+    t_rt_node* parent_rt_node = rt_node->parent_node;
+    int inode = rt_node->inode;
+
+    //Calculate upstream resistance
+    float R_upstream = 0.;
+    if (parent_rt_node) {
+        int iswitch = rt_node->parent_switch;
+        bool switch_buffered = switch_inf_[iswitch].buffered();
+
+        if (!switch_buffered) {
+            R_upstream += parent_rt_node->R_upstream; //Parent upstream R
+        }
+        R_upstream += switch_inf_[iswitch].R; //Parent switch R
+    }
+    R_upstream += node_inf_[inode].R(); //Current node R
+
+    rt_node->R_upstream = R_upstream;
+
+    //Update children
+    for (t_linked_rt_edge* edge = rt_node->u.child_list; edge != nullptr; edge = edge->next) {
+        load_new_subtree_R_upstream(edge->child); //Recurse
+    }
+}

--- a/vpr/src/route/route_tree_timing_obj.hpp
+++ b/vpr/src/route/route_tree_timing_obj.hpp
@@ -1,7 +1,9 @@
 #include "clustered_netlist_fwd.h"
 
 template<typename RrNodeInf, typename RrNodeSetInf, typename SwitchInf>
-t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::init_route_tree_to_source(ClusterNetId inet) {
+t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::init_route_tree_to_source(
+    const vtr::vector<ClusterNetId, std::vector<int>>& net_rr_terminals,
+    ClusterNetId inet) {
     /* Initializes the routing tree to just the net source, and returns the root
      * node of the rt_tree (which is just the net source).                       */
 
@@ -13,7 +15,7 @@ t_rt_node* RouteTreeTiming<RrNodeInf, RrNodeSetInf, SwitchInf>::init_route_tree_
     rt_root->parent_switch = OPEN;
     rt_root->re_expand = true;
 
-    int inode = net_rr_terminals_[inet][0]; /* Net source */
+    int inode = net_rr_terminals[inet][0]; /* Net source */
 
     rt_root->inode = inode;
     rt_root->C_downstream = node_inf_[inode].C();


### PR DESCRIPTION
#### Description

This PR converts the core of route tree timing to use no global data!

#### Related Issue

This is first commit for https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1018

#### Motivation and Context

See #1018

#### How Has This Been Tested?

- [x] vtr_reg_basic
- [x] vtr_reg_strong
- [ ] Titan QoR

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
