### PR TITLE
WIP: Generate profile of netlist characteristics from BLIF or Verilog Input in Odin-II

### DIFF
--- a/ODIN_II/SRC/generate_blif_stats.cpp
+++ b/ODIN_II/SRC/generate_blif_stats.cpp
@@ -1,0 +1,1128 @@
+/*
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include "odin_types.h"
+#include "odin_globals.h"
+
+#include "netlist_utils.h"
+#include "odin_util.h"
+#include "output_blif.h"
+#include "generate_blif_stats.h"
+
+#include "node_creation_library.h"
+
+#include "multipliers.h"
+#include "hard_blocks.h"
+#include "adders.h"
+#include "subtractions.h"
+#include "vtr_util.h"
+#include "vtr_memory.h"
+
+void depth_first_traversal_to_output_stats(short marker_value, netlist_t *netlist, FILE *out);
+void depth_traverse_output_blif_stats(nnode_t *node, int traverse_mark_number);
+void gather_vcc_gnd_stats(short marker_value, netlist_t *netlist);
+void output_node_stats(nnode_t *node, short traverse_number);
+void depth_traverse_gnd_vcc(nnode_t *node, int traverse_mark_number);
+void depth_traverse_clear_stat(nnode_t *node, int traverse_mark_number , bool hardClear);
+int get_max_levels_rec(nnode_t *node, int traverse_mark_number, int cycleId, netlist_t *netlist);
+int get_max_levels(short marker_value, netlist_t *netlist);
+void single_node_lookahead(nnode_t *node, short travId, short marker);
+//int reverse_lvl(short marker_value, netlist_t *netlist);
+//int reverse_lvl_rec(nnode_t *node, int traverse_mark_number, int cycleId, netlist_t *netlist);
+void node_profile(nnode_t *node, bool verbose, FILE *out);
+int get_node_fanout(nnode_t *node);
+void set_path_lengths(nnode_t *node, short marker);
+int pathlen_heuristic(nnode_t *node, short marker);
+
+static unsigned int num_latches = 0;
+static unsigned int vcc_fanout_live = 0;
+static unsigned int gnd_fanout_live = 0;
+static unsigned int pad_fanout_live = 0;
+static unsigned int vcc_fanout_all = 0;
+static unsigned int gnd_fanout_all = 0;
+static unsigned int pad_fanout_all = 0;
+static unsigned int max_input_pathrange = 0; // this is like reverse net_range bc it is dist to output not depth, abs(min-max pathlength)
+static unsigned int min_input_pathrange = 0-1;
+static float avg_pathrange = 0;
+static unsigned int num_nodes = 0;
+static unsigned int num_carry_func = 0;
+static unsigned int num_names = 0; // consider renaming this to num_gates bc that's what it is
+static unsigned int num_nets = 0; // same as output pin total it seems
+static unsigned int num_edges_fo = 0; // fan out total for all nets (includes vcc and gnd, unclear if it should, abc does not)
+static unsigned int num_edges_fi = 0; // fan in total, will equal num_total_input_pins and thus is redundant
+static unsigned int num_logic_nodes = 0;
+static unsigned int num_total_input_pins = 0; // reflects number of edges in graph that are live, should equal num_edges_fo but may not if there are fo pins w/out node 
+static unsigned int output_pin_total = 0; // this (should) always be the same as num_nets, maybe redundant
+static unsigned int num_subckts = 0;
+static unsigned int num_muxes = 0;
+static unsigned int num_generic_nodes = 0;
+static unsigned int num_input_nodes = 0;
+static unsigned int top_input_fanout = 0;
+static unsigned int num_unconn = 0; // Unreliable, maybe count pad traversals
+static unsigned int num_clock_nodes = 0;
+static unsigned int num_adders = 0;
+
+// This is all metadata on the number of traversals it took to calculate these figures, not passed to parser
+static unsigned int num_traversals_stat = 0; // how many depth first traversals have we done? Internal stat metric to measure cost of collection
+static unsigned int num_traversals_input = 0; // only counts traversals from top inputs (derived value not counter)
+static unsigned int gnd_vcc_pad_traverals = 0; // metadata on measuring gnd and vcc traversals, should be minimal if non-verbose and after all other traversals
+static unsigned int num_clearing_traversals = 0; // node traversals from clearing stat structs
+
+//static unsigned int num_unique_paths = 0; // Experimental, number of unique paths, this would be hard to calculate
+static unsigned int fanin_outputs_total = 0; // this is possibly not a useful stat
+//static unsigned int longest_chain = 1; // we're looking at latches but one might want adders or carries etc.
+//static unsigned int longest_consecutive_chain = 1;
+static unsigned int fanin_node_to_output = 0; // not very interesting
+static unsigned int fanout_node_to_output = 0; // experimental
+static unsigned int num_nodes_leading_to_output = 0; // unless we have fanout in net this will equal fanin_outputs_total, isn't v interesting but needed to derive
+static unsigned int num_deadends = 0; // experimental, every time we hit a deadEnd in path not including already visited nodes
+static unsigned int num_already_visited = 0; // experimental, every time we hit a previously visited node, prob not interesting but maybe
+static unsigned int num_deadend_inputs = 0; // number of inputs that go nowhere, dist values of 0, not including vcc and gnd for now
+static unsigned int max_fanout_node = 0; // highest # of fanout pins of a node including all of its associated nets
+static unsigned int max_outpins_node = 0; // highest num_output_pins of a node, tends to be low
+static unsigned int max_fanout_net = 0; // num_output_pins of net with highest value
+static unsigned int max_fanin_node = 0;
+static int output_node_count = 0; // count outputs so we can figure out if any outputs are unconn
+// our averages do not include zero length paths
+static unsigned int max_dist_out = 0;
+static unsigned int min_dist_out = 0-1;
+static unsigned int gnd_min_path = 0;
+static unsigned int vcc_min_path = 0;
+static unsigned int gnd_max_path = 0;
+static unsigned int vcc_max_path = 0;
+static unsigned int shortest_maxpath = 0-1; 
+static unsigned int longest_minpath = 0;
+static float top_input_avg_dist_max = 0; // avg longest path of top level inputs
+static float top_input_avg_dist_min = 0;
+static float top_lvl_avg_max = 0; // this name is confusing, sum of node->stat->avg_max_dist_to_out of top input nodes, experimental, possibly not useful (average of averages...)
+static unsigned int num_memories = 0;
+static unsigned int max_level = 0; // max number of levels in a CIs logic cone
+static bool sequentialCycles = false; // not for parser
+
+static bool verbose_mode = false; // only set once, hoping to avoid parameter bloat
+
+void output_blif_stats(std::string file_name, netlist_t *netlist, bool verbose)
+{
+	if(verbose)
+		verbose_mode = true; // file scope var
+	FILE *out = fopen(file_name.c_str(), "w");
+	
+	if (out == NULL) // if output not specified print to stdout
+	{
+		// This will only work with "" as the output file, can't be nothing
+		printf("No output file specified, printing to stdout\n");
+		out = stdout;
+		// the parser can read the output but for now we don't care about it so it's just a printf
+		printf("output_file: stdout\n"); // it's more important to get input_file to the parser but we may as well capture this too
+	}
+	else{
+		printf("output_file: %s\n", file_name.c_str());
+		printf("input_file: %s\n", configuration.list_of_file_names[0].c_str()); // print this to stdout and to fout later
+	}
+	fprintf(out, "input_file: %s\n", configuration.list_of_file_names[0].c_str());
+
+	for (int i = 0; i < netlist->num_top_output_nodes; i++)
+	{
+		if (netlist->top_output_nodes[i]->input_pins[0]->net->driver_pin == NULL)
+		{
+			// remove maybe
+			warning_message(NETLIST_ERROR, netlist->top_output_nodes[i]->related_ast_node->line_number, netlist->top_output_nodes[i]->related_ast_node->file_number, "This output is undriven (%s) and will be removed\n", netlist->top_output_nodes[i]->name);
+		}
+	}
+	/* add gnd, unconn, and vcc */
+	num_names+=3; // consider removing, not in spirit of tracking .names (but yields same results as other node counter from simulator)
+
+	/* traverse the internals of the flat net-list */
+		max_level = get_max_levels(SEQUENTIAL_LEVELIZE, netlist); // get levels first (full traversal required)
+		depth_first_traversal_to_output_stats(STATS, netlist, out);
+
+/* ==== This is by far the most costly approach to gathering (average) path length statistics, less prone feedback loops*/
+		/*int sum_all_dist = 0;
+		int k = 0;
+		while(k < netlist->num_top_input_nodes){
+			for(int i = 0; i<100; i++){
+				depth_traverse_clear_stat(netlist->top_input_nodes[k], RESET, true);
+				sum_all_dist += pathlen_heuristic(netlist->top_input_nodes[k], marker);
+				if(sum_all_dist == 0)
+					continue;
+			}
+			if(sum_all_dist != 0)
+				printf("average path length heuristic %f\t", (float)sum_all_dist / (float)1000);
+			node_profile(netlist->top_input_nodes[k], false, out);
+			k++;
+			sum_all_dist = 0;
+		}
+		*/
+
+	/* connect all the outputs up to the last gate */
+	for (int i = 0; i < netlist->num_top_output_nodes; i++)
+	{
+		nnode_t *node = netlist->top_output_nodes[i];
+		if (node->input_pins[0]->net->driver_pin != NULL)
+		{
+			if (global_args.high_level_block.provenance() == argparse::Provenance::SPECIFIED)
+				num_names++;
+			else
+			{
+				/*  Use the name of the driver pin as the name of the driver as long as that name is set, and is not equal to the name of the output pin.
+				 *  Otherwise, use the name of the driver node.*/
+				char *driver = node->input_pins[0]->net->driver_pin->name;
+				char *output = node->name;
+				if (!driver || !strcmp(driver,output))
+					driver = node->input_pins[0]->net->driver_pin->node->name; // I still don't know what this is
+				/* Skip if the driver and output have the same name (i.e. the output of a flip-flop) */
+				if (strcmp(driver,output) != 0)
+					num_names++;
+			}
+		}
+	}
+	float avg_output_pins_per_node = (float)output_pin_total / (float)num_nodes; // POs don't have output pins so probably < 1, not very interesting number
+	fprintf(out, "==============COUNTERS=============\n");
+	fprintf(out, "num_nodes: %u\n", num_nodes); // verified correct
+	fprintf(out, "num_latches: %u\n", num_latches); // verified correct
+	fprintf(out, "num_total_input_pins: %u\n", num_total_input_pins); // a measure of fanin to nodes
+	fprintf(out, "num_nets: %u\n", num_nets);
+	fprintf(out, "num_names: %u\n", num_names); // verified correct
+	fprintf(out, "num_edges_fo: %u\n", num_edges_fo); // All fanout from all nets
+	//fprintf(out, "num_edges_fi: %u\n", num_edges_fi); // probably pointless? should always be == num_total_input_pins
+	fprintf(out, "output_pin_total: %u\n", output_pin_total); // pointless? If including output nodes the number can be < 1
+	fprintf(out, "num_subckts: %u\n", num_subckts);
+	fprintf(out, "num_muxes: %u\n", num_muxes);
+	//fprintf(out, "num_ff_nodes: %d\n", netlist->num_ff_nodes); // # latches: This value is already available and seems correct always but we play it safe and count the latches
+	fprintf(out, "num_top_output_nodes: %u\n", netlist->num_top_output_nodes);	
+	fprintf(out, "num_input_nodes: %u\n", num_input_nodes); // this tends to be off by one compared to struct member, represents true input nodes, not clocks
+	if(verbose_mode)
+	{
+		fprintf(out, "(W/ clock %d top inputs)\n", netlist->num_top_input_nodes); // includes clock, not in parser
+		fprintf(out, "num_deadend_inputs: %u\n", num_deadend_inputs); // number of inputs that go nowhere, dist values of 0
+		fprintf(out, "num_clock_nodes: %u\n", num_clock_nodes); // this doesn't include global sim base clock which is confusingly of type input
+		fprintf(out, "num_logic_nodes: %u\n", num_logic_nodes);
+		fprintf(out, "num_carry_func: %u\n", num_carry_func);
+		fprintf(out, "num_generic_nodes: %u\n", num_generic_nodes);
+		fprintf(out, "num_unconn: %u\n", num_unconn); // unreliable, how would we find an unconn node?
+		fprintf(out, "num_memories: %u\n", num_memories);
+		fprintf(out, "num_adders: %u\n", num_adders);
+		fprintf(out, "num_deadends: %u\n", num_deadends); // unclear if fully reliable
+		fprintf(out, "num_already_visited: %u\n", num_already_visited); // How many times do we encounter a node we've already visited
+		if(output_node_count < netlist->num_top_output_nodes) // not super important
+		{
+			fprintf(out, "WARNING UNCONNECTED OUTPUTS, TRUE COUNT: %d\n", output_node_count); // difference is we counted these, only show if there is a disparity
+			fprintf(out, "num_dead_outputs: %d\n", abs(output_node_count - netlist->num_top_output_nodes)); // should we print this always? Doesn't do parser much good
+		}
+	}
+
+	fprintf(out, "==============FANIN FANOUT=============\n");
+	fprintf(out, "avg_fanin_per_node: %f\n", ((float)num_edges_fi / (float)num_nodes));
+	fprintf(out, "avg_fanout_per_net: %f\n", ((float)num_edges_fo/(float)num_nets));
+	fprintf(out, "top_input_fanout: %u\n", top_input_fanout); // this does not include clock fanout, this refers to top input's net fanout, confusing
+	float avg_top_lvl_fanout = (num_input_nodes - num_deadend_inputs > 0) ? ((float)top_input_fanout/(float)(num_input_nodes - num_deadend_inputs)) : 0.0; // no div by 0
+	fprintf(out, "avg_top_lvl_fanout: %f\n", avg_top_lvl_fanout); // this does not include clock fanout (or deadend inputs for now)
+	fprintf(out, "max_outpins_node: %u\n", max_outpins_node); // node with most output pins
+	fprintf(out, "max_fanout_node: %u\n", max_fanout_node); // fanout including all connected output pins and associated nets
+	fprintf(out, "max_fanout_net: %u\n", max_fanout_net);
+	fprintf(out, "max_fanin_node: %u\n", max_fanin_node);
+	fprintf(out, "pad_fanout_all: %u\n", pad_fanout_all);
+	fprintf(out, "vcc_fanout_all: %u\n", vcc_fanout_all);
+	fprintf(out, "gnd_fanout_all: %u\n", gnd_fanout_all);
+	if(verbose_mode)
+	{
+		fprintf(out, "pad_fanout_live: %u\n", pad_fanout_live);
+		fprintf(out, "vcc_fanout_live: %u\n", vcc_fanout_live);
+		fprintf(out, "gnd_fanout_live: %u\n", gnd_fanout_live);
+		fprintf(out, "avg_output_pins_per_node: %f\n", avg_output_pins_per_node);
+		fprintf(out, "fanin_outputs_total: %u\n", fanin_outputs_total); // num inputs for all top level outputs, seems to often match num outputs
+		fprintf(out, "fanin_outputs_avg: %f\n", (float)(fanin_outputs_total / netlist->num_top_output_nodes)); // maybe only use this since the above can be derived
+		/* Even in verbose mode these seem unimportant */
+		fprintf(out, "fanin_node_to_output: %u\n", fanin_node_to_output); // node that leads to output
+		fprintf(out, "fanout_node_to_output: %u\n", fanout_node_to_output); // node that leads to output
+		fprintf(out, "avg_fanin_node_leading_to_output: %f\n", (float)fanin_node_to_output / (float)num_nodes_leading_to_output); // var too long, not important or in parser
+		fprintf(out, "avg_fanout_node_leading_to_output: %f\n", (float)fanout_node_to_output / (float)num_nodes_leading_to_output); // var too long, not important or in parser
+	}
+
+	fprintf(out, "==============DEPTH=============\n");
+	fprintf(out,"max_level: %u\n", max_level); // largest number of levels in COs logic cone, is actually verifiably accurate unlike other possibly flawed path metrics
+	/* Unclear how reliable these numbers are for circuits with sequential feedback loops */
+	if(verbose_mode)
+	{
+		fprintf(out, "min_dist_out: %u\n", min_dist_out); // min dist input to output
+		fprintf(out, "max_dist_out: %u\n", max_dist_out);
+		fprintf(out, "top_input_avg_dist_min: %f\n", top_input_avg_dist_min); // not including vcc,gnd,clock
+		fprintf(out, "top_input_avg_dist_max: %f\n", top_input_avg_dist_max);
+		fprintf(out, "gnd_min_path: %u\n", gnd_min_path);
+		fprintf(out, "gnd_max_path: %u\n", gnd_max_path);
+		fprintf(out, "vcc_min_path: %u\n", vcc_min_path);
+		fprintf(out, "vcc_max_path: %u\n", vcc_max_path);
+		fprintf(out, "shortest_maxpath: %u\n", shortest_maxpath);
+		fprintf(out, "longest_minpath: %u\n", longest_minpath);
+		fprintf(out, "min_input_pathrange: %u\n", min_input_pathrange);
+		fprintf(out, "max_input_pathrange: %u\n", max_input_pathrange);
+		fprintf(out, "avg_pathrange: %f\n", avg_pathrange);
+
+		//fprintf(out, "----------------Approximation-------------\n");
+		// TODO: Some kind of mechanism that counts the longest chain of latches or something, maybe with the get_max_levels algorithm
+		//fprintf(out, "longest_latch_chain: %u\n", longest_chain); // number of nodes of same type in chain in one path, in this case latches
+		//fprintf(out, "longest_consecutive_latch_chain: %u\n", longest_consecutive_chain); // number of node type connected to eachother in one path, in this case latches
+		fprintf(out, "==============EXPERIMENTAL/METADATA=============\n");
+		fprintf(out, "num_traversals_stat: %u\n", num_traversals_stat);
+		//fprintf(out, "num_unique_paths: %u\n", num_unique_paths); // this would be hard to calculate
+		fprintf(out, "num_traversals_input: %u\n", num_traversals_input);
+		fprintf(out, "gnd_vcc_pad_traverals: %u\n", gnd_vcc_pad_traverals);
+		fprintf(out, "num_clearing_traversals: %u\n", num_clearing_traversals);
+		fprintf(out, "top_lvl_avg_max: %f\n", top_lvl_avg_max); // confusing name, avg of avg max dist of top input nodes
+		std::string sequential_cycle_out = sequentialCycles ? "Yes" : "No";
+		fprintf(out, "has_sequential_cycles: %s\n", sequential_cycle_out.c_str()); // not for parser 
+	}
+}
+
+/*---------------------------------------------------------------------------
+ * (function: depth_first_traversal_to_output_stats()
+ *-------------------------------------------------------------------------------------------*/
+void depth_first_traversal_to_output_stats(short marker_value, netlist_t *netlist, FILE *out)
+{
+	/* start with the primary input list */
+	int min_dist_temp = 0;
+	int max_dist_temp = 0;
+	int total_dist_out_max = 0;
+	int total_dist_out_min = 0;
+	int pathrange = 0; // temp var
+	int total_pathrange = 0;
+	float sum_avgs = 0;
+	for (int i = 0; i < netlist->num_top_input_nodes; i++)
+	{
+		if (netlist->top_input_nodes[i] != NULL)
+		{
+			/* Without altering mark number the first few paths traversed will always yield higher values so top input pathlen is inherently flawed value */
+			depth_traverse_output_blif_stats(netlist->top_input_nodes[i], marker_value);
+		}
+	}
+	if(verbose_mode)
+	{
+		for (int i = 0; i < netlist->num_top_input_nodes; i++)
+		{
+			if (netlist->top_input_nodes[i] == NULL) //this outcome is fairly unlikely and perhaps should just throw and error and quit
+			{
+				num_deadend_inputs++;
+				num_deadends++;
+				continue;
+			}
+			/* The idea here is to separate path calcs from node profiling so that we can clear the netlist stat structs and markers on each top lvl traversal.
+			 * Very costly but otherwise top level results wrong.*/
+			depth_traverse_clear_stat(netlist->top_input_nodes[i], RESET, true);
+			set_path_lengths(netlist->top_input_nodes[i], marker_value);
+			//node_profile(netlist->top_input_nodes[i], true, out); // For netlists with larger numbers of inputs this may be far too verbose but is sometimes helpful
+			/* Without altering/resetting mark number the first few paths traversed will always yield higher values so top input pathlen will be a flawed value */
+			min_dist_temp = netlist->top_input_nodes[i]->stat->min_dist_to_out;
+			max_dist_temp = netlist->top_input_nodes[i]->stat->max_dist_to_out;
+			float avg_max_temp = netlist->top_input_nodes[i]->stat->avg_max_dist;
+			if(max_dist_temp == 0)
+				num_deadend_inputs++;
+			sum_avgs += avg_max_temp;
+			// exclude deadend inputs (e.g. sim clock)
+			if(min_dist_temp != 0-1 && max_dist_temp != 0)
+			{
+				total_dist_out_min += min_dist_temp;
+				total_dist_out_max += max_dist_temp;
+				if(max_dist_temp > max_dist_out)
+					max_dist_out = max_dist_temp;
+				if(min_dist_temp < min_dist_out && min_dist_temp != 0) // don't count zero length chains
+					min_dist_out = min_dist_temp;
+				if(max_dist_temp < shortest_maxpath && max_dist_temp > 0)
+					shortest_maxpath = max_dist_temp;
+				if(min_dist_temp > longest_minpath)
+					longest_minpath = min_dist_temp;
+				pathrange = abs(min_dist_temp - max_dist_temp);
+				total_pathrange += pathrange;
+				if(pathrange > max_input_pathrange)
+					max_input_pathrange = pathrange;
+				if(pathrange < max_input_pathrange)
+					min_input_pathrange = pathrange;
+			}
+		}
+		top_input_avg_dist_min = (float)total_dist_out_min / (float)(netlist->num_top_input_nodes - num_deadend_inputs); // now not excluding clock
+		top_input_avg_dist_max = (float)total_dist_out_max / (float)(netlist->num_top_input_nodes - num_deadend_inputs);
+		avg_pathrange = (float)total_pathrange / (float)(netlist->num_top_input_nodes - num_deadend_inputs);
+		top_lvl_avg_max = (float)sum_avgs / (float)(netlist->num_top_input_nodes - num_deadend_inputs);
+	}
+	/* traverse gnd, vcc, pad nodes */
+	num_nodes += 3;
+	gather_vcc_gnd_stats(STATS, netlist); // collect vcc and gnd stats after normal stats collected
+	num_traversals_input = num_traversals_stat - gnd_vcc_pad_traverals;
+}
+
+/* Begins Traversal of gnd, vcc and pad nodes, we run this after traversing inputs because otherwise they will affect input node stats */
+void gather_vcc_gnd_stats(short marker_value, netlist_t *netlist)
+{
+	netlist->gnd_node->name = vtr::strdup("gnd");
+	netlist->vcc_node->name = vtr::strdup("vcc");
+	netlist->pad_node->name = vtr::strdup("unconn");
+	/* now traverse the ground, vcc, and unconn pins */
+	// we just quintupled our traversals to collect gnd stats, reconsider
+	vcc_fanout_all = get_node_fanout(netlist->vcc_node);
+	gnd_fanout_all = get_node_fanout(netlist->gnd_node);
+	pad_fanout_all = get_node_fanout(netlist->pad_node);
+	num_edges_fo += (vcc_fanout_all + gnd_fanout_all + pad_fanout_all); // ABC does not count these as edges, should we?
+	// these are very aggressive clearing measures
+	if(verbose_mode)
+	{
+		depth_traverse_clear_stat(netlist->gnd_node, RESET, true);
+		depth_traverse_gnd_vcc(netlist->gnd_node, marker_value);
+		gnd_max_path = netlist->gnd_node->stat->max_dist_to_out;
+		gnd_min_path = (netlist->gnd_node->stat->min_dist_to_out == 0-1) ? gnd_max_path: netlist->gnd_node->stat->min_dist_to_out;
+		depth_traverse_clear_stat(netlist->gnd_node, RESET, true);
+		depth_traverse_clear_stat(netlist->vcc_node, RESET, true);
+		depth_traverse_gnd_vcc(netlist->vcc_node, marker_value);
+		vcc_max_path = netlist->vcc_node->stat->max_dist_to_out;
+		vcc_min_path = (netlist->vcc_node->stat->min_dist_to_out == 0-1) ? vcc_max_path: netlist->vcc_node->stat->min_dist_to_out;
+		depth_traverse_clear_stat(netlist->vcc_node, RESET, true);
+		depth_traverse_gnd_vcc(netlist->pad_node, marker_value);
+		depth_traverse_clear_stat(netlist->pad_node, RESET, true);
+	}
+	num_traversals_stat += gnd_vcc_pad_traverals;
+}
+
+/*--------------------------------------------------------------------------
+ * (function: depth_traverse_output_blif_stats)
+ *------------------------------------------------------------------------*/
+void depth_traverse_output_blif_stats(nnode_t *node, int traverse_mark_number)
+{
+	num_traversals_stat++;
+	int i, j;
+	nnode_t *next_node = NULL;
+	nnet_t *next_net = NULL;
+	if (node->traverse_visited == traverse_mark_number)
+	{
+		num_already_visited++;
+		return;
+	}
+	else
+	{
+		unsigned int total_node_fanout = 0; // experimental
+		/* ELSE - this is a new node so depth visit it */
+		output_node_stats(node, traverse_mark_number);
+		output_pin_total += node->num_output_pins;
+		/* mark that we have visitied this node now */
+		node->traverse_visited = traverse_mark_number;
+		num_edges_fi += node->num_input_pins;
+
+		if(node->num_output_pins > max_outpins_node)
+			max_outpins_node = node->num_output_pins;
+
+		if(node->num_input_pins > max_fanin_node)
+			max_fanin_node = node->num_input_pins;
+
+		if(node->type == OUTPUT_NODE)
+			fanin_outputs_total += node->num_input_pins;
+
+		if(node->num_output_pins == 0 && node->type != OUTPUT_NODE)
+			num_deadends++;
+
+		for (i = 0; i < node->num_output_pins; i++)
+		{
+			if (node->output_pins[i]->net == NULL)
+			{
+				num_deadends++;
+				continue;
+			}
+
+			next_net = node->output_pins[i]->net;
+			num_nets++;
+			//next_net->traversal_id = 0;
+			if(node->type == INPUT_NODE)
+			{
+				top_input_fanout += next_net->num_fanout_pins;
+			}
+			bool check_fanout = true; // exclude vcc and gnd from max fanout of a net check (this may be obsolete)
+			/* If we want to exclude a node type's fanout in calculations check for it here and set check_fanout to false
+			*/
+			if(check_fanout && next_net->num_fanout_pins > max_fanout_net)
+				max_fanout_net = next_net->num_fanout_pins;
+			if(next_net->num_fanout_pins == 0 && node->type != OUTPUT_NODE)
+				num_deadends++;
+			total_node_fanout += next_net->num_fanout_pins;
+
+			for (j = 0; j < next_net->num_fanout_pins; j++)
+			{
+				if(next_net->fanout_pins[j] == NULL)
+				{
+					num_deadends++;
+					continue;
+				}
+				num_edges_fo++;
+				next_node = next_net->fanout_pins[j]->node;
+				if (next_node == NULL)
+				{
+					num_deadends++;
+					continue;
+				}
+				if(next_node->type == PAD_NODE)
+					num_unconn++; // unclear if this will work, do unconn nodes lead to or from PAD? (probably from)
+
+				if(next_node->type == OUTPUT_NODE)
+				{
+					num_nodes_leading_to_output++;
+					fanin_node_to_output += node->num_input_pins;
+					fanout_node_to_output += node->num_output_pins;
+				}
+				/* recursive call point */
+				depth_traverse_output_blif_stats(next_node, traverse_mark_number);
+			}
+		}
+		if(total_node_fanout > max_fanout_node)
+			max_fanout_node = total_node_fanout;
+		return;
+	}
+}
+/*-------------------------------------------------------------------
+ * (function: output_node_stats)
+ * 	Depending on node type, collects node stats
+ *------------------------------------------------------------------*/
+void output_node_stats(nnode_t *node, short /*traverse_number*/)
+{
+	num_nodes++;
+	num_total_input_pins += node->num_input_pins; // living edges
+	if( (node->type >= 17 && node->type <=24) || node->type == LOGICAL_EQUAL)
+	{
+		num_logic_nodes++;
+		num_names++;
+		return;
+	}
+	switch (node->type)
+	{
+		case INPUT_NODE:
+			num_input_nodes++;
+			break;
+		case OUTPUT_NODE:
+			output_node_count++;
+			//node->stat->min_dist_to_out = node->stat->max_dist_to_out = 0; // obsolete probably
+			break;
+		case VCC_NODE:
+			break;
+		case CLOCK_NODE:
+			num_clock_nodes++;
+			break;
+		case GND_NODE: 
+			break;
+		case PAD_NODE:
+			num_unconn++; // not very useful
+			break;
+		case CARRY_FUNC:
+			num_names++;
+			num_carry_func++;
+			break;
+		case ADDER_FUNC:
+			num_adders++; /* FALLTHROUGH */
+		case LT:
+		case GT:
+		case BITWISE_NOT:
+			num_names++;
+ 			break;
+		case MUX_2:
+			num_names++;
+			num_muxes++;
+			break;
+		case MULTIPLY:
+		case HARD_IP:
+		case ADD:
+			num_subckts++;
+			break;
+		case FF_NODE: 
+			num_latches++;
+			break;
+		case GENERIC:
+			num_generic_nodes++;
+			num_names++;
+			break;
+		case MEMORY:
+			num_memories++;
+			break;
+		default:
+			break;
+	}
+}
+
+/*-------------------------------------------------------------------
+ * (function: depth_traverse_gnd_vcc)
+ * 	Traversal of gnd, vcc and pad nodes, which we treat as separate from the top input node traversal
+ *------------------------------------------------------------------*/
+void depth_traverse_gnd_vcc(nnode_t *node, int traverse_mark_number)
+{
+	gnd_vcc_pad_traverals++;
+	int i, j;
+	nnode_t *next_node = NULL;
+	nnet_t *next_net = NULL;
+	if (node->traverse_visited == traverse_mark_number)
+	{
+		// The idea here is to fill in gaps when a node has been left unset but visited because of a cycle, it looks ahead one to see if its neighbours have been since set
+		if(node->stat->min_dist_to_out+1 == 0)
+		{
+			single_node_lookahead(node, node->stat->traversal_id+1, traverse_mark_number);
+		}
+		return;
+	}
+	else
+	{
+		if(!node->stat)
+			node->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+		node->stat->max_dist_to_out = 0;
+		node->stat->min_dist_to_out = 0-1;
+		node->stat->avg_max_dist = 0; // experimental value sum max dist of all nets
+		// mark node as visited
+		node->traverse_visited = traverse_mark_number;
+		if(node->type == OUTPUT_NODE)
+		{
+			node->stat->min_dist_to_out = node->stat->max_dist_to_out = 0;
+			return;
+		}
+		for (i = 0; i < node->num_output_pins; i++)
+		{
+			if (node->output_pins[i]->net == NULL)
+				continue;
+
+			next_net = node->output_pins[i]->net;
+			for (j = 0; j < next_net->num_fanout_pins; j++)
+			{
+				if(next_net->fanout_pins[j] == NULL)
+					continue;
+
+				next_node = next_net->fanout_pins[j]->node;
+				if (next_node == NULL)
+				{
+					continue;
+				}
+				// this is a pretty uninteresting metric, maybe remove
+				if(node->type == VCC_NODE)
+					vcc_fanout_live++;
+				if(node->type == GND_NODE)
+					gnd_fanout_live++;
+				if(node->type == PAD_NODE)
+					pad_fanout_live++;
+				unsigned int test_max = 0;
+				unsigned int test_min = 0-1;
+				depth_traverse_gnd_vcc(next_node, traverse_mark_number);
+				if(verbose_mode)
+				{
+					test_min = next_node->stat->min_dist_to_out+1;
+					test_max = next_node->stat->max_dist_to_out+1;
+					if(test_min == 0)
+						continue;
+					if(node->stat->min_dist_to_out>test_min)
+						node->stat->min_dist_to_out = test_min;
+					if(node->stat->max_dist_to_out < test_max)
+						node->stat->max_dist_to_out = test_max;
+				}
+			}
+		}
+		return;
+	}
+}
+
+/*-------------------------------------------------------------------
+ * (function: depth_traverse_clear_stat)
+ * 	Traversal of netlist, unmarking all nodes and optionally freeing all node->stat structs.
+ *------------------------------------------------------------------*/
+void depth_traverse_clear_stat(nnode_t *node, int traverse_mark_number, bool hardClear)
+{
+	num_clearing_traversals++;
+	int i, j;
+	nnode_t *next_node = NULL;
+	nnet_t *next_net = NULL;
+	if(node->traverse_visited == traverse_mark_number) // preferably RESET
+	{
+		return;
+	}
+	else // Clear anything that isn't traverse_mark_number, removed check for specific mark
+	{
+		if(node->stat && hardClear)
+		{
+			free(node->stat);
+			node->stat = NULL;
+		}
+		node->traverse_visited = traverse_mark_number;
+		for (i = 0; i < node->num_output_pins; i++)
+		{
+			if (node->output_pins[i]->net == NULL)
+			{
+				continue;
+			}
+			next_net = node->output_pins[i]->net;
+			for (j = 0; j < next_net->num_fanout_pins; j++)
+			{
+				if(next_net->fanout_pins[j] == NULL)
+				{
+					continue;
+				}
+				next_node = next_net->fanout_pins[j]->node;
+				if(next_node == NULL)
+				{
+					continue;
+				}
+				depth_traverse_clear_stat(next_node, traverse_mark_number, hardClear);
+			}
+		}
+		return;
+	}
+}
+
+/*-------------------------------------------------------------------
+ * (function: get_max_levels)
+ * Recursively computes the number of levels in logic cone of each PO and Latch Output and the max level, results and method consistent with that seen in ABC. Considered using this system to get more detailed
+ * path information but unable to verify if results were accurate/useful.
+ * 	Efforts towards breaking cycles or at least preventing feedback loops from causing huge path length values have not yielded different results, it may be that the path lengths are correct
+	and/or not actually being changed by feedback loops or not all cycles are found, more cycles are found traversing inputs upwards than outputs downwards. cycleId is the ID of the associated latch.
+	This presently has little - no function as identifying the cycles has breaking them has unclear if any effect. It may be more worthwhile to search for combinational loops.
+*/
+int get_max_levels(short marker_value, netlist_t *netlist)
+{
+	int levelMax = 0;
+	for (int i = 0; i < netlist->num_top_input_nodes; i++)
+	{
+		if (netlist->top_input_nodes[i] != NULL)
+		{
+			if(!netlist->top_input_nodes[i]->stat)
+			{
+				netlist->top_input_nodes[i]->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+				netlist->top_input_nodes[i]->stat->traversal_id = 0;
+			}
+			netlist->top_input_nodes[i]->stat->depth = 0;
+		}
+	}
+	for (int i = 0; i < netlist->num_ff_nodes; i++)
+	{
+		if (netlist->ff_nodes[i] != NULL)
+		{
+			if(!netlist->ff_nodes[i]->stat)
+			{
+				netlist->ff_nodes[i]->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+				netlist->ff_nodes[i]->stat->traversal_id = 0;
+			}
+			netlist->ff_nodes[i]->stat->depth = 0;
+		}
+	}
+	for (int i = 0; i < netlist->num_ff_nodes; i++)
+	{
+		for(int j=0; j < netlist->ff_nodes[i]->num_input_pins; j++)
+		{
+			nnode_t *node = netlist->ff_nodes[i]->input_pins[j]->net->driver_pin->node;
+			get_max_levels_rec(node, marker_value, netlist->ff_nodes[i]->unique_id, netlist);
+			// this yields very different results by transmitting level datapoint to the latch itself 
+			/*if(netlist->ff_nodes[i]->stat->depth < node->stat->depth+1){
+				netlist->ff_nodes[i]->stat->depth = node->stat->depth+1;
+			 }*/
+            if(levelMax < (int)node->stat->depth)
+               	levelMax = (int)node->stat->depth;
+		}
+	}
+	for (int i = 0; i < (netlist->num_top_output_nodes); i++)
+	{
+		if (netlist->top_output_nodes[i] != NULL)
+		{
+			// possibly off by one at PO level if not starting at input node of PO (need 2 extra loops for this)
+			nnode_t *node = netlist->top_output_nodes[i];
+			get_max_levels_rec(node, marker_value, netlist->top_output_nodes[i]->unique_id, netlist);
+			if(levelMax < (int)node->stat->depth)
+			{
+				levelMax = (int)node->stat->depth;
+			}
+			// only makes sense if latch lvl set and node is the PO's input node
+			//if(netlist->top_output_nodes[i]->stat->depth < node->stat->depth+1)
+				//netlist->top_output_nodes[i]->stat->depth = (node->stat->depth+1);
+        }
+	}
+	return levelMax;
+}
+
+int get_max_levels_rec(nnode_t *node, int traverse_mark_number, int cycleId, netlist_t *netlist)
+{
+	nnode_t *next;
+    int level = 0;
+	if(!node->stat)
+	{
+		node->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+	}
+	if(node->unique_id == cycleId && node->type != OUTPUT_NODE) // indicates cycle, has little effect and choice of which edge is cycle somewhat arbitrary
+	{
+		sequentialCycles = true;
+		//	return -1;
+	}
+	if(node->type == CLOCK_NODE)
+		return -1;
+
+	if(node->type == INPUT_NODE || node->type == FF_NODE || /* maybe remove ->*/ node->type == VCC_NODE || node->type == GND_NODE || node->type == PAD_NODE)
+	{
+		return node->stat->depth;
+	}
+	if (node->traverse_visited == traverse_mark_number)
+	{
+		return node->stat->depth;
+	}
+	node->traverse_visited = traverse_mark_number;
+	node->stat->depth = 0;
+	for (int i = 0; i < node->num_input_pins; i++)
+	{
+		next = node->input_pins[i]->net->driver_pin->node;
+		level = get_max_levels_rec(next, traverse_mark_number, cycleId, netlist);
+		//If cycle found, mark the pin, did not work as intended and unclear whether cycles caused bad path values
+		/*if(level == -1)
+			node->input_pins[i]->cycle = true;
+		else node->input_pins[i]->cycle = false; */
+        if(node->stat->depth < level)
+            node->stat->depth = level;
+    }
+	node->stat->depth++;
+    return node->stat->depth;
+}
+
+/*-------------------------------------------------------------------
+ * (function: node_profile)
+ * 	Debugging Tool, print basic or verbose stats about a node
+ *------------------------------------------------------------------*/
+void node_profile(nnode_t *node, bool verbose, FILE *out)
+{
+	if(!node) return;
+	int total_fanout = 0;
+	for(int i=0; i<node->num_output_pins; i++)
+	{
+		if(!node->output_pins[i]->net)
+			continue;
+		total_fanout += node->output_pins[i]->net->num_fanout_pins;
+	}
+	fprintf(out, "node_name: %s ID: %ld type: %d nOut_pins: %ld nFI: %ld nFO: %d ", node->name, node->unique_id, node->type, node->num_output_pins, node->num_input_pins, total_fanout);
+	if(verbose && node->stat)
+		fprintf(out, "shortest_path_out: %u longest_path_out: %u avg_max_path: %f", node->stat->min_dist_to_out, node->stat->max_dist_to_out, node->stat->avg_max_dist);
+	fprintf(out,"\n");
+}
+
+/*-------------------------------------------------------------------
+ * (function: get_node_fanout)
+ * 	for collecting vcc, gnd node fanout without interference
+ *------------------------------------------------------------------*/
+int get_node_fanout(nnode_t *node)
+{
+	if(!node) 
+		return 0;
+	int total_fanout = 0;
+	bool incr_counts = false;
+	if(node->type == VCC_NODE || node->type == GND_NODE || node->type == PAD_NODE)
+	{
+		incr_counts = true;
+		output_pin_total += node->num_output_pins; // count output pins which are almost certainly == num_nets if pin points to nothing (unlikely)
+	}
+	for(int i=0; i<node->num_output_pins; i++)
+	{
+		if(!node->output_pins[i]->net)
+			continue;
+		if(incr_counts)
+			num_nets++; // count live nets just in case output pins are not reflective of net count (possibly off by one bc of pad)
+		total_fanout += node->output_pins[i]->net->num_fanout_pins;
+	}
+	return total_fanout;
+}
+
+/* This is similar to the level finding function except in reverse, starting at PIs / LOs (CIs) and traversing downwards recursively
+	Additionally there are some experimental changes that maybe should be removed if they can't be verified as accurate or useful
+	Specifically, each PI traversal increments the mark number, thus traversing as if no nodes have been visited. The hope was that this might give good path length data.
+	Unable to verify if this is the case. Incrementing traversal ID for FFs as well gives very different results with larger level counts for PIs.
+	Additionally reverse_lvl_rec detects cycles in latches and breaks traversal if one is detected, disregarding invalid purely cyclical paths. Also FF nodes get updated lvl values.
+	Another approach would be to have 3 different travIDs, one for current, one for prev and one for never visited, this can detect combinational loops.
+*/
+/*int reverse_lvl(short marker_value, netlist_t *netlist){
+	int levelMax = 0;
+	short traversalInc = 50; // Experimental: traversal mark increments for each PI
+	for (int i = 0; i < netlist->num_top_output_nodes; i++)
+	{
+		if (netlist->top_output_nodes[i] != NULL)
+		{
+			if(!netlist->top_output_nodes[i]->stat)
+				netlist->top_output_nodes[i]->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+			netlist->top_output_nodes[i]->stat->depth = 0;
+		}
+	}
+	 for (int i = 0; i < netlist->num_ff_nodes; i++)
+	{
+		if (netlist->ff_nodes[i] != NULL)
+		{
+			if(!netlist->ff_nodes[i]->stat)
+				netlist->ff_nodes[i]->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+			netlist->ff_nodes[i]->stat->depth = 0;
+		}
+	}
+	for (int i = 0; i < netlist->num_ff_nodes; i++)
+	{
+		for(int j=0; j < netlist->ff_nodes[i]->num_output_pins; j++)
+		{
+			for(int k=0; k < netlist->ff_nodes[i]->output_pins[j]->net->num_fanout_pins; k++){
+				nnode_t *node = netlist->ff_nodes[i]->output_pins[j]->net->fanout_pins[k]->node;
+				reverse_lvl_rec(node, marker_value, netlist->ff_nodes[i]->unique_id, netlist);
+				//reverse_lvl_rec(node, traversalInc, netlist->ff_nodes[i]->unique_id, netlist); // EXPERIMENTAL
+				if(netlist->ff_nodes[i]->stat->depth < node->stat->depth+1){
+					netlist->ff_nodes[i]->stat->depth = node->stat->depth+1;
+				}
+            	if(levelMax < node->stat->depth ){
+                	levelMax = node->stat->depth;
+				}
+				traversalInc++; // experimental
+			}
+		}
+	}
+	for (int i = 0; i < (netlist->num_top_input_nodes); i++)
+	{
+		if (netlist->top_input_nodes[i] != NULL)
+		{
+			nnode_t *node = netlist->top_input_nodes[i];
+			reverse_lvl_rec(node, marker_value, netlist->top_input_nodes[i]->unique_id, netlist);
+			//reverse_lvl_rec(node, traversalInc, netlist->top_input_nodes[i]->unique_id, netlist); // experimental
+			if(levelMax < node->stat->depth){
+				levelMax = node->stat->depth;
+			}
+        }
+		traversalInc++; // experimental
+	}
+	return levelMax;
+}
+
+int reverse_lvl_rec(nnode_t *node, int traverse_mark_number, int cycleId, netlist_t *netlist){
+	nnode_t *next;
+    int level = 0;
+	if(!node->stat){
+		node->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+	}
+	if(node->unique_id == cycleId && node->type != INPUT_NODE){ // cycle detected
+		return -1;
+	}
+	if(node->type == OUTPUT_NODE || node->type == FF_NODE || node->type == CLOCK_NODE || node->type == VCC_NODE || node->type == GND_NODE || node->type == PAD_NODE){
+		return node->stat->depth;
+	}
+	if (node->traverse_visited == traverse_mark_number)
+	{
+		return node->stat->depth;
+	}
+	node->traverse_visited = traverse_mark_number;
+	node->stat->depth = 0;
+	bool validPath = false;
+	for (int i = 0; i < node->num_output_pins; i++){
+		for(int j = 0; j < node->output_pins[i]->net->num_fanout_pins; j++){
+			next = node->output_pins[i]->net->fanout_pins[j]->node;
+			level = reverse_lvl_rec(next, traverse_mark_number, cycleId, netlist);
+			if(level >= 0)
+				validPath = true;
+			else
+				continue;
+        	if(node->stat->depth < level)
+            	node->stat->depth = level;
+		}
+    }
+	if(!validPath){
+		node->stat->depth = -1; // mark invalid path, this doesn't do as much as hoped as it only spots complete deadend cycle paths
+	}
+    else
+		node->stat->depth++;
+    return node->stat->depth;
+}
+*/
+
+/*-------------------------------------------------------------------
+ * (function: set_path_lengths)
+ * This basically does what the path calculations do but in isolation, ideally the other node properties should be separated from path length stuff because you need to
+ * unmark the nodes after each top input traversal. In combination with dfs_clear this produces consistent path length results that are independent of which
+ * input is evaluated first.
+ *------------------------------------------------------------------*/
+void set_path_lengths(nnode_t *node, short marker)
+{
+	num_traversals_stat++;
+	nnode_t *next_node = NULL;
+	nnet_t *next_net = NULL;
+	
+	if(node->traverse_visited == marker)
+	{
+		// The idea here is to fill in gaps when a node has been left unset but visited because of a cycle, it looks ahead one to see if its neighbours have been since set
+		if(node->stat->min_dist_to_out+1 == 0)
+		{
+			single_node_lookahead(node, node->stat->traversal_id+1, marker);
+		}
+		return;
+	}
+	if(!node->stat)
+	{
+		node->stat = (nnode_stats_t *) vtr::calloc(1, sizeof(nnode_stats_t));
+		node->stat->traversal_id = 0;
+	}
+	node->stat->max_dist_to_out = 0;
+	node->stat->min_dist_to_out = 0-1;
+	unsigned int sum_dist = 0;
+	node->stat->avg_max_dist = 0;
+	unsigned int total_node_fanout = 0;
+	node->traverse_visited = marker;
+	if(node->type == OUTPUT_NODE)
+	{
+		node->stat->min_dist_to_out = node->stat->max_dist_to_out = 0;
+		return;
+	}
+	node->stat->traversal_id++;
+	for (int i = 0; i < node->num_output_pins; i++)
+	{
+		if (node->output_pins[i]->net == NULL)
+			continue;
+		next_net = node->output_pins[i]->net;
+		next_net->traversal_id++;
+		total_node_fanout += next_net->num_fanout_pins;
+		for (int j = 0; j < next_net->num_fanout_pins; j++)
+		{
+			if(next_net->fanout_pins[j] == NULL) // this happens with .v input sometimes
+				continue;
+			next_node = next_net->fanout_pins[j]->node;
+			if(next_node == NULL)
+				continue;
+			unsigned int test_max;
+			unsigned int test_min;
+			// if on path, skip
+			if(next_node->traverse_visited == marker && next_node->stat->traversal_id == next_net->traversal_id)
+			{
+				continue;
+			}
+			set_path_lengths(next_node, marker);
+			test_min = next_node->stat->min_dist_to_out;
+			if(test_min+1 == 0)
+				continue; // don't bother setting anything if next_node is itself unset
+			test_max = next_node->stat->max_dist_to_out+1;
+			sum_dist += test_max;
+			if(node->stat->min_dist_to_out > test_min)
+				node->stat->min_dist_to_out = test_min+1;
+			if(node->stat->max_dist_to_out < test_max)
+				node->stat->max_dist_to_out = test_max;
+		}
+		next_net->traversal_id = 0;
+	}
+	node->stat->traversal_id = 0;
+	node->stat->avg_max_dist = (sum_dist == 0) ? 0.0 : ((float)sum_dist / (float)total_node_fanout);
+	return;
+}
+
+/*-------------------------------------------------------------------
+ * (function: pathlen_heuristic)
+ * The idea of this is to do a dfs starting at random fanout node and run many times to see if this gives us any kind of indication of what mean path lengths should be.
+ * Ideally would probably iterate over the precreding fanout nodes after as well. Over enough iterations the results are consistent.
+ * Very very costly to just repeat this many times.	
+ *------------------------------------------------------------------*/
+int pathlen_heuristic(nnode_t *node, short marker)
+{
+	nnode_t *next_node = NULL;
+	nnet_t *next_net = NULL;
+	unsigned int max = 0;
+	if(node->traverse_visited == marker)
+		return 0;
+	node->traverse_visited = marker;
+	if(node->type == OUTPUT_NODE)
+	{
+		return 1;
+	}
+	for (int i = 0; i < node->num_output_pins; i++)
+	{
+		if (node->output_pins[i]->net == NULL)
+			continue;
+		next_net = node->output_pins[i]->net;
+		int startAt = 0;
+		if(next_net->num_fanout_pins > 0)
+			startAt = rand() % next_net->num_fanout_pins;
+		for (int j = startAt; j < next_net->num_fanout_pins; j++)
+		{
+			if(next_net->fanout_pins[j] == NULL) // this happens with .v input sometimes
+				continue;
+			next_node = next_net->fanout_pins[j]->node;
+			if(next_node == NULL)
+				continue;
+			unsigned int test_max = 0;
+			test_max = pathlen_heuristic(next_node, marker);
+			if(max<test_max)
+				max = test_max+1;
+		}
+	}
+	return max;
+}
+
+/*-------------------------------------------------------------------
+ * (function: single_node_lookahead)
+ * If a node is visited but unset then it is possible that the latch that caused the problem has since been set properly.
+ *  This won't address if the latch hasn't been set yet.
+ *------------------------------------------------------------------*/
+void single_node_lookahead(nnode_t *node, short travId, short marker)
+{
+	nnode_t *next_node = NULL;
+	nnet_t *next_net = NULL;
+	int sum_max = 0;
+	int total_fanout = 0;
+	if(node->stat->traversal_id == travId) // no effect?
+		return;
+	node->stat->traversal_id++;
+	for (int i = 0; i < node->num_output_pins; i++)
+	{
+		if (node->output_pins[i]->net == NULL)
+			continue;
+		next_net = node->output_pins[i]->net;
+		if(next_net->traversal_id == travId)
+			continue;
+		next_net->traversal_id++;
+		for (int j = 0; j < next_net->num_fanout_pins; j++)
+		{
+			total_fanout++;
+			if(next_net->fanout_pins[j] == NULL) // this happens with .v input sometimes
+				continue;
+			next_node = next_net->fanout_pins[j]->node;
+			if(next_node == NULL)
+				continue;
+			unsigned int test_max;
+			unsigned int test_min;
+			if(!next_node->stat)
+				continue;
+			if(next_node->type == OUTPUT_NODE)
+			{
+				node->stat->min_dist_to_out = 1;
+				node->stat->max_dist_to_out = (node->stat->max_dist_to_out < 1) ? 1 : node->stat->max_dist_to_out;
+			}
+			if(next_node->stat->traversal_id == travId || next_node->traverse_visited != marker) // don't do anything with unvisited nodes
+				continue;
+			// do this because a chain of MUX_2 nodes can have bad values and may need to look ahead further. (possibly flawed)
+			// The end result of this is not very dramatic, fills in the gaps of some unmarked nodes, generally leads to slightly longer path lens when many muxes & FFs in netlist
+			// This can get caught in (combinational?) loops, and this marking scheme is generally meant to detect that but we're using it for something else so take only 1 fo pin
+			if(/*next_net->num_fanout_pins == 1 && */j == next_net->num_fanout_pins-1 && next_node->stat->min_dist_to_out+1 == 0 && next_node->stat->traversal_id != travId && node->stat->min_dist_to_out+1 == 0)
+			{
+				single_node_lookahead(next_node, travId, marker);
+			}
+			test_max = next_node->stat->max_dist_to_out+1;
+			test_min = next_node->stat->min_dist_to_out;
+			if(test_min+1 == 0)
+				continue;
+			sum_max += test_max;
+			if(node->stat->min_dist_to_out > test_min)
+				node->stat->min_dist_to_out = test_min+1;
+			if(node->stat->max_dist_to_out < test_max)
+				node->stat->max_dist_to_out = test_max;
+		}
+		next_net->traversal_id = 0; // unclear if this works as intended
+	}
+	node->stat->traversal_id = 0; // resetting this makes loop possible if second lookahead is not limited to 1 fo pin
+	node->stat->avg_max_dist = (float)sum_max / (float)total_fanout;
+}

--- a/ODIN_II/SRC/include/generate_blif_stats.h
+++ b/ODIN_II/SRC/include/generate_blif_stats.h
@@ -1,0 +1,10 @@
+#ifndef GENERATE_BLIF_STATS_H
+#define GENERATE_BLIF_STATS_H
+
+#include "odin_types.h"
+#include <string>
+
+void output_blif_stats(std::string file_name, netlist_t *netlist, bool verbose);
+
+#endif
+

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -75,6 +75,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 struct ast_node_t;
 struct nnode_t;
+struct nnode_stats_t;
 struct npin_t;
 struct nnet_t;
 struct netlist_t;
@@ -91,6 +92,9 @@ struct global_args_t
 	argparse::ArgValue<std::string> output_file;
 	argparse::ArgValue<std::string> arch_file; // Name of the FPGA architecture file
 	argparse::ArgValue<bool> permissive; //turn possible_errors into warnings
+
+	argparse::ArgValue<std::string> generate_stats;
+	argparse::ArgValue<std::string> generate_stats_verbose;
 
 	argparse::ArgValue<std::string> high_level_block; //Legacy option, no longer used
 
@@ -483,6 +487,7 @@ struct nnode_t
 	
 	//Generic gate output
 	unsigned char generic_output; //describes the output (1 or 0) of generic blocks
+	nnode_stats_t *stat;
 };
 
 struct npin_t
@@ -507,7 +512,6 @@ struct npin_t
 	unsigned long coverage;
 	bool is_default; // The pin is feeding a mux from logic representing an else or default.
 	bool is_implied; // This signal is implied.
-
 };
 
 struct nnet_t
@@ -523,7 +527,7 @@ struct nnet_t
 
 	short unique_net_data_id;
 	void *net_data;
-
+	short traversal_id;
 	/////////////////////
 	// For simulation
 	std::shared_ptr<AtomicBuffer> values;
@@ -531,6 +535,14 @@ struct nnet_t
 	signed char has_initial_value; // initial value assigned?
 	signed char initial_value; // initial net value
 	//////////////////////
+};
+
+struct nnode_stats_t{
+	int depth; // perhaps more accurately calls level, as in level from CO
+	unsigned int min_dist_to_out;
+	unsigned int max_dist_to_out;
+	float avg_max_dist;
+	short traversal_id; // combo loop detection
 };
 
 struct signal_list_t

--- a/ODIN_II/SRC/netlist_utils.cpp
+++ b/ODIN_II/SRC/netlist_utils.cpp
@@ -87,6 +87,7 @@ nnode_t* allocate_nnode() {
 	new_node->initial_value = 0;
 
 	new_node->generic_output = -1;
+	new_node->stat = NULL;
 
 	return new_node;
 }
@@ -99,7 +100,8 @@ nnode_t *free_nnode(nnode_t *to_free)
 	if (to_free)
 	{
 		/* need to free node_data */
-
+		if(to_free->stat)
+			vtr::free(to_free->stat);
 		for (int i = 0; i < to_free->num_input_pins; i++) {
 			if (to_free->input_pins[i] && to_free->input_pins[i]->name) {
 				vtr::free(to_free->input_pins[i]->name);

--- a/ODIN_II/parse_odin_stats.py
+++ b/ODIN_II/parse_odin_stats.py
@@ -1,0 +1,948 @@
+#!/usr/bin/env python3
+from __future__ import division
+from datetime import datetime
+import sys, os
+
+current_line = ""
+delim = ","
+threshold_file = ""
+
+def time_to_millis(time_in):
+    time_in.strip()
+    time_in.replace(' ', '')
+    
+    result = 'NaN'
+
+
+    if 'ms'	in time_in:
+        result = str(assert_float(time_in.replace('ms','')))
+
+    elif 's' in time_in:
+        result = str(assert_float(time_in.replace('s','')) * 1000.0)
+
+    elif 'm' in time_in:
+        result = str(assert_float(time_in.replace('m','')) * 60.0 * 1000.0)
+
+    elif 'h' in time_in:
+        result = str(assert_float(time_in.replace('h','')) * 60.0 * 60.0 * 1000.0)
+
+    return result
+
+def help_menu(code):
+    if(code == 0):
+        print("-------------------------------------")
+        print("parse_odin_stats: Tool for parsing and analyzing the output of the --stat flag in Odin_II")
+        print("USAGE:\n")
+        print("MULTI MODE: -m")
+        print("Reads multiple inputs and places their respective metrics in a line within the specified csv/tsv file")
+        print("e.g.\t[./parse_odin_stats.py <-m> <output.csv/tsv> <input-1> ... <input-n>")
+        print("-------------------------------------")
+        print("MULTI-COMPARE MODE: -mc")
+        print("Reads multiple inputs and for every two inputs in order prints the difference between them on a third line")
+        print("e.g.\t[./exec <-mc> (optional)<--flags/-f> (opt)<--concise> <output.csv> <input-1> ... <input-n>]")
+        print("options: --flags")
+        print("-con or --concise: don't print diff summary")
+        print("-------------------------------------")
+        print("COMPARE MODE: -c")
+        print("e.g.\t./parse_odin_stats.py <-c> <output.csv> <input.log> <input2.log>")
+        print("Compare two stat_gen outputs, write both metrics and diff on csv, creates flag file for results that differ significantly from (optional) threshold file, print summary of diff to stdout")
+        print("-------------------------------------")
+        print("THRESHOLD GENERATOR MODE:")
+        print("Specify +/- % of acceptable change and optionally threshold file (else it will be default filename) to generate file to be used in compareMode")
+        print("\t-Will generate same ratio for certain core stats, otherwise must customize your own threshold file with metrics you want and ratio")
+        print("\t-Format is metric_name: <ratio>\nmetric_name2: <ratio>")
+        print("-------------------------------------")
+        print("SPECIFY THRESHOLD FILE:")
+        print("\tInclude [-t <threshold_filename>] to either compare mode before input/output to include threshold file to test against")
+        print("-------------------------------------")
+        print("SIMPLE_MODE:")
+        print("Take output of stat_gen as input, parse it and place results as one line in csv/tsv")
+        print("e.g.\t[./parse_odin_stats.py <input.log> <output.csv>]\n")
+        
+    elif(code == 1):
+        print("Nothing to compare, use -mc mode")
+
+    elif(code == 2):
+        print("\tNo inputs and/or outputs specified, expecting [./exec <-m/mc> (optional)<--flags/-f> (opt)<--concise> <output> <input-1> ... <input-n>]")
+
+    elif(code == 3):
+        print("Incorrect threshold generator usage. Acceptable patterns below:")
+        print("\n1) [./exec -gen] -> yields thresholds.txt with every value as 0.15 ('-g' also accepted)")
+        print("2) [./exec -gen <ratio>] (e.g. -gen 0.25) -> specify ratio to generate thresholds.txt with custom ratio")
+        print("3) [./exec -gen <ratio> <outputfilename.txt>] -> yields specified threshold file name with specified ratio (custom name requires custom ratio)\n")
+
+    elif(code==4):
+        print("No input specified")
+    elif(code==5):
+        print("Formatting error: check log file")
+    elif(code==6):
+        print("Wrong number of arguments, expecting [./exec -c <input.log> <input2.log> (opt)<output.csv>]")
+    elif(code==7):
+        # this is our only mechanism against the possibility of overwriting the log file, important that input files are .log
+        print("\nImproper output format, output file must not begin with '-' or end in .log, use no args or -h/--help for proper format")
+
+
+def size_to_MiB(size_in):
+    size_in = format_token(size_in)
+
+    base_size = 1.0
+    if 'b' in size_in:
+        base_size = 8.0
+
+    size_in = size_in.replace('i','')
+    size_in = size_in.replace('I','')
+    size_in = size_in.replace('b','')
+    size_in = size_in.replace('B','')
+
+    if 'G' in size_in or 'g' in size_in:
+        size_in = str(assert_float(size_in.replace('G','').replace('g','')) / 1024.0 / 1024.0 / base_size)
+
+    elif 'M' in size_in or 'm' in size_in:
+        size_in = str(assert_float(size_in.replace('M','').replace('m','')) / 1024.0 / base_size)
+
+    elif 'K' in size_in or 'k' in size_in:
+        size_in = str(assert_float(size_in.replace('K','').replace('k','')) / 1024.0 / base_size)
+
+    #we are now in byte
+    return str(assert_float(size_in) * 1024.0 * 1024.0)
+
+def contains(line_in, on_tokens):
+    for token in on_tokens:
+        if token not in line_in:
+            return False
+
+    return True
+
+def assert_float(input_str):
+    try:
+        return float(input_str)
+    except ValueError:
+        global current_line
+        print("Error, line: " + current_line)
+        exit(1);
+
+    return str(input_str)
+
+def format_token(input_str):
+    return input_str.strip().replace(' ', '').replace('(','').replace(')','').replace('%','').replace(',','')
+
+def format_token_dots(input_str):
+    return input_str.strip().replace('.','_')
+
+#strips path portion out of input if it exists
+def format_path_token(input_str):
+    x = input_str.split("/")
+    return x[len(x)-1]
+
+# 1 indexed
+def get_token(line_in, index):
+    return str(line_in.split(" ")[index-1])
+
+# 0 indexed, can specify split symbol
+def get_token_sym(line_in, index, symbol):
+    try:
+        ret_tok = str(line_in.split(symbol)[index])
+    except Exception as e:
+        help_menu(5)
+        print("Problem Line (first 100 chars): "+line_in[0:100]) # printing the line is potentially risky if it's something extremely long
+        print("index:",str(index),"error:", e)
+        exit(5)
+    return ret_tok
+
+def stringify(value_map, key):
+    if key not in value_map:
+        return str(float("NaN"))
+    else:
+        return str(value_map[key])
+
+def get_all_value(value_map, key_list, index):
+    return_str = ""
+    for key in key_list:
+        if(stringify(value_map[index], key) != str(float("NaN"))):
+            if(key == "input_file"):
+                return_str += format_path_token(stringify(value_map[index], key)) + delim
+            else:
+                return_str += stringify(value_map[index], key) + delim
+        else:
+            for values in value_map:
+                if key in values:
+                    return_str += "NaN" + delim
+                    break
+    # lose the last comma
+    return return_str
+
+# only include keys that have at least one valid entry (but only first one for some reason)
+def get_all_valid_key(value_map, key_list):
+    return_str = ""
+    for key in key_list:
+        if(len(value_map) > 1): # I can't remember what this is for
+            if key in value_map[0] or key in value_map[1]:
+                return_str += key + delim
+        else:
+            return_str += (key + delim) if (key in value_map[0]) else "" # I don't know why this does this
+    return return_str
+
+# TODO this should replace the above function I just don't have time to break the above function, also make this more pythonic
+def get_all_valid_key_multi(value_map, key_list):
+    return_str = ""
+    metric_absent_all = True
+    for key in key_list:
+        i = 0
+        while(i < len(value_map)):
+            if key in value_map[i]:
+                metric_absent_all = False
+            i += 1
+        if(not metric_absent_all):
+            return_str += (key + delim)
+        metric_absent_all = True
+    return return_str
+
+# old function, remove or update later
+def get_all_key(value_map, key_list):
+    return_str = ""
+    for key in key_list:
+        return_str += key + "\t"
+
+    return return_str
+
+# experimental: something that search directory for threshold file, so this can work in a testing suite
+# for now not going to deal with ratios or anything just raw +/- values
+# TODO make thresh name not hardcoded, change name of function
+def threshold_test():
+    thresholds = {}
+    try:
+        file = threshold_file if(threshold_file != "") else "thresholds.txt"
+        ft = open(file, "r")
+        if ft == None:
+            print("thresholds.txt file not included")
+            return
+        else:
+            for wholeLine in ft:
+                parse_line(thresholds, wholeLine)
+    except:
+        print("unable to open threshold file", file)
+        return
+    return thresholds
+
+#   slightly redundant but will be useful in producing our final non-redundant output
+#   checks if value was flagged as +/- outside of threshold or changed to or from 0
+def is_flagged(inLimit, sym1, sym2):
+    if(inLimit == "No"):
+        return True
+    elif((sym1 and not sym2) or (sym2 and not sym1)):
+        return True
+    else:
+        return False
+
+# many different ways to approach this, unclear which is right way, just proof of concept, for now it flags anything +/- threshold limit
+# Change to not be abs value if only increases should be flagged
+def within_threshold(thresholds, category, diff, percentChange):
+    ret_str = ""
+    limit = thresholds.get(category, "N/A") #this doesn't work as hoped
+    if limit == "N/A":
+        return limit
+    if abs(percentChange) <= float(limit):
+        # This is too messy and is not formatted for percentage
+        #ret_str += "Yes\t("+str(abs(int(float(limit) - diff)))+" under limit)"
+        ret_str += "Yes"
+    else:
+        #ret_str += "No \t("+str(abs(int(float(limit) - diff)))+" over limit)"
+        ret_str += "No"
+    return ret_str
+
+def flag_line(header, inLimit, flagCount, diff, thresholdCoefficient, value2, percentChange):
+    line = str(flagCount) + ")  " + header + " flagged because: "
+    reason = ""
+    if(inLimit == None or inLimit == "N/A"):
+        reason += "[Change to/from Zero]: "
+        if(diff>0):
+            reason += "Value in input1 increased from 0 to "+str(diff)+" (relative to input2)"
+        else:
+            reason += "Value in input1 decreased from "+str(value2)+" to 0"+" (relative to input2)"
+    else:
+        # range of non-flagged values is +- tolerance
+        tolerance = thresholdCoefficient * value2
+        if(diff<0):
+            reason += "[Significant Reduction]: Value in input1 ("+str(int(value2+diff))+") decreased below specified threshold ("+str(value2 - (tolerance))+") by "+str(abs(diff - tolerance))
+            
+        else:
+            reason += "[Significant Increase]: Value in input1 ("+str(int(value2+abs(diff)))+") exceeded max threshold ("+str(value2 - (tolerance))+") by "+str(diff - tolerance)
+        reason += " ("+str(round(float(percentChange) - thresholdCoefficient*100,2))+"%)" +" (relative to input2)"
+    line += reason + "\n\n"
+    return line
+
+def output_flagged(flagLines, flagCount, in_file, generate_flag_files):
+    timeTag = str(datetime.now()).replace(" ", "_").split(".")[0].replace(":","")
+    # TODO  consider either trimming date or removing altogether as it makes the file name rly long
+    filename = "flagged_"+format_token_dots(in_file)+"-"+timeTag+".txt" if(generate_flag_files) else "[FLAG OUTPUT DISABLED]"
+    print(str(flagCount) + " flags raised, see "+filename+" for details")
+    if(generate_flag_files):
+        flagout = open(filename, "w+")
+        # see specified output csv or diff results for further details
+        out_str = "===========Flagged Results===========\n" + flagLines
+        flagout.write(out_str)
+    
+#  line_in1 and 2 in order that they are inputted on cmd line
+def get_diff(header_in, line_in1, line_in2, index, generate_flag_files, conciseOutput, printRatios):
+    # this won't work if 'columns' aren't aligned, maybe inelegant but no reason for these to not be aligned
+    print("======Preliminary QoR Results======\n(a=input1 b=input2)\t(see output csv for more data)\n")
+    headerVal = ""
+    ret_str = "Difference" + delim
+    ratioLine = "Percent" + delim # only used if printRatio true
+    if(conciseOutput):
+        print("No summary (concise mode)\n")
+    else:
+        print("\tCategory\t\t\t\tDifference (b-a)\tRatio (b/a)\t\t% Change   (sign)\tWithin Threshold?\tFlagged")
+        print("-------------------------------------------------------------------------------------------------------------------------------------------------------")
+    headerVal = str(header_in.split(delim)[index])
+    # TODO Replace float(symbol*) etc multiple conversions with one conversion (program is lightweight anyway so doesn't matter for perf, just messy)
+    # TODO Make the spacing / tabbing situation more consistent and less awful
+    # TODO Saying N/A for changes from/to zero is a bit vague, change to something else
+    thresholds = threshold_test()
+    flags = 0
+    flagLine = ""
+    input1_name = ""
+
+    while headerVal != "\n":
+        if(headerVal == ("input_file")):
+            input1_name = get_token_sym(line_in1, index, delim) # we want the second input name to name our flag file after
+            input2_name = get_token_sym(line_in2, index, delim)
+            print("Testing "+input2_name+" (b) against "+input1_name+" (a)")
+            index += 1
+            headerVal = str(header_in.split(delim)[index])
+            ret_str += "N/A"+delim
+            ratioLine += "N/A"+delim
+            continue
+        symbolB = get_token_sym(line_in2, index, delim)
+        symbolA = get_token_sym(line_in1, index, delim)
+        # get diff of headerVal, write diff to ret line, check flags and store them as string to be outputted right before function return, prints summary to stdout
+        if((symbolB and symbolA) and symbolB.lower() != "nan" and symbolA.lower() != "nan" and symbolA != "\n" and symbolB != "\n"):
+            diff = int(float(symbolB) - float(symbolA))
+            ret_str += str(diff) + delim
+            #sign = "" if (diff == 0) else ("+" if diff > 0 else "-")
+            sign = "" if diff <= 0 else "+"
+            biggerSmaller = " No Change" if (diff == 0) else (" b > a" if diff > 0 else " a > b")
+            spacing = "" if (len(headerVal) >= 15) else "\t"
+            ratio ="0.0 (a=b=0)" if (not float(symbolB) and not float(symbolA)) else "undef (a=0)" if (float(symbolB) and not float(symbolA)) else str(round(float(symbolB) / float(symbolA),5))
+            # this is a very janky formatting thing, cleanup later
+            ratio += " "*(11-len(ratio))
+            percentChange = "INF" if float(symbolB) and not float(symbolA) else "0" if diff == 0 else str(round((diff / float(symbolA) * 100),3))
+            ratioLine += "INF" if(percentChange=="INF") else "0" if(diff==0) else "-100.0" if float(symbolA) and not float(symbolB) else str(round((diff / float(symbolA)),4)*100)
+            ratioLine += delim
+            if(thresholds and thresholds.get(headerVal) != None):
+                if(float(symbolB) == 0 or float(symbolA) == 0):
+                    withinLimit = "N/A"
+                else:
+                    withinLimit = within_threshold(thresholds, headerVal, diff, float(percentChange))
+            else:
+                withinLimit = "N/A"
+            isFlagged = is_flagged(withinLimit, float(symbolB), float(symbolA))
+            flagged = "No"
+            if(isFlagged):
+                flagged = "Yes"
+                flags += 1
+                thresholdCoefficient = 0.0
+                if(thresholds and thresholds.get(headerVal) != None):
+                    thresholdCoefficient = float(thresholds.get(headerVal)) / 100
+                flagLine += flag_line(headerVal, withinLimit, flags, diff, thresholdCoefficient, float(symbolA), percentChange)
+            percentChange +="%"+" "*(10-len(percentChange))
+            if(not conciseOutput):
+                print("\t"+headerVal+":\t\t\t"+spacing+sign+str(diff)+"\t\t\t"+str(ratio)+"\t\t"+percentChange+biggerSmaller+" \t"+withinLimit+"\t\t\t"+flagged)
+        else:
+            ret_str += "NaN"+delim
+            ratioLine += "NaN"+delim if(printRatios) else ""
+        index += 1
+        headerVal = str(header_in.split(delim)[index])
+    if(flags >= 1):
+        output_flagged(flagLine, flags, input1_name, generate_flag_files)
+    ret_str += ("\n"+ratioLine) if(printRatios) else ""
+    return ret_str
+    
+
+def insert_string(value_map, key, input_str):
+    value_map[key] = format_token(input_str)
+
+def insert_decimal(value_map, key, input_str):
+    value_map[key] = str(assert_float(format_token(input_str)))
+
+# quickly generates thresholds for core stats, same value for each stat
+def generate_thresholds(percentage, filename):
+    ft = open(filename,"w+")
+    wrt = ""
+    coreStats = ["num_nodes"
+        , "num_names"
+        , "num_latches"
+        , "num_edges_fo"
+        , "num_input_nodes"
+        , "num_top_output_nodes"
+        , "max_dist_out"
+        , "min_dist_out"
+        , "num_already_visited"
+        , "top_input_avg_dist_min"
+        , "top_input_avg_dist_max"
+        , "longest_minpath"
+        , "shortest_maxpath"
+        , "vcc_fanout_live"
+        , "gnd_fanout_live"]
+        #, "nodeOutputCount"]
+    for header in coreStats:
+        wrt += header + ": "+str(percentage)+"\n"
+    ft.write(wrt)
+
+# TODO the parser really doesn't like newline after word w/out space, which could cause problems for people creating their own threshold files
+def parse_line(benchmarks, line):
+
+    line.strip()
+    line.strip("\n")
+    line = " ".join(line.split())
+    
+    global current_line
+    current_line = line
+
+    if contains(line, {"Executing simulation with", "threads"}):
+        insert_decimal(benchmarks, "max_thread_count", get_token(line,8))
+
+    elif contains(line, {"Simulating", "vectors"}):
+        insert_decimal(benchmarks, "number_of_vectors", get_token(line,2))
+#file_names, most importantly input_file
+    elif contains(line, {"input_file:"}):
+        insert_string(benchmarks, "input_file", get_token(line,2))
+# unclear we even want this?
+    #elif contains(line, {"output_file:"}):
+    #    insert_string(benchmarks, "output_file", get_token(line,2))
+
+# PARSE STATS 
+    elif contains(line, {"num_nodes:"}):
+        insert_decimal(benchmarks, "num_nodes", get_token(line,2))
+
+    elif contains(line, {"num_names:"}):
+        insert_decimal(benchmarks, "num_names", get_token(line,2))
+
+    elif contains(line, {"num_latches:"}):
+        insert_decimal(benchmarks, "num_latches", get_token(line,2))
+
+    elif contains(line, {"vcc_fanout_live:"}):
+        insert_decimal(benchmarks, "vcc_fanout_live", get_token(line,2))
+
+    elif contains(line, {"gnd_fanout_live:"}):
+        insert_decimal(benchmarks, "gnd_fanout_live", get_token(line,2))
+
+    elif contains(line, {"num_subckts:"}):
+        insert_decimal(benchmarks, "num_subckts", get_token(line,2))
+    
+    elif contains(line, {"num_logic_nodes:"}):
+        insert_decimal(benchmarks, "num_logic_nodes", get_token(line,2))
+
+    elif contains(line, {"num_nets:"}):
+        insert_decimal(benchmarks, "num_nets", get_token(line,2))
+    
+    elif contains(line, {"num_edges_fo:"}):
+        insert_decimal(benchmarks, "num_edges_fo", get_token(line,2))
+
+    elif contains(line, {"num_total_input_pins:"}):
+        insert_decimal(benchmarks, "num_total_input_pins", get_token(line,2))
+
+    elif contains(line, {"gnd_path_length:"}):
+        insert_decimal(benchmarks, "gnd_path_length", get_token(line,2))
+
+    elif contains(line, {"vcc_path_length:"}):
+        insert_decimal(benchmarks, "vcc_path_length", get_token(line,2))
+
+    elif contains(line, {"max_level:"}):
+        insert_decimal(benchmarks, "max_level", get_token(line,2))
+    
+
+    #elif contains(line, {"longest_toplvl_path:"}):
+    #    insert_decimal(benchmarks, "longest_toplvl_path", get_token(line,2))
+
+    #elif contains(line, {"shortest_toplvl_path:"}):
+    #    insert_decimal(benchmarks, "shortest_toplvl_path", get_token(line,2))
+
+    elif contains(line, {"num_input_nodes:"}):
+        insert_decimal(benchmarks, "num_input_nodes", get_token(line,2))
+
+    elif contains(line, {"num_top_output_nodes:"}):
+        insert_decimal(benchmarks, "num_top_output_nodes", get_token(line,2))
+
+    elif contains(line, {"num_memories:"}):
+        insert_decimal(benchmarks, "num_memories", get_token(line,2))
+
+    elif contains(line, {"num_adders:"}):
+        insert_decimal(benchmarks, "num_adders", get_token(line,2))
+    
+    elif contains(line, {"num_muxes:"}):
+        insert_decimal(benchmarks, "num_muxes", get_token(line,2))
+
+    elif contains(line, {"num_carry_func:"}):
+        insert_decimal(benchmarks, "num_carry_func", get_token(line,2))
+
+    elif contains(line, {"num_generic_nodes:"}):
+        insert_decimal(benchmarks, "num_generic_nodes", get_token(line,2))
+
+    elif contains(line, {"num_unconn:"}):
+        insert_decimal(benchmarks, "num_unconn", get_token(line,2))
+    
+    elif contains(line, {"num_deadends:"}):
+        insert_decimal(benchmarks, "num_deadends", get_token(line,2))
+
+    elif contains(line, {"num_deadend_inputs:"}):
+        insert_decimal(benchmarks, "num_deadend_inputs", get_token(line,2))
+
+    elif contains(line, {"num_already_visited:"}):
+        insert_decimal(benchmarks, "num_already_visited", get_token(line,2))
+
+    elif contains(line, {"avg_fanin_per_node:"}):
+        insert_decimal(benchmarks, "avg_fanin_per_node", get_token(line,2))
+
+    elif contains(line, {"avg_fanout_per_net:"}):
+        insert_decimal(benchmarks, "avg_fanout_per_net", get_token(line,2))
+
+    elif contains(line, {"avg_output_pins_per_node:"}): # too long
+        insert_decimal(benchmarks, "avg_outpins_per_node", get_token(line,2))
+
+    elif contains(line, {"avg_top_lvl_fanout:"}):
+        insert_decimal(benchmarks, "avg_top_lvl_fanout", get_token(line,2))
+
+    elif contains(line, {"top_input_fanout:"}):
+        insert_decimal(benchmarks, "top_input_fanout", get_token(line,2))
+
+    elif contains(line, {"pad_node_fanout:"}):
+        insert_decimal(benchmarks, "pad_node_fanout", get_token(line,2))
+
+    elif contains(line, {"fanin_outputs_total:"}):
+        insert_decimal(benchmarks, "fanin_outputs_total", get_token(line,2))
+
+    elif contains(line, {"fanin_outputs_avg:"}):
+        insert_decimal(benchmarks, "fanin_outputs_avg", get_token(line,2))
+
+    elif contains(line, {"fanin_node_to_output:"}):
+        insert_decimal(benchmarks, "fanin_node_to_output", get_token(line,2))
+
+    elif contains(line, {"max_fanout_node:"}):
+        insert_decimal(benchmarks, "max_fanout_node", get_token(line,2))
+
+    elif contains(line, {"max_fanin_node:"}):
+        insert_decimal(benchmarks, "max_fanin_node", get_token(line,2))
+
+    elif contains(line, {"avg_toplvl_chain_max_length:"}):
+        insert_decimal(benchmarks, "avg_toplvl_chain_max_length", get_token(line,2))
+
+    # new stats
+    elif contains(line, {"min_dist_out:"}):
+        insert_decimal(benchmarks, "min_dist_out", get_token(line,2))
+
+    elif contains(line, {"max_dist_out:"}):
+        insert_decimal(benchmarks, "max_dist_out", get_token(line,2))
+
+    elif contains(line, {"top_input_avg_dist_max:"}):
+        insert_decimal(benchmarks, "top_input_avg_dist_max", get_token(line,2))
+
+    elif contains(line, {"top_input_avg_dist_min:"}):
+        insert_decimal(benchmarks, "top_input_avg_dist_min", get_token(line,2))
+
+    elif contains(line, {"avg_min_dist_out:"}):
+        insert_decimal(benchmarks, "avg_min_dist_out", get_token(line,2))
+
+    elif contains(line, {"longest_minpath:"}):
+        insert_decimal(benchmarks, "longest_minpath", get_token(line,2))
+
+    elif contains(line, {"shortest_maxpath:"}):
+        insert_decimal(benchmarks, "shortest_maxpath", get_token(line,2))
+
+    elif contains(line, {"vcc_max_path:"}):
+        insert_decimal(benchmarks, "vcc_max_path", get_token(line,2))
+
+    elif contains(line, {"gnd_max_path:"}):
+        insert_decimal(benchmarks, "gnd_max_path", get_token(line,2))
+
+    elif contains(line, {"vcc_min_path:"}):
+        insert_decimal(benchmarks, "vcc_min_path", get_token(line,2))
+
+    elif contains(line, {"gnd_min_path:"}):
+        insert_decimal(benchmarks, "gnd_min_path", get_token(line,2))
+
+    elif contains(line, {"gnd_fanout_all:"}):
+        insert_decimal(benchmarks, "gnd_fanout_all", get_token(line,2))
+
+    elif contains(line, {"vcc_fanout_all:"}):
+        insert_decimal(benchmarks, "vcc_fanout_all", get_token(line,2))
+
+    elif contains(line, {"pad_fanout_all:"}):
+        insert_decimal(benchmarks, "pad_fanout_all", get_token(line,2))
+
+    elif contains(line, {"max_input_pathrange:"}):
+        insert_decimal(benchmarks, "max_input_pathrange", get_token(line,2))
+
+    elif contains(line, {"min_input_pathrange:"}):
+        insert_decimal(benchmarks, "min_input_pathrange", get_token(line,2))
+
+    elif contains(line, {"avg_pathrange:"}):
+        insert_decimal(benchmarks, "avg_pathrange", get_token(line,2))
+
+    elif contains(line, {"top_lvl_avg_max:"}):
+        insert_decimal(benchmarks, "top_lvl_avg_max", get_token(line,2))
+
+    #elif contains(line, {"avg_node_max_dist:"}):
+    #   insert_decimal(benchmarks, "avg_node_max_dist", get_token(line,2))
+
+##################################
+    elif contains(line, {"num_output_nodes:"}):
+        insert_decimal(benchmarks, "num_output_nodes", get_token(line,2))
+
+# The name of this value is perhaps more clear than max_dist_out but less accurate
+#    elif contains(line, {"Longest Chain:"}):
+#        insert_decimal(benchmarks, "longest_chain", get_token(line,2))
+
+    elif contains(line, {"Simulation time:"}):
+        insert_decimal(benchmarks, "simulation_time", time_to_millis(get_token(line,3)))
+
+    elif contains(line, {"Elapsed time:"}):
+        insert_decimal(benchmarks, "elapsed_time", time_to_millis(get_token(line,3)))
+
+    elif contains(line, {"Coverage:"}):
+        insert_decimal(benchmarks, "percent_coverage", get_token(line,3))
+
+    elif contains(line, {"Odin ran with exit status:"}):
+        insert_decimal(benchmarks, "exit_code", get_token(line,6))
+
+    elif contains(line, {"Odin II took", "seconds", "(max_rss"}):
+        insert_decimal(benchmarks, "total_time", time_to_millis(get_token(line,4) + 's'))
+        insert_decimal(benchmarks, "max_rss", size_to_MiB(get_token(line,7) + get_token(line,8)))
+
+    elif contains(line, {"context-switches #"}):
+        insert_decimal(benchmarks, "context_switches", get_token(line,1))
+
+    elif contains(line, {"cpu-migrations #"}):
+        insert_decimal(benchmarks, "cpu_migration", get_token(line,1))
+
+    elif contains(line, {"page-faults #"}):
+        insert_decimal(benchmarks, "page_faults", get_token(line,1))
+
+    elif contains(line, {"stalled-cycles-frontend #"}):
+        insert_decimal(benchmarks, "stalled_cycle_frontend", get_token(line,1))
+
+    elif contains(line, {"stalled-cycles-backend #"}):
+        insert_decimal(benchmarks, "stalled_cycle_backend", get_token(line,1))
+
+    elif contains(line, {"cycles #"}):
+        insert_decimal(benchmarks, "cycles", get_token(line,1))
+
+    elif contains(line, {"branches #"}):
+        insert_decimal(benchmarks, "branches", get_token(line,1))
+
+    elif contains(line, {"branch-misses #"}):
+        insert_decimal(benchmarks, "branch_misses", get_token(line,1))
+
+    elif contains(line, {"LLC-loads #"}):
+        insert_decimal(benchmarks, "llc_loads", get_token(line,1))
+
+    elif contains(line, {"LLC-load-misses #"}):
+        insert_decimal(benchmarks, "llc_load_miss", get_token(line,1))
+
+    elif contains(line, {"CPU:"}):
+        insert_decimal(benchmarks, "percent_cpu_usage", get_token(line,2))
+
+    elif contains(line, {"Minor PF:"}):
+        insert_decimal(benchmarks, "minor_page_faults", get_token(line,2))
+    # Unimplemented   
+    """elif contains(line, {"Connections:"}):
+        insert_decimal(benchmarks, "number_of_connections", get_token(line,2))
+
+    elif contains(line, {"Threads:"}):
+        insert_decimal(benchmarks, "used_threads", get_token(line,2))	
+
+    elif contains(line, {"Degree:"}):
+        insert_decimal(benchmarks, "degree", get_token(line,2))
+
+    elif contains(line, {"Stages:"}):
+        insert_decimal(benchmarks, "number_of_stages", get_token(line,2))
+    """
+
+
+def main():
+    if(len(sys.argv)<2 or sys.argv[1] == "--help" or sys.argv[1] == "-h"):
+        help_menu(0)
+        exit(0)
+    
+    benchmarks = [{}]
+    key_list = [
+        "max_thread_count"
+        , "number_of_vectors"
+        , "input_file"
+        , "num_nodes"
+        , "num_names"
+        , "num_latches"
+        , "num_input_nodes"
+        , "num_top_output_nodes"
+        , "max_depth"
+        , "longest_chain"
+        , "output_counter"
+        , "num_subckts"
+        , "num_unconn"
+        , "num_nets"
+        , "num_logic_nodes"
+        , "num_memories"
+        , "num_muxes"
+        , "num_adders"
+        , "num_total_input_pins"
+        , "num_carry_func"
+        , "num_generic_nodes"
+        , "num_deadends"
+        , "num_deadend_inputs"
+        , "num_already_visited"
+        , "avg_outpins_per_node"
+        , "avg_fanin_per_node"
+        , "avg_fanout_per_net"
+        , "top_input_fanout"
+        , "avg_top_lvl_fanout"
+        , "pad_node_fanout"
+        , "fanin_outputs_total"
+        , "fanin_outputs_avg"
+        , "num_nodes_to_output"
+        , "max_fanout_node"
+        , "max_fanin_node"
+        , "max_level"
+        , "gnd_path_length"
+        , "vcc_path_length"
+        , "vcc_max_path"
+        , "vcc_min_path"
+        , "max_dist_out"
+        , "min_dist_out"
+        , "top_input_avg_dist_min"
+        , "top_input_avg_dist_max"
+        #, "longest_toplvl_path"
+        #, "shortest_toplvl_path"
+        ,"shortest_maxpath"
+        , "longest_minpath"
+        , "top_lvl_avg_max"
+        , "avg_node_max_dist"
+        , "avg_toplvl_chain_max_length"
+        , "longest_latch_chain"
+        , "longest_consecutive_latch_chain"
+        , "num_edges_fo"
+        , "num_edges_fi"
+        #######################
+        , "vcc_fanout_live"
+        , "gnd_fanout_live"
+        , "pad_fanout_live"
+        , "gnd_fanout_all"
+        , "vcc_fanout_all"
+        , "pad_fanout_all"
+        , "max_input_pathrange"
+        , "min_input_pathrange"
+        , "output_file"
+        ########################## from prev parser
+        , "simulation_time"
+        , "elapsed_time"
+        , "percent_coverage"
+        , "exit_code"
+        , "total_time"
+        , "max_rss"
+        , "context_switches"
+        , "cpu_migration"
+        , "page_faults"
+        , "stalled_cycle_frontend"
+        , "stalled_cycle_backend"
+        , "cycles"
+        , "branches"
+        , "branch_misses"
+        , "llc_loads"
+        , "llc_load_miss"
+        , "percent_cpu_usage"
+        , "minor_page_faults"
+    ]
+        #removed for now - unimplemented
+    """ 
+        , "number_of_connections"
+        , "used_threads"
+        , "degree"
+        , "number_of_stages"
+        """
+
+    """
+    # TODO add --help / -h flag and put all formatting options in sep function, call function on error or help
+    # multimode, multiple inputs into csv and do nothing else 
+    # TODO Streamline all this args stuff into something more elegant
+    # Minimum of 3 inputs required
+    # TODO (maybe) Could do diffs on these as well as long as they are bunched in twos but that is perhaps overkill
+    # TODO Maybe add percent changes as a fourth line
+    # this hinges on the x.abc.blif a.odin.blif format generated by run_vtr_flow and supplied in alphabetical order
+    # This is kind of the inverse of how we presently use compare mode, which assumes the 'reduced' log will be compared against input1
+    # NOTE This now by default does not produce flag files for -mc mode (but still flag warnings) unless "--flags explicitly specified 
+    # Also --concise flag disables printing of summary to stdout
+    # TODO Multicompare works fine with 2 inputs and so compareMode is somewhat redundant, only different in defaulting to flags on
+    # Another way to do multicompare would be to test every line against every previous line, not sure if that is better or worse than using pairs"""
+    global threshold_file
+    i = 0
+    global delim
+    output_file = ""
+    conciseOutput = False
+    printRatios = False
+    flag_offset = 0      # rename to something more general given its dual role
+    flags = False   # to handle disabling the flag files which gets to be very unwieldy
+    j = 2
+    while(j < 8): # again this should maybe check against -mc but at least this is stable and doesn't require handling
+        if(j < len(sys.argv)-2 ): # if you specify flags and no input then nothing should happen
+            if(sys.argv[j] == "--flags" or sys.argv[j] == "-f"): # This should check if(-mc) but this way they can specify --flags and be ignored and not break everything
+                if(sys.argv[1] != "-mc" and sys.argv[1] != "-c"):
+                    help_menu(1)
+                flags = True
+                flag_offset += 1
+            elif(sys.argv[j] == "--concise" or sys.argv[j] == "-con"):
+                conciseOutput = True
+                flag_offset += 1
+            elif(sys.argv[j] == "--ratio" or sys.argv[j] == "-r" or sys.argv[j] == "-p"): # print ratios as well as diff, remove the r part it's not a ratio anymore
+                printRatios = True
+                flag_offset+=1
+            elif(sys.argv[j] == "-t"): # if you really wanted to screw this up you could stick it in the middle of the outputs and mess up the offset
+                if(sys.argv[j+1][0] != "-"):
+                    threshold_file = sys.argv[j+1]
+                    flag_offset += 2
+                    print("Threshold File: "+threshold_file)
+        else:
+            break
+        j+=1
+    if(sys.argv[1] == "-m" or sys.argv[1] == "-mc"):
+        if(len(sys.argv) <= 3):
+            help_menu(2)
+            exit(1)
+
+        inputCount = (len(sys.argv)-(3 + flag_offset))
+        if(inputCount==0):
+            help_menu(4)
+            exit(4)
+
+        if(output_file[len(output_file)-4 : len(output_file)] != ".log"):
+            output_file = sys.argv[2+flag_offset]
+        else: # this almost is not worth the effort
+            output_file = "default_out.csv"
+            inputCount -= 1
+            flag_offset -= 1
+        if(output_file[0]=="-"):
+            help_menu(7)
+            exit(7)
+        if(output_file[len(output_file)-4:len(output_file)] == ".tsv"): # this is used verbatim below, think of streamlining this
+            delim = "\t" # default is ","
+
+        values_in = [""]*inputCount
+        log_file_to_parse = [""]*inputCount
+        header_in = ""
+        # output must always be at end of flags, which isn't very versatile might change, also light guard against not including an output file only works if log file explicitly is .log
+
+        print("printing to output_file: "+output_file)
+        
+        # TODO Maybe guard against inputs starting with -
+        while(i < inputCount):
+            benchmarks.append({})
+            log_file_to_parse[i] = sys.argv[i+(3+flag_offset)]
+            fileContext = open(log_file_to_parse[i], "r")
+            for wholeLine in fileContext:
+                parse_line(benchmarks[i], wholeLine)
+            i += 1
+        i = 0
+        while(i < inputCount):
+            values_in[i] += "Input" + str(i+1) + delim + get_all_value(benchmarks, key_list, i) + "\n"
+            i += 1
+        # TODO Some kind of check in case one of the inputs is totally empty or invalid
+        header_in += "Headers"+delim+get_all_valid_key_multi(benchmarks, key_list) + "\n"
+        f = open(output_file,"w+")
+        f.write(header_in)
+        alternator = 0 # this is probably ... not the best way to do a toggle
+        for index, vals in enumerate(values_in):
+            f.write(vals) # write out line to csv output
+            alternator += 1
+            # compare every second line with preceding line
+            if(sys.argv[1] == "-mc" and alternator % 2 == 0):
+                # verify this print doesn't break anything with > 2 inputs
+                print("Logfiles: Input1=\""+log_file_to_parse[alternator-2]+"\" | Input2=\""+log_file_to_parse[alternator-1]+"\"\n") # to reduce confusion when comparing same input file names but different logs
+                line1 = values_in[index-1] # preceding line
+                f.write(get_diff(header_in, line1, vals, 1, flags, conciseOutput, printRatios)+"\n")
+        f.close()
+        exit(0)
+    # generate thresholds file
+    if len(sys.argv) >= 2 and (sys.argv[1] == "-gen" or sys.argv[1] == "-g"):
+        # if you specify file you must specify percent first
+        try:
+            percent = 0.15 if(len(sys.argv) < 3) else float(sys.argv[2])
+        except:
+            help_menu(3)
+            exit(3)
+        threshold_file = "thresholds.txt" if len(sys.argv) < 4 else sys.argv[3]
+        # if you want to specify a file you have to put in -f 
+        print("Generating "+threshold_file+" for core stats, +/- "+str(100*percent)+"%")
+        generate_thresholds(percent, threshold_file)
+        exit(0)
+
+    # at this point we've fallen through to compare and/or simple mode
+    log_file_to_parse = ["", ""]
+
+    compareMode = 0 
+    # -c == compareMode (TODO maybe this should not alter the original csv supplied to it)
+    # TODO In making -mc mode the simple mode and -c were not similarly upgraded and/or tested so do that
+    # TODO Make -t part of -mc
+    if(sys.argv[1] == "-c"):
+        compareMode = 1
+        #there should be a better argument control structure, this really got out of hand
+        if(len(sys.argv)<(4+flag_offset)):
+            help_menu(6)
+            exit(6)
+        output_file = "default_out.csv" if (len(sys.argv) < 5 + flag_offset) else sys.argv[2+flag_offset]
+        while i < len(sys.argv)-1: # This now exists only to pickup the (non-specified) use-case of using -t <thresh> after input2 in compare mode
+            if(threshold_file != ""):
+                break
+            if(sys.argv[i] == "-t"):
+                threshold_file = sys.argv[i+1]
+                print("Threshold File: "+threshold_file)
+            i += 1
+
+        log_file_to_parse[0] = sys.argv[3+flag_offset]
+        log_file_to_parse[1] = sys.argv[4+flag_offset]
+    else: # simple mode, turn one input into an output csv/tsv
+        log_file_to_parse[0] = sys.argv[1]
+        output_file = "default_out.csv" if(len(sys.argv) < 3) else sys.argv[2+flag_offset] # offset should = 0 here but in case it doesn't just offset args and push thru
+
+    if(output_file[0]=="-" or output_file[len(output_file)-4 : len(output_file)] == ".log"):
+            help_menu(7)
+            exit(7)
+    if(output_file[len(output_file)-3:len(output_file)] == "tsv"):
+        delim = "\t" # default is ","
+    i = 0
+    f = open(output_file,"w+")
+    line1 = "" # The stats we want to evaluate
+    line2 = "" # The stats we are comparing against
+    header_in = ""
+
+    # Compare or simple mode -- TODO This has become somewhat inelegant and redundant as -mc will handle 2 or more inputs and this handles 1 or 2
+    values_in = [""]*(compareMode+1)
+    print("Output CSV: "+output_file)
+    if(compareMode): benchmarks.append({}) # benchmark is now list of two dictionaries
+    while i <= compareMode:
+        fileContext = open(log_file_to_parse[i], "r")
+        for wholeLine in fileContext:
+            parse_line(benchmarks[i], wholeLine)
+        i += 1
+
+    # no longer any need for line1 and line2 just use the list values themselves as strings
+    values_in[0] += "Input" + str(1) + delim + get_all_value(benchmarks, key_list, 0) + "\n"
+    line1 = values_in[0]
+    # Going through entire keylist for just input files is a bit inefficient but acceptable for now
+    # this is supposed to strip headers that are missing both values but it might do it if only second num is missing, can't tell
+    header_in += "Headers"+delim+get_all_valid_key(benchmarks, key_list) + "\n"
+    f.write(header_in)
+    f.write(values_in[0])
+    # these are reversed because it was backwards, 'a' is baseline
+    if(compareMode):
+        values_in[1] += "Input" + str(2) + delim + get_all_value(benchmarks, key_list, 1) + "\n"
+        line2 = values_in[1] # TODO remove line1 and line2 probably
+        f.write(values_in[1])
+        print("====================")
+        flag = 0
+        print("Logfiles: Input1=\""+log_file_to_parse[0]+"\" | Input2=\""+log_file_to_parse[1]+"\"\n") # to reduce confusion when comparing same input file names but different logs
+        f.write(get_diff(header_in, line1, line2, 1, flags, conciseOutput, printRatios) + "\n")
+    f.close()
+    exit(0)
+    #TODO have some way to have a different exit code if flags or something
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Squashed commit of project to generate netlist statistics including of
node types, levels, fanout and path length. Parser file to process the
output. Additional arguments added to Odin for Verbose and non-verbose
versions.

#### Description
This is the project aimed at gathering netlist characteristics in Odin like node type, counts, levels, fanout and path length.
The mechanism of collection for basic node information is just a recursive dfs traversal based on output_blif. I ended up separating verbose and non-verbose versions of the stat generator in part because some of the verbose data is irrelevant to basic profiling (# nodes, edges etc.) and because collecting path statistics is costly and possibly not as reliable and/or desirable. The non-verbose version still does a separate dfs of all COs to get the max level. 

Adds to odin.cpp "--stat" and --stat_verbose" arguments.

The parser parse_odin_stats.py processes the output of generate_blif_stats.cpp and dumps it into a csv/tsv. It also can compare outputs and flag major changes etc as part of a set of basic QoR features. The parser could probably be made a bit cleaner in terms of readability but adding/removing metrics is fairly simple.

I left this as a WIP because there were a couple things I wasn't sure about and I wasn't sure to what degree this should be pared down or added to. For example: I left a commented out reversed get_max_levels function in but I don't have any use for it presently, it can be used as a different way of getting path length data but I assume should be removed? I have questions w/r/t the way the max path is calculated. _I will include these questions as well as highlighted code shortly._
In particular the increased overhead of adding data members to the node and net structs should be discussed.

#### Motivation and Context
The intention of the project was to collect data on the netlist struct generated after using -V or -b in Odin-II to quantify possible changes between netlists either as a result of changing the Odin-II logic synthesis process or between Odin and ABC BLIF outputs or other reasons. Basic count information (e.g. #latches) is known or obtained easily from the netlist struct and can be found with the simulator or ABC but other metrics are not as easily obtained, this is a different non-simulator means of collecting basic or verbose stats and at the least provides the framework with which to add other metrics for collection. It is my understanding that there was a netlist_stat struct that was never fully used or implemented. Perhaps it would be easier to start with the non-verbose version, which provides basic desirable information with low overhead.

#### How Has This Been Tested?
Passed running "make test" on previous commit, will run again. Unclear what counts as full test coverage. Failed one large memory benchmark because of limitations in testing environment. Works with verilog input and BLIF input although Verilog input will yield very slightly different results. Does not substantially alter existing code aside from odin_types.h and odin_ii.cpp. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
