### PR TITLE
Add missing C_internal to is_valid_route_tree.

### DIFF
--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -1370,6 +1370,8 @@ bool is_valid_route_tree(const t_rt_node* root) {
             return false;
         }
 
+        C_downstream_children += device_ctx.rr_switch_inf[edge->iswitch].Cinternal;
+
         if (!device_ctx.rr_switch_inf[edge->iswitch].buffered()) {
             C_downstream_children += edge->child->C_downstream;
         }


### PR DESCRIPTION
#### Description

I believe when C_internal support was added, VPR was not tested at `-DVTR_ASSERT_LEVEL=3`, and as a result it was not noticed that `is_valid_route_tree` was failing.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

Assertion violation on 7-series tests when running at `-DVTR_ASSERT_LEVEL=3`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
