### PR TITLE
build: Don't apply additional flags to external libraries/tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,6 @@ endif()
 separate_arguments(
     ADDITIONAL_FLAGS UNIX_COMMAND "${SANITIZE_FLAGS} ${PROFILING_FLAGS} ${COVERAGE_FLAGS} ${LOGGING_FLAGS} ${COLORED_COMPILE}"
     )
-add_compile_options(${ADDITIONAL_FLAGS})
 separate_arguments(
     WARN_FLAGS UNIX_COMMAND "${WARN_FLAGS}"
     )
@@ -349,6 +348,8 @@ add_subdirectory(libs) #libs/CMakeLists.txt handles adding warnings flags to non
 
 #Add the various tools
 add_compile_options(${WARN_FLAGS}) #Add warn flags for VTR tools
+add_compile_options(${ADDITIONAL_FLAGS})
+link_libraries(${ADDITIONAL_FLAGS})
 add_subdirectory(vpr)
 add_subdirectory(ODIN_II)
 add_subdirectory(ace2)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(EXTERNAL)
 # VTR developed libraries
 #  Only add warn flags for VPR internal libraries.
 add_compile_options(${WARN_FLAGS})
+add_compile_options(${ADDITIONAL_FLAGS})
 add_subdirectory(libarchfpga)
 add_subdirectory(libvtrutil)
 add_subdirectory(liblog)


### PR DESCRIPTION
Previously additional compilation flags (e.g. to enable sanitizers) were
also applied to external libraries causing for instance the capnproto
compiler to be build with sanitizers which could then cause the build to
fail.

We now only apply additional flags to internal libraries to avoid this.