### PR TITLE
VTR flow: Add hostname and run directory to parse results

### DIFF
--- a/vtr_flow/parse/parse_config/common/vpr.common.txt
+++ b/vtr_flow/parse/parse_config/common/vpr.common.txt
@@ -1,6 +1,8 @@
 #General
 vpr_revision;vpr.out;Revision:\s(.*);unknown
 vpr_status;output.txt;vpr_status=(.*)
+hostname;output.txt;hostname=(.*)
+rundir;output.txt;rundir=(.*)
 
 #Run-time Metrics
 max_vpr_mem;vpr.out;Maximum resident set size \(kbytes\): (\d+)

--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -39,6 +39,7 @@
 use strict;
 use warnings;
 use Cwd;
+use Sys::Hostname;
 use File::Spec;
 use POSIX;
 use File::Copy;
@@ -1175,6 +1176,8 @@ open( RESULTS, "> $results_path" );
 # Output vpr status and runtime
 print RESULTS "vpr_status=$q\n";
 print RESULTS "vpr_seconds=$seconds\n";
+print RESULTS "rundir=" . getcwd() . "\n";
+print RESULTS "hostname=" . hostname() . "\n";
 
 # Parse VPR output
 if ( open( VPROUT, "< vpr.out" ) ) {


### PR DESCRIPTION
This provides metadata about where golden/parse results came from which can help
debugging/tracing/reproducibility issues.
