### PR TITLE
flow: Improve separator detection in qor_compare.py

### DIFF
--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -120,7 +120,13 @@ def main():
     for i, csv in enumerate(args.parse_result_files):
         #Load as CSV
         print "Loading", csv
-        df = pd.read_csv(csv, sep='\t')
+
+        base, ext = os.path.splitext(csv)
+        if ext == '.txt':
+            sep='\t'
+        else:
+            sep=','
+        df = pd.read_csv(csv, sep=sep)
 
         avail_metrics.update(df.columns) #Record available metrics
 


### PR DESCRIPTION
It will now detect:
  * '.txt' -> '\t' separator
  * '.csv' -> ',' separator
