### PR TITLE
Add a bitmap to speed up non_configurable look up

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -288,6 +288,14 @@ struct RoutingContext : public Context {
 
     std::vector<t_rr_node_route_inf> rr_node_route_inf; /* [0..device_ctx.num_rr_nodes-1] */
 
+    //Information about whether a node is part of a non-configurable set
+    //(i.e. connected to others with non-configurable edges like metal shorts that can't be disabled)
+    //Stored in a single bit per rr_node for efficiency
+    //  bit value 0: node is not part of a non-configurable set
+    //  bit value 1: node is part of a non-configurable set
+    //Initialized once when RoutingContext is initialized, static throughout invocation of router
+    vtr::dynamic_bitset<> non_configurable_bitset; /*[0...device_ctx.num_rr_nodes] */
+
     //Information about current routing status of each net
     t_net_routing_status net_status;
 

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -195,5 +195,4 @@ void make_room_in_vector(T* vec, size_t elem_position) {
 
     vec->resize(elem_position + 1);
 }
-
 #endif


### PR DESCRIPTION
#### Description
Use the two bytes free space in t_rr_node_route_inf to implement a bitmap so that configurable nodes do not have to go through hash map look ups.

#### Related Issue
For configurable nodes (majority of nodes), looking through hash map to determine if the node is a non_configurable node is slow due to possible collision. A bitmap can be implemented to mitigate the issue.

#### How Has This Been Tested?
Tests from symbiflow: picosoc, murax, top_bram_n1-3, dram_test_64x1d and buttons have been run with the change. Execution time of Routing section is reduced by around 15% without affecting quality of results.

Run through Benchmarks QoR Measurements. All tests passed. Since the tests do not have non_configurable nodes, there's no obvious improvement to execution time. Used to prove no increase in memory utilization.

Still waiting for results from Titan Benchmarks.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
