### PR TITLE
Adding documentation for two stage clock routing cmd line option

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -182,12 +182,14 @@ General Options
 
      **Default:** ``ideal``
 
-.. option:: --two_stage_clock_routing
+.. option:: --two_stage_clock_routing {on | off}
 
     Routes clock nets in two stages using a dedicated clock network.
 
-     * First stage: From the net source (e.g. an I/O pin) to a dedicated clock network source (e.g. center of chip)
-     * Second stage: From the clock network source to net sinks.
+     * First stage: From the net source (e.g. an I/O pin) to a dedicated clock network root (e.g. center of chip)
+     * Second stage: From the clock network root to net sinks.
+
+    Note this option only works when specifying a clock architecture, see :ref:`Clock Architecture Format <clock_architecture_format>`; it does not work when reading a routing resource graph (i.e. :option:`--read_rr_graph`).
 
      **Default:** ``off``
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -182,6 +182,15 @@ General Options
 
      **Default:** ``ideal``
 
+.. option:: --two_stage_clock_routing
+
+    Routes clock nets in two stages using a dedicated clock network.
+
+     * First stage: From the net source (e.g. an I/O pin) to a dedicated clock network source (e.g. center of chip)
+     * Second stage: From the clock network source to net sinks.
+
+     **Default:** ``off``
+
 .. option:: --exit_before_pack {on | off}
 
     Causes VPR to exit before packing starts (useful for statistics collection).


### PR DESCRIPTION
Updating the documentation to add the two_stage_clock_routing cmd line option


#### Related Issue
Addresses part of https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/928#issuecomment-555432218

#### Motivation and Context
Adds documentation to an existing command line option

#### How Has This Been Tested?
N/A

#### Types of changes
Documentation

#### Checklist:
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
