### PR TITLE
Clear cache of critical path and sTNS/sWNS.

### DIFF
--- a/vpr/src/timing/concrete_timing_info.h
+++ b/vpr/src/timing/concrete_timing_info.h
@@ -97,12 +97,6 @@ class ConcreteSetupTimingInfo : public SetupTimingInfo {
         if (warn_unconstrained_) {
             warn_unconstrained(analyzer());
         }
-
-        //Reset cached values to invalid (calculated lazily in accessors)
-        sTNS_ = std::numeric_limits<float>::quiet_NaN();
-        sWNS_ = std::numeric_limits<float>::quiet_NaN();
-        least_slack_critical_path_ = tatum::TimingPathInfo();
-        longest_critical_path_ = tatum::TimingPathInfo();
     }
 
     void update_setup() override {
@@ -130,9 +124,12 @@ class ConcreteSetupTimingInfo : public SetupTimingInfo {
         timing_ctx.stats.sta_wallclock_time += sta_wallclock_time;
         timing_ctx.stats.slack_wallclock_time += slack_wallclock_time;
         timing_ctx.stats.num_full_setup_updates += 1;
+
+        clear_cache();
     }
 
     void update_setup_slacks() {
+        clear_cache();
         slack_crit_.update_slacks_and_criticalities(*timing_graph_, *setup_analyzer_);
     }
 
@@ -157,6 +154,14 @@ class ConcreteSetupTimingInfo : public SetupTimingInfo {
 
     typedef std::chrono::duration<double> dsec;
     typedef std::chrono::high_resolution_clock Clock;
+
+    //Reset cached values to invalid (calculated lazily in accessors)
+    void clear_cache() {
+        sTNS_ = std::numeric_limits<float>::quiet_NaN();
+        sWNS_ = std::numeric_limits<float>::quiet_NaN();
+        least_slack_critical_path_ = tatum::TimingPathInfo();
+        longest_critical_path_ = tatum::TimingPathInfo();
+    }
 };
 
 template<class DelayCalc>


### PR DESCRIPTION
#### Description

Previous code was only clearing caching in one of 3 relevant places.

#### Related Issue

#1036 

#### Motivation and Context

Caching code introduced in https://github.com/verilog-to-routing/vtr-verilog-to-routing/commit/485697eacfdea46ebf4efdb727866e0b522e186f did not clear the cache in all paths, resulting in the router iteration display showing stale data.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
