### PR TITLE
docs: Rework the readme file in the vtr_flow directory.

### DIFF
--- a/vtr_flow/README.md
+++ b/vtr_flow/README.md
@@ -1,0 +1,7 @@
+# VTR Flow
+
+This folder contains architecture files, benchmark circuits and scripts for running the VTR flow.
+
+For a description see the ['Running the VTR Flow' documentation at https://docs.verilogtorouting.org](https://docs.verilogtorouting.org/en/latest/vtr/running_vtr/),
+or the [`run_vtr_flow.rst` file](../doc/src/vtr/run_vtr_flow.rst) in the [`doc` folder](../doc)
+in the [root of the VTR source tree](https://github.com/SymbiFlow/vtr-verilog-to-routing).

--- a/vtr_flow/Readme.txt
+++ b/vtr_flow/Readme.txt
@@ -1,3 +1,0 @@
-This folder contains architecture files, benchmark circuits and scripts for running the VTR flow.
-
-For a description see the 'Running the VTR Flow' documentation at https://docs.verilogtorouting.org, or the 'docs' folder in the root of the VTR source tree.


### PR DESCRIPTION
 * Convert the file to markdown.
 * Actually link to the "running the vtr flow" docs.

See what this looks like at https://github.com/mithro/vtr-verilog-to-routing/tree/vtr-flow-readme-fix/vtr_flow or click the "Display Rich Diff" button (the paper looking one near the `<>` button).