### PR TITLE
Support for string internment and use interned strings for metadata

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -104,9 +104,10 @@ class t_metadata_value {
 };
 
 // Metadata storage dictionary.
-struct t_metadata_dict : std::unordered_map<
+struct t_metadata_dict : vtr::flat_map<
                              vtr::interned_string,
-                             std::vector<t_metadata_value>> {
+                             std::vector<t_metadata_value>,
+                             vtr::interned_string_less> {
     // Is this key present in the map?
     inline bool has(vtr::interned_string key) const {
         return this->count(key) >= 1;
@@ -142,7 +143,7 @@ struct t_metadata_dict : std::unordered_map<
     void add(vtr::interned_string key, vtr::interned_string value) {
         // Get the iterator to the key, which may already have elements if
         // add was called with this key in the past.
-        auto iter_inserted = this->emplace(key, std::vector<t_metadata_value>());
+        auto iter_inserted = this->emplace(std::make_pair(key, std::vector<t_metadata_value>()));
         iter_inserted.first->second.push_back(t_metadata_value(value));
     }
 };

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -143,8 +143,7 @@ struct t_metadata_dict : vtr::flat_map<
     void add(vtr::interned_string key, vtr::interned_string value) {
         // Get the iterator to the key, which may already have elements if
         // add was called with this key in the past.
-        auto iter_inserted = this->emplace(std::make_pair(key, std::vector<t_metadata_value>()));
-        iter_inserted.first->second.push_back(t_metadata_value(value));
+        (*this)[key].emplace_back(t_metadata_value(value));
     }
 };
 

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -39,6 +39,7 @@
 #include "vtr_ndmatrix.h"
 #include "vtr_hash.h"
 #include "vtr_bimap.h"
+#include "vtr_string_interning.h"
 
 #include "logic_types.h"
 #include "clock_types.h"
@@ -90,31 +91,31 @@ enum class e_sb_type;
 // Metadata value storage.
 class t_metadata_value {
   public:
-    explicit t_metadata_value(std::string v)
+    explicit t_metadata_value(vtr::interned_string v)
         : value_(v) {}
     explicit t_metadata_value(const t_metadata_value& o)
         : value_(o.value_) {}
 
     // Return string value.
-    std::string as_string() const { return value_; }
+    vtr::interned_string as_string() const { return value_; }
 
   private:
-    std::string value_;
+    vtr::interned_string value_;
 };
 
 // Metadata storage dictionary.
 struct t_metadata_dict : std::unordered_map<
-                             std::string,
+                             vtr::interned_string,
                              std::vector<t_metadata_value>> {
     // Is this key present in the map?
-    inline bool has(std::string key) const {
+    inline bool has(vtr::interned_string key) const {
         return this->count(key) >= 1;
     }
 
     // Get all metadata values matching key.
     //
     // Returns nullptr if key is not found.
-    inline const std::vector<t_metadata_value>* get(std::string key) const {
+    inline const std::vector<t_metadata_value>* get(vtr::interned_string key) const {
         auto iter = this->find(key);
         if (iter != this->end()) {
             return &iter->second;
@@ -126,7 +127,7 @@ struct t_metadata_dict : std::unordered_map<
     //
     // Returns nullptr if key is not found or if multiple values are prsent
     // per key.
-    inline const t_metadata_value* one(std::string key) const {
+    inline const t_metadata_value* one(vtr::interned_string key) const {
         auto values = get(key);
         if (values == nullptr) {
             return nullptr;
@@ -138,7 +139,7 @@ struct t_metadata_dict : std::unordered_map<
     }
 
     // Adds value to key.
-    void add(std::string key, std::string value) {
+    void add(vtr::interned_string key, vtr::interned_string value) {
         // Get the iterator to the key, which may already have elements if
         // add was called with this key in the past.
         auto iter_inserted = this->emplace(key, std::vector<t_metadata_value>());
@@ -1585,6 +1586,8 @@ struct t_clock_arch_spec {
 
 /*   Detailed routing architecture */
 struct t_arch {
+    mutable vtr::string_internment strings;
+
     char* architecture_id; //Secure hash digest of the architecture file to uniquely identify this architecture
 
     t_chan_width_dist Chans;

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -120,7 +120,8 @@ static void ProcessEquivalentSiteCustomConnection(pugi::xml_node Parent,
                                                   t_logical_block_type* LogicalBlockType,
                                                   std::string site_name,
                                                   const pugiutil::loc_data& loc_data);
-static void ProcessPb_Type(pugi::xml_node Parent,
+static void ProcessPb_Type(vtr::string_internment* strings,
+                           pugi::xml_node Parent,
                            t_pb_type* pb_type,
                            t_mode* mode,
                            const bool timing_enabled,
@@ -135,9 +136,9 @@ static void ProcessPinToPinAnnotations(pugi::xml_node parent,
                                        t_pin_to_pin_annotation* annotation,
                                        t_pb_type* parent_pb_type,
                                        const pugiutil::loc_data& loc_data);
-static void ProcessInterconnect(pugi::xml_node Parent, t_mode* mode, const pugiutil::loc_data& loc_data);
-static void ProcessMode(pugi::xml_node Parent, t_mode* mode, const bool timing_enabled, const t_arch& arch, const pugiutil::loc_data& loc_data);
-static t_metadata_dict ProcessMetadata(pugi::xml_node Parent, const pugiutil::loc_data& loc_data);
+static void ProcessInterconnect(vtr::string_internment* strings, pugi::xml_node Parent, t_mode* mode, const pugiutil::loc_data& loc_data);
+static void ProcessMode(vtr::string_internment* strings, pugi::xml_node Parent, t_mode* mode, const bool timing_enabled, const t_arch& arch, const pugiutil::loc_data& loc_data);
+static t_metadata_dict ProcessMetadata(vtr::string_internment* strings, pugi::xml_node Parent, const pugiutil::loc_data& loc_data);
 static void Process_Fc_Values(pugi::xml_node Node, t_default_fc_spec& spec, const pugiutil::loc_data& loc_data);
 static void Process_Fc(pugi::xml_node Node,
                        t_physical_tile_type* PhysicalTileType,
@@ -157,13 +158,9 @@ static void ProcessChanWidthDistrDir(pugi::xml_node Node, t_chan* chan, const pu
 static void ProcessModels(pugi::xml_node Node, t_arch* arch, const pugiutil::loc_data& loc_data);
 static void ProcessModelPorts(pugi::xml_node port_group, t_model* model, std::set<std::string>& port_names, const pugiutil::loc_data& loc_data);
 static void ProcessLayout(pugi::xml_node Node, t_arch* arch, const pugiutil::loc_data& loc_data);
-static t_grid_def ProcessGridLayout(pugi::xml_node layout_type_tag, const pugiutil::loc_data& loc_data);
+static t_grid_def ProcessGridLayout(vtr::string_internment* strings, pugi::xml_node layout_type_tag, const pugiutil::loc_data& loc_data);
 static void ProcessDevice(pugi::xml_node Node, t_arch* arch, t_default_fc_spec& arch_def_fc, const pugiutil::loc_data& loc_data);
-static void ProcessComplexBlocks(pugi::xml_node Node,
-                                 std::vector<t_logical_block_type>& LogicalBlockTypes,
-                                 t_arch& arch,
-                                 const bool timing_enabled,
-                                 const pugiutil::loc_data& loc_data);
+static void ProcessComplexBlocks(vtr::string_internment* strings, pugi::xml_node Node, std::vector<t_logical_block_type>& LogicalBlockTypes, t_arch& arch, const bool timing_enabled, const pugiutil::loc_data& loc_data);
 static void ProcessSwitches(pugi::xml_node Node,
                             t_arch_switch_inf** Switches,
                             int* NumSwitches,
@@ -320,7 +317,7 @@ void XmlReadArch(const char* ArchFile,
 
         /* Process logical block types */
         Next = get_single_child(architecture, "complexblocklist", loc_data);
-        ProcessComplexBlocks(Next, LogicalBlockTypes, *arch, timing_enabled, loc_data);
+        ProcessComplexBlocks(&arch->strings, Next, LogicalBlockTypes, *arch, timing_enabled, loc_data);
 
         /* Process logical block types */
         Next = get_single_child(architecture, "tiles", loc_data);
@@ -1304,7 +1301,7 @@ static void ProcessPb_TypePowerEstMethod(pugi::xml_node Parent, t_pb_type* pb_ty
 }
 
 /* Takes in a pb_type, allocates and loads data for it and recurses downwards */
-static void ProcessPb_Type(pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mode, const bool timing_enabled, const t_arch& arch, const pugiutil::loc_data& loc_data) {
+static void ProcessPb_Type(vtr::string_internment* strings, pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mode, const bool timing_enabled, const t_arch& arch, const pugiutil::loc_data& loc_data) {
     int num_ports, i, j, k, num_annotations;
     const char* Prop;
     pugi::xml_node Cur;
@@ -1559,7 +1556,7 @@ static void ProcessPb_Type(pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mo
             pb_type->modes = new t_mode[pb_type->num_modes];
             pb_type->modes[i].parent_pb_type = pb_type;
             pb_type->modes[i].index = i;
-            ProcessMode(Parent, &pb_type->modes[i], timing_enabled, arch, loc_data);
+            ProcessMode(strings, Parent, &pb_type->modes[i], timing_enabled, arch, loc_data);
             i++;
         } else {
             pb_type->modes = new t_mode[pb_type->num_modes];
@@ -1569,7 +1566,7 @@ static void ProcessPb_Type(pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mo
                 if (0 == strcmp(Cur.name(), "mode")) {
                     pb_type->modes[i].parent_pb_type = pb_type;
                     pb_type->modes[i].index = i;
-                    ProcessMode(Cur, &pb_type->modes[i], timing_enabled, arch, loc_data);
+                    ProcessMode(strings, Cur, &pb_type->modes[i], timing_enabled, arch, loc_data);
 
                     ret_mode_names = mode_names.insert(std::pair<std::string, int>(pb_type->modes[i].name, 0));
                     if (!ret_mode_names.second) {
@@ -1590,7 +1587,7 @@ static void ProcessPb_Type(pugi::xml_node Parent, t_pb_type* pb_type, t_mode* mo
     pb_port_names.clear();
     mode_names.clear();
 
-    pb_type->meta = ProcessMetadata(Parent, loc_data);
+    pb_type->meta = ProcessMetadata(strings, Parent, loc_data);
     ProcessPb_TypePower(Parent, pb_type, loc_data);
 }
 
@@ -1825,7 +1822,7 @@ static void ProcessPb_TypePort(pugi::xml_node Parent, t_port* port, e_power_esti
     ProcessPb_TypePort_Power(Parent, port, power_method, loc_data);
 }
 
-static void ProcessInterconnect(pugi::xml_node Parent, t_mode* mode, const pugiutil::loc_data& loc_data) {
+static void ProcessInterconnect(vtr::string_internment* strings, pugi::xml_node Parent, t_mode* mode, const pugiutil::loc_data& loc_data) {
     int num_interconnect = 0;
     int num_complete, num_direct, num_mux;
     int i, j, k, L_index, num_annotations;
@@ -1879,7 +1876,7 @@ static void ProcessInterconnect(pugi::xml_node Parent, t_mode* mode, const pugiu
 
             Prop = get_attribute(Cur, "name", loc_data).value();
             mode->interconnect[i].name = vtr::strdup(Prop);
-            mode->interconnect[i].meta = ProcessMetadata(Cur, loc_data);
+            mode->interconnect[i].meta = ProcessMetadata(strings, Cur, loc_data);
 
             ret_interc_names = interc_names.insert(std::pair<std::string, int>(mode->interconnect[i].name, 0));
             if (!ret_interc_names.second) {
@@ -1941,7 +1938,7 @@ static void ProcessInterconnect(pugi::xml_node Parent, t_mode* mode, const pugiu
     VTR_ASSERT(i == num_interconnect);
 }
 
-static void ProcessMode(pugi::xml_node Parent, t_mode* mode, const bool timing_enabled, const t_arch& arch, const pugiutil::loc_data& loc_data) {
+static void ProcessMode(vtr::string_internment* strings, pugi::xml_node Parent, t_mode* mode, const bool timing_enabled, const t_arch& arch, const pugiutil::loc_data& loc_data) {
     int i;
     const char* Prop;
     pugi::xml_node Cur;
@@ -1964,7 +1961,7 @@ static void ProcessMode(pugi::xml_node Parent, t_mode* mode, const bool timing_e
         Cur = get_first_child(Parent, "pb_type", loc_data);
         while (Cur != nullptr) {
             if (0 == strcmp(Cur.name(), "pb_type")) {
-                ProcessPb_Type(Cur, &mode->pb_type_children[i], mode, timing_enabled, arch, loc_data);
+                ProcessPb_Type(strings, Cur, &mode->pb_type_children[i], mode, timing_enabled, arch, loc_data);
 
                 ret_pb_types = pb_type_names.insert(
                     std::pair<std::string, int>(mode->pb_type_children[i].name, 0));
@@ -1989,18 +1986,17 @@ static void ProcessMode(pugi::xml_node Parent, t_mode* mode, const bool timing_e
     if (!implied_mode) {
         // Implied mode metadata is attached to the pb_type, rather than
         // the t_mode object.
-        mode->meta = ProcessMetadata(Parent, loc_data);
+        mode->meta = ProcessMetadata(strings, Parent, loc_data);
     }
 
     /* Clear STL map used for duplicate checks */
     pb_type_names.clear();
 
     Cur = get_single_child(Parent, "interconnect", loc_data);
-    ProcessInterconnect(Cur, mode, loc_data);
+    ProcessInterconnect(strings, Cur, mode, loc_data);
 }
 
-static t_metadata_dict ProcessMetadata(pugi::xml_node Parent,
-                                       const pugiutil::loc_data& loc_data) {
+static t_metadata_dict ProcessMetadata(vtr::string_internment* strings, pugi::xml_node Parent, const pugiutil::loc_data& loc_data) {
     //	<metadata>
     //	  <meta>CLBLL_L_</meta>
     //	</metadata>
@@ -2009,10 +2005,11 @@ static t_metadata_dict ProcessMetadata(pugi::xml_node Parent,
     if (metadata) {
         auto meta_tag = get_first_child(metadata, "meta", loc_data);
         while (meta_tag) {
-            std::string key = get_attribute(meta_tag, "name", loc_data).as_string();
+            auto key = get_attribute(meta_tag, "name", loc_data).as_string();
 
             auto value = meta_tag.child_value();
-            data.add(key, value);
+            data.add(strings->intern_string(vtr::string_view(key)),
+                     strings->intern_string(vtr::string_view(value)));
             meta_tag = meta_tag.next_sibling(meta_tag.name());
         }
     }
@@ -2561,13 +2558,13 @@ static void ProcessLayout(pugi::xml_node layout_tag, t_arch* arch, const pugiuti
     VTR_ASSERT_MSG(auto_layout_cnt == 0 || auto_layout_cnt == 1, "<auto_layout> may appear at most once");
 
     for (auto layout_type_tag : layout_tag.children()) {
-        t_grid_def grid_def = ProcessGridLayout(layout_type_tag, loc_data);
+        t_grid_def grid_def = ProcessGridLayout(&arch->strings, layout_type_tag, loc_data);
 
         arch->grid_layouts.emplace_back(std::move(grid_def));
     }
 }
 
-static t_grid_def ProcessGridLayout(pugi::xml_node layout_type_tag, const pugiutil::loc_data& loc_data) {
+static t_grid_def ProcessGridLayout(vtr::string_internment* strings, pugi::xml_node layout_type_tag, const pugiutil::loc_data& loc_data) {
     t_grid_def grid_def;
 
     //Determine the grid specification type
@@ -2605,7 +2602,7 @@ static t_grid_def ProcessGridLayout(pugi::xml_node layout_type_tag, const pugiut
         auto loc_type = loc_spec_tag.name();
         auto type_name = get_attribute(loc_spec_tag, "type", loc_data).value();
         int priority = get_attribute(loc_spec_tag, "priority", loc_data).as_int();
-        t_metadata_dict meta = ProcessMetadata(loc_spec_tag, loc_data);
+        t_metadata_dict meta = ProcessMetadata(strings, loc_spec_tag, loc_data);
 
         if (loc_type == std::string("perimeter")) {
             expect_only_attributes(loc_spec_tag, {"type", "priority"}, loc_data);
@@ -3335,11 +3332,7 @@ static void ProcessEquivalentSiteCustomConnection(pugi::xml_node Parent,
 
 /* Takes in node pointing to <typelist> and loads all the
  * child type objects. */
-static void ProcessComplexBlocks(pugi::xml_node Node,
-                                 std::vector<t_logical_block_type>& LogicalBlockTypes,
-                                 t_arch& arch,
-                                 const bool timing_enabled,
-                                 const pugiutil::loc_data& loc_data) {
+static void ProcessComplexBlocks(vtr::string_internment* strings, pugi::xml_node Node, std::vector<t_logical_block_type>& LogicalBlockTypes, t_arch& arch, const bool timing_enabled, const pugiutil::loc_data& loc_data) {
     pugi::xml_node CurBlockType;
     pugi::xml_node Cur;
     std::map<std::string, int> pb_type_descriptors;
@@ -3375,7 +3368,7 @@ static void ProcessComplexBlocks(pugi::xml_node Node,
         /* Load pb_type info to assign to the Logical Block Type */
         LogicalBlockType.pb_type = new t_pb_type;
         LogicalBlockType.pb_type->name = vtr::strdup(LogicalBlockType.name);
-        ProcessPb_Type(CurBlockType, LogicalBlockType.pb_type, nullptr, timing_enabled, arch, loc_data);
+        ProcessPb_Type(strings, CurBlockType, LogicalBlockType.pb_type, nullptr, timing_enabled, arch, loc_data);
 
         LogicalBlockType.index = index;
 

--- a/libs/libvtrutil/src/vtr_flat_map.h
+++ b/libs/libvtrutil/src/vtr_flat_map.h
@@ -86,6 +86,10 @@ class flat_map {
 
     //direct vector constructor
     explicit flat_map(std::vector<value_type>&& values) {
+        assign(std::move(values));
+    }
+
+    void assign(std::vector<value_type>&& values) {
         //By moving the values this should be more efficient
         //than the range constructor which must copy each element
         vec_ = std::move(values);
@@ -166,6 +170,19 @@ class flat_map {
         }
     }
 
+    std::pair<iterator, bool> emplace(const value_type&& value) {
+        auto iter = lower_bound(value.first);
+        if (iter != end() && keys_equivalent(iter->first, value.first)) {
+            //Found existing
+            return std::make_pair(iter, false);
+        } else {
+            //Emplace
+            iter = emplace(iter, value);
+
+            return std::make_pair(iter, true);
+        }
+    }
+
     //Insert value with position hint
     iterator insert(const_iterator position, const value_type& value) {
         //In a legal position
@@ -173,6 +190,17 @@ class flat_map {
         VTR_ASSERT((size() > 0 && position == --end()) || position == end() || !value_comp()(*(position + 1), value));
 
         iterator iter = vec_.insert(position, value);
+
+        return iter;
+    }
+
+    //Emplace value with position hint
+    iterator emplace(const_iterator position, const value_type& value) {
+        //In a legal position
+        VTR_ASSERT(position == begin() || value_comp()(*(position - 1), value));
+        VTR_ASSERT((size() > 0 && position == --end()) || position == end() || !value_comp()(*(position + 1), value));
+
+        iterator iter = vec_.emplace(position, value);
 
         return iter;
     }

--- a/libs/libvtrutil/src/vtr_string_interning.h
+++ b/libs/libvtrutil/src/vtr_string_interning.h
@@ -134,11 +134,11 @@ class interned_string_iterator {
     vtr::string_view view_;
 };
 
-bool operator==(const interned_string_iterator& lhs, const interned_string_iterator& rhs) {
+inline bool operator==(const interned_string_iterator& lhs, const interned_string_iterator& rhs) {
     return lhs.internment_ == rhs.internment_ && lhs.num_parts_ == rhs.num_parts_ && lhs.parts_ == rhs.parts_ && lhs.part_idx_ == rhs.part_idx_ && lhs.str_idx_ == rhs.str_idx_ && lhs.view_ == rhs.view_;
 }
 
-bool operator!=(const interned_string_iterator& lhs, const interned_string_iterator& rhs) {
+inline bool operator!=(const interned_string_iterator& lhs, const interned_string_iterator& rhs) {
     return !(lhs == rhs);
 }
 
@@ -180,6 +180,15 @@ class interned_string {
     //
     // internment must the object that generated this interned_string.
     void get(const string_internment* internment, std::string* output) const;
+
+    // Returns the underlying string as a std::string.
+    //
+    // This method will allocated memory.
+    std::string get(const string_internment* internment) const {
+        std::string result;
+        get(internment, &result);
+        return result;
+    }
 
     // Bind the parent string_internment and return a bound_interned_string
     // object.  That bound_interned_string lifetime must be shorter than this
@@ -258,28 +267,28 @@ class interned_string {
     std::array<uint8_t, kSizeSize + kMaxParts * kBytesPerId> storage_;
 };
 
-bool operator==(interned_string lhs,
-                interned_string rhs) noexcept {
+inline bool operator==(interned_string lhs,
+                       interned_string rhs) noexcept {
     return lhs.storage_ == rhs.storage_;
 }
-bool operator!=(interned_string lhs,
-                interned_string rhs) noexcept {
+inline bool operator!=(interned_string lhs,
+                       interned_string rhs) noexcept {
     return lhs.storage_ != rhs.storage_;
 }
-bool operator<(bound_interned_string lhs,
-               bound_interned_string rhs) noexcept {
+inline bool operator<(bound_interned_string lhs,
+                      bound_interned_string rhs) noexcept {
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
-bool operator>=(bound_interned_string lhs,
-                bound_interned_string rhs) noexcept {
+inline bool operator>=(bound_interned_string lhs,
+                       bound_interned_string rhs) noexcept {
     return !std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
-bool operator>(bound_interned_string lhs,
-               bound_interned_string rhs) noexcept {
+inline bool operator>(bound_interned_string lhs,
+                      bound_interned_string rhs) noexcept {
     return rhs < lhs;
 }
-bool operator<=(bound_interned_string lhs,
-                bound_interned_string rhs) noexcept {
+inline bool operator<=(bound_interned_string lhs,
+                       bound_interned_string rhs) noexcept {
     return rhs >= lhs;
 }
 
@@ -357,7 +366,7 @@ class string_internment {
     std::unordered_map<std::string, StringId> string_to_id_;
 };
 
-void interned_string::get(const string_internment* internment, std::string* output) const {
+inline void interned_string::get(const string_internment* internment, std::string* output) const {
     // Implements
     // kSplitChar.join(interned_string->get_string(id(idx)) for idx in range(num_parts())));
     size_t parts = num_parts();
@@ -380,7 +389,7 @@ void interned_string::get(const string_internment* internment, std::string* outp
     }
 }
 
-interned_string_iterator::interned_string_iterator(const string_internment* internment, std::array<StringId, kMaxParts> intern_ids, size_t n)
+inline interned_string_iterator::interned_string_iterator(const string_internment* internment, std::array<StringId, kMaxParts> intern_ids, size_t n)
     : internment_(internment)
     , num_parts_(n)
     , parts_(intern_ids)
@@ -393,7 +402,7 @@ interned_string_iterator::interned_string_iterator(const string_internment* inte
     }
 }
 
-interned_string_iterator& interned_string_iterator::operator++() {
+inline interned_string_iterator& interned_string_iterator::operator++() {
     if (num_parts_ == size_t(-1)) {
         throw std::out_of_range("Invalid iterator");
     }
@@ -427,22 +436,22 @@ interned_string_iterator& interned_string_iterator::operator++() {
     return *this;
 }
 
-interned_string_iterator interned_string_iterator::operator++(int) {
+inline interned_string_iterator interned_string_iterator::operator++(int) {
     interned_string_iterator prev = *this;
     ++*this;
 
     return prev;
 }
 
-interned_string_iterator bound_interned_string::begin() const {
+inline interned_string_iterator bound_interned_string::begin() const {
     return str_->begin(internment_);
 }
 
-interned_string_iterator bound_interned_string::end() const {
+inline interned_string_iterator bound_interned_string::end() const {
     return interned_string_iterator();
 }
 
-std::ostream& operator<<(std::ostream& os, bound_interned_string const& value) {
+inline std::ostream& operator<<(std::ostream& os, bound_interned_string const& value) {
     for (const auto& c : value) {
         os << c;
     }

--- a/libs/libvtrutil/src/vtr_string_interning.h
+++ b/libs/libvtrutil/src/vtr_string_interning.h
@@ -57,6 +57,7 @@ namespace vtr {
 // Forward declare classes for pointers.
 class string_internment;
 class interned_string;
+class interned_string_less;
 
 // StrongId for identifying unique string pieces.
 struct interned_string_tag;
@@ -219,6 +220,7 @@ class interned_string {
     friend bool operator!=(interned_string lhs,
                            interned_string rhs) noexcept;
     friend std::hash<interned_string>;
+    friend interned_string_less;
 
   private:
     void set_num_parts(size_t n) {
@@ -457,6 +459,13 @@ inline std::ostream& operator<<(std::ostream& os, bound_interned_string const& v
     }
     return os;
 }
+
+class interned_string_less {
+  public:
+    bool operator()(const vtr::interned_string& lhs, const vtr::interned_string& rhs) const {
+        return lhs.storage_ < rhs.storage_;
+    }
+};
 
 } // namespace vtr
 

--- a/libs/libvtrutil/src/vtr_string_interning.h
+++ b/libs/libvtrutil/src/vtr_string_interning.h
@@ -1,0 +1,467 @@
+// Provides basic string interning, along with pattern splitting suitable
+// for use with FASM.
+//
+// For reference, string interning refers to keeping a unique copy of a string
+// in storage, and then handing out an id to that storage location, rather than
+// keeping the string around.  This deduplicates memory overhead for strings.
+//
+// This string internment has an additional feature that is splitting the
+// input string into "parts" based on '.', which happens to be the feature
+// seperator for FASM.  This means the string "TILE.CLB.A" and "TILE.CLB.B"
+// would be made up of the intern ids for {"TILE", "CLB", "A"} and
+// {"TILE", "CLB", "B"} respectively, allowing some internal deduplication.
+//
+// Strings can contain up to kMaxParts, before they will be interned as their
+// whole string.
+//
+// Interned strings (interned_string) that come from the same internment
+// object (string_internment) can safely be checked for equality and hashed
+// without touching the underlying string.  Lexigraphical comprisions (e.g. <)
+// requires reconstructing the string.
+//
+// Basic usage:
+// 1) Create a string_internment
+// 2) Invoke string_internment::intern_string, which returns the
+//    interned_string object that is the interned string's unique idenfier.
+//    This idenfier can be checked for equality or hashed. If
+//    string_internment::intern_string is called with the same string, a value
+//    equivalent interned_string object will be returned.
+// 3. If the original string is required, interned_string::get can be invoked
+//    to copy the string into a std::string.
+//    interned_string also provides iteration via begin/end, however the begin
+//    method requires a pointer to original string_internment object.  This is
+//    not suitable for range iteration, so the method interned_string::bind
+//    can be used to create a bound_interned_string that can be used in a
+//    range iteration context.
+//
+//    For reference, the reason that interned_string's does not have a
+//    reference back to the string_internment object is to keep their memory
+//    footprint lower.
+#ifndef VTR_STRING_INTERNING_H_
+#define VTR_STRING_INTERNING_H_
+
+#include <cstring>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <stdexcept>
+#include <climits>
+#include <algorithm>
+
+#include "vtr_strong_id.h"
+#include "vtr_string_view.h"
+#include "vtr_vector.h"
+
+namespace vtr {
+
+// Forward declare classes for pointers.
+class string_internment;
+class interned_string;
+
+// StrongId for identifying unique string pieces.
+struct interned_string_tag;
+typedef StrongId<interned_string_tag> StringId;
+
+// To keep interned_string memory footprint lower and flexible, these values
+// control the size of the storage used.
+
+// Number of bytes to represent the StringId.  This implies a maximum number
+// of unique strings available equal to (1 << (kBytesPerId*CHAR_BIT)).
+constexpr size_t kBytesPerId = 3;
+// Maximum number of splits to accomidate before just interning the entire string.
+constexpr size_t kMaxParts = 3;
+// Number of bytes to represent the number of splits present in an interned string.
+constexpr size_t kSizeSize = 1;
+// Which character to split the input string by.
+constexpr char kSplitChar = '.';
+
+static_assert((1 << (CHAR_BIT * kSizeSize)) > kMaxParts, "Size of size data is too small");
+
+// Iterator over interned string.
+// This object is much heavier memory wise than interned_string, so do not
+// store these.
+//
+// This iterator only accomidates the forward_iterator concept.
+//
+// Do no construct this iterator directly.  Use either
+// bound_interned_string::begin/end or interned_string;:begin/end.
+class interned_string_iterator {
+  public:
+    interned_string_iterator(const string_internment* internment, std::array<StringId, kMaxParts> intern_ids, size_t n);
+
+    interned_string_iterator() {
+        clear();
+    }
+
+    using value_type = char;
+    using difference_type = void;
+    using pointer = const char*;
+    using reference = const char&;
+    using iterator_category = std::forward_iterator_tag;
+
+    char operator*() const {
+        if (num_parts_ == size_t(-1)) {
+            throw std::out_of_range("Invalid iterator");
+        }
+
+        if (str_idx_ >= view_.size()) {
+            return kSplitChar;
+        } else {
+            return view_.at(str_idx_);
+        }
+    }
+
+    interned_string_iterator& operator++();
+    interned_string_iterator operator++(int);
+
+    friend bool operator==(const interned_string_iterator& lhs, const interned_string_iterator& rhs);
+
+  private:
+    void clear() {
+        internment_ = nullptr;
+        num_parts_ = size_t(-1);
+        std::fill(parts_.begin(), parts_.end(), StringId());
+        part_idx_ = size_t(-1);
+        str_idx_ = size_t(-1);
+        view_ = vtr::string_view();
+    }
+
+    const string_internment* internment_;
+    size_t num_parts_;
+    std::array<StringId, kMaxParts> parts_;
+    size_t part_idx_;
+    size_t str_idx_;
+    vtr::string_view view_;
+};
+
+bool operator==(const interned_string_iterator& lhs, const interned_string_iterator& rhs) {
+    return lhs.internment_ == rhs.internment_ && lhs.num_parts_ == rhs.num_parts_ && lhs.parts_ == rhs.parts_ && lhs.part_idx_ == rhs.part_idx_ && lhs.str_idx_ == rhs.str_idx_ && lhs.view_ == rhs.view_;
+}
+
+bool operator!=(const interned_string_iterator& lhs, const interned_string_iterator& rhs) {
+    return !(lhs == rhs);
+}
+
+// A interned_string bound to it's string_internment object.
+//
+// This object is heavier than just an interned_string.
+// This object holds a pointer to interned_string, so its lifetime must be
+// shorter than the parent interned_string.
+class bound_interned_string {
+  public:
+    bound_interned_string(const string_internment* internment, const interned_string* str)
+        : internment_(internment)
+        , str_(str) {}
+
+    interned_string_iterator begin() const;
+    interned_string_iterator end() const;
+
+  private:
+    const string_internment* internment_;
+    const interned_string* str_;
+};
+
+// Interned string value returned from a string_internment object.
+//
+// This is a value object without allocation.  It can be checked for equality
+// and hashed safely against other interned_string's generated from the same
+// string_internment.
+class interned_string {
+  public:
+    interned_string(std::array<StringId, kMaxParts> intern_ids, size_t n) {
+        std::fill(storage_.begin(), storage_.end(), 0);
+        set_num_parts(n);
+        for (size_t i = 0; i < n; ++i) {
+            set_id(i, intern_ids[i]);
+        }
+    }
+
+    // Copy the underlying string into output.
+    //
+    // internment must the object that generated this interned_string.
+    void get(const string_internment* internment, std::string* output) const;
+
+    // Bind the parent string_internment and return a bound_interned_string
+    // object.  That bound_interned_string lifetime must be shorter than this
+    // interned_string object lifetime, as bound_interned_string contains
+    // a reference this object, along with a reference to the internment
+    // object.
+    bound_interned_string bind(const string_internment* internment) const {
+        return bound_interned_string(internment, this);
+    }
+
+    interned_string_iterator begin(const string_internment* internment) const {
+        size_t n = num_parts();
+        std::array<StringId, kMaxParts> intern_ids;
+
+        for (size_t i = 0; i < n; ++i) {
+            intern_ids[i] = id(i);
+        }
+
+        return interned_string_iterator(internment, intern_ids, n);
+    }
+
+    interned_string_iterator end() const {
+        return interned_string_iterator();
+    }
+
+    friend bool operator==(interned_string lhs,
+                           interned_string rhs) noexcept;
+    friend bool operator!=(interned_string lhs,
+                           interned_string rhs) noexcept;
+    friend std::hash<interned_string>;
+
+  private:
+    void set_num_parts(size_t n) {
+        for (size_t i = 0; i < kSizeSize; ++i) {
+            storage_[i] = (n >> (i * CHAR_BIT)) & UCHAR_MAX;
+        }
+
+        if (num_parts() != n) {
+            throw std::runtime_error("Storage size exceeded.");
+        }
+    }
+
+    size_t num_parts() const {
+        size_t n = 0;
+        for (size_t i = 0; i < kSizeSize; ++i) {
+            n |= storage_[i] << (i * CHAR_BIT);
+        }
+
+        return n;
+    }
+
+    void set_id(size_t idx, StringId id) {
+        if (idx >= kMaxParts) {
+            throw std::runtime_error("Storage size exceeded.");
+        }
+
+        size_t val = (size_t)id;
+        for (size_t i = 0; i < kBytesPerId; ++i) {
+            storage_[kSizeSize + i + idx * kBytesPerId] = (val >> (i * CHAR_BIT)) & UCHAR_MAX;
+        }
+
+        if (this->id(idx) != id) {
+            throw std::runtime_error("Storage size exceeded.");
+        }
+    }
+
+    StringId id(size_t idx) const {
+        size_t val = 0;
+        for (size_t i = 0; i < kBytesPerId; ++i) {
+            val |= storage_[kSizeSize + i + idx * kBytesPerId] << (i * CHAR_BIT);
+        }
+
+        return StringId(val);
+    }
+
+    std::array<uint8_t, kSizeSize + kMaxParts * kBytesPerId> storage_;
+};
+
+bool operator==(interned_string lhs,
+                interned_string rhs) noexcept {
+    return lhs.storage_ == rhs.storage_;
+}
+bool operator!=(interned_string lhs,
+                interned_string rhs) noexcept {
+    return lhs.storage_ != rhs.storage_;
+}
+bool operator<(bound_interned_string lhs,
+               bound_interned_string rhs) noexcept {
+    return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+bool operator>=(bound_interned_string lhs,
+                bound_interned_string rhs) noexcept {
+    return !std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+bool operator>(bound_interned_string lhs,
+               bound_interned_string rhs) noexcept {
+    return rhs < lhs;
+}
+bool operator<=(bound_interned_string lhs,
+                bound_interned_string rhs) noexcept {
+    return rhs >= lhs;
+}
+
+// Storage of interned string, and object capable of generating new
+// interned_string objects.
+class string_internment {
+  public:
+    // Intern a string, and return a unique identifier to that string.
+    //
+    // If interned_string is ever called with two strings of the same value,
+    // the interned_string will be equal.
+    interned_string intern_string(vtr::string_view view) {
+        size_t num_parts = 1;
+        for (const auto& c : view) {
+            if (c == kSplitChar) {
+                num_parts += 1;
+            }
+        }
+
+        std::array<StringId, kMaxParts> parts;
+        if (num_parts == 1 || num_parts > kMaxParts) {
+            // Intern entire string.
+            parts[0] = intern_one_string(view);
+            return interned_string(parts, 1);
+        } else {
+            // Implements parts = [intern_one_string(s) for s in view.split(kSplitChar)]
+            size_t idx = 0;
+            size_t start = 0;
+
+            for (size_t i = 0; i < view.size(); ++i) {
+                if (view[i] == kSplitChar) {
+                    parts[idx++] = intern_one_string(view.substr(start, i - start));
+                    start = i + 1;
+                    if (idx == num_parts - 1) {
+                        break;
+                    }
+                }
+            }
+
+            parts[idx++] = intern_one_string(view.substr(start));
+            return interned_string(parts, num_parts);
+        }
+    }
+
+    // Retrieve a string part based on id.  This method should not generally
+    // be called directly.
+    vtr::string_view get_string(StringId id) const {
+        auto& str = strings_[id];
+        return vtr::string_view(str.data(), str.size());
+    }
+
+    // Number of unique string parts stored.
+    size_t unique_strings() const {
+        return strings_.size();
+    }
+
+  private:
+    StringId intern_one_string(vtr::string_view view) {
+        temporary_.assign(view.begin(), view.end());
+        StringId next_id(strings_.size());
+        auto result = string_to_id_.insert(std::make_pair(temporary_, next_id));
+        if (result.second) {
+            strings_.push_back(std::move(temporary_));
+        }
+
+        return result.first->second;
+    }
+
+    // FIXME: This storage scheme does store 2x memory for the strings storage,
+    // however it does avoid having to be concerned with what happens when
+    // strings_ resizes, so for a simplier initial implementation, this is the
+    // approach taken.
+    vtr::vector<StringId, std::string> strings_;
+    std::string temporary_;
+    std::unordered_map<std::string, StringId> string_to_id_;
+};
+
+void interned_string::get(const string_internment* internment, std::string* output) const {
+    // Implements
+    // kSplitChar.join(interned_string->get_string(id(idx)) for idx in range(num_parts())));
+    size_t parts = num_parts();
+    size_t storage_needed = parts - 1;
+    std::array<StringId, kMaxParts> intern_ids;
+    for (size_t i = 0; i < parts; ++i) {
+        intern_ids[i] = id(i);
+        storage_needed += internment->get_string(intern_ids[i]).size();
+    }
+
+    output->clear();
+    output->reserve(storage_needed);
+
+    for (size_t i = 0; i < parts; ++i) {
+        auto view = internment->get_string(intern_ids[i]);
+        std::copy(view.begin(), view.end(), std::back_inserter(*output));
+        if (i + 1 < parts) {
+            output->push_back(kSplitChar);
+        }
+    }
+}
+
+interned_string_iterator::interned_string_iterator(const string_internment* internment, std::array<StringId, kMaxParts> intern_ids, size_t n)
+    : internment_(internment)
+    , num_parts_(n)
+    , parts_(intern_ids)
+    , part_idx_(0)
+    , str_idx_(0) {
+    if (num_parts_ == 0) {
+        clear();
+    } else {
+        view_ = internment_->get_string(parts_[0]);
+    }
+}
+
+interned_string_iterator& interned_string_iterator::operator++() {
+    if (num_parts_ == size_t(-1)) {
+        throw std::out_of_range("Invalid iterator");
+    }
+
+    if (str_idx_ < view_.size()) {
+        // Current string has characters left, advance.
+        str_idx_ += 1;
+        // Normally when str_idx_ the iterator will next emit a kSplitChar,
+        // but this is omitted on the last part of the string.
+        if (str_idx_ == view_.size() && part_idx_ + 1 == num_parts_) {
+            clear();
+        }
+    } else {
+        // Current part of the string is out of characters, and the
+        // kSplitChar has been emitted, advance to the next part.
+        str_idx_ = 0;
+        part_idx_ += 1;
+        if (part_idx_ == num_parts_) {
+            // No more parts.
+            clear();
+        } else {
+            view_ = internment_->get_string(parts_[part_idx_]);
+            if (view_.size() == 0 && part_idx_ + 1 == num_parts_) {
+                // The last string part is empty, and because this is the last
+                // part we don't want to emit another kSplitChar.
+                clear();
+            }
+        }
+    }
+
+    return *this;
+}
+
+interned_string_iterator interned_string_iterator::operator++(int) {
+    interned_string_iterator prev = *this;
+    ++*this;
+
+    return prev;
+}
+
+interned_string_iterator bound_interned_string::begin() const {
+    return str_->begin(internment_);
+}
+
+interned_string_iterator bound_interned_string::end() const {
+    return interned_string_iterator();
+}
+
+std::ostream& operator<<(std::ostream& os, bound_interned_string const& value) {
+    for (const auto& c : value) {
+        os << c;
+    }
+    return os;
+}
+
+} // namespace vtr
+
+namespace std {
+template<>
+struct hash<vtr::interned_string> {
+    std::size_t operator()(vtr::interned_string const& s) const noexcept {
+        std::size_t h = 0;
+        for (const auto& data : s.storage_) {
+            vtr::hash_combine(h, std::hash<char>()(data));
+        }
+        return h;
+    }
+};
+} // namespace std
+
+#endif /* VTR_STRING_INTERNING_H_ */

--- a/libs/libvtrutil/src/vtr_string_view.h
+++ b/libs/libvtrutil/src/vtr_string_view.h
@@ -1,0 +1,155 @@
+#ifndef VTR_STRING_VIEW_H_
+#define VTR_STRING_VIEW_H_
+
+#include <cstring>
+#include <ostream>
+#include <string>
+#include <stdexcept>
+
+#include "vtr_hash.h"
+
+namespace vtr {
+
+// Implements a view to a fixed length string.
+// The underlying string does not need to be NULL terminated.
+class string_view {
+  public:
+    static constexpr size_t npos = size_t(-1);
+
+    explicit constexpr string_view()
+        : data_(nullptr)
+        , size_(0) {}
+    explicit string_view(const char* str)
+        : data_(str)
+        , size_(strlen(str)) {}
+    explicit constexpr string_view(const char* str, size_t size)
+        : data_(str)
+        , size_(size) {}
+
+    constexpr string_view(const string_view& other) noexcept = default;
+    constexpr string_view& operator=(const string_view& view) noexcept {
+        data_ = view.data_;
+        size_ = view.size_;
+        return *this;
+    }
+
+    constexpr char operator[](size_t pos) const {
+        return data_[pos];
+    }
+
+    const char& at(size_t pos) const {
+        if (pos >= size()) {
+            throw std::out_of_range("Pos is out of range.");
+        }
+
+        return data_[pos];
+    }
+
+    constexpr const char& front() const {
+        return data_[0];
+    }
+
+    constexpr const char& back() const {
+        return data_[size() - 1];
+    }
+
+    constexpr const char* data() const {
+        return data_;
+    }
+
+    constexpr size_t size() const noexcept {
+        return size_;
+    }
+    constexpr size_t length() const noexcept {
+        return size_;
+    }
+
+    constexpr bool empty() const noexcept {
+        return size_ != 0;
+    }
+
+    constexpr const char* begin() const noexcept {
+        return data_;
+    }
+    constexpr const char* cbegin() const noexcept {
+        return data_;
+    }
+
+    constexpr const char* end() const noexcept {
+        return data_ + size_;
+    }
+    constexpr const char* cend() const noexcept {
+        return data_ + size_;
+    }
+
+    void swap(string_view& v) noexcept {
+        std::swap(data_, v.data_);
+        std::swap(size_, v.size_);
+    }
+
+    string_view substr(size_t pos = 0, size_t count = npos) {
+        if (pos > size()) {
+            throw std::out_of_range("Pos is out of range.");
+        }
+
+        size_t rcount = size_ - pos;
+        if (count != npos && (pos + count) < size_) {
+            rcount = count;
+        }
+
+        return string_view(data_ + pos, rcount);
+    }
+
+  private:
+    const char* data_;
+    size_t size_;
+};
+
+bool operator==(string_view lhs,
+                string_view rhs) noexcept {
+    return lhs.size() == rhs.size() && strncmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size())) == 0;
+}
+bool operator!=(string_view lhs,
+                string_view rhs) noexcept {
+    return lhs.size() != rhs.size() || strncmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size())) != 0;
+}
+bool operator<(string_view lhs,
+               string_view rhs) noexcept {
+    return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+bool operator>=(string_view lhs,
+                string_view rhs) noexcept {
+    return !std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+bool operator>(string_view lhs,
+               string_view rhs) noexcept {
+    return rhs < lhs;
+}
+bool operator<=(string_view lhs,
+                string_view rhs) noexcept {
+    return rhs >= lhs;
+}
+
+std::ostream& operator<<(std::ostream& os, string_view const& value) {
+    for (const auto& c : value) {
+        os << c;
+    }
+    return os;
+}
+
+} // namespace vtr
+
+namespace std {
+template<>
+struct hash<vtr::string_view> {
+    std::size_t operator()(vtr::string_view const& s) const noexcept {
+        std::size_t h = 0;
+        for (const auto& data : s) {
+            vtr::hash_combine(h, std::hash<char>()(data));
+        }
+        return h;
+    }
+};
+} // namespace std
+
+#endif /* VTR_STRING_VIEW_H_ */

--- a/libs/libvtrutil/src/vtr_string_view.h
+++ b/libs/libvtrutil/src/vtr_string_view.h
@@ -105,32 +105,32 @@ class string_view {
     size_t size_;
 };
 
-bool operator==(string_view lhs,
-                string_view rhs) noexcept {
+inline bool operator==(string_view lhs,
+                       string_view rhs) noexcept {
     return lhs.size() == rhs.size() && strncmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size())) == 0;
 }
-bool operator!=(string_view lhs,
-                string_view rhs) noexcept {
+inline bool operator!=(string_view lhs,
+                       string_view rhs) noexcept {
     return lhs.size() != rhs.size() || strncmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size())) != 0;
 }
-bool operator<(string_view lhs,
-               string_view rhs) noexcept {
+inline bool operator<(string_view lhs,
+                      string_view rhs) noexcept {
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
-bool operator>=(string_view lhs,
-                string_view rhs) noexcept {
+inline bool operator>=(string_view lhs,
+                       string_view rhs) noexcept {
     return !std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
-bool operator>(string_view lhs,
-               string_view rhs) noexcept {
+inline bool operator>(string_view lhs,
+                      string_view rhs) noexcept {
     return rhs < lhs;
 }
-bool operator<=(string_view lhs,
-                string_view rhs) noexcept {
+inline bool operator<=(string_view lhs,
+                       string_view rhs) noexcept {
     return rhs >= lhs;
 }
 
-std::ostream& operator<<(std::ostream& os, string_view const& value) {
+inline std::ostream& operator<<(std::ostream& os, string_view const& value) {
     for (const auto& c : value) {
         os << c;
     }

--- a/libs/libvtrutil/test/test_strings.cpp
+++ b/libs/libvtrutil/test/test_strings.cpp
@@ -1,0 +1,210 @@
+#include "catch.hpp"
+
+#include "vtr_string_interning.h"
+
+TEST_CASE("String view", "[vtr_string_view/string_view]") {
+    vtr::string_view a("test");
+    vtr::string_view b("test");
+    vtr::string_view c("tes");
+    vtr::string_view d("est");
+    vtr::string_view e("es");
+
+    REQUIRE(a.size() == 4);
+    REQUIRE(b.size() == 4);
+    REQUIRE(c.size() == 3);
+    REQUIRE(d.size() == 3);
+    REQUIRE(e.size() == 2);
+
+    REQUIRE(a[0] == 't');
+    REQUIRE(a[1] == 'e');
+    REQUIRE(a[2] == 's');
+    REQUIRE(a[3] == 't');
+
+    auto itr = a.begin();
+    REQUIRE(*itr++ == 't');
+    REQUIRE(*itr++ == 'e');
+    REQUIRE(*itr++ == 's');
+    REQUIRE(*itr++ == 't');
+    REQUIRE(itr == a.end());
+
+    REQUIRE(a.front() == 't');
+    REQUIRE(c.front() == 't');
+    REQUIRE(c.back() == 's');
+
+    REQUIRE(a == b);
+    REQUIRE(a <= b);
+    REQUIRE(a >= b);
+    REQUIRE(a != c);
+
+    REQUIRE(c < a);
+    REQUIRE(a >= c);
+
+    REQUIRE(a > c);
+    REQUIRE(c <= a);
+
+    REQUIRE(c != d);
+    REQUIRE(a.substr(0, 3) == c);
+    REQUIRE(a.substr(1, 3) == d);
+    REQUIRE(a.substr(1) == d);
+    REQUIRE(a.substr(1, 2) == e);
+    REQUIRE(std::hash<vtr::string_view>()(a) == std::hash<vtr::string_view>()(b));
+    REQUIRE(std::hash<vtr::string_view>()(a) != std::hash<vtr::string_view>()(c));
+
+    vtr::string_view f = a;
+    REQUIRE(b == f);
+
+    f = e;
+    REQUIRE(b != f);
+    REQUIRE(e == f);
+
+    std::swap(a, f);
+    REQUIRE(a == e);
+    REQUIRE(f == b);
+}
+
+TEST_CASE("Basic string internment", "[vtr_string_interning/string_internment") {
+    vtr::string_internment internment;
+
+    vtr::interned_string a = internment.intern_string(vtr::string_view("test"));
+    vtr::interned_string b = internment.intern_string(vtr::string_view("test"));
+    vtr::interned_string c = internment.intern_string(vtr::string_view("tes"));
+    vtr::interned_string d = internment.intern_string(vtr::string_view("est"));
+    vtr::interned_string e = internment.intern_string(vtr::string_view("es"));
+
+    auto itr = a.begin(&internment);
+    REQUIRE(*itr++ == 't');
+    REQUIRE(*itr++ == 'e');
+    REQUIRE(*itr++ == 's');
+    REQUIRE(*itr++ == 't');
+    REQUIRE(itr == a.end());
+
+    itr = a.begin(&internment);
+    REQUIRE(*itr == 't');
+    ++itr;
+    REQUIRE(*itr == 'e');
+    ++itr;
+    REQUIRE(*itr == 's');
+    ++itr;
+    REQUIRE(*itr == 't');
+    ++itr;
+    REQUIRE(itr == a.end());
+
+    REQUIRE(a == b);
+    REQUIRE(a.bind(&internment) <= b.bind(&internment));
+    REQUIRE(a.bind(&internment) >= b.bind(&internment));
+    REQUIRE(a != c);
+
+    REQUIRE(c.bind(&internment) < a.bind(&internment));
+    REQUIRE(a.bind(&internment) >= c.bind(&internment));
+
+    REQUIRE(a.bind(&internment) > c.bind(&internment));
+    REQUIRE(c.bind(&internment) <= a.bind(&internment));
+
+    REQUIRE(c != d);
+    REQUIRE(std::hash<vtr::interned_string>()(a) == std::hash<vtr::interned_string>()(b));
+    REQUIRE(std::hash<vtr::interned_string>()(a) != std::hash<vtr::interned_string>()(c));
+
+    std::string g;
+    a.get(&internment, &g);
+    REQUIRE(g == "test");
+    c.get(&internment, &g);
+    REQUIRE(g == "tes");
+    d.get(&internment, &g);
+    REQUIRE(g == "est");
+
+    vtr::interned_string f = a;
+    REQUIRE(b == f);
+
+    f = e;
+    REQUIRE(b != f);
+    REQUIRE(e == f);
+
+    std::swap(a, f);
+    REQUIRE(a == e);
+    REQUIRE(f == b);
+}
+
+static void test_internment_retreval(const vtr::string_internment* internment, vtr::interned_string str, const char* expect) {
+    std::string copy;
+    str.get(internment, &copy);
+    REQUIRE(copy == expect);
+    copy.clear();
+    std::copy(str.begin(internment), str.end(), std::back_inserter(copy));
+    REQUIRE(copy == expect);
+}
+
+TEST_CASE("Split string internment", "[vtr_string_interning/string_internment") {
+    vtr::string_internment internment;
+
+    size_t unique_strings = 0;
+
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string a = internment.intern_string(vtr::string_view("test"));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string b = internment.intern_string(vtr::string_view("test.test"));
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string c = internment.intern_string(vtr::string_view("test.test.test"));
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string d = internment.intern_string(vtr::string_view("test.test.test.test"));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+
+    test_internment_retreval(&internment, a, "test");
+    test_internment_retreval(&internment, b, "test.test");
+    test_internment_retreval(&internment, c, "test.test.test");
+    test_internment_retreval(&internment, d, "test.test.test.test");
+
+    vtr::interned_string f = internment.intern_string(vtr::string_view("a"));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string g = internment.intern_string(vtr::string_view("b.c"));
+    unique_strings += 2;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string h = internment.intern_string(vtr::string_view("d.e.f"));
+    unique_strings += 3;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string i = internment.intern_string(vtr::string_view("g.h.i.j"));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+
+    test_internment_retreval(&internment, f, "a");
+    test_internment_retreval(&internment, g, "b.c");
+    test_internment_retreval(&internment, h, "d.e.f");
+    test_internment_retreval(&internment, i, "g.h.i.j");
+
+    vtr::interned_string j = internment.intern_string(vtr::string_view("."));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string k = internment.intern_string(vtr::string_view(".."));
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string l = internment.intern_string(vtr::string_view("..."));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string m = internment.intern_string(vtr::string_view("...."));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+
+    test_internment_retreval(&internment, j, ".");
+    test_internment_retreval(&internment, k, "..");
+    test_internment_retreval(&internment, l, "...");
+    test_internment_retreval(&internment, m, "....");
+
+    vtr::interned_string n = internment.intern_string(vtr::string_view(".q"));
+    unique_strings += 1;
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string o = internment.intern_string(vtr::string_view(".a."));
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string p = internment.intern_string(vtr::string_view("b.c.d"));
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string q = internment.intern_string(vtr::string_view("e..f"));
+    REQUIRE(internment.unique_strings() == unique_strings);
+    vtr::interned_string r = internment.intern_string(vtr::string_view("e."));
+    REQUIRE(internment.unique_strings() == unique_strings);
+
+    test_internment_retreval(&internment, n, ".q");
+    test_internment_retreval(&internment, o, ".a.");
+    test_internment_retreval(&internment, p, "b.c.d");
+    test_internment_retreval(&internment, q, "e..f");
+    test_internment_retreval(&internment, r, "e.");
+}

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -53,7 +53,7 @@ namespace fasm {
 class FasmWriterVisitor : public NetlistVisitor {
 
   public:
-      FasmWriterVisitor(std::ostream& f);
+      FasmWriterVisitor(vtr::string_internment *strings, std::ostream& f);
 
   private:
       void visit_top_impl(const char* top_level_name) override;
@@ -81,7 +81,11 @@ class FasmWriterVisitor : public NetlistVisitor {
       // Walk from node to parents and search for a CLB prefix.
       void find_clb_prefix(const t_pb_graph_node *node,
         bool *have_prefix, std::string *clb_prefix) const;
+      std::string handle_fasm_prefix(const t_metadata_dict *meta,
+        const t_pb_graph_node *pb_graph_node, const t_pb_type *pb_type) const;
+      const t_metadata_dict *get_fasm_type(const t_pb_graph_node* pb_graph_node, std::string target_type) const;
 
+      vtr::string_internment *strings_;
       std::ostream& os_;
 
       t_pb_graph_node *root_clb_;
@@ -97,6 +101,14 @@ class FasmWriterVisitor : public NetlistVisitor {
       std::map<const t_pb_type*, Parameters> parameters_;
 
       std::map<const std::string, std::string> tags_;
+
+      vtr::interned_string fasm_lut;
+      vtr::interned_string fasm_features;
+      vtr::interned_string fasm_params;
+      vtr::interned_string fasm_prefix;
+      vtr::interned_string fasm_placeholders;
+      vtr::interned_string fasm_type;
+      vtr::interned_string fasm_mux;
 };
 
 } // namespace fasm

--- a/utils/fasm/src/main.cpp
+++ b/utils/fasm/src/main.cpp
@@ -35,12 +35,13 @@ constexpr int INTERRUPTED_EXIT_CODE = 3; //VPR was interrupted by the user (e.g.
  * Writes FASM file based on the netlist name by walking the netlist.
  */
 static bool write_fasm() {
+  auto& device_ctx = g_vpr_ctx.mutable_device();
   auto& atom_ctx = g_vpr_ctx.atom();
 
   std::string fasm_filename = atom_ctx.nlist.netlist_name() + ".fasm";
   vtr::printf("Writing Implementation FASM: %s\n", fasm_filename.c_str());
   std::ofstream fasm_os(fasm_filename);
-  fasm::FasmWriterVisitor visitor(fasm_os);
+  fasm::FasmWriterVisitor visitor(&device_ctx.arch->strings, fasm_os);
   NetlistWalker nl_walker(visitor);
   nl_walker.walk();
 

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -190,9 +190,10 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
             for(t_edge_size iedge = 0; iedge < device_ctx.rr_nodes[inode].num_edges(); ++iedge) {
                 auto sink_inode = device_ctx.rr_nodes[inode].edge_sink_node(iedge);
                 auto switch_id = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                auto value = vtr::string_fmt("%d_%d_%zu",
+                            inode, sink_inode, switch_id);
                 vpr::add_rr_edge_metadata(inode, sink_inode, switch_id,
-                        "fasm_features", vtr::string_fmt("%d_%d_%zu",
-                            inode, sink_inode, switch_id));
+                        vtr::string_view("fasm_features"), vtr::string_view(value.data(), value.size()));
             }
         }
 
@@ -225,7 +226,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     REQUIRE(flow_succeeded == true);
 
     std::stringstream fasm_string;
-    fasm::FasmWriterVisitor visitor(fasm_string);
+    fasm::FasmWriterVisitor visitor(&arch.strings, fasm_string);
     NetlistWalker nl_walker(visitor);
     nl_walker.walk();
 

--- a/vpr/src/base/metadata_storage.h
+++ b/vpr/src/base/metadata_storage.h
@@ -1,0 +1,105 @@
+#ifndef _METADATA_STORAGE_H_
+#define _METADATA_STORAGE_H_
+
+#include "vtr_string_interning.h"
+
+// MetadataStorage is a two phase data structure.  In the first phase,
+// metadata is added cheaply by simply pushing onto a vector.  This is
+// unsuitable for lookup, but is fast, and because strings are interned, not
+// too expensive memory wise.
+//
+// The second phase occurs after all data has been inserted.  When/if a lookup
+// is needed, the vector is sorted and the final metadata lookup is generated.
+// In the event that the lookup is never needed, this saves the time spent
+// building the lookup, and reduces the number of outstanding memory
+// allocations dramatically.
+template<typename LookupKey>
+class MetadataStorage {
+  public:
+    void add_metadata(const LookupKey& lookup_key, vtr::interned_string meta_key, vtr::interned_string meta_value) {
+        // Can only add metadata prior to building the map.
+        VTR_ASSERT(map_.empty());
+        data_.push_back(std::make_tuple(lookup_key, meta_key, meta_value));
+    }
+
+    typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator find(const LookupKey& lookup_key) const {
+        check_for_map();
+
+        return map_.find(lookup_key);
+    }
+
+    void clear() {
+        data_.clear();
+        map_.clear();
+    }
+
+    size_t size() const {
+        check_for_map();
+        return map_.size();
+    }
+
+    typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator begin() const {
+        check_for_map();
+        return map_.begin();
+    }
+
+    typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator end() const {
+        check_for_map();
+        return map_.end();
+    }
+
+  private:
+    // Check to see if the map has been built yet, builds it if it hasn't been
+    // built.
+    void check_for_map() const {
+        if (map_.empty() && !data_.empty()) {
+            build_map();
+        }
+    }
+
+    // Constructs the metadata lookup map from the flat data.
+    void build_map() const {
+        VTR_ASSERT(!data_.empty());
+        VTR_ASSERT(map_.empty());
+
+        std::sort(data_.begin(), data_.end(), [](const std::tuple<LookupKey, vtr::interned_string, vtr::interned_string>& lhs, const std::tuple<LookupKey, vtr::interned_string, vtr::interned_string>& rhs) {
+            return std::get<0>(lhs) < std::get<0>(rhs);
+        });
+
+        LookupKey prev = std::get<0>(data_.front());
+        size_t count = 1;
+        for (const auto& value : data_) {
+            if (prev != std::get<0>(value)) {
+                count += 1;
+                prev = std::get<0>(value);
+            }
+        }
+
+        std::vector<typename vtr::flat_map<LookupKey, t_metadata_dict>::value_type> storage;
+        storage.resize(count);
+        size_t idx = 0;
+        storage[idx].first = std::get<0>(data_[0]);
+
+        for (const auto& value : data_) {
+            if (storage[idx].first != std::get<0>(value)) {
+                idx += 1;
+                VTR_ASSERT(idx < count);
+                storage[idx].first = std::get<0>(value);
+            }
+
+            storage[idx].second.add(std::get<1>(value), std::get<2>(value));
+        }
+
+        VTR_ASSERT(idx + 1 == count);
+
+        map_.assign(std::move(storage));
+
+        data_.clear();
+        data_.shrink_to_fit();
+    }
+
+    mutable std::vector<std::tuple<LookupKey, vtr::interned_string, vtr::interned_string>> data_;
+    mutable vtr::flat_map<LookupKey, t_metadata_dict> map_;
+};
+
+#endif /* _METADATA_STORAGE_H_ */

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -21,6 +21,7 @@
 #include "router_lookahead.h"
 #include "place_macro.h"
 #include "compressed_grid.h"
+#include "metadata_storage.h"
 
 //A Context is collection of state relating to a particular part of VPR
 //
@@ -106,105 +107,6 @@ struct hash<std::tuple<int, int, short>> {
     }
 };
 } // namespace std
-
-// MetadataStorage is a two phase data structure.  In the first phase,
-// metadata is added cheaply by simply pushing onto a vector.  This is
-// unsuitable for lookup, but is fast, and because strings are interned, not
-// too expensive memory wise.
-//
-// The second phase occurs after all data has been inserted.  When/if a lookup
-// is needed, the vector is sorted and the final metadata lookup is generated.
-// In the event that the lookup is never needed, this saves the time spent
-// building the lookup, and reduces the number of outstanding memory
-// allocations dramatically.
-template<typename LookupKey>
-class MetadataStorage {
-  public:
-    void add_metadata(const LookupKey& lookup_key, vtr::interned_string meta_key, vtr::interned_string meta_value) {
-        // Can only add metadata prior to building the map.
-        VTR_ASSERT(map_.empty());
-        data_.push_back(std::make_tuple(lookup_key, meta_key, meta_value));
-    }
-
-    typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator find(const LookupKey& lookup_key) const {
-        check_for_map();
-
-        return map_.find(lookup_key);
-    }
-
-    void clear() {
-        data_.clear();
-        map_.clear();
-    }
-
-    size_t size() const {
-        check_for_map();
-        return map_.size();
-    }
-
-    typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator begin() const {
-        check_for_map();
-        return map_.begin();
-    }
-
-    typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator end() const {
-        check_for_map();
-        return map_.end();
-    }
-
-  private:
-    // Check to see if the map has been built yet, builds it if it hasn't been
-    // built.
-    void check_for_map() const {
-        if (map_.empty() && !data_.empty()) {
-            build_map();
-        }
-    }
-
-    // Constructs the metadata lookup map from the flat data.
-    void build_map() const {
-        VTR_ASSERT(!data_.empty());
-        VTR_ASSERT(map_.empty());
-
-        std::sort(data_.begin(), data_.end(), [](const std::tuple<LookupKey, vtr::interned_string, vtr::interned_string>& lhs, const std::tuple<LookupKey, vtr::interned_string, vtr::interned_string>& rhs) {
-            return std::get<0>(lhs) < std::get<0>(rhs);
-        });
-
-        LookupKey prev = std::get<0>(data_.front());
-        size_t count = 1;
-        for (const auto& value : data_) {
-            if (prev != std::get<0>(value)) {
-                count += 1;
-                prev = std::get<0>(value);
-            }
-        }
-
-        std::vector<typename vtr::flat_map<LookupKey, t_metadata_dict>::value_type> storage;
-        storage.resize(count);
-        size_t idx = 0;
-        storage[idx].first = std::get<0>(data_[0]);
-
-        for (const auto& value : data_) {
-            if (storage[idx].first != std::get<0>(value)) {
-                idx += 1;
-                VTR_ASSERT(idx < count);
-                storage[idx].first = std::get<0>(value);
-            }
-
-            storage[idx].second.add(std::get<1>(value), std::get<2>(value));
-        }
-
-        VTR_ASSERT(idx + 1 == count);
-
-        map_.assign(std::move(storage));
-
-        data_.clear();
-        data_.shrink_to_fit();
-    }
-
-    mutable std::vector<std::tuple<LookupKey, vtr::interned_string, vtr::interned_string>> data_;
-    mutable vtr::flat_map<LookupKey, t_metadata_dict> map_;
-};
 
 //State relating the device
 //

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -170,15 +170,31 @@ class MetadataStorage {
             return std::get<0>(lhs) < std::get<0>(rhs);
         });
 
-        std::vector<typename vtr::flat_map<LookupKey, t_metadata_dict>::value_type> storage;
-        storage.push_back(std::make_pair(std::get<0>(data_[0]), t_metadata_dict()));
+        LookupKey prev = std::get<0>(data_.front());
+        size_t count = 1;
         for (const auto& value : data_) {
-            if (storage.back().first != std::get<0>(value)) {
-                storage.push_back(std::make_pair(std::get<0>(value), t_metadata_dict()));
+            if (prev != std::get<0>(value)) {
+                count += 1;
+                prev = std::get<0>(value);
+            }
+        }
+
+        std::vector<typename vtr::flat_map<LookupKey, t_metadata_dict>::value_type> storage;
+        storage.resize(count);
+        size_t idx = 0;
+        storage[idx].first = std::get<0>(data_[0]);
+
+        for (const auto& value : data_) {
+            if (storage[idx].first != std::get<0>(value)) {
+                idx += 1;
+                VTR_ASSERT(idx < count);
+                storage[idx].first = std::get<0>(value);
             }
 
-            storage.back().second.add(std::get<1>(value), std::get<2>(value));
+            storage[idx].second.add(std::get<1>(value), std::get<2>(value));
         }
+
+        VTR_ASSERT(idx + 1 == count);
 
         map_.assign(std::move(storage));
 

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -376,7 +376,7 @@ void process_nodes(pugi::xml_node parent, const pugiutil::loc_data& loc_data) {
             while (rr_node_meta) {
                 auto key = get_attribute(rr_node_meta, "name", loc_data).as_string();
 
-                vpr::add_rr_node_metadata(inode, key, rr_node_meta.child_value());
+                vpr::add_rr_node_metadata(inode, vtr::string_view(key), vtr::string_view(rr_node_meta.child_value()));
 
                 rr_node_meta = rr_node_meta.next_sibling(rr_node_meta.name());
             }
@@ -469,7 +469,7 @@ void process_edges(pugi::xml_node parent, const pugiutil::loc_data& loc_data, in
                 auto key = get_attribute(edges_meta, "name", loc_data).as_string();
 
                 vpr::add_rr_edge_metadata(source_node, sink_node, switch_id,
-                                          key, edges_meta.child_value());
+                                          vtr::string_view(key), vtr::string_view(edges_meta.child_value()));
 
                 edges_meta = edges_meta.next_sibling(edges_meta.name());
             }

--- a/vpr/src/route/rr_graph_writer.cpp
+++ b/vpr/src/route/rr_graph_writer.cpp
@@ -63,14 +63,15 @@ void write_rr_graph(const char* file_name, const std::vector<t_segment_inf>& seg
 }
 
 static void add_metadata_to_xml(std::fstream& fp, const char* tab_prefix, const t_metadata_dict& meta) {
+    auto& device_ctx = g_vpr_ctx.device();
     fp << tab_prefix << "<metadata>" << std::endl;
 
     for (const auto& meta_elem : meta) {
-        const std::string& key = meta_elem.first;
+        const auto& key = meta_elem.first;
         const std::vector<t_metadata_value>& values = meta_elem.second;
         for (const auto& value : values) {
-            fp << tab_prefix << "\t<meta name=\"" << key << "\"";
-            fp << ">" << value.as_string() << "</meta>" << std::endl;
+            fp << tab_prefix << "\t<meta name=\"" << key.bind(&device_ctx.arch->strings) << "\"";
+            fp << ">" << value.as_string().bind(&device_ctx.arch->strings) << "</meta>" << std::endl;
         }
     }
     fp << tab_prefix << "</metadata>" << std::endl;

--- a/vpr/src/route/rr_metadata.cpp
+++ b/vpr/src/route/rr_metadata.cpp
@@ -7,22 +7,18 @@ namespace vpr {
 const t_metadata_value* rr_node_metadata(int src_node, vtr::interned_string key) {
     auto& device_ctx = g_vpr_ctx.device();
 
-    if (device_ctx.rr_node_metadata.size() == 0 || device_ctx.rr_node_metadata.count(src_node) == 0) {
+    auto iter = device_ctx.rr_node_metadata.find(src_node);
+    if (iter == device_ctx.rr_node_metadata.end()) {
         return nullptr;
     }
-    auto& data = device_ctx.rr_node_metadata.at(src_node);
-    return data.one(key);
+    return iter->second.one(key);
 }
 
 void add_rr_node_metadata(int src_node, vtr::string_view key, vtr::string_view value) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
-
-    if (device_ctx.rr_node_metadata.count(src_node) == 0) {
-        device_ctx.rr_node_metadata.emplace(src_node, t_metadata_dict());
-    }
-    auto& data = device_ctx.rr_node_metadata.at(src_node);
-    data.add(device_ctx.arch->strings.intern_string(key),
-             device_ctx.arch->strings.intern_string(value));
+    device_ctx.rr_node_metadata.add_metadata(src_node,
+                                             device_ctx.arch->strings.intern_string(key),
+                                             device_ctx.arch->strings.intern_string(value));
 }
 
 const t_metadata_value* rr_edge_metadata(int src_node, int sink_id, short switch_id, vtr::interned_string key) {
@@ -40,12 +36,9 @@ const t_metadata_value* rr_edge_metadata(int src_node, int sink_id, short switch
 void add_rr_edge_metadata(int src_node, int sink_id, short switch_id, vtr::string_view key, vtr::string_view value) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
     auto rr_edge = std::make_tuple(src_node, sink_id, switch_id);
-    if (device_ctx.rr_edge_metadata.count(rr_edge) == 0) {
-        device_ctx.rr_edge_metadata.emplace(rr_edge, t_metadata_dict());
-    }
-    auto& data = device_ctx.rr_edge_metadata.at(rr_edge);
-    data.add(device_ctx.arch->strings.intern_string(key),
-             device_ctx.arch->strings.intern_string(value));
+    device_ctx.rr_edge_metadata.add_metadata(rr_edge,
+                                             device_ctx.arch->strings.intern_string(key),
+                                             device_ctx.arch->strings.intern_string(value));
 }
 
 } // namespace vpr

--- a/vpr/src/route/rr_metadata.cpp
+++ b/vpr/src/route/rr_metadata.cpp
@@ -4,7 +4,7 @@
 
 namespace vpr {
 
-const t_metadata_value* rr_node_metadata(int src_node, std::string key) {
+const t_metadata_value* rr_node_metadata(int src_node, vtr::interned_string key) {
     auto& device_ctx = g_vpr_ctx.device();
 
     if (device_ctx.rr_node_metadata.size() == 0 || device_ctx.rr_node_metadata.count(src_node) == 0) {
@@ -14,17 +14,18 @@ const t_metadata_value* rr_node_metadata(int src_node, std::string key) {
     return data.one(key);
 }
 
-void add_rr_node_metadata(int src_node, std::string key, std::string value) {
+void add_rr_node_metadata(int src_node, vtr::string_view key, vtr::string_view value) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
 
     if (device_ctx.rr_node_metadata.count(src_node) == 0) {
         device_ctx.rr_node_metadata.emplace(src_node, t_metadata_dict());
     }
     auto& data = device_ctx.rr_node_metadata.at(src_node);
-    data.add(key, value);
+    data.add(device_ctx.arch->strings.intern_string(key),
+             device_ctx.arch->strings.intern_string(value));
 }
 
-const t_metadata_value* rr_edge_metadata(int src_node, int sink_id, short switch_id, std::string key) {
+const t_metadata_value* rr_edge_metadata(int src_node, int sink_id, short switch_id, vtr::interned_string key) {
     const auto& device_ctx = g_vpr_ctx.device();
     auto rr_edge = std::make_tuple(src_node, sink_id, switch_id);
 
@@ -36,14 +37,15 @@ const t_metadata_value* rr_edge_metadata(int src_node, int sink_id, short switch
     return iter->second.one(key);
 }
 
-void add_rr_edge_metadata(int src_node, int sink_id, short switch_id, std::string key, std::string value) {
+void add_rr_edge_metadata(int src_node, int sink_id, short switch_id, vtr::string_view key, vtr::string_view value) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
     auto rr_edge = std::make_tuple(src_node, sink_id, switch_id);
     if (device_ctx.rr_edge_metadata.count(rr_edge) == 0) {
         device_ctx.rr_edge_metadata.emplace(rr_edge, t_metadata_dict());
     }
     auto& data = device_ctx.rr_edge_metadata.at(rr_edge);
-    data.add(key, value);
+    data.add(device_ctx.arch->strings.intern_string(key),
+             device_ctx.arch->strings.intern_string(value));
 }
 
 } // namespace vpr

--- a/vpr/src/route/rr_metadata.h
+++ b/vpr/src/route/rr_metadata.h
@@ -5,11 +5,11 @@
 
 namespace vpr {
 
-const t_metadata_value* rr_node_metadata(int src_node, std::string key);
-void add_rr_node_metadata(int src_node, std::string key, std::string value);
+const t_metadata_value* rr_node_metadata(int src_node, vtr::interned_string key);
+void add_rr_node_metadata(int src_node, vtr::string_view key, vtr::string_view value);
 
-const t_metadata_value* rr_edge_metadata(int src_node, int sink_node, short switch_id, std::string key);
-void add_rr_edge_metadata(int src_node, int sink_node, short switch_id, std::string key, std::string value);
+const t_metadata_value* rr_edge_metadata(int src_node, int sink_node, short switch_id, vtr::interned_string key);
+void add_rr_edge_metadata(int src_node, int sink_node, short switch_id, vtr::string_view key, vtr::string_view value);
 
 } // namespace vpr
 


### PR DESCRIPTION
#### Description

String internment is basically the idea that if you know you have a small pool of strings relative to the number of total strings, you can save memory and maybe save CPU time by interning the strings.  Then the leafs of the code have intern ids rather than the full strings.

This PR adds a simple string internment using `std::unordered_map` for use when interning strings, and a `std::vector` for intern id to string lookup. This simple string internment does use 2x the memory for string storage, but is straight forward to implement and verify.

This PR also converts the metadata structures to use interned string ids instead of `std::string`.  This is not critical for metadata on objects in physical types, but is critical when there is metadata that is on a per edge or per node basis.  The CPU overhead of build the string internship is small (order 2.5 seconds for 22 million internments), but the memory reduction is significant if the strings and/or substrings are repeated, which is very typical.

This PR also adds a `MetadataStorage` object, which performs delay'd map generation.  Because node and edge metadata is always insert all data, followed by query, a simple two-phase data structure can be used.  This saves CPU time by avoiding the needed to maintain a live map during initial insertion.

#### Motivation and Context

This is a CPU - memory trade-off.  On the artix 50T, the cost of storing edge metadata is roughly 5 GiB of memory without internment, and that memory usage scales linearly with the number of edges (22 million on the 50T).  By using string internment, the memory used still scales linearly, but the constant factor and number of allocations drops dramatically.  If `absl` is added to VTR, the number of allocations can potentially be brought to 0 using `absl::InlinedVector`.

#### How Has This Been Tested?

- CI passes
- CPU and memory usage profiled before and after change.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
