### PR TITLE
Convert 5-level nested vectors to 3-level array/NdMatrix/vector.

### DIFF
--- a/libs/libvtrutil/src/vtr_ndmatrix.h
+++ b/libs/libvtrutil/src/vtr_ndmatrix.h
@@ -33,6 +33,8 @@ class NdMatrixProxy {
         , dim_strides_(dim_strides)
         , start_(start) {}
 
+    NdMatrixProxy<T, N>& operator=(const NdMatrixProxy<T, N>& other) = delete;
+
     const NdMatrixProxy<T, N - 1> operator[](size_t index) const {
         VTR_ASSERT_SAFE_MSG(index >= 0, "Index out of range (below dimension minimum)");
         VTR_ASSERT_SAFE_MSG(index < dim_sizes_[0], "Index out of range (above dimension maximum)");
@@ -64,6 +66,8 @@ class NdMatrixProxy<T, 1> {
         : dim_sizes_(dim_sizes)
         , dim_strides_(dim_stride)
         , start_(start) {}
+
+    NdMatrixProxy<T, 1>& operator=(const NdMatrixProxy<T, 1>& other) = delete;
 
     const T& operator[](size_t index) const {
         VTR_ASSERT_SAFE_MSG(dim_strides_[0] == 1, "Final dimension must have stride 1");

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1131,8 +1131,6 @@ struct t_linked_f_pointer {
     float* fptr;
 };
 
-typedef std::vector<std::vector<std::vector<std::vector<std::vector<int>>>>> t_rr_node_indices; //[0..num_rr_types-1][0..grid_width-1][0..grid_height-1][0..NUM_SIDES-1][0..max_ptc-1]
-
 /* Type of a routing resource node.  x-directed channel segment,   *
  * y-directed channel segment, input pin to a clb to pad, output   *
  * from a clb or pad (i.e. output pin of a net) and:               *
@@ -1152,6 +1150,9 @@ typedef enum e_rr_type : unsigned char {
 
 constexpr std::array<t_rr_type, NUM_RR_TYPES> RR_TYPES = {{SOURCE, SINK, IPIN, OPIN, CHANX, CHANY}};
 constexpr std::array<const char*, NUM_RR_TYPES> rr_node_typename{{"SOURCE", "SINK", "IPIN", "OPIN", "CHANX", "CHANY"}};
+
+//[0..num_rr_types-1][0..grid_width-1][0..grid_height-1][0..NUM_SIDES-1][0..max_ptc-1]
+typedef std::array<vtr::NdMatrix<std::vector<int>, 3>, NUM_RR_TYPES> t_rr_node_indices;
 
 /* Basic element used to store the traceback (routing) of each net.        *
  * index:   Array index (ID) of this routing resource node.                *

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1374,11 +1374,11 @@ void free_rr_graph() {
 
     device_ctx.read_rr_graph_filename.clear();
 
-    device_ctx.rr_node_indices.clear();
+    for (auto& data : device_ctx.rr_node_indices) {
+        data.clear();
+    }
 
     device_ctx.rr_nodes.clear();
-
-    device_ctx.rr_node_indices.clear();
 
     device_ctx.rr_indexed_data.clear();
 

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1030,13 +1030,11 @@ static void load_chan_rr_indices(const int max_chan_width,
                                  const t_chan_details& chan_details,
                                  t_rr_node_indices& indices,
                                  int* index) {
-    VTR_ASSERT(indices[type].size() == size_t(num_chans));
+    VTR_ASSERT(indices[type].dim_size(0) == size_t(num_chans));
+    VTR_ASSERT(indices[type].dim_size(1) == size_t(chan_len));
+    VTR_ASSERT(indices[type].dim_size(2) == NUM_SIDES);
     for (int chan = 0; chan < num_chans - 1; ++chan) {
-        VTR_ASSERT(indices[type][chan].size() == size_t(chan_len));
-
         for (int seg = 1; seg < chan_len - 1; ++seg) {
-            VTR_ASSERT(indices[type][chan][seg].size() == NUM_SIDES);
-
             /* Alloc the track inode lookup list */
             //Since channels have no side, we just use the first side
             indices[type][chan][seg][0].resize(max_chan_width, OPEN);
@@ -1154,8 +1152,8 @@ static void load_block_rr_indices(const DeviceGrid& grid,
                 int root_x = x - width_offset;
                 int root_y = y - height_offset;
 
-                indices[SOURCE][x][y] = indices[SOURCE][root_x][root_y];
-                indices[SINK][x][y] = indices[SINK][root_x][root_y];
+                indices[SOURCE][x][y][0] = indices[SOURCE][root_x][root_y][0];
+                indices[SINK][x][y][0] = indices[SINK][root_x][root_y][0];
             }
         }
     }
@@ -1173,24 +1171,11 @@ t_rr_node_indices alloc_and_load_rr_node_indices(const int max_chan_width,
     t_rr_node_indices indices;
 
     /* Alloc the lookup table */
-    indices.resize(NUM_RR_TYPES);
     for (t_rr_type rr_type : RR_TYPES) {
         if (rr_type == CHANX) {
-            indices[rr_type].resize(grid.height());
-            for (size_t y = 0; y < grid.height(); ++y) {
-                indices[rr_type][y].resize(grid.width());
-                for (size_t x = 0; x < grid.width(); ++x) {
-                    indices[rr_type][y][x].resize(NUM_SIDES);
-                }
-            }
+            indices[rr_type].resize({grid.height(), grid.width(), NUM_SIDES});
         } else {
-            indices[rr_type].resize(grid.width());
-            for (size_t x = 0; x < grid.width(); ++x) {
-                indices[rr_type][x].resize(grid.height());
-                for (size_t y = 0; y < grid.height(); ++y) {
-                    indices[rr_type][x][y].resize(NUM_SIDES);
-                }
-            }
+            indices[rr_type].resize({grid.width(), grid.height(), NUM_SIDES});
         }
     }
 

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -681,8 +681,6 @@ void process_rr_node_indices(const DeviceGrid& grid) {
 
     auto& indices = device_ctx.rr_node_indices;
 
-    indices.resize(NUM_RR_TYPES);
-
     typedef struct max_ptc {
         short chanx_max_ptc = 0;
         short chany_max_ptc = 0;
@@ -699,21 +697,9 @@ void process_rr_node_indices(const DeviceGrid& grid) {
     /* Alloc the lookup table */
     for (t_rr_type rr_type : RR_TYPES) {
         if (rr_type == CHANX) {
-            indices[rr_type].resize(grid.height());
-            for (size_t y = 0; y < grid.height(); ++y) {
-                indices[rr_type][y].resize(grid.width());
-                for (size_t x = 0; x < grid.width(); ++x) {
-                    indices[rr_type][y][x].resize(NUM_SIDES);
-                }
-            }
+            indices[rr_type].resize({grid.height(), grid.width(), NUM_SIDES});
         } else {
-            indices[rr_type].resize(grid.width());
-            for (size_t x = 0; x < grid.width(); ++x) {
-                indices[rr_type][x].resize(grid.height());
-                for (size_t y = 0; y < grid.height(); ++y) {
-                    indices[rr_type][x][y].resize(NUM_SIDES);
-                }
-            }
+            indices[rr_type].resize({grid.width(), grid.height(), NUM_SIDES});
         }
     }
 
@@ -826,8 +812,8 @@ void process_rr_node_indices(const DeviceGrid& grid) {
                 int root_x = x - width_offset;
                 int root_y = y - height_offset;
 
-                indices[SOURCE][x][y] = indices[SOURCE][root_x][root_y];
-                indices[SINK][x][y] = indices[SINK][root_x][root_y];
+                indices[SOURCE][x][y][0] = indices[SOURCE][root_x][root_y][0];
+                indices[SINK][x][y][0] = indices[SINK][root_x][root_y][0];
             }
         }
     }


### PR DESCRIPTION
#### Description

By converting the first 4 layers into array+NdMatrix, the memory
locality is improved and the number of pointer chases changes from 5 to
2ish.

#### Motivation and Context

There is almost never a time where 5 nested std::vector's are the right data structure.  Changing the middle 3 std::vector's to an `NdMatrix` isn't ideal, but it is better.  Given that root vector is fixed size, using std::array instead of std::vector saves one layer of indirection.

#### How Has This Been Tested?

- CI is green
- Profiled change before and after

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
