### PR TITLE
Remove copy of vtr::bimap in get_physical_pin

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1628,7 +1628,7 @@ static void timing_driven_expand_cheapest(t_heap* cheapest,
                                         target_node,
                                         router_stats);
     } else {
-        //Post-heap prune, do not re-explore from the current/new partial path as it 
+        //Post-heap prune, do not re-explore from the current/new partial path as it
         //has worse cost than the best partial path to this node found so far
         VTR_LOGV_DEBUG(f_router_debug, "    Worse cost to %d\n", inode);
         VTR_LOGV_DEBUG(f_router_debug, "    Old total cost: %g\n", best_total_cost);

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -2152,7 +2152,7 @@ int get_physical_pin(t_physical_tile_type_ptr physical_tile,
                      int pin) {
     t_logical_pin logical_pin(pin);
 
-    const auto &direct_map = physical_tile->tile_block_pin_directs_map.at(logical_block->index);
+    const auto& direct_map = physical_tile->tile_block_pin_directs_map.at(logical_block->index);
     auto result = direct_map.find(logical_pin);
 
     if (result == direct_map.end()) {

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -2152,7 +2152,7 @@ int get_physical_pin(t_physical_tile_type_ptr physical_tile,
                      int pin) {
     t_logical_pin logical_pin(pin);
 
-    auto direct_map = physical_tile->tile_block_pin_directs_map.at(logical_block->index);
+    const auto &direct_map = physical_tile->tile_block_pin_directs_map.at(logical_block->index);
     auto result = direct_map.find(logical_pin);
 
     if (result == direct_map.end()) {


### PR DESCRIPTION
#### Description

This was causing 100 billion allocations to be generated.

#### Related Issue
#### Motivation and Context

Avoids 100 billion allocations during PnR.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
