### PR TITLE
Implement serialization of map lookahead.

### DIFF
--- a/libs/libvtrcapnproto/CMakeLists.txt
+++ b/libs/libvtrcapnproto/CMakeLists.txt
@@ -21,6 +21,7 @@ capnp_generate_cpp(CAPNP_SRCS CAPNP_HDRS
     place_delay_model.capnp
     matrix.capnp
     gen/rr_graph_uxsdcxx.capnp
+    map_lookahead.capnp
     )
 
 add_library(libvtrcapnproto STATIC

--- a/libs/libvtrcapnproto/map_lookahead.capnp
+++ b/libs/libvtrcapnproto/map_lookahead.capnp
@@ -1,0 +1,11 @@
+@0x947b9a80fec4ea2c;
+
+using Matrix = import "matrix.capnp";
+
+struct VprMapCostEntry {
+    delay @0 :Float32;
+    congestion @1 :Float32;
+}
+struct VprMapLookahead {
+    costMap @0 :Matrix.Matrix(VprMapCostEntry);
+}

--- a/libs/libvtrcapnproto/serdes_utils.h
+++ b/libs/libvtrcapnproto/serdes_utils.h
@@ -8,4 +8,12 @@
 void writeMessageToFile(const std::string& file,
         ::capnp::MessageBuilder* builder);
 
+inline ::capnp::ReaderOptions default_large_capnp_opts() {
+    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
+
+    /* Increase reader limit to 1G words to allow for large files. */
+    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    return opts;
+}
+
 #endif /* SERDES_UTILS_H_ */

--- a/vpr/src/place/place_delay_model.cpp
+++ b/vpr/src/place/place_delay_model.cpp
@@ -188,8 +188,7 @@ void DeltaDelayModel::read(const std::string& file) {
     MmapFile f(file);
 
     /* Increase reader limit to 1G words to allow for large files. */
-    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
-    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    ::capnp::ReaderOptions opts = default_large_capnp_opts();
 
     // FlatArrayMessageReader is used to read the message from the data array
     // provided by MmapFile.
@@ -245,8 +244,7 @@ void OverrideDelayModel::read(const std::string& file) {
     MmapFile f(file);
 
     /* Increase reader limit to 1G words to allow for large files. */
-    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
-    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    ::capnp::ReaderOptions opts = default_large_capnp_opts();
     ::capnp::FlatArrayMessageReader reader(f.getData(), opts);
 
     vtr::Matrix<float> delays;

--- a/vpr/src/place/place_delay_model.cpp
+++ b/vpr/src/place/place_delay_model.cpp
@@ -187,9 +187,13 @@ void DeltaDelayModel::read(const std::string& file) {
     // when the object leaves scope.
     MmapFile f(file);
 
+    /* Increase reader limit to 1G words to allow for large files. */
+    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
+    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+
     // FlatArrayMessageReader is used to read the message from the data array
     // provided by MmapFile.
-    ::capnp::FlatArrayMessageReader reader(f.getData());
+    ::capnp::FlatArrayMessageReader reader(f.getData(), opts);
 
     // When reading capnproto files the Reader object to use is named
     // <schema name>::Reader.
@@ -239,7 +243,11 @@ void DeltaDelayModel::write(const std::string& file) const {
 
 void OverrideDelayModel::read(const std::string& file) {
     MmapFile f(file);
-    ::capnp::FlatArrayMessageReader reader(f.getData());
+
+    /* Increase reader limit to 1G words to allow for large files. */
+    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
+    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    ::capnp::FlatArrayMessageReader reader(f.getData(), opts);
 
     vtr::Matrix<float> delays;
     auto model = reader.getRoot<VprOverrideDelayModel>();

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -105,6 +105,14 @@ void MapLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
     compute_router_lookahead(segment_inf.size());
 }
 
+void MapLookahead::read(const std::string& file) {
+    read_router_lookahead(file);
+}
+
+void MapLookahead::write(const std::string& file) const {
+    write_router_lookahead(file);
+}
+
 float NoOpLookahead::get_expected_cost(int /*current_node*/, int /*target_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
     return 0.;
 }

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -72,12 +72,8 @@ class MapLookahead : public RouterLookahead {
   protected:
     float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
     void compute(const std::vector<t_segment_inf>& segment_inf) override;
-    void read(const std::string& /*file*/) override {
-        VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read unimplemented");
-    }
-    void write(const std::string& /*file*/) const override {
-        VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write unimplemented");
-    }
+    void read(const std::string& file) override;
+    void write(const std::string& file) const override;
 };
 
 class NoOpLookahead : public RouterLookahead {

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -59,23 +59,6 @@ enum e_representative_entry_method {
     MEDIAN
 };
 
-/* f_cost_map is an array of these cost entries that specifies delay/congestion estimates
- * to travel relative x/y distances */
-class Cost_Entry {
-  public:
-    float delay;
-    float congestion;
-
-    Cost_Entry() {
-        delay = -1.0;
-        congestion = -1.0;
-    }
-    Cost_Entry(float set_delay, float set_congestion) {
-        delay = set_delay;
-        congestion = set_congestion;
-    }
-};
-
 /* a class that stores delay/congestion information for a given relative coordinate during the Dijkstra expansion.
  * since it stores multiple cost entries, it is later boiled down to a single representative cost entry to be stored
  * in the final lookahead cost map */
@@ -181,11 +164,6 @@ class PQ_Entry {
         return (this->cost > obj.cost);
     }
 };
-
-/* provides delay/congestion estimates to travel specified distances
- * in the x/y direction */
-typedef vtr::NdMatrix<Cost_Entry, 4> t_cost_map; //[0..1][[0..num_seg_types-1]0..device_ctx.grid.width()-1][0..device_ctx.grid.height()-1]
-                                                 //[0..1] entry distinguish between CHANX/CHANY start nodes respectively
 
 /* used during Dijkstra expansion to store delay/congestion info lists for each relative coordinate for a given segment and channel type.
  * the list at each coordinate is later boiled down to a single representative cost entry to be stored in the final cost map */
@@ -720,8 +698,7 @@ void read_router_lookahead(const std::string& file) {
     MmapFile f(file);
 
     /* Increase reader limit to 1G words to allow for large files. */
-    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
-    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    ::capnp::ReaderOptions opts = default_large_capnp_opts();
     ::capnp::FlatArrayMessageReader reader(f.getData(), opts);
 
     auto map = reader.getRoot<VprMapLookahead>();

--- a/vpr/src/route/router_lookahead_map.h
+++ b/vpr/src/route/router_lookahead_map.h
@@ -1,6 +1,29 @@
 #pragma once
 
 #include <string>
+#include "vtr_ndmatrix.h"
+
+/* f_cost_map is an array of these cost entries that specifies delay/congestion estimates
+ * to travel relative x/y distances */
+class Cost_Entry {
+  public:
+    float delay;
+    float congestion;
+
+    Cost_Entry() {
+        delay = -1.0;
+        congestion = -1.0;
+    }
+    Cost_Entry(float set_delay, float set_congestion) {
+        delay = set_delay;
+        congestion = set_congestion;
+    }
+};
+
+/* provides delay/congestion estimates to travel specified distances
+ * in the x/y direction */
+typedef vtr::NdMatrix<Cost_Entry, 4> t_cost_map; //[0..1][[0..num_seg_types-1]0..device_ctx.grid.width()-1][0..device_ctx.grid.height()-1]
+                                                 //[0..1] entry distinguish between CHANX/CHANY start nodes respectively
 
 void read_router_lookahead(const std::string& file);
 void write_router_lookahead(const std::string& file);

--- a/vpr/src/route/router_lookahead_map.h
+++ b/vpr/src/route/router_lookahead_map.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <string>
+
+void read_router_lookahead(const std::string& file);
+void write_router_lookahead(const std::string& file);
+
 /* Computes the lookahead map to be used by the router. If a map was computed prior to this, a new one will not be computed again.
  * The rr graph must have been built before calling this function. */
 void compute_router_lookahead(int num_segments);

--- a/vpr/test/test_map_lookahead_serdes.cpp
+++ b/vpr/test/test_map_lookahead_serdes.cpp
@@ -1,0 +1,62 @@
+#include "catch.hpp"
+
+#include "router_lookahead_map.h"
+
+extern t_cost_map f_cost_map;
+
+namespace {
+
+#ifdef VTR_ENABLE_CAPNPROTO
+static constexpr const char kMapLookaheadBin[] = "test_map_lookahead.bin";
+
+TEST_CASE("round_trip_map_lookahead", "[vpr]") {
+    constexpr std::array<size_t, 4> kDim({10, 12, 15, 16});
+
+    f_cost_map.resize(kDim);
+    for (size_t x = 0; x < kDim[0]; ++x) {
+        for (size_t y = 0; y < kDim[1]; ++y) {
+            for (size_t z = 0; z < kDim[2]; ++z) {
+                for (size_t w = 0; w < kDim[3]; ++w) {
+                    f_cost_map[x][y][z][w].delay = (x + 1) * (y + 1) * (z + 1) * (w + 1);
+                    f_cost_map[x][y][z][w].congestion = 2 * (x + 1) * (y + 1) * (z + 1) * (w + 1);
+                }
+            }
+        }
+    }
+
+    write_router_lookahead(kMapLookaheadBin);
+
+    for (size_t x = 0; x < kDim[0]; ++x) {
+        for (size_t y = 0; y < kDim[1]; ++y) {
+            for (size_t z = 0; z < kDim[2]; ++z) {
+                for (size_t w = 0; w < kDim[3]; ++w) {
+                    f_cost_map[x][y][z][w].delay = 0.f;
+                    f_cost_map[x][y][z][w].congestion = 0.f;
+                }
+            }
+        }
+    }
+
+    f_cost_map.resize({0, 0, 0, 0});
+
+    read_router_lookahead(kMapLookaheadBin);
+
+    for (size_t i = 0; i < kDim.size(); ++i) {
+        REQUIRE(f_cost_map.dim_size(i) == kDim[i]);
+    }
+
+    for (size_t x = 0; x < kDim[0]; ++x) {
+        for (size_t y = 0; y < kDim[1]; ++y) {
+            for (size_t z = 0; z < kDim[2]; ++z) {
+                for (size_t w = 0; w < kDim[3]; ++w) {
+                    REQUIRE(f_cost_map[x][y][z][w].delay == (x + 1) * (y + 1) * (z + 1) * (w + 1));
+                    REQUIRE(f_cost_map[x][y][z][w].congestion == 2 * (x + 1) * (y + 1) * (z + 1) * (w + 1));
+                }
+            }
+        }
+    }
+}
+
+#endif
+
+} // namespace


### PR DESCRIPTION
#### Description

Now that capnp and the place delay lookahead are merged, this PR adds serialization for the map lookahead.

#### Related Issue

#989

#### Motivation and Context

As part of working on memory and CPU optimization for Titan benchmarks, iteration speed is important.  As an example, running routing only on the `gsm_switch_stratixiv_arch_timing.blif` takes ~1000 seconds.   Around 400 seconds of that time is computing the lookahead map.  The ability to save lookahead map saves those 400 seconds, and means that any resulting profile will be focused samples from the router.

#### How Has This Been Tested?

- [x] CI is green
- [x] Smoke tested by showing that gsm_switch routes the same using compute on the fly and precomputed lookahead map.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
