### PR TITLE
Add dynamic_bitset and convert net status to use dynamic bitset.

### DIFF
--- a/libs/libvtrutil/src/vtr_dynamic_bitset.h
+++ b/libs/libvtrutil/src/vtr_dynamic_bitset.h
@@ -1,0 +1,54 @@
+#ifndef VTR_DYNAMIC_BITSET
+#define VTR_DYNAMIC_BITSET
+
+#include <limits>
+#include <vector>
+
+namespace vtr {
+
+template<typename Storage = unsigned int>
+class dynamic_bitset {
+  public:
+    // Bits in underlying storage.
+    static constexpr size_t kWidth = std::numeric_limits<Storage>::digits;
+
+    void resize(size_t size) {
+        array_.resize((size + kWidth - 1) / kWidth);
+    }
+
+    void clear() {
+        array_.clear();
+        array_.shrink_to_fit();
+    }
+
+    size_t size() const {
+        return array_.size() * kWidth;
+    }
+
+    void fill(bool set) {
+        if (set) {
+            std::fill(array_.begin(), array_.end(), std::numeric_limits<Storage>::max());
+        } else {
+            std::fill(array_.begin(), array_.end(), 0);
+        }
+    }
+
+    void set(size_t index, bool val) {
+        if (val) {
+            array_[index / kWidth] |= (1 << (index % kWidth));
+        } else {
+            array_[index / kWidth] &= ~(1u << (index % kWidth));
+        }
+    }
+
+    bool get(size_t index) const {
+        return (array_[index / kWidth] & (1u << (index % kWidth))) != 0;
+    }
+
+  private:
+    std::vector<Storage> array_;
+};
+
+} // namespace vtr
+
+#endif /* VTR_DYNAMIC_BITSET */

--- a/libs/libvtrutil/src/vtr_dynamic_bitset.h
+++ b/libs/libvtrutil/src/vtr_dynamic_bitset.h
@@ -6,11 +6,15 @@
 
 namespace vtr {
 
-template<typename Storage = unsigned int>
+template<typename Index = size_t, typename Storage = unsigned int>
 class dynamic_bitset {
   public:
     // Bits in underlying storage.
     static constexpr size_t kWidth = std::numeric_limits<Storage>::digits;
+    static_assert(!std::numeric_limits<Storage>::is_signed,
+                  "dynamic_bitset storage must be unsigned!");
+    static_assert(std::numeric_limits<Storage>::is_integer,
+                  "dynamic_bitset storage must be integer!");
 
     void resize(size_t size) {
         array_.resize((size + kWidth - 1) / kWidth);
@@ -33,16 +37,20 @@ class dynamic_bitset {
         }
     }
 
-    void set(size_t index, bool val) {
+    void set(Index index, bool val) {
+        size_t index_value(index);
+        VTR_ASSERT_SAFE(index_value < size());
         if (val) {
-            array_[index / kWidth] |= (1 << (index % kWidth));
+            array_[index_value / kWidth] |= (1 << (index_value % kWidth));
         } else {
-            array_[index / kWidth] &= ~(1u << (index % kWidth));
+            array_[index_value / kWidth] &= ~(1u << (index_value % kWidth));
         }
     }
 
-    bool get(size_t index) const {
-        return (array_[index / kWidth] & (1u << (index % kWidth))) != 0;
+    bool get(Index index) const {
+        size_t index_value(index);
+        VTR_ASSERT_SAFE(index_value < size());
+        return (array_[index_value / kWidth] & (1u << (index_value % kWidth))) != 0;
     }
 
   private:

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -291,7 +291,7 @@ struct RoutingContext : public Context {
     std::vector<t_rr_node_route_inf> rr_node_route_inf; /* [0..device_ctx.num_rr_nodes-1] */
 
     //Information about current routing status of each net
-    vtr::vector<ClusterNetId, t_net_routing_status> net_status; //[0..cluster_ctx.clb_nlist.nets().size()-1]
+    t_net_routing_status net_status;
 
     //Limits area within which each net must be routed.
     vtr::vector<ClusterNetId, t_bb> route_bb; /* [0..cluster_ctx.clb_nlist.nets().size()-1]*/

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1251,14 +1251,12 @@ class t_net_routing_status {
     }
 
   private:
-    size_t index(ClusterNetId net) const {
+    ClusterNetId index(ClusterNetId net) const {
         VTR_ASSERT_SAFE(net != ClusterNetId::INVALID());
-        size_t index = size_t(net);
-        VTR_ASSERT_SAFE(index < is_routed_.size());
-        return index;
+        return net;
     }
-    vtr::dynamic_bitset<> is_routed_; //Whether the net has been legally routed
-    vtr::dynamic_bitset<> is_fixed_;  //Whether the net is fixed (i.e. not to be re-routed)
+    vtr::dynamic_bitset<ClusterNetId> is_routed_; //Whether the net has been legally routed
+    vtr::dynamic_bitset<ClusterNetId> is_fixed_;  //Whether the net is fixed (i.e. not to be re-routed)
 };
 
 struct t_node_edge {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1251,7 +1251,7 @@ class t_net_routing_status {
     }
 
   private:
-    static size_t index(ClusterNetId net) {
+    size_t index(ClusterNetId net) const {
         VTR_ASSERT_SAFE(net != ClusterNetId::INVALID());
         size_t index = size_t(net);
         VTR_ASSERT_SAFE(index < is_routed_.size());

--- a/vpr/src/route/route_breadth_first.cpp
+++ b/vpr/src/route/route_breadth_first.cpp
@@ -70,8 +70,8 @@ bool try_breadth_first_route(const t_router_opts& router_opts) {
 
         /* Reset "is_routed" and "is_fixed" flags to indicate nets not pre-routed (yet) */
         for (auto net_id : cluster_ctx.clb_nlist.nets()) {
-            route_ctx.net_status[net_id].is_routed = false;
-            route_ctx.net_status[net_id].is_fixed = false;
+            route_ctx.net_status.set_is_routed(net_id, false);
+            route_ctx.net_status.set_is_fixed(net_id, false);
         }
 
         for (auto net_id : cluster_ctx.clb_nlist.nets()) {
@@ -122,7 +122,7 @@ bool try_breadth_first_route_net(BinaryHeap& heap, ClusterNetId net_id, float pr
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
-    if (route_ctx.net_status[net_id].is_fixed) { /* Skip pre-routed nets. */
+    if (route_ctx.net_status.is_fixed(net_id)) { /* Skip pre-routed nets. */
         is_routed = true;
 
     } else if (cluster_ctx.clb_nlist.net_is_ignored(net_id)) { /* Skip ignored nets. */
@@ -134,7 +134,7 @@ bool try_breadth_first_route_net(BinaryHeap& heap, ClusterNetId net_id, float pr
 
         /* Impossible to route? (disconnected rr_graph) */
         if (is_routed) {
-            route_ctx.net_status[net_id].is_routed = false;
+            route_ctx.net_status.set_is_routed(net_id, false);
         } else {
             VTR_LOG("Routing failed.\n");
         }

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -385,8 +385,8 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
 
         /* Reset "is_routed" and "is_fixed" flags to indicate nets not pre-routed (yet) */
         for (auto net_id : cluster_ctx.clb_nlist.nets()) {
-            route_ctx.net_status[net_id].is_routed = false;
-            route_ctx.net_status[net_id].is_fixed = false;
+            route_ctx.net_status.set_is_routed(net_id, false);
+            route_ctx.net_status.set_is_fixed(net_id, false);
         }
 
         if (itry_since_last_convergence >= 0) {
@@ -744,7 +744,7 @@ bool try_timing_driven_route_net(ConnectionRouter& router,
 
     connections_inf.prepare_routing_for_net(net_id);
 
-    if (route_ctx.net_status[net_id].is_fixed) { /* Skip pre-routed nets. */
+    if (route_ctx.net_status.is_fixed(net_id)) { /* Skip pre-routed nets. */
         is_routed = true;
     } else if (cluster_ctx.clb_nlist.net_is_ignored(net_id)) { /* Skip ignored nets. */
         is_routed = true;
@@ -772,7 +772,7 @@ bool try_timing_driven_route_net(ConnectionRouter& router,
 
         /* Impossible to route? (disconnected rr_graph) */
         if (is_routed) {
-            route_ctx.net_status[net_id].is_routed = true;
+            route_ctx.net_status.set_is_routed(net_id, true);
         } else {
             VTR_LOG("Routing failed.\n");
         }


### PR DESCRIPTION
#### Description

I'm converting the `vtr:vector<ClusterNetId, t_net_routing_status>` to just an `t_net_routing_status` object.  The backing store is now a bitset instead of vector to lower the memory requirement for `t_net_routing_status` and put clearer boundries on when `t_net_routing_status` is updated.

Follow up PR will more `t_net_routing_status` and other mutable state out of raw RoutingContext into a set of dedicated objects for tracking router state per #1018 

#### Related Issue

#1018

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
