### PR TITLE
Make it easier to use GDB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,16 @@ else()
 endif()
 
 #
+# Build type flags
+#
+
+if(NOT MSVC)
+    # for GCC and Clang
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -g3")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g3")
+endif()
+
+#
 # Warning flags
 #
 set(WARN_FLAGS "") #The actual warning flags to be applied


### PR DESCRIPTION
Turn off optimization and add debug flags for the "debug" build type.

This avoids the dreaded `<value optimized out>` in GDB.