### PR TITLE
Use 2 boolean's per physical types instead of std::set to mark IO types.

### DIFF
--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -1321,3 +1321,38 @@ bool is_library_model(const char* model_name) {
 bool is_library_model(const t_model* model) {
     return is_library_model(model->name);
 }
+
+//Returns true if the specified block type contains the specified blif model name
+bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::string& blif_model_name) {
+    return pb_type_contains_blif_model(type->pb_type, blif_model_name);
+}
+
+//Returns true of a pb_type (or it's children) contain the specified blif model name
+bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::string& blif_model_name) {
+    if (!pb_type) {
+        return false;
+    }
+
+    if (pb_type->blif_model != nullptr) {
+        //Leaf pb_type
+        VTR_ASSERT(pb_type->num_modes == 0);
+        if (blif_model_name == pb_type->blif_model
+            || ".subckt " + blif_model_name == pb_type->blif_model) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        for (int imode = 0; imode < pb_type->num_modes; ++imode) {
+            const t_mode* mode = &pb_type->modes[imode];
+
+            for (int ichild = 0; ichild < mode->num_pb_type_children; ++ichild) {
+                const t_pb_type* pb_type_child = &mode->pb_type_children[ichild];
+                if (pb_type_contains_blif_model(pb_type_child, blif_model_name)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -1323,6 +1323,10 @@ bool is_library_model(const t_model* model) {
 }
 
 //Returns true if the specified block type contains the specified blif model name
+//
+// TODO: Remove block_type_contains_blif_model / pb_type_contains_blif_model
+// as part of
+// https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1193
 bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::string& blif_model_name) {
     return pb_type_contains_blif_model(type->pb_type, blif_model_name);
 }

--- a/libs/libarchfpga/src/arch_util.h
+++ b/libs/libarchfpga/src/arch_util.h
@@ -1,6 +1,7 @@
 #ifndef ARCH_UTIL_H
 #define ARCH_UTIL_H
 
+#include <regex>
 #include "physical_types.h"
 
 class InstPort {
@@ -74,4 +75,11 @@ bool segment_exists(const t_arch* arch, std::string name);
 const t_segment_inf* find_segment(const t_arch* arch, std::string name);
 bool is_library_model(const char* model_name);
 bool is_library_model(const t_model* model);
+
+//Returns true if the specified block type contains the specified blif model name
+bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::string& blif_model_name);
+
+//Returns true of a pb_type (or it's children) contain the specified blif model name
+bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::string& blif_model_name);
+
 #endif

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -620,7 +620,13 @@ struct t_physical_tile_type {
     /* Returns the indices of pins that contain a clock for this physical logic block */
     std::vector<int> get_clock_pins_indices() const;
 
+    // TODO: Remove is_input_type / is_output_type as part of
+    // https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1193
+
+    // Does this t_physical_tile_type contain an inpad?
     bool is_input_type;
+
+    // Does this t_physical_tile_type contain an outpad?
     bool is_output_type;
 };
 
@@ -1347,11 +1353,11 @@ enum class BufferSize {
  *            we would expect an additional "internal capacitance"           *
  *            to arise when the pass transistor is enabled and the signal    *
  *            must propogate to the buffer. See diagram of one stream below: *
- *                                                                           *   
+ *                                                                           *
  *                  Pass Transistor                                          *
  *                       |                                                   *
  *                     -----                                                 *
- *                     -----      Buffer                                     *   
+ *                     -----      Buffer                                     *
  *                    |     |       |\                                       *
  *              ------       -------| \--------                              *
  *                |             |   | /    |                                 *

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -619,6 +619,9 @@ struct t_physical_tile_type {
 
     /* Returns the indices of pins that contain a clock for this physical logic block */
     std::vector<int> get_clock_pins_indices() const;
+
+    bool is_input_type;
+    bool is_output_type;
 };
 
 /** A logical pin defines the pin index of a logical block type (i.e. a top level PB type)

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -98,6 +98,7 @@ static void ProcessTiles(pugi::xml_node Node,
                          const t_default_fc_spec& arch_def_fc,
                          t_arch& arch,
                          const pugiutil::loc_data& loc_data);
+static void MarkIoTypes(std::vector<t_physical_tile_type>& PhysicalTileTypes);
 static void ProcessTileProps(pugi::xml_node Node,
                              t_physical_tile_type* PhysicalTileType,
                              const pugiutil::loc_data& loc_data);
@@ -398,6 +399,7 @@ void XmlReadArch(const char* ArchFile,
         SyncModelsPbTypes(arch, LogicalBlockTypes);
         UpdateAndCheckModels(arch);
 
+        MarkIoTypes(PhysicalTileTypes);
     } catch (pugiutil::XmlError& e) {
         archfpga_throw(ArchFile, e.line(),
                        "%s", e.what());
@@ -3047,6 +3049,27 @@ static void ProcessTiles(pugi::xml_node Node,
         CurTileType = CurTileType.next_sibling(CurTileType.name());
     }
     tile_type_descriptors.clear();
+}
+
+static void MarkIoTypes(std::vector<t_physical_tile_type>& PhysicalTileTypes) {
+    for (auto& type : PhysicalTileTypes) {
+        type.is_input_type = false;
+        type.is_output_type = false;
+
+        for (const auto& equivalent_site : type.equivalent_sites) {
+            if (block_type_contains_blif_model(equivalent_site, MODEL_INPUT)) {
+                type.is_input_type = true;
+                break;
+            }
+        }
+
+        for (const auto& equivalent_site : type.equivalent_sites) {
+            if (block_type_contains_blif_model(equivalent_site, MODEL_OUTPUT)) {
+                type.is_output_type = true;
+                break;
+            }
+        }
+    }
 }
 
 static void ProcessTileProps(pugi::xml_node Node,

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -98,6 +98,9 @@ static void ProcessTiles(pugi::xml_node Node,
                          const t_default_fc_spec& arch_def_fc,
                          t_arch& arch,
                          const pugiutil::loc_data& loc_data);
+// TODO: Remove block_type_contains_blif_model / pb_type_contains_blif_model
+// as part of
+// https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1193
 static void MarkIoTypes(std::vector<t_physical_tile_type>& PhysicalTileTypes);
 static void ProcessTileProps(pugi::xml_node Node,
                              t_physical_tile_type* PhysicalTileType,

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -112,24 +112,20 @@ void SetupVPR(const t_options* Options,
 
     /* TODO: this is inelegant, I should be populating this information in XmlReadArch */
     device_ctx.EMPTY_PHYSICAL_TILE_TYPE = nullptr;
-    for (const auto& type : device_ctx.physical_tile_types) {
+    int num_inputs = 0;
+    int num_outputs = 0;
+    for (auto& type : device_ctx.physical_tile_types) {
         if (strcmp(type.name, EMPTY_BLOCK_NAME) == 0) {
             VTR_ASSERT(device_ctx.EMPTY_PHYSICAL_TILE_TYPE == nullptr);
             device_ctx.EMPTY_PHYSICAL_TILE_TYPE = &type;
-        } else {
-            for (const auto& equivalent_site : type.equivalent_sites) {
-                if (block_type_contains_blif_model(equivalent_site, MODEL_INPUT)) {
-                    device_ctx.input_types.insert(&type);
-                    break;
-                }
-            }
+        }
 
-            for (const auto& equivalent_site : type.equivalent_sites) {
-                if (block_type_contains_blif_model(equivalent_site, MODEL_OUTPUT)) {
-                    device_ctx.output_types.insert(&type);
-                    break;
-                }
-            }
+        if (type.is_input_type) {
+            num_inputs += 1;
+        }
+
+        if (type.is_output_type) {
+            num_outputs += 1;
         }
     }
 
@@ -149,12 +145,12 @@ void SetupVPR(const t_options* Options,
     VTR_ASSERT(device_ctx.EMPTY_PHYSICAL_TILE_TYPE != nullptr);
     VTR_ASSERT(device_ctx.EMPTY_LOGICAL_BLOCK_TYPE != nullptr);
 
-    if (device_ctx.input_types.empty()) {
+    if (num_inputs == 0) {
         VPR_ERROR(VPR_ERROR_ARCH,
                   "Architecture contains no top-level block type containing '.input' models");
     }
 
-    if (device_ctx.output_types.empty()) {
+    if (num_outputs == 0) {
         VPR_ERROR(VPR_ERROR_ARCH,
                   "Architecture contains no top-level block type containing '.output' models");
     }

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -110,7 +110,6 @@ void SetupVPR(const t_options* Options,
     *user_models = Arch->models;
     *library_models = Arch->model_library;
 
-    /* TODO: this is inelegant, I should be populating this information in XmlReadArch */
     device_ctx.EMPTY_PHYSICAL_TILE_TYPE = nullptr;
     int num_inputs = 0;
     int num_outputs = 0;

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -120,10 +120,6 @@ struct DeviceContext : public Context {
     /* x and y dimensions of the FPGA itself */
     DeviceGrid grid; /* FPGA complex block grid [0 .. grid.width()-1][0 .. grid.height()-1] */
 
-    /* Special pointers to identify special blocks on an FPGA: I/Os, unused, and default */
-    std::set<t_physical_tile_type_ptr> input_types;
-    std::set<t_physical_tile_type_ptr> output_types;
-
     /* Empty types */
     t_physical_tile_type_ptr EMPTY_PHYSICAL_TILE_TYPE;
     t_logical_block_type_ptr EMPTY_LOGICAL_BLOCK_TYPE;

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -72,7 +72,6 @@ static AtomPinId find_atom_pin_for_pb_route_id(ClusterBlockId clb, int pb_route_
 
 static bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::regex& blif_model_regex);
 static bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::regex& blif_model_regex);
-
 static t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type);
 static void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type);
 
@@ -544,15 +543,11 @@ bool is_opin(int ipin, t_physical_tile_type_ptr type) {
 }
 
 bool is_input_type(t_physical_tile_type_ptr type) {
-    auto& device_ctx = g_vpr_ctx.device();
-
-    return device_ctx.input_types.count(type);
+    return type->is_input_type;
 }
 
 bool is_output_type(t_physical_tile_type_ptr type) {
-    auto& device_ctx = g_vpr_ctx.device();
-
-    return device_ctx.output_types.count(type);
+    return type->is_output_type;
 }
 
 bool is_io_type(t_physical_tile_type_ptr type) {
@@ -811,45 +806,9 @@ int find_pin(t_physical_tile_type_ptr type, std::string port_name, int pin_index
     return ipin;
 }
 
-//Returns true if the specified block type contains the specified blif model name
-bool block_type_contains_blif_model(t_logical_block_type_ptr type, std::string blif_model_name) {
-    return pb_type_contains_blif_model(type->pb_type, blif_model_name);
-}
-
 static bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::regex& blif_model_regex) {
     return pb_type_contains_blif_model(type->pb_type, blif_model_regex);
 }
-
-//Returns true of a pb_type (or it's children) contain the specified blif model name
-bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::string& blif_model_name) {
-    if (!pb_type) {
-        return false;
-    }
-
-    if (pb_type->blif_model != nullptr) {
-        //Leaf pb_type
-        VTR_ASSERT(pb_type->num_modes == 0);
-        if (blif_model_name == pb_type->blif_model
-            || ".subckt " + blif_model_name == pb_type->blif_model) {
-            return true;
-        } else {
-            return false;
-        }
-    } else {
-        for (int imode = 0; imode < pb_type->num_modes; ++imode) {
-            const t_mode* mode = &pb_type->modes[imode];
-
-            for (int ichild = 0; ichild < mode->num_pb_type_children; ++ichild) {
-                const t_pb_type* pb_type_child = &mode->pb_type_children[ichild];
-                if (pb_type_contains_blif_model(pb_type_child, blif_model_name)) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
 static bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::regex& blif_model_regex) {
     if (!pb_type) {
         return false;

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -542,6 +542,8 @@ bool is_opin(int ipin, t_physical_tile_type_ptr type) {
         return false;
 }
 
+// TODO: Remove is_input_type / is_output_type / is_io_type as part of
+// https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1193
 bool is_input_type(t_physical_tile_type_ptr type) {
     return type->is_input_type;
 }

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -3,7 +3,6 @@
 
 #include <vector>
 #include <string>
-#include <regex>
 
 #include "vpr_types.h"
 #include "atom_netlist.h"
@@ -112,12 +111,6 @@ int find_pin(t_physical_tile_type_ptr type, std::string port_name, int pin_index
 
 //Returns the block type which is most likely the logic block
 t_logical_block_type_ptr infer_logic_block_type(const DeviceGrid& grid);
-
-//Returns true if the specified block type contains the specified blif model name
-bool block_type_contains_blif_model(t_logical_block_type_ptr type, std::string blif_model_name);
-
-//Returns true of a pb_type (or it's children) contain the specified blif model name
-bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::string& blif_model_name);
 
 int get_max_primitives_in_pb_type(t_pb_type* pb_type);
 int get_max_depth_of_pb_type(t_pb_type* pb_type);


### PR DESCRIPTION
#### Description

`std::set` is a fairly heavy-weight data structure, and consumes more
memory and is slower than a boolean.

#### Motivation and Context

Using a `std::set` is both slower and more memory intensive than simply using two booleans.  The new code no longer accommodates iterating over input or output tiles, but that was never done in the old code.

#### How Has This Been Tested?

- CI is green
- Profiled before and after

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
