### PR TITLE
Prevent non-termination with high fanout routing logic

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -373,6 +373,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->clock_modeling = Options.clock_modeling;
     RouterOpts->two_stage_clock_routing = Options.two_stage_clock_routing;
     RouterOpts->high_fanout_threshold = Options.router_high_fanout_threshold;
+    RouterOpts->high_fanout_max_slope = Options.router_high_fanout_max_slope;
     RouterOpts->router_debug_net = Options.router_debug_net;
     RouterOpts->router_debug_sink_rr = Options.router_debug_sink_rr;
     RouterOpts->router_debug_iteration = Options.router_debug_iteration;

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1986,9 +1986,10 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     route_timing_grp.add_argument<float>(args.router_high_fanout_max_slope, "--router_high_fanout_max_slope")
         .help(
-            "Maximum routing predictor slope where high fanout routing is enabled.\n"
-            " -1.0 is normal progress, 0 is no progress.")
-        .default_value("-0.5")
+            "Minimum routing progress where high fanout routing is enabled."
+            " This is a ratio of the actual congestion reduction to what is expected based in the history.\n"
+            " 1.0 is normal progress, 0 is no progress.")
+        .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_timing_grp.add_argument<e_router_lookahead, ParseRouterLookahead>(args.router_lookahead_type, "--router_lookahead")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1984,6 +1984,13 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("64")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<float>(args.router_high_fanout_max_slope, "--router_high_fanout_max_slope")
+        .help(
+            "Maximum routing predictor slope where high fanout routing is enabled.\n"
+            " -1.0 is normal progress, 0 is no progress.")
+        .default_value("-0.5")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument<e_router_lookahead, ParseRouterLookahead>(args.router_lookahead_type, "--router_lookahead")
         .help(
             "Controls what lookahead the router uses to calculate cost of completing a connection.\n"

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -163,6 +163,7 @@ struct t_options {
     argparse::ArgValue<float> congested_routing_iteration_threshold_frac;
     argparse::ArgValue<e_route_bb_update> route_bb_update;
     argparse::ArgValue<int> router_high_fanout_threshold;
+    argparse::ArgValue<float> router_high_fanout_max_slope;
     argparse::ArgValue<int> router_debug_net;
     argparse::ArgValue<int> router_debug_sink_rr;
     argparse::ArgValue<int> router_debug_iteration;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1065,6 +1065,7 @@ struct t_router_opts {
     enum e_clock_modeling clock_modeling; ///<How clock pins and nets should be handled
     bool two_stage_clock_routing;         ///<How clock nets on dedicated networks should be routed
     int high_fanout_threshold;
+    float high_fanout_max_slope;
     int router_debug_net;
     int router_debug_sink_rr;
     int router_debug_iteration;

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1223,7 +1223,7 @@ static bool timing_driven_route_sink(
     //We normally route high fanout nets by only adding spatially close-by routing to the heap (reduces run-time).
     //However, if the current sink is 'critical' from a timing perspective, we put the entire route tree back onto
     //the heap to ensure it has more flexibility to find the best path.
-    if (high_fanout && !sink_critical && !net_is_global && !net_is_clock && !(routing_predictor.get_slope() > router_opts.high_fanout_max_slope)) {
+    if (high_fanout && !sink_critical && !net_is_global && !net_is_clock && -routing_predictor.get_slope() > router_opts.high_fanout_max_slope) {
         std::tie(found_path, cheapest) = router.timing_driven_route_connection_from_route_tree_high_fanout(rt_root,
                                                                                                            sink_node,
                                                                                                            cost_params,

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -82,7 +82,8 @@ static bool timing_driven_route_sink(
     t_rt_node* rt_root,
     t_rt_node** rt_node_of_sink,
     SpatialRouteTreeLookup& spatial_rt_lookup,
-    RouterStats& router_stats);
+    RouterStats& router_stats,
+    const RoutingPredictor& routing_predictor);
 
 template<typename ConnectionRouter>
 static bool timing_driven_pre_route_to_clock_root(
@@ -414,7 +415,8 @@ bool try_timing_driven_route_tmpl(const t_router_opts& router_opts,
                                                            route_timing_info,
                                                            pin_timing_invalidator.get(),
                                                            budgeting_inf,
-                                                           was_rerouted);
+                                                           was_rerouted,
+                                                           routing_predictor);
             if (!is_routable) {
                 return (false); //Impossible to route
             }
@@ -756,7 +758,8 @@ bool try_timing_driven_route_net(ConnectionRouter& router,
                                  std::shared_ptr<SetupTimingInfo> timing_info,
                                  ClusteredPinTimingInvalidator* pin_timing_invalidator,
                                  route_budgets& budgeting_inf,
-                                 bool& was_rerouted) {
+                                 bool& was_rerouted,
+                                 const RoutingPredictor& routing_predictor) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
@@ -787,7 +790,8 @@ bool try_timing_driven_route_net(ConnectionRouter& router,
                                             netlist_pin_lookup,
                                             timing_info,
                                             pin_timing_invalidator,
-                                            budgeting_inf);
+                                            budgeting_inf,
+                                            routing_predictor);
 
         profiling::net_fanout_end(cluster_ctx.clb_nlist.net_sinks(net_id).size());
 
@@ -911,7 +915,8 @@ bool timing_driven_route_net(ConnectionRouter& router,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                              std::shared_ptr<SetupTimingInfo> timing_info,
                              ClusteredPinTimingInvalidator* pin_timing_invalidator,
-                             route_budgets& budgeting_inf) {
+                             route_budgets& budgeting_inf,
+                             const RoutingPredictor& routing_predictor) {
     /* Returns true as long as found some way to hook up this net, even if that *
      * way resulted in overuse of resources (congestion).  If there is no way   *
      * to route this net, even ignoring congestion, it returns false.  In this  *
@@ -1047,7 +1052,8 @@ bool timing_driven_route_net(ConnectionRouter& router,
                                       router_opts.high_fanout_threshold,
                                       rt_root, rt_node_of_sink,
                                       spatial_route_tree_lookup,
-                                      router_stats))
+                                      router_stats,
+                                      routing_predictor))
             return false;
 
         profiling::conn_finish(route_ctx.net_rr_terminals[net_id][0],
@@ -1187,7 +1193,8 @@ static bool timing_driven_route_sink(
     t_rt_node* rt_root,
     t_rt_node** rt_node_of_sink,
     SpatialRouteTreeLookup& spatial_rt_lookup,
-    RouterStats& router_stats) {
+    RouterStats& router_stats,
+    const RoutingPredictor& routing_predictor) {
     /* Build a path from the existing route tree rooted at rt_root to the target_node
      * add this branch to the existing route tree and update pathfinder costs and rr_node_route_inf to reflect this */
     auto& route_ctx = g_vpr_ctx.mutable_routing();
@@ -1216,7 +1223,7 @@ static bool timing_driven_route_sink(
     //We normally route high fanout nets by only adding spatially close-by routing to the heap (reduces run-time).
     //However, if the current sink is 'critical' from a timing perspective, we put the entire route tree back onto
     //the heap to ensure it has more flexibility to find the best path.
-    if (high_fanout && !sink_critical && !net_is_global && !net_is_clock) {
+    if (high_fanout && !sink_critical && !net_is_global && !net_is_clock && !(routing_predictor.get_slope() > -0.5)) {
         std::tie(found_path, cheapest) = router.timing_driven_route_connection_from_route_tree_high_fanout(rt_root,
                                                                                                            sink_node,
                                                                                                            cost_params,

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -78,7 +78,7 @@ static bool timing_driven_route_sink(
     unsigned itarget,
     int target_pin,
     const t_conn_cost_params cost_params,
-    int high_fanout_threshold,
+    const t_router_opts& router_opts,
     t_rt_node* rt_root,
     t_rt_node** rt_node_of_sink,
     SpatialRouteTreeLookup& spatial_rt_lookup,
@@ -1049,7 +1049,7 @@ bool timing_driven_route_net(ConnectionRouter& router,
                                       itarget,
                                       target_pin,
                                       cost_params,
-                                      router_opts.high_fanout_threshold,
+                                      router_opts,
                                       rt_root, rt_node_of_sink,
                                       spatial_route_tree_lookup,
                                       router_stats,
@@ -1189,7 +1189,7 @@ static bool timing_driven_route_sink(
     unsigned itarget,
     int target_pin,
     const t_conn_cost_params cost_params,
-    int high_fanout_threshold,
+    const t_router_opts& router_opts,
     t_rt_node* rt_root,
     t_rt_node** rt_node_of_sink,
     SpatialRouteTreeLookup& spatial_rt_lookup,
@@ -1215,7 +1215,7 @@ static bool timing_driven_route_sink(
     t_bb bounding_box = route_ctx.route_bb[net_id];
 
     bool net_is_global = cluster_ctx.clb_nlist.net_is_global(net_id);
-    bool high_fanout = is_high_fanout(cluster_ctx.clb_nlist.net_sinks(net_id).size(), high_fanout_threshold);
+    bool high_fanout = is_high_fanout(cluster_ctx.clb_nlist.net_sinks(net_id).size(), router_opts.high_fanout_threshold);
     constexpr float HIGH_FANOUT_CRITICALITY_THRESHOLD = 0.9;
     bool sink_critical = (cost_params.criticality > HIGH_FANOUT_CRITICALITY_THRESHOLD);
     bool net_is_clock = route_ctx.is_clock_net[net_id] != 0;
@@ -1223,7 +1223,7 @@ static bool timing_driven_route_sink(
     //We normally route high fanout nets by only adding spatially close-by routing to the heap (reduces run-time).
     //However, if the current sink is 'critical' from a timing perspective, we put the entire route tree back onto
     //the heap to ensure it has more flexibility to find the best path.
-    if (high_fanout && !sink_critical && !net_is_global && !net_is_clock && !(routing_predictor.get_slope() > -0.5)) {
+    if (high_fanout && !sink_critical && !net_is_global && !net_is_clock && !(routing_predictor.get_slope() > router_opts.high_fanout_max_slope)) {
         std::tie(found_path, cheapest) = router.timing_driven_route_connection_from_route_tree_high_fanout(rt_root,
                                                                                                            sink_node,
                                                                                                            cost_params,

--- a/vpr/src/route/route_timing.h
+++ b/vpr/src/route/route_timing.h
@@ -12,6 +12,7 @@
 #include "spatial_route_tree_lookup.h"
 #include "connection_router_interface.h"
 #include "heap_type.h"
+#include "routing_predictor.h"
 
 int get_max_pins_per_net();
 
@@ -39,7 +40,8 @@ bool try_timing_driven_route_net(ConnectionRouter& router,
                                  std::shared_ptr<SetupTimingInfo> timing_info,
                                  ClusteredPinTimingInvalidator* pin_timing_invalidator,
                                  route_budgets& budgeting_inf,
-                                 bool& was_rerouted);
+                                 bool& was_rerouted,
+                                 const RoutingPredictor& routing_predictor);
 
 template<typename ConnectionRouter>
 bool timing_driven_route_net(ConnectionRouter& router,
@@ -55,7 +57,8 @@ bool timing_driven_route_net(ConnectionRouter& router,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                              std::shared_ptr<SetupTimingInfo> timing_info,
                              ClusteredPinTimingInvalidator* pin_timing_invalidator,
-                             route_budgets& budgeting_inf);
+                             route_budgets& budgeting_inf,
+                             const RoutingPredictor& routing_predictor);
 
 void alloc_timing_driven_route_structs(float** pin_criticality_ptr,
                                        int** sink_order_ptr,

--- a/vpr/src/route/routing_predictor.cpp
+++ b/vpr/src/route/routing_predictor.cpp
@@ -63,12 +63,9 @@ float covariance(std::vector<size_t> x_values, std::vector<float> y_values, floa
     return cov;
 }
 
-float RoutingPredictor::get_slope() {
-    if (iterations_.size() > min_history_) {
-        auto model = fit_model(iterations_, iteration_overused_rr_node_counts_, history_factor_);
-        return model.get_slope();
-    }
-    return -1;
+float RoutingPredictor::get_slope() const {
+    //Return cached slope, computed in add_iteration_overuse()
+    return slope_;
 }
 
 LinearModel simple_linear_regression(std::vector<size_t> x_values, std::vector<float> y_values) {
@@ -155,7 +152,8 @@ LinearModel fit_model(std::vector<size_t> iterations, std::vector<size_t> overus
 
 RoutingPredictor::RoutingPredictor(size_t min_history, float history_factor)
     : min_history_(min_history)
-    , history_factor_(history_factor) {
+    , history_factor_(history_factor)
+    , slope_(-1) {
     //nop
 }
 
@@ -204,4 +202,10 @@ float RoutingPredictor::estimate_overuse_slope() {
 void RoutingPredictor::add_iteration_overuse(size_t iteration, size_t overused_rr_node_count) {
     iterations_.push_back(iteration);
     iteration_overused_rr_node_counts_.push_back(overused_rr_node_count);
+
+    //Update slope
+    if (iterations_.size() > min_history_) {
+        auto model = fit_model(iterations_, iteration_overused_rr_node_counts_, history_factor_);
+        slope_ = model.get_slope();
+    }
 }

--- a/vpr/src/route/routing_predictor.h
+++ b/vpr/src/route/routing_predictor.h
@@ -25,7 +25,7 @@ class RoutingPredictor {
 
     void add_iteration_overuse(size_t iteration, size_t overused_rr_node_count);
 
-    float get_slope();
+    float get_slope() const;
 
   private:
     size_t min_history_;
@@ -33,6 +33,7 @@ class RoutingPredictor {
 
     std::vector<size_t> iterations_;
     std::vector<size_t> iteration_overused_rr_node_counts_;
+    float slope_;
 };
 
 #endif


### PR DESCRIPTION
#### Description
This change uses the routing predictor to detect when congestion resolution slows down, and disables the high fanout routing logic.

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/479

#### Motivation and Context
High fanout routing logic has been disabled in Symbiflow due to non-termination in some tests. This fixes that.

#### How Has This Been Tested?
This change has been tested in Symbiflow, and also strong and nightly tests have been run locally.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
