### PR TITLE
Replace some uses of malloc/free with std::unique_ptr

### DIFF
--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -44,9 +44,9 @@ struct t_trace_branch {
 
 /**************** Static variables local to route_common.c ******************/
 
-static t_heap** heap; /* Indexed from [1..heap_size] */
-static int heap_size; /* Number of slots in the heap array */
-static int heap_tail; /* Index of first unused slot in the heap array */
+static t_heap** heap = nullptr; /* Indexed from [1..heap_size] */
+static int heap_size;           /* Number of slots in the heap array */
+static int heap_tail;           /* Index of first unused slot in the heap array */
 
 /* For managing my own list of currently free heap data structures.     */
 static t_heap* heap_free_head = nullptr;
@@ -467,14 +467,18 @@ void pathfinder_update_cost(float pres_fac, float acc_fac) {
     }
 }
 
+// Note: malloc()/free() must be used for the heap,
+//       or realloc() must be eliminated from add_to_heap()
+//       because there is no C++ equivalent.
 void init_heap(const DeviceGrid& grid) {
     if (heap != nullptr) {
         vtr::free(heap + 1);
-        heap = nullptr;
     }
+
     heap_size = (grid.width() - 1) * (grid.height() - 1);
-    heap = (t_heap**)vtr::malloc(heap_size * sizeof(t_heap*));
-    heap--; /* heap stores from [1..heap_size] */
+
+    // heap stores from [1..heap_size]
+    heap = (t_heap**)vtr::malloc(heap_size * sizeof(t_heap*)) - 1;
     heap_tail = 1;
 }
 

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -838,17 +838,11 @@ void alloc_timing_driven_route_structs(float** pin_criticality_ptr,
                                        t_rt_node*** rt_node_of_sink_ptr) {
     /* Allocates all the structures needed only by the timing-driven router.   */
 
-    int max_pins_per_net = get_max_pins_per_net();
-    int max_sinks = std::max(max_pins_per_net - 1, 0);
+    int max_sinks = std::max(get_max_pins_per_net() - 1, 0);
 
-    float* pin_criticality = (float*)vtr::malloc(max_sinks * sizeof(float));
-    *pin_criticality_ptr = pin_criticality - 1; /* First sink is pin #1. */
-
-    int* sink_order = (int*)vtr::malloc(max_sinks * sizeof(int));
-    *sink_order_ptr = sink_order - 1;
-
-    t_rt_node** rt_node_of_sink = (t_rt_node**)vtr::malloc(max_sinks * sizeof(t_rt_node*));
-    *rt_node_of_sink_ptr = rt_node_of_sink - 1;
+    *pin_criticality_ptr = new float[max_sinks] - 1; /* First sink is pin #1. */
+    *sink_order_ptr = new int[max_sinks] - 1;
+    *rt_node_of_sink_ptr = new t_rt_node*[max_sinks] - 1;
 
     alloc_route_tree_timing_structs();
 }
@@ -861,11 +855,11 @@ void free_timing_driven_route_structs(float* pin_criticality, int* sink_order, t
     /* Frees all the stuctures needed only by the timing-driven router.        */
 
     // coverity[offset_free : Intentional]
-    free(pin_criticality + 1); /* Starts at index 1. */
+    delete[](pin_criticality + 1); /* Starts at index 1. */
     // coverity[offset_free : Intentional]
-    free(sink_order + 1);
+    delete[](sink_order + 1);
     // coverity[offset_free : Intentional]
-    free(rt_node_of_sink + 1);
+    delete[](rt_node_of_sink + 1);
 
     free_route_tree_timing_structs();
 }

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1628,7 +1628,7 @@ static void timing_driven_expand_cheapest(t_heap* cheapest,
                                         target_node,
                                         router_stats);
     } else {
-        //Post-heap prune, do not re-explore from the current/new partial path as it 
+        //Post-heap prune, do not re-explore from the current/new partial path as it
         //has worse cost than the best partial path to this node found so far
         VTR_LOGV_DEBUG(f_router_debug, "    Worse cost to %d\n", inode);
         VTR_LOGV_DEBUG(f_router_debug, "    Old total cost: %g\n", best_total_cost);

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -91,7 +91,7 @@ bool alloc_route_tree_timing_structs(bool exists_ok) {
 
 void free_route_tree_timing_structs() {
     /* Frees the structures needed to build routing trees, and really frees
-     * (i.e. calls free) all the data on the free lists.                         */
+     * (i.e. deletes) all the data on the free lists.                         */
 
     t_rt_node *rt_node, *next_node;
     t_linked_rt_edge *rt_edge, *next_edge;
@@ -102,7 +102,7 @@ void free_route_tree_timing_structs() {
 
     while (rt_node != nullptr) {
         next_node = rt_node->u.next;
-        free(rt_node);
+        delete rt_node;
         rt_node = next_node;
     }
 
@@ -112,7 +112,7 @@ void free_route_tree_timing_structs() {
 
     while (rt_edge != nullptr) {
         next_edge = rt_edge->next;
-        free(rt_edge);
+        delete rt_edge;
         rt_edge = next_edge;
     }
 
@@ -131,7 +131,7 @@ alloc_rt_node() {
     if (rt_node != nullptr) {
         rt_node_free_list = rt_node->u.next;
     } else {
-        rt_node = (t_rt_node*)vtr::malloc(sizeof(t_rt_node));
+        rt_node = new t_rt_node;
     }
 
     return (rt_node);
@@ -156,7 +156,7 @@ alloc_linked_rt_edge() {
     if (linked_rt_edge != nullptr) {
         rt_edge_free_list = linked_rt_edge->next;
     } else {
-        linked_rt_edge = (t_linked_rt_edge*)vtr::malloc(sizeof(t_linked_rt_edge));
+        linked_rt_edge = new t_linked_rt_edge;
     }
 
     VTR_ASSERT(linked_rt_edge != nullptr);

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -214,9 +214,9 @@ void load_sblock_pattern_lookup(const int i,
                                 const enum e_switch_block_type switch_block_type,
                                 t_sblock_pattern& sblock_pattern);
 
-int* get_seg_track_counts(const int num_sets,
-                          const std::vector<t_segment_inf>& segment_inf,
-                          const bool use_full_seg_groups);
+std::unique_ptr<int[]> get_seg_track_counts(const int num_sets,
+                                            const std::vector<t_segment_inf>& segment_inf,
+                                            const bool use_full_seg_groups);
 
 void dump_seg_details(const t_chan_seg_details* seg_details,
                       int max_chan_width,


### PR DESCRIPTION
#### Description
`malloc()` and `free()` can be error-prone, so I'm working on replacing them with safer alternatives, but without adding overhead.

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/506

#### Motivation and Context
See issue above.

#### How Has This Been Tested?
I've run `vtr_reg_strong` tests.

#### Types of changes
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
