### PR TITLE
Refactor vtr::flat_map operator []

### DIFF
--- a/libs/libvtrutil/src/vtr_flat_map.h
+++ b/libs/libvtrutil/src/vtr_flat_map.h
@@ -122,13 +122,22 @@ class flat_map {
     }
 
     mapped_type& operator[](const key_type& key) {
-        auto iter = find(key);
+        auto iter = std::lower_bound(begin(), end(), key, value_comp());
         if (iter == end()) {
-            //Not found
-            iter = insert(std::make_pair(key, mapped_type())).first;
+            // The new element should be placed at the end, so do so.
+            vec_.emplace_back(std::make_pair(key, mapped_type()));
+            return vec_.back().second;
+        } else {
+            if (iter->first == key) {
+                // The element already exists, return it.
+                return iter->second;
+            } else {
+                // The element does not exist, insert such that vector remains
+                // sorted.
+                iter = vec_.emplace(iter, std::make_pair(key, mapped_type()));
+                return iter->second;
+            }
         }
-
-        return iter->second;
     }
 
     mapped_type& at(const key_type& key) {


### PR DESCRIPTION
#### Description

Previous implementation of the flat_map `operator []` did a `find` followed by an `insert`.  This effectively did a binary search twice (`find` calls `std::lower_bound`, and so does `insert`).  The correct optimal solution is to use `std::lower_bound`, and avoid the second lookup.

#### Related Issue

#### Motivation and Context

This makes using `operator []` faster by avoiding a second call to `std::lower_bound`.

#### How Has This Been Tested?

- [x] CI is green
- [x] Change was profiled before and after

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
