### PR TITLE
Add some bounding box methods to vtr::Rect with unit tests

### DIFF
--- a/libs/libvtrutil/src/vtr_geometry.h
+++ b/libs/libvtrutil/src/vtr_geometry.h
@@ -75,9 +75,10 @@ class Point {
 template<class T>
 class Rect {
   public: //Constructors
+    Rect();
     Rect(T left_val, T bottom_val, T right_val, T top_val);
     Rect(Point<T> bottom_left_val, Point<T> top_right_val);
-    Rect();
+    Rect(Point<T> bottom_left_val, T size);
 
   public: //Accessors
     //Co-ordinates
@@ -101,8 +102,16 @@ class Rect {
     //Returns true if the point is coincident with the rectangle (including the top-right edges)
     bool coincident(Point<T> point) const;
 
+    //Returns true if no points are contained in the rectangle
+    bool empty() const;
+
     friend bool operator== <>(const Rect<T>& lhs, const Rect<T>& rhs);
     friend bool operator!= <>(const Rect<T>& lhs, const Rect<T>& rhs);
+
+    template<class U>
+    friend Rect<U> operator|(const Rect<U>& lhs, const Rect<U>& rhs);
+    template<class U>
+    friend Rect<U>& operator|=(Rect<U>& lhs, const Rect<U>& rhs);
 
   public: //Mutators
     //Co-ordinates

--- a/libs/libvtrutil/src/vtr_geometry.h
+++ b/libs/libvtrutil/src/vtr_geometry.h
@@ -1,6 +1,7 @@
 #ifndef VTR_GEOMETRY_H
 #define VTR_GEOMETRY_H
 #include "vtr_range.h"
+#include "vtr_assert.h"
 
 #include <vector>
 #include <tuple>
@@ -117,11 +118,6 @@ class Rect {
     friend bool operator== <>(const Rect<T>& lhs, const Rect<T>& rhs);
     friend bool operator!= <>(const Rect<T>& lhs, const Rect<T>& rhs);
 
-    //Return the smallest rectangle containing both given rectangles
-    //Note that this isn't a union and the resulting rectangle may include points not in either given rectangle
-    template<class U>
-    friend Rect<U> bounding_box(const Rect<U>& lhs, const Rect<U>& rhs);
-
   public: //Mutators
     //Co-ordinates
     void set_xmin(T xmin_val);
@@ -136,6 +132,19 @@ class Rect {
     Point<T> bottom_left_;
     Point<T> top_right_;
 };
+
+//Return the smallest rectangle containing both given rectangles
+//Note that this isn't a union and the resulting rectangle may include points not in either given rectangle
+template<class T>
+Rect<T> bounding_box(const Rect<T>& lhs, const Rect<T>& rhs);
+
+//Sample on a uniformly spaced grid within a rectangle
+//  sample(vtr::Rect(l, h), 0, 0, M) == l
+//  sample(vtr::Rect(l, h), M, M, M) == h
+//To avoid the edges, use `sample(r, x+1, y+1, N+1) for x, y, in 0..N-1
+//Only defined for integral types
+template<typename T, typename std::enable_if<std::is_integral<T>::value>::type...>
+Point<T> sample(const vtr::Rect<T>& r, T x, T y, T d);
 
 //A 2D line
 template<class T>

--- a/libs/libvtrutil/src/vtr_geometry.tpp
+++ b/libs/libvtrutil/src/vtr_geometry.tpp
@@ -81,10 +81,11 @@ Rect<T>::Rect(Point<T> bottom_left_val, Point<T> top_right_val)
 }
 
 template<class T>
-Rect<T>::Rect(Point<T> bottom_left_val, T size)
-    : bottom_left_(bottom_left_val)
-    , top_right_(bottom_left_val.x() + size,
-                 bottom_left_val.y() + size) {
+template<typename U, typename std::enable_if<std::is_integral<U>::value>::type...>
+Rect<T>::Rect(Point<U> point)
+    : bottom_left_(point)
+    , top_right_(point.x() + 1,
+                 point.y() + 1) {
     //pass
 }
 
@@ -166,6 +167,14 @@ bool operator!=(const Rect<T>& lhs, const Rect<T>& rhs) {
 }
 
 template<class T>
+Rect<T> bounding_box(const Rect<T>& lhs, const Rect<T>& rhs) {
+    return Rect<T>(std::min(lhs.xmin(), rhs.xmin()),
+                   std::min(lhs.ymin(), rhs.ymin()),
+                   std::max(lhs.xmax(), rhs.xmax()),
+                   std::max(lhs.ymax(), rhs.ymax()));
+}
+
+template<class T>
 void Rect<T>::set_xmin(T xmin_val) {
     bottom_left_.set_x(xmin_val);
 }
@@ -186,16 +195,9 @@ void Rect<T>::set_ymax(T ymax_val) {
 }
 
 template<class T>
-Rect<T> operator|(const Rect<T>& lhs, const Rect<T>& rhs) {
-    return Rect<T>(std::min(lhs.xmin(), rhs.xmin()),
-                   std::min(lhs.ymin(), rhs.ymin()),
-                   std::max(lhs.xmax(), rhs.xmax()),
-                   std::max(lhs.ymax(), rhs.ymax()));
-}
-
-template<class T>
-Rect<T>& operator|=(Rect<T>& lhs, const Rect<T>& rhs) {
-    return lhs = lhs | rhs;
+Rect<T>& Rect<T>::expand_bounding_box(const Rect<T>& other) {
+    *this = bounding_box(*this, other);
+    return *this;
 }
 
 /*

--- a/libs/libvtrutil/src/vtr_geometry.tpp
+++ b/libs/libvtrutil/src/vtr_geometry.tpp
@@ -80,6 +80,7 @@ Rect<T>::Rect(Point<T> bottom_left_val, Point<T> top_right_val)
     //pass
 }
 
+//Only defined for integral types
 template<class T>
 template<typename U, typename std::enable_if<std::is_integral<U>::value>::type...>
 Rect<T>::Rect(Point<U> point)
@@ -174,6 +175,7 @@ Rect<T> bounding_box(const Rect<T>& lhs, const Rect<T>& rhs) {
                    std::max(lhs.ymax(), rhs.ymax()));
 }
 
+//Only defined for integral types
 template<typename T, typename std::enable_if<std::is_integral<T>::value>::type...>
 Point<T> sample(const vtr::Rect<T>& r, T x, T y, T d) {
     VTR_ASSERT(d > 0 && x <= d && y <= d && !r.empty());

--- a/libs/libvtrutil/src/vtr_geometry.tpp
+++ b/libs/libvtrutil/src/vtr_geometry.tpp
@@ -62,6 +62,12 @@ void Point<T>::swap() {
  * Rect
  */
 template<class T>
+Rect<T>::Rect()
+    : Rect<T>(Point<T>(0, 0), Point<T>(0, 0)) {
+    //pass
+}
+
+template<class T>
 Rect<T>::Rect(T left_val, T bottom_val, T right_val, T top_val)
     : Rect<T>(Point<T>(left_val, bottom_val), Point<T>(right_val, top_val)) {
     //pass
@@ -71,6 +77,14 @@ template<class T>
 Rect<T>::Rect(Point<T> bottom_left_val, Point<T> top_right_val)
     : bottom_left_(bottom_left_val)
     , top_right_(top_right_val) {
+    //pass
+}
+
+template<class T>
+Rect<T>::Rect(Point<T> bottom_left_val, T size)
+    : bottom_left_(bottom_left_val)
+    , top_right_(bottom_left_val.x() + size,
+                 bottom_left_val.y() + size) {
     //pass
 }
 
@@ -136,6 +150,11 @@ bool Rect<T>::coincident(Point<T> point) const {
 }
 
 template<class T>
+bool Rect<T>::empty() const {
+    return xmax() <= xmin() || ymax() <= ymin();
+}
+
+template<class T>
 bool operator==(const Rect<T>& lhs, const Rect<T>& rhs) {
     return lhs.bottom_left() == rhs.bottom_left()
            && lhs.top_right() == rhs.top_right();
@@ -164,6 +183,19 @@ void Rect<T>::set_xmax(T xmax_val) {
 template<class T>
 void Rect<T>::set_ymax(T ymax_val) {
     top_right_.set_y(ymax_val);
+}
+
+template<class T>
+Rect<T> operator|(const Rect<T>& lhs, const Rect<T>& rhs) {
+    return Rect<T>(std::min(lhs.xmin(), rhs.xmin()),
+                   std::min(lhs.ymin(), rhs.ymin()),
+                   std::max(lhs.xmax(), rhs.xmax()),
+                   std::max(lhs.ymax(), rhs.ymax()));
+}
+
+template<class T>
+Rect<T>& operator|=(Rect<T>& lhs, const Rect<T>& rhs) {
+    return lhs = lhs | rhs;
 }
 
 /*

--- a/libs/libvtrutil/src/vtr_geometry.tpp
+++ b/libs/libvtrutil/src/vtr_geometry.tpp
@@ -174,6 +174,13 @@ Rect<T> bounding_box(const Rect<T>& lhs, const Rect<T>& rhs) {
                    std::max(lhs.ymax(), rhs.ymax()));
 }
 
+template<typename T, typename std::enable_if<std::is_integral<T>::value>::type...>
+Point<T> sample(const vtr::Rect<T>& r, T x, T y, T d) {
+    VTR_ASSERT(d > 0 && x <= d && y <= d && !r.empty());
+    return Point<T>((r.xmin() * (d - x) + r.xmax() * x + d / 2) / d,
+                    (r.ymin() * (d - y) + r.ymax() * y + d / 2) / d);
+}
+
 template<class T>
 void Rect<T>::set_xmin(T xmin_val) {
     bottom_left_.set_x(xmin_val);

--- a/libs/libvtrutil/test/test_geometry.cpp
+++ b/libs/libvtrutil/test/test_geometry.cpp
@@ -20,108 +20,128 @@ TEST_CASE("Point", "[vtr_geometry/Point]") {
 }
 
 TEST_CASE("Rect", "[vtr_geometry/Rect]") {
-    vtr::Point<int> pi_1(5, 3);
-    vtr::Point<int> pi_2(10, 11);
+    // int tests
+    {
+        vtr::Point<int> pi_1(5, 3);
+        vtr::Point<int> pi_2(10, 11);
+        vtr::Point<int> pi_3(7, 9);
 
-    vtr::Rect<int> r1(pi_1.x(), pi_1.y(), pi_2.x(), pi_2.y());
-    vtr::Rect<int> r2(pi_1, pi_2);
+        vtr::Rect<int> r1(pi_1.x(), pi_1.y(), pi_2.x(), pi_2.y());
+        vtr::Rect<int> r2(pi_1, pi_2);
+        vtr::Rect<int> r3(pi_1, pi_3);
+        vtr::Rect<int> r4(pi_3, pi_2);
 
-    SECTION("equality") {
-        REQUIRE(r1 == r2);
+        SECTION("equality") {
+            REQUIRE(r1 == r2);
+        }
+
+        SECTION("location") {
+            REQUIRE(r1.xmin() == pi_1.x());
+            REQUIRE(r1.xmax() == pi_2.x());
+            REQUIRE(r1.ymin() == pi_1.y());
+            REQUIRE(r1.ymax() == pi_2.y());
+        }
+
+        SECTION("point_accessors") {
+            REQUIRE(r1.bottom_left() == pi_1);
+            REQUIRE(r1.top_right() == pi_2);
+            REQUIRE(r2.bottom_left() == pi_1);
+            REQUIRE(r2.top_right() == pi_2);
+        }
+
+        SECTION("dimensions") {
+            REQUIRE(r1.width() == 5);
+            REQUIRE(r1.height() == 8);
+            REQUIRE(r2.width() == 5);
+            REQUIRE(r2.height() == 8);
+        }
+
+        SECTION("contains_int") {
+            REQUIRE(r2.contains(pi_1));
+            REQUIRE(r2.contains({6, 4}));
+            REQUIRE_FALSE(r2.contains({100, 4}));
+            REQUIRE_FALSE(r2.contains(pi_2));
+        }
+
+        SECTION("strictly_contains_int") {
+            REQUIRE_FALSE(r2.strictly_contains(pi_1));
+            REQUIRE(r2.strictly_contains({6, 4}));
+            REQUIRE_FALSE(r2.strictly_contains({100, 4}));
+            REQUIRE_FALSE(r2.strictly_contains(pi_2));
+        }
+
+        SECTION("coincident_int") {
+            REQUIRE(r2.coincident(pi_1));
+            REQUIRE(r2.coincident({6, 4}));
+            REQUIRE_FALSE(r2.coincident({100, 4}));
+            REQUIRE(r2.coincident(pi_2));
+        }
+
+        SECTION("bounds_int") {
+            REQUIRE(r1 == (r3 | r4));
+        }
     }
 
-    SECTION("location") {
-        REQUIRE(r1.xmin() == pi_1.x());
-        REQUIRE(r1.xmax() == pi_2.x());
-        REQUIRE(r1.ymin() == pi_1.y());
-        REQUIRE(r1.ymax() == pi_2.y());
-    }
+    // float tests
+    {
+        vtr::Point<float> pf_1(5.3, 3.9);
+        vtr::Point<float> pf_2(10.5, 11.1);
+        vtr::Point<float> pf_3(7.2, 9.4);
 
-    SECTION("point_accessors") {
-        REQUIRE(r1.bottom_left() == pi_1);
-        REQUIRE(r1.top_right() == pi_2);
-        REQUIRE(r2.bottom_left() == pi_1);
-        REQUIRE(r2.top_right() == pi_2);
-    }
+        vtr::Rect<float> r3(pf_1.x(), pf_1.y(), pf_2.x(), pf_2.y());
+        vtr::Rect<float> r4(pf_1, pf_2);
+        vtr::Rect<float> r5(pf_1, pf_3);
+        vtr::Rect<float> r6(pf_3, pf_2);
 
-    SECTION("dimensions") {
-        REQUIRE(r1.width() == 5);
-        REQUIRE(r1.height() == 8);
-        REQUIRE(r2.width() == 5);
-        REQUIRE(r2.height() == 8);
-    }
+        SECTION("equality_float") {
+            REQUIRE(r3 == r4);
+        }
 
-    SECTION("contains_int") {
-        REQUIRE(r2.contains(pi_1));
-        REQUIRE(r2.contains({6, 4}));
-        REQUIRE_FALSE(r2.contains({100, 4}));
-        REQUIRE_FALSE(r2.contains(pi_2));
-    }
+        SECTION("location_float") {
+            REQUIRE(r3.xmin() == pf_1.x());
+            REQUIRE(r3.xmax() == pf_2.x());
+            REQUIRE(r3.ymin() == pf_1.y());
+            REQUIRE(r3.ymax() == pf_2.y());
+        }
 
-    SECTION("strictly_contains_int") {
-        REQUIRE_FALSE(r2.strictly_contains(pi_1));
-        REQUIRE(r2.strictly_contains({6, 4}));
-        REQUIRE_FALSE(r2.strictly_contains({100, 4}));
-        REQUIRE_FALSE(r2.strictly_contains(pi_2));
-    }
+        SECTION("point_accessors_float") {
+            REQUIRE(r3.bottom_left() == pf_1);
+            REQUIRE(r3.top_right() == pf_2);
+            REQUIRE(r4.bottom_left() == pf_1);
+            REQUIRE(r4.top_right() == pf_2);
+        }
 
-    SECTION("coincident_int") {
-        REQUIRE(r2.coincident(pi_1));
-        REQUIRE(r2.coincident({6, 4}));
-        REQUIRE_FALSE(r2.coincident({100, 4}));
-        REQUIRE(r2.coincident(pi_2));
-    }
+        SECTION("dimensions") {
+            REQUIRE(r3.width() == Approx(5.2));
+            REQUIRE(r3.height() == Approx(7.2));
+            REQUIRE(r4.width() == Approx(5.2));
+            REQUIRE(r4.height() == Approx(7.2));
+        }
 
-    vtr::Point<float> pf_1(5.3, 3.9);
-    vtr::Point<float> pf_2(10.5, 11.1);
+        SECTION("contains_float") {
+            REQUIRE(r4.contains(pf_1));
+            REQUIRE(r4.contains({6, 4}));
+            REQUIRE_FALSE(r4.contains({100, 4}));
+            REQUIRE_FALSE(r4.contains(pf_2));
+        }
 
-    vtr::Rect<float> r3(pf_1.x(), pf_1.y(), pf_2.x(), pf_2.y());
-    vtr::Rect<float> r4(pf_1, pf_2);
+        SECTION("strictly_contains_float") {
+            REQUIRE_FALSE(r4.strictly_contains(pf_1));
+            REQUIRE(r4.strictly_contains({6, 4}));
+            REQUIRE_FALSE(r4.strictly_contains({100, 4}));
+            REQUIRE_FALSE(r4.strictly_contains(pf_2));
+        }
 
-    SECTION("equality_float") {
-        REQUIRE(r3 == r4);
-    }
+        SECTION("coincident_float") {
+            REQUIRE(r4.coincident(pf_1));
+            REQUIRE(r4.coincident({6, 4}));
+            REQUIRE_FALSE(r4.coincident({100, 4}));
+            REQUIRE(r4.coincident(pf_2));
+        }
 
-    SECTION("location_float") {
-        REQUIRE(r3.xmin() == pf_1.x());
-        REQUIRE(r3.xmax() == pf_2.x());
-        REQUIRE(r3.ymin() == pf_1.y());
-        REQUIRE(r3.ymax() == pf_2.y());
-    }
-
-    SECTION("point_accessors_float") {
-        REQUIRE(r3.bottom_left() == pf_1);
-        REQUIRE(r3.top_right() == pf_2);
-        REQUIRE(r4.bottom_left() == pf_1);
-        REQUIRE(r4.top_right() == pf_2);
-    }
-
-    SECTION("dimensions") {
-        REQUIRE(r3.width() == Approx(5.2));
-        REQUIRE(r3.height() == Approx(7.2));
-        REQUIRE(r4.width() == Approx(5.2));
-        REQUIRE(r4.height() == Approx(7.2));
-    }
-
-    SECTION("contains_float") {
-        REQUIRE(r4.contains(pf_1));
-        REQUIRE(r4.contains({6, 4}));
-        REQUIRE_FALSE(r4.contains({100, 4}));
-        REQUIRE_FALSE(r4.contains(pf_2));
-    }
-
-    SECTION("strictly_contains_float") {
-        REQUIRE_FALSE(r4.strictly_contains(pf_1));
-        REQUIRE(r4.strictly_contains({6, 4}));
-        REQUIRE_FALSE(r4.strictly_contains({100, 4}));
-        REQUIRE_FALSE(r4.strictly_contains(pf_2));
-    }
-
-    SECTION("coincident_float") {
-        REQUIRE(r4.coincident(pf_1));
-        REQUIRE(r4.coincident({6, 4}));
-        REQUIRE_FALSE(r4.coincident({100, 4}));
-        REQUIRE(r4.coincident(pf_2));
+        SECTION("bounds_float") {
+            REQUIRE(r3 == (r5 | r6));
+        }
     }
 }
 

--- a/libs/libvtrutil/test/test_geometry.cpp
+++ b/libs/libvtrutil/test/test_geometry.cpp
@@ -85,6 +85,14 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
         SECTION("empty_int") {
             REQUIRE(vtr::Rect<int>().empty());
         }
+
+        SECTION("sample_int") {
+            auto r = vtr::Rect<int>(pi_1, pi_2);
+            REQUIRE(sample(r, 0, 0, 17) == pi_1);
+            REQUIRE(sample(r, 17, 17, 17) == pi_2);
+            auto inside = sample(r, 3, 11, 17);
+            REQUIRE(r.contains(inside));
+        }
     }
 
     // float tests

--- a/libs/libvtrutil/test/test_geometry.cpp
+++ b/libs/libvtrutil/test/test_geometry.cpp
@@ -61,6 +61,7 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
             REQUIRE(r2.contains({6, 4}));
             REQUIRE_FALSE(r2.contains({100, 4}));
             REQUIRE_FALSE(r2.contains(pi_2));
+            REQUIRE(vtr::Rect<int>(pi_1).contains(pi_1));
         }
 
         SECTION("strictly_contains_int") {
@@ -78,7 +79,7 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
         }
 
         SECTION("bounds_int") {
-            REQUIRE(r1 == (r3 | r4));
+            REQUIRE(r1 == bounding_box(r3, r4));
         }
     }
 
@@ -92,6 +93,7 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
         vtr::Rect<float> r4(pf_1, pf_2);
         vtr::Rect<float> r5(pf_1, pf_3);
         vtr::Rect<float> r6(pf_3, pf_2);
+        // vtr::Rect<float> r7(pf_1); // <-- will fail to compile
 
         SECTION("equality_float") {
             REQUIRE(r3 == r4);
@@ -140,7 +142,7 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
         }
 
         SECTION("bounds_float") {
-            REQUIRE(r3 == (r5 | r6));
+            REQUIRE(r3 == bounding_box(r5, r6));
         }
     }
 }

--- a/libs/libvtrutil/test/test_geometry.cpp
+++ b/libs/libvtrutil/test/test_geometry.cpp
@@ -81,6 +81,10 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
         SECTION("bounds_int") {
             REQUIRE(r1 == bounding_box(r3, r4));
         }
+
+        SECTION("empty_int") {
+            REQUIRE(vtr::Rect<int>().empty());
+        }
     }
 
     // float tests
@@ -143,6 +147,10 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
 
         SECTION("bounds_float") {
             REQUIRE(r3 == bounding_box(r5, r6));
+        }
+
+        SECTION("empty_float") {
+            REQUIRE(vtr::Rect<float>().empty());
         }
     }
 }

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1628,7 +1628,7 @@ static void timing_driven_expand_cheapest(t_heap* cheapest,
                                         target_node,
                                         router_stats);
     } else {
-        //Post-heap prune, do not re-explore from the current/new partial path as it 
+        //Post-heap prune, do not re-explore from the current/new partial path as it
         //has worse cost than the best partial path to this node found so far
         VTR_LOGV_DEBUG(f_router_debug, "    Worse cost to %d\n", inode);
         VTR_LOGV_DEBUG(f_router_debug, "    Old total cost: %g\n", best_total_cost);


### PR DESCRIPTION
Add some bounding box methods to vtr::Rect with unit tests.

#### Description
Adds a couple of useful constructors, `empty()` and `bounding_box` and `expand_bounding_box` to compute bounding rectangles.

#### Motivation and Context
I added a bounding box class while working on the connection box based lookahead, and vtr::Rect had most of what I implemented in the new class, so this allows me to use vtr::Rect instead.

#### How Has This Been Tested?
I've added unit tests.

#### Types of changes
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
