### PR TITLE
Coverity Fix for unchecked dynamic cast in setup_clocks

### DIFF
--- a/vpr/src/base/setup_clocks.cpp
+++ b/vpr/src/base/setup_clocks.cpp
@@ -129,50 +129,50 @@ void setup_clock_connections(const t_arch& Arch) {
     for (auto clock_connection_arch : clock_connections_arch) {
         if (clock_connection_arch.from == "ROUTING") {
             clock_connections_device.emplace_back(new RoutingToClockConnection);
-            RoutingToClockConnection* routing_to_clock = dynamic_cast<RoutingToClockConnection*>(clock_connections_device.back().get());
+            if (RoutingToClockConnection* routing_to_clock = dynamic_cast<RoutingToClockConnection*>(clock_connections_device.back().get())) {
+                //TODO: Add error check to check that clock name and tap name exist and that only
+                //      two names are returned by the below function
+                auto names = vtr::split(clock_connection_arch.to, ".");
+                VTR_ASSERT_MSG(names.size() == 2, "Invalid clock name.\n");
+                routing_to_clock->set_clock_name_to_connect_to(names[0]);
+                routing_to_clock->set_clock_switch_point_name(names[1]);
 
-            //TODO: Add error check to check that clock name and tap name exist and that only
-            //      two names are returned by the below function
-            auto names = vtr::split(clock_connection_arch.to, ".");
-            VTR_ASSERT_MSG(names.size() == 2, "Invalid clock name.\n");
-            routing_to_clock->set_clock_name_to_connect_to(names[0]);
-            routing_to_clock->set_clock_switch_point_name(names[1]);
-
-            routing_to_clock->set_switch_location(
-                parse_formula(clock_connection_arch.locationx, vars),
-                parse_formula(clock_connection_arch.locationy, vars));
-            routing_to_clock->set_switch(clock_connection_arch.arch_switch_idx);
-            routing_to_clock->set_fc_val(clock_connection_arch.fc);
+                routing_to_clock->set_switch_location(
+                    parse_formula(clock_connection_arch.locationx, vars),
+                    parse_formula(clock_connection_arch.locationy, vars));
+                routing_to_clock->set_switch(clock_connection_arch.arch_switch_idx);
+                routing_to_clock->set_fc_val(clock_connection_arch.fc);
+            }
 
         } else if (clock_connection_arch.to == "CLOCK") {
             clock_connections_device.emplace_back(new ClockToPinsConnection);
-            ClockToPinsConnection* clock_to_pins = dynamic_cast<ClockToPinsConnection*>(clock_connections_device.back().get());
+            if (ClockToPinsConnection* clock_to_pins = dynamic_cast<ClockToPinsConnection*>(clock_connections_device.back().get())) {
+                //TODO: Add error check to check that clock name and tap name exist and that only
+                //      two names are returned by the below function
+                auto names = vtr::split(clock_connection_arch.from, ".");
+                VTR_ASSERT_MSG(names.size() == 2, "Invalid clock name.\n");
+                clock_to_pins->set_clock_name_to_connect_from(names[0]);
+                clock_to_pins->set_clock_switch_point_name(names[1]);
 
-            //TODO: Add error check to check that clock name and tap name exist and that only
-            //      two names are returned by the below function
-            auto names = vtr::split(clock_connection_arch.from, ".");
-            VTR_ASSERT_MSG(names.size() == 2, "Invalid clock name.\n");
-            clock_to_pins->set_clock_name_to_connect_from(names[0]);
-            clock_to_pins->set_clock_switch_point_name(names[1]);
-
-            clock_to_pins->set_switch(clock_connection_arch.arch_switch_idx);
-            clock_to_pins->set_fc_val(clock_connection_arch.fc);
+                clock_to_pins->set_switch(clock_connection_arch.arch_switch_idx);
+                clock_to_pins->set_fc_val(clock_connection_arch.fc);
+            }
         } else {
             clock_connections_device.emplace_back(new ClockToClockConneciton);
-            ClockToClockConneciton* clock_to_clock = dynamic_cast<ClockToClockConneciton*>(clock_connections_device.back().get());
+            if (ClockToClockConneciton* clock_to_clock = dynamic_cast<ClockToClockConneciton*>(clock_connections_device.back().get())) {
+                //TODO: Add error check to check that clock name and tap name exist and that only
+                //      two names are returned by the below function
+                auto to_names = vtr::split(clock_connection_arch.to, ".");
+                auto from_names = vtr::split(clock_connection_arch.from, ".");
+                VTR_ASSERT_MSG(to_names.size() == 2, "Invalid clock name.\n");
+                clock_to_clock->set_to_clock_name(to_names[0]);
+                clock_to_clock->set_to_clock_switch_point_name(to_names[1]);
+                clock_to_clock->set_from_clock_name(from_names[0]);
+                clock_to_clock->set_from_clock_switch_point_name(from_names[1]);
 
-            //TODO: Add error check to check that clock name and tap name exist and that only
-            //      two names are returned by the below function
-            auto to_names = vtr::split(clock_connection_arch.to, ".");
-            auto from_names = vtr::split(clock_connection_arch.from, ".");
-            VTR_ASSERT_MSG(to_names.size() == 2, "Invalid clock name.\n");
-            clock_to_clock->set_to_clock_name(to_names[0]);
-            clock_to_clock->set_to_clock_switch_point_name(to_names[1]);
-            clock_to_clock->set_from_clock_name(from_names[0]);
-            clock_to_clock->set_from_clock_switch_point_name(from_names[1]);
-
-            clock_to_clock->set_switch(clock_connection_arch.arch_switch_idx);
-            clock_to_clock->set_fc_val(clock_connection_arch.fc);
+                clock_to_clock->set_switch(clock_connection_arch.arch_switch_idx);
+                clock_to_clock->set_fc_val(clock_connection_arch.fc);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes an unchecked dynamic cast

#### Description
Minor change: uses an if statement to check that a dynamic cast is returned

#### Related Issue
Unchecked dynamic cast #732

#### Motivation and Context
Fixes coverity warnings

#### How Has This Been Tested?
N/A

#### Types of changes
Creates safer code

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
