### PR TITLE
vpr: Add support for dumping timing graph in GraphViz dot format

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -523,6 +523,7 @@ static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysi
     analysis_opts.timing_report_npaths = Options.timing_report_npaths;
     analysis_opts.timing_report_detail = Options.timing_report_detail;
     analysis_opts.timing_report_skew = Options.timing_report_skew;
+    analysis_opts.echo_dot_timing_graph_node = Options.echo_dot_timing_graph_node;
 }
 
 static void SetupPowerOpts(const t_options& Options, t_power_opts* power_opts, t_arch* Arch) {

--- a/vpr/src/base/netlist.h
+++ b/vpr/src/base/netlist.h
@@ -697,6 +697,11 @@ class Netlist {
     //  port_bit: The bit index of the pin in the port
     PinId find_pin(const PortId port_id, BitIndex port_bit) const;
 
+    //Returns the PinId of the specified pin or PinId::INVALID() if not found
+    //NOTE: this method is SLOW, O(num_pins) -- avoid if possible
+    //  name : The name of the pin
+    PinId find_pin(const std::string name) const;
+
   public: //Public Mutators
     //Add the specified pin to the specified net as pin_type. Automatically removes
     //any previous net connection for this pin.

--- a/vpr/src/base/netlist.tpp
+++ b/vpr/src/base/netlist.tpp
@@ -508,6 +508,17 @@ PinId Netlist<BlockId, PortId, PinId, NetId>::find_pin(const PortId port_id, Bit
     }
 }
 
+template<typename BlockId, typename PortId, typename PinId, typename NetId>
+PinId Netlist<BlockId, PortId, PinId, NetId>::find_pin(const std::string name) const {
+    //We don't store a fast look-up for pin names, so do a slow linear search
+    for (PinId pin : pins()) {
+        if (pin_name(pin) == name) {
+            return pin;
+        }
+    }
+    return PinId::INVALID();
+}
+
 /*
  *
  * Validation

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1685,6 +1685,16 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("off")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    analysis_grp.add_argument(args.echo_dot_timing_graph_node, "--echo_dot_timing_graph_node")
+        .help(
+            "Controls how the timing graph echo file in DOT/GraphViz format is created when\n"
+            "'--echo_file on' is set:\n"
+            " * -1: All nodes are dumped into the DOT file\n"
+            " * >= 0: Only the transitive fanin/fanout of the node is dumped (easier to view)\n"
+            " * a string: Interpretted as a VPR pin name which is converted to a node id, and dumped as above\n")
+        .default_value("-1")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& power_grp = parser.add_argument_group("power analysis options");
 
     power_grp.add_argument<bool, ParseOnOff>(args.do_power, "--power")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -395,6 +395,8 @@ struct ParseTimingReportDetail {
             conv_value.set_value(e_timing_report_detail::AGGREGATED);
         else if (str == "detailed")
             conv_value.set_value(e_timing_report_detail::DETAILED_ROUTING);
+        else if (str == "debug")
+            conv_value.set_value(e_timing_report_detail::DEBUG);
         else {
             std::stringstream msg;
             msg << "Invalid conversion from '" << str << "' to e_timing_report_detail (expected one of: " << argparse::join(default_choices(), ", ") << ")";
@@ -412,12 +414,15 @@ struct ParseTimingReportDetail {
         } else if (val == e_timing_report_detail::DETAILED_ROUTING) {
             VTR_ASSERT(val == e_timing_report_detail::DETAILED_ROUTING);
             conv_value.set_value("detailed");
+        } else {
+            VTR_ASSERT(val == e_timing_report_detail::DEBUG);
+            conv_value.set_value("debug");
         }
         return conv_value;
     }
 
     std::vector<std::string> default_choices() {
-        return {"netlist", "aggregated", "detailed"};
+        return {"netlist", "aggregated", "detailed", "debug"};
     }
 };
 
@@ -1676,7 +1681,8 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
             "Controls how much detail is provided in timing reports.\n"
             " * netlist: Shows only netlist pins\n"
             " * aggregated: Like 'netlist', but also shows aggregated intra-block/inter-block delays\n"
-            " * detailed: Lke 'aggregated' but shows detailed routing instead of aggregated inter-block delays\n")
+            " * detailed: Like 'aggregated' but shows detailed routing instead of aggregated inter-block delays\n"
+            " * debug: Like 'detailed' but shows additional tool internal debug information\n")
         .default_value("netlist")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -160,6 +160,7 @@ struct t_options {
     argparse::ArgValue<int> timing_report_npaths;
     argparse::ArgValue<e_timing_report_detail> timing_report_detail;
     argparse::ArgValue<bool> timing_report_skew;
+    argparse::ArgValue<std::string> echo_dot_timing_graph_node;
 };
 
 argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args);

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -894,6 +894,7 @@ enum class e_timing_report_detail {
     NETLIST,          //Only show netlist elements
     AGGREGATED,       //Show aggregated intra-block and inter-block delays
     DETAILED_ROUTING, //Show inter-block routing resources used
+    DEBUG,            //Show additional internal debugging information
 };
 
 enum class e_incr_reroute_delay_ripup {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -960,6 +960,7 @@ struct t_analysis_opts {
     int timing_report_npaths;
     e_timing_report_detail timing_report_detail;
     bool timing_report_skew;
+    std::string echo_dot_timing_graph_node;
 };
 
 /* Defines the detailed routing architecture of the FPGA.  Only important   *

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -507,6 +507,9 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
             auto& timing_ctx = g_vpr_ctx.timing();
             tatum::write_echo(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH),
                               *timing_ctx.graph, *timing_ctx.constraints, *clustering_delay_calc, timing_info->analyzer());
+
+            write_setup_timing_graph_dot(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH) + std::string(".dot"),
+                                         *timing_info);
         }
 
         {

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -508,8 +508,9 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
             tatum::write_echo(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH),
                               *timing_ctx.graph, *timing_ctx.constraints, *clustering_delay_calc, timing_info->analyzer());
 
+            tatum::NodeId debug_tnode = id_or_pin_name_to_tnode(analysis_opts.echo_dot_timing_graph_node);
             write_setup_timing_graph_dot(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH) + std::string(".dot"),
-                                         *timing_info);
+                                         *timing_info, debug_tnode);
         }
 
         {

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -534,6 +534,9 @@ void try_place(const t_placer_opts& placer_opts,
 
             tatum::write_echo(getEchoFileName(E_ECHO_INITIAL_PLACEMENT_TIMING_GRAPH),
                               *timing_ctx.graph, *timing_ctx.constraints, *placement_delay_calc, timing_info->analyzer());
+
+            write_setup_timing_graph_dot(getEchoFileName(E_ECHO_INITIAL_PLACEMENT_TIMING_GRAPH) + std::string(".dot"),
+                                         *timing_info);
         }
 
         /*now we can properly compute costs  */
@@ -768,6 +771,9 @@ void try_place(const t_placer_opts& placer_opts,
 
             tatum::write_echo(getEchoFileName(E_ECHO_FINAL_PLACEMENT_TIMING_GRAPH),
                               *timing_ctx.graph, *timing_ctx.constraints, *placement_delay_calc, timing_info->analyzer());
+
+            write_setup_timing_graph_dot(getEchoFileName(E_ECHO_FINAL_PLACEMENT_TIMING_GRAPH) + std::string(".dot"),
+                                         *timing_info);
         }
 
         generate_post_place_timing_reports(placer_opts,

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -535,8 +535,9 @@ void try_place(const t_placer_opts& placer_opts,
             tatum::write_echo(getEchoFileName(E_ECHO_INITIAL_PLACEMENT_TIMING_GRAPH),
                               *timing_ctx.graph, *timing_ctx.constraints, *placement_delay_calc, timing_info->analyzer());
 
+            tatum::NodeId debug_tnode = id_or_pin_name_to_tnode(analysis_opts.echo_dot_timing_graph_node);
             write_setup_timing_graph_dot(getEchoFileName(E_ECHO_INITIAL_PLACEMENT_TIMING_GRAPH) + std::string(".dot"),
-                                         *timing_info);
+                                         *timing_info, debug_tnode);
         }
 
         /*now we can properly compute costs  */
@@ -772,8 +773,9 @@ void try_place(const t_placer_opts& placer_opts,
             tatum::write_echo(getEchoFileName(E_ECHO_FINAL_PLACEMENT_TIMING_GRAPH),
                               *timing_ctx.graph, *timing_ctx.constraints, *placement_delay_calc, timing_info->analyzer());
 
+            tatum::NodeId debug_tnode = id_or_pin_name_to_tnode(analysis_opts.echo_dot_timing_graph_node);
             write_setup_timing_graph_dot(getEchoFileName(E_ECHO_FINAL_PLACEMENT_TIMING_GRAPH) + std::string(".dot"),
-                                         *timing_info);
+                                         *timing_info, debug_tnode);
         }
 
         generate_post_place_timing_reports(placer_opts,

--- a/vpr/src/timing/concrete_timing_info.h
+++ b/vpr/src/timing/concrete_timing_info.h
@@ -73,21 +73,15 @@ class ConcreteSetupTimingInfo : public SetupTimingInfo {
         return slack_crit_.setup_pin_criticality(pin);
     }
 
-    std::shared_ptr<const tatum::TimingAnalyzer> analyzer() const override {
-        return setup_analyzer();
-    }
+    std::shared_ptr<const tatum::TimingAnalyzer> analyzer() const override { return setup_analyzer(); }
 
-    std::shared_ptr<const tatum::TimingGraph> timing_graph() const override {
-        return timing_graph_;
-    }
+    std::shared_ptr<const tatum::SetupTimingAnalyzer> setup_analyzer() const override { return setup_analyzer_; }
 
-    std::shared_ptr<const tatum::TimingConstraints> timing_constraints() const override {
-        return timing_constraints_;
-    }
+    std::shared_ptr<const tatum::TimingGraph> timing_graph() const override { return timing_graph_; }
 
-    std::shared_ptr<const tatum::SetupTimingAnalyzer> setup_analyzer() const override {
-        return setup_analyzer_;
-    }
+    std::shared_ptr<const tatum::DelayCalculator> delay_calculator() const override { return delay_calc_; }
+
+    std::shared_ptr<const tatum::TimingConstraints> timing_constraints() const override { return timing_constraints_; }
 
   public:
     //Mutators
@@ -201,6 +195,7 @@ class ConcreteHoldTimingInfo : public HoldTimingInfo {
     std::shared_ptr<const tatum::TimingAnalyzer> analyzer() const override { return hold_analyzer(); }
     std::shared_ptr<const tatum::HoldTimingAnalyzer> hold_analyzer() const override { return hold_analyzer_; }
     std::shared_ptr<const tatum::TimingGraph> timing_graph() const override { return timing_graph_; }
+    std::shared_ptr<const tatum::DelayCalculator> delay_calculator() const override { return delay_calc_; }
     std::shared_ptr<const tatum::TimingConstraints> timing_constraints() const override { return timing_constraints_; }
 
   public:
@@ -304,10 +299,8 @@ class ConcreteSetupHoldTimingInfo : public SetupHoldTimingInfo {
 
     //TimingInfo related
     std::shared_ptr<const tatum::TimingAnalyzer> analyzer() const override { return setup_hold_analyzer(); }
-    std::shared_ptr<const tatum::TimingGraph> timing_graph() const override {
-        return setup_timing_.timing_graph();
-        ;
-    }
+    std::shared_ptr<const tatum::TimingGraph> timing_graph() const override { return setup_timing_.timing_graph(); }
+    std::shared_ptr<const tatum::DelayCalculator> delay_calculator() const override { return setup_timing_.delay_calculator(); }
     std::shared_ptr<const tatum::TimingConstraints> timing_constraints() const override { return setup_timing_.timing_constraints(); }
 
   public:
@@ -410,10 +403,8 @@ class ConstantTimingInfo : public SetupHoldTimingInfo {
 
     //TimingInfo related
     std::shared_ptr<const tatum::TimingAnalyzer> analyzer() const override { return nullptr; }
-    std::shared_ptr<const tatum::TimingGraph> timing_graph() const override {
-        return nullptr;
-        ;
-    }
+    std::shared_ptr<const tatum::TimingGraph> timing_graph() const override { return nullptr; }
+    std::shared_ptr<const tatum::DelayCalculator> delay_calculator() const override { return nullptr; }
     std::shared_ptr<const tatum::TimingConstraints> timing_constraints() const override { return nullptr; }
 
     void set_warn_unconstrained(bool /*val*/) override {}

--- a/vpr/src/timing/timing_info.h
+++ b/vpr/src/timing/timing_info.h
@@ -44,6 +44,9 @@ class TimingInfo {
     //Return the underlying timing analyzer
     virtual std::shared_ptr<const tatum::TimingAnalyzer> analyzer() const = 0;
 
+    //Return the underlying delay calculator
+    virtual std::shared_ptr<const tatum::DelayCalculator> delay_calculator() const = 0;
+
     //Return the underlying timing graph
     virtual std::shared_ptr<const tatum::TimingGraph> timing_graph() const = 0;
 
@@ -61,6 +64,9 @@ class TimingInfo {
 class SetupTimingInfo : public virtual TimingInfo {
   public:
     //Accessors
+
+    //Returns the underlying setup timing analyzer
+    virtual std::shared_ptr<const tatum::SetupTimingAnalyzer> setup_analyzer() const = 0;
 
     //Return the critical path with the least slack
     virtual tatum::TimingPathInfo least_slack_critical_path() const = 0;
@@ -83,9 +89,6 @@ class SetupTimingInfo : public virtual TimingInfo {
     //Return the setup criticality of the worst connection passing through pin
     virtual float setup_pin_criticality(AtomPinId pin) const = 0;
 
-    //Return the underlying timing analyzer
-    virtual std::shared_ptr<const tatum::SetupTimingAnalyzer> setup_analyzer() const = 0;
-
   public:
     //Mutators
     virtual void update_setup() = 0;
@@ -99,6 +102,9 @@ class HoldTimingInfo : public virtual TimingInfo {
   public:
     //Accessors
 
+    //Returns the underlying hold timing analyzer
+    virtual std::shared_ptr<const tatum::HoldTimingAnalyzer> hold_analyzer() const = 0;
+
     //Return the total negative slack w.r.t. hold constraints
     virtual float hold_total_negative_slack() const = 0;
 
@@ -110,9 +116,6 @@ class HoldTimingInfo : public virtual TimingInfo {
 
     //Return the hold criticality of the worst connection passing through pin
     virtual float hold_pin_criticality(AtomPinId pin) const = 0;
-
-    //Return the underlying timing analyzer
-    virtual std::shared_ptr<const tatum::HoldTimingAnalyzer> hold_analyzer() const = 0;
 
   public:
     //Mutators

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -605,3 +605,41 @@ void print_tatum_cpds(std::vector<tatum::TimingPathInfo> cpds) {
         VTR_LOG("Tatum   %zu -> %zu: least_slack=%g cpd=%g\n", size_t(path.launch_domain()), size_t(path.capture_domain()), float(path.slack()), float(path.delay()));
     }
 }
+
+void write_setup_timing_graph_dot(std::string filename, SetupTimingInfo& timing_info, tatum::NodeId debug_node) {
+    auto& timing_graph = *timing_info.timing_graph();
+
+    auto dot_writer = tatum::make_graphviz_dot_writer(timing_graph, *timing_info.delay_calculator());
+
+    std::vector<tatum::NodeId> nodes;
+    if (debug_node) {
+        //Transitive fanin/fanout
+        nodes = tatum::find_transitively_connected_nodes(timing_graph, {debug_node});
+    } else {
+        //All
+        auto tg_nodes = timing_graph.nodes();
+        nodes = std::vector<tatum::NodeId>(tg_nodes.begin(), tg_nodes.end());
+    }
+    dot_writer.set_nodes_to_dump(nodes);
+
+    dot_writer.write_dot_file(filename, *timing_info.setup_analyzer());
+}
+
+void write_hold_timing_graph_dot(std::string filename, HoldTimingInfo& timing_info, tatum::NodeId debug_node) {
+    auto& timing_graph = *timing_info.timing_graph();
+
+    auto dot_writer = tatum::make_graphviz_dot_writer(timing_graph, *timing_info.delay_calculator());
+
+    std::vector<tatum::NodeId> nodes;
+    if (debug_node) {
+        //Transitive fanin/fanout
+        nodes = tatum::find_transitively_connected_nodes(timing_graph, {debug_node});
+    } else {
+        //All
+        auto tg_nodes = timing_graph.nodes();
+        nodes = std::vector<tatum::NodeId>(tg_nodes.begin(), tg_nodes.end());
+    }
+    dot_writer.set_nodes_to_dump(nodes);
+
+    dot_writer.write_dot_file(filename, *timing_info.hold_analyzer());
+}

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -606,6 +606,39 @@ void print_tatum_cpds(std::vector<tatum::TimingPathInfo> cpds) {
     }
 }
 
+tatum::NodeId id_or_pin_name_to_tnode(std::string pin_name_or_tnode) {
+    std::istringstream ss(pin_name_or_tnode);
+    int id;
+    if (ss >> id) { //Successfully converted
+
+        if (id < 0) {
+            return tatum::NodeId::INVALID();
+        } else {
+            return tatum::NodeId(id);
+        }
+    }
+
+    return pin_name_to_tnode(pin_name_or_tnode);
+}
+
+tatum::NodeId pin_name_to_tnode(std::string pin_name) {
+    auto& atom_ctx = g_vpr_ctx.atom();
+
+    AtomPinId pin = atom_ctx.nlist.find_pin(pin_name);
+
+    if (!pin) {
+        VPR_THROW(VPR_ERROR_ATOM_NETLIST, "Failed to find pin named '%s'\n", pin_name.c_str());
+    }
+
+    tatum::NodeId tnode = atom_ctx.lookup.atom_pin_tnode(pin);
+
+    if (!tnode) {
+        VPR_THROW(VPR_ERROR_TIMING, "Failed to find tnode for pin '%s' (pin: %zu)\n", pin_name.c_str(), size_t(pin));
+    }
+
+    return tnode;
+}
+
 void write_setup_timing_graph_dot(std::string filename, SetupTimingInfo& timing_info, tatum::NodeId debug_node) {
     auto& timing_graph = *timing_info.timing_graph();
 

--- a/vpr/src/timing/timing_util.h
+++ b/vpr/src/timing/timing_util.h
@@ -99,4 +99,8 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
  * Debug
  */
 void print_tatum_cpds(std::vector<tatum::TimingPathInfo> cpds);
+
+void write_setup_timing_graph_dot(std::string filename, SetupTimingInfo& timing_info, tatum::NodeId debug_node = tatum::NodeId::INVALID());
+void write_hold_timing_graph_dot(std::string filename, HoldTimingInfo& timing_info, tatum::NodeId debug_node = tatum::NodeId::INVALID());
+
 #endif

--- a/vpr/src/timing/timing_util.h
+++ b/vpr/src/timing/timing_util.h
@@ -100,6 +100,9 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
  */
 void print_tatum_cpds(std::vector<tatum::TimingPathInfo> cpds);
 
+tatum::NodeId id_or_pin_name_to_tnode(std::string name_or_id);
+tatum::NodeId pin_name_to_tnode(std::string name);
+
 void write_setup_timing_graph_dot(std::string filename, SetupTimingInfo& timing_info, tatum::NodeId debug_node = tatum::NodeId::INVALID());
 void write_hold_timing_graph_dot(std::string filename, HoldTimingInfo& timing_info, tatum::NodeId debug_node = tatum::NodeId::INVALID());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Adds support for dumping the timing graph in GraphViz's DOT format to aid debugging.

Also adds support for 'debug' timing reports which include additional debug-level information (like timing graph node ids) which is helpful for interpreting the DOT format.