### PR TITLE
Remove empty statement in switch/case. Add missing break in another.

### DIFF
--- a/vpr/src/base/netlist.tpp
+++ b/vpr/src/base/netlist.tpp
@@ -277,7 +277,7 @@ PinType Netlist<BlockId, PortId, PinId, NetId>::pin_type(const PinId pin_id) con
 
     PinType type = PinType::OPEN;
     switch (port_type(port_id)) {
-        case PortType::INPUT: /*fallthrough */;
+        case PortType::INPUT: /*fallthrough */
         case PortType::CLOCK:
             type = PinType::SINK;
             break;

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -545,6 +545,7 @@ static void check_rr_edge(int from_node, int iedge, int to_node) {
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
             }
+            break;
         case SwitchType::TRISTATE:  //Fallthrough
         case SwitchType::MUX:       //Fallthrough
         case SwitchType::PASS_GATE: //Fallthrough


### PR DESCRIPTION
o The semicolon in the empty fallthrough statement in netlist.tpp
  triggers fallthrough warnings, so removing the semicolon better
  reflects the intentions.
o check_rr_graph: there is a missing break in the switch/case which
  happens to not introduce a bug as the following cases also break.
  Add 'break' to reflect intention of code.