### PR TITLE
infra: Add sanitized versions of basic and strong regression tests

### DIFF
--- a/.github/travis/build.sh
+++ b/.github/travis/build.sh
@@ -7,7 +7,7 @@ $SPACER
 
 start_section "vtr.build" "${GREEN}Building..${NC}"
 export FAILURE=0
-make -k BUILD_TYPE=${BUILD_TYPE} CMAKE_PARAMS=${CMAKE_PARAMS} -j2 || export FAILURE=1
+make -k BUILD_TYPE=${BUILD_TYPE} CMAKE_PARAMS="${CMAKE_PARAMS} ${CMAKE_INSTALL_PREFIX_PARAMS}" -j2 || export FAILURE=1
 end_section "vtr.build"
 
 # When the build fails, produce the failure output in a clear way

--- a/.github/travis/common.sh
+++ b/.github/travis/common.sh
@@ -32,5 +32,5 @@ function end_section() {
 }
 
 export PREFIX=$HOME/vtr
-export CMAKE_PARAMS="-DCMAKE_INSTALL_PREFIX=$PREFIX"
+export CMAKE_INSTALL_PREFIX_PARAMS="-DCMAKE_INSTALL_PREFIX=$PREFIX"
 export BUILD_DIR=$HOME/vtr-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,17 +145,18 @@ jobs:
         - ./.github/travis/build.sh
         #We skip QoR since we are only checking for errors in sanitizer runs
         - ./run_reg_test.pl vtr_reg_basic -show_failures -skip_qor -j2
-    - stage: Test
-      name: "Sanitized Strong Regression Tests"
-      env:
-        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-        - BUILD_TYPE=debug
-        - LSAN_OPTIONS="exitcode=42" #Use a non-standard exit code to ensure LSAN errors are detected
-      script:
-        - ./.github/travis/build.sh
-        #We skip QoR since we are only checking for errors in sanitizer runs
-        - travis_wait 60 ./run_reg_test.pl vtr_reg_strong -show_failures -skip_qor -j2
+    #Currently strong regression with sanitizers is disabled as it exceeds the maximum travis job run-time
+    #- stage: Test
+      #name: "Sanitized Strong Regression Tests"
+      #env:
+        #- CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
+        #- MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+        #- BUILD_TYPE=debug
+        #- LSAN_OPTIONS="exitcode=42" #Use a non-standard exit code to ensure LSAN errors are detected
+      #script:
+        #- ./.github/travis/build.sh
+        ##We skip QoR since we are only checking for errors in sanitizer runs
+        #- travis_wait 60 ./run_reg_test.pl vtr_reg_strong -show_failures -skip_qor -j2
     - stage: Test
       name: "ODIN-II Micro Tests"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ jobs:
         - ./run_reg_test.pl vtr_reg_valgrind_small -show_failures -j2
       name: "Sanitized Basic Regression Tests"
       env:
-        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DWITH_BLIFEXPLORER=on"
+        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
       script:
         - ./.github/travis/build.sh
@@ -145,7 +145,7 @@ jobs:
     - stage: Test
       name: "Sanitized Strong Regression Tests"
       env:
-        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DWITH_BLIFEXPLORER=on"
+        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
       script:
         - ./.github/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,21 @@ jobs:
       script:
         - ./.github/travis/build.sh
         - ./run_reg_test.pl vtr_reg_valgrind_small -show_failures -j2
+      name: "Sanitized Basic Regression Tests"
+      env:
+        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DWITH_BLIFEXPLORER=on"
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      script:
+        - ./.github/travis/build.sh
+        - ./run_reg_test.pl vtr_reg_basic -show_failures -j2
+    - stage: Test
+      name: "Sanitized Strong Regression Tests"
+      env:
+        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DWITH_BLIFEXPLORER=on"
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      script:
+        - ./.github/travis/build.sh
+        - travis_wait 30 ./run_reg_test.pl vtr_reg_strong -show_failures -j2
     - stage: Test
       name: "ODIN-II Micro Tests"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ jobs:
       env:
           #In order to get compilation warnings produced per source file, we must do a non-IPO build
           #We also turn warnings into errors for this target by doing a strict compile
-        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DVTR_ENABLE_STRICT_COMPILE=on -DVTR_ENABLE_IPO_BUILD=off"
+        - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DVTR_ENABLE_STRICT_COMPILE=on -DVTR_IPO_BUILD=off"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
       script:
         - ./.github/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,7 @@ jobs:
         - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
         - BUILD_TYPE=debug
+        - LSAN_OPTIONS="exitcode=42" #Use a non-standard exit code to ensure LSAN errors are detected
       script:
         - ./.github/travis/build.sh
         #We skip QoR since we are only checking for errors in sanitizer runs
@@ -150,6 +151,7 @@ jobs:
         - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
         - BUILD_TYPE=debug
+        - LSAN_OPTIONS="exitcode=42" #Use a non-standard exit code to ensure LSAN errors are detected
       script:
         - ./.github/travis/build.sh
         #We skip QoR since we are only checking for errors in sanitizer runs

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,7 @@ jobs:
       env:
         - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+        - BUILD_TYPE=debug
       script:
         - ./.github/travis/build.sh
         - ./run_reg_test.pl vtr_reg_basic -show_failures -j2
@@ -147,6 +148,7 @@ jobs:
       env:
         - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+        - BUILD_TYPE=debug
       script:
         - ./.github/travis/build.sh
         - travis_wait 30 ./run_reg_test.pl vtr_reg_strong -show_failures -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,8 @@ jobs:
         - BUILD_TYPE=debug
       script:
         - ./.github/travis/build.sh
-        - ./run_reg_test.pl vtr_reg_basic -show_failures -j2
+        #We skip QoR since we are only checking for errors in sanitizer runs
+        - ./run_reg_test.pl vtr_reg_basic -show_failures -skip_qor -j2
     - stage: Test
       name: "Sanitized Strong Regression Tests"
       env:
@@ -151,7 +152,8 @@ jobs:
         - BUILD_TYPE=debug
       script:
         - ./.github/travis/build.sh
-        - travis_wait 30 ./run_reg_test.pl vtr_reg_strong -show_failures -j2
+        #We skip QoR since we are only checking for errors in sanitizer runs
+        - travis_wait 60 ./run_reg_test.pl vtr_reg_strong -show_failures -skip_qor -j2
     - stage: Test
       name: "ODIN-II Micro Tests"
       env:

--- a/ace2/ace.c
+++ b/ace2/ace.c
@@ -299,6 +299,7 @@ int ace_calc_activity(Abc_Ntk_t * ntk, int num_vectors, char * clk_name) {
 		VTR_ASSERT(info2->switch_act >= 0);
 	}
     Vec_PtrFree(nodes_logic);
+    Vec_PtrFree(nodes_all);
     Vec_PtrFree(latches_in_cycles_vec);
 
 	return error;
@@ -443,6 +444,7 @@ int main(int argc, char * argv[]) {
 		Io_WriteHie(ntk, blif_file_name, new_blif_file_name);
 		printf("Done\n");
 	}
+    Abc_NtkDelete(new_ntk);
 
 	fflush(0);
 	return 0;

--- a/ace2/bdd.c
+++ b/ace2/bdd.c
@@ -245,10 +245,17 @@ double calc_cube_switch_prob(DdManager * mgr, DdNode * bdd, ace_cube_t * cube,
 		Vec_Ptr_t * inputs, int phase) {
 	double sp;
 	st__table * visited;
+    st__generator * gen;
+    const char* pKey;
+    char* pValue;
 
 	visited = st__init_table(st__ptrcmp, st__ptrhash);
 
 	sp = calc_cube_switch_prob_recur(mgr, bdd, cube, inputs, visited, phase);
+
+    st__foreach_item(visited, gen, (const char **)&pKey, (char **)&pValue) {
+        free(pValue);
+    }
 
 	st__free_table(visited);
 
@@ -376,6 +383,8 @@ double ace_bdd_calc_switch_act(DdManager * mgr, Abc_Obj_t * obj,
 			* calc_switch_prob_recur(mgr, bdd, bdd, cube, fanins, 1.0, n1 > n0)
 			* (double) d;
 	//switch_act = 2.0 * calc_switch_prob_recur (mgr, bdd, bdd, cube, fanins, 1.0, 1) * (double) d;
+
+    ace_cube_free(cube);
 
 	return switch_act;
 }

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(EXTERNAL)
 #  Only add warn flags for VPR internal libraries.
 add_compile_options(${WARN_FLAGS})
 add_compile_options(${ADDITIONAL_FLAGS})
+link_libraries(${ADDITIONAL_FLAGS})
 add_subdirectory(libarchfpga)
 add_subdirectory(libvtrutil)
 add_subdirectory(liblog)

--- a/run_reg_test.pl
+++ b/run_reg_test.pl
@@ -62,6 +62,7 @@ my $create_golden = 0;
 my $check_golden = 0;
 my $calc_geomean = 0;
 my $display_qor = 0;
+my $skip_qor = 0;
 my $show_failures = 0;
 my $num_cpu = 1;
 my $long_task_names = 0;
@@ -78,6 +79,8 @@ while ( $token = shift(@ARGV) ) {
 		$calc_geomean = 1;
 	} elsif ( $token eq "-display_qor" ) {
 		$display_qor = 1;
+	} elsif ( $token eq "-skip_qor" ) {
+		$skip_qor = 1;
 	} elsif ( $token eq "-show_failures" ) {
 		$show_failures = 1;
 	} elsif ( $token eq "-long_task_names" ) {
@@ -156,6 +159,8 @@ if ( $#tests > -1 ) {
             # Create/Check golden results
             if ($create_golden) {
                 parse_single_test("create", "calculate");
+            } elsif ($skip_qor) {
+                print "\nSkipping QoR checks...\n";
             } else {
                 my $qor_test_failures = parse_single_test("check", "calculate");
                 print "\nTest '$test' had $qor_test_failures qor test failures\n";

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -71,7 +71,7 @@ class FasmWriterVisitor : public NetlistVisitor {
       void check_features(const t_metadata_dict *meta) const;
       void check_interconnect(const t_pb_routes &pb_route, int inode);
       void check_for_lut(const t_pb* atom);
-      void output_fasm_mux(std::string fasm_mux, t_interconnect *interconnect, t_pb_graph_pin *mux_input_pin);
+      void output_fasm_mux(std::string fasm_mux, t_interconnect *interconnect, const t_pb_graph_pin *mux_input_pin);
       void walk_routing();
       void walk_route_tree(const t_rt_node *root);
       std::string build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const;
@@ -96,7 +96,7 @@ class FasmWriterVisitor : public NetlistVisitor {
       std::string clb_prefix_;
       std::map<const t_pb_graph_node *, std::string> clb_prefix_map_;
       ClusterBlockId current_blk_id_;
-      std::vector<t_pb_graph_pin**> pb_graph_pin_lookup_from_index_by_type_;
+      IntraLbPbPinLookup pb_graph_pin_lookup_from_index_by_type_;
       std::map<const t_pb_type*, std::vector<std::pair<std::string, LutOutputDefinition>>> lut_definitions_;
       std::map<const t_pb_type*, Parameters> parameters_;
 

--- a/vpr/src/base/atom_netlist_utils.cpp
+++ b/vpr/src/base/atom_netlist_utils.cpp
@@ -1475,7 +1475,7 @@ void print_netlist_clock_info(const AtomNetlist& netlist) {
             auto blk_id = netlist.pin_block(pin_id);
             clk_blks.insert(blk_id);
         }
-        VTR_LOG("  Netlist Clock '%s' Fanout: %zu pins (%.1f%), %zu blocks (%.1f%)\n", netlist.net_name(net_id).c_str(), fanout, 100. * float(fanout) / netlist.pins().size(), clk_blks.size(), 100 * float(clk_blks.size()) / netlist.blocks().size());
+        VTR_LOG("  Netlist Clock '%s' Fanout: %zu pins (%.1f%%), %zu blocks (%.1f%%)\n", netlist.net_name(net_id).c_str(), fanout, 100. * float(fanout) / netlist.pins().size(), clk_blks.size(), 100 * float(clk_blks.size()) / netlist.blocks().size());
     }
 }
 

--- a/vpr/src/base/check_netlist.cpp
+++ b/vpr/src/base/check_netlist.cpp
@@ -26,7 +26,7 @@ static int check_for_duplicated_names();
 
 static int check_clb_conn(ClusterBlockId iblk, int num_conn);
 
-static int check_clb_internal_nets(ClusterBlockId iblk);
+static int check_clb_internal_nets(ClusterBlockId iblk, const IntraLbPbPinLookup& intra_lb_pb_pini_lookup);
 
 /*********************** Subroutine definitions *****************************/
 
@@ -57,11 +57,14 @@ void check_netlist(int verbosity) {
     free_hash_table(net_hash_table);
     VTR_LOG_WARN("Netlist contains %d global net to non-global architecture pin connections\n", global_to_non_global_connection_count);
 
+    auto& device_ctx = g_vpr_ctx.device();
+    IntraLbPbPinLookup intra_lb_pb_pin_lookup(device_ctx.logical_block_types);
+
     /* Check that each block makes sense. */
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
         num_conn = (int)cluster_ctx.clb_nlist.block_pins(blk_id).size();
         error += check_clb_conn(blk_id, num_conn);
-        error += check_clb_internal_nets(blk_id);
+        error += check_clb_internal_nets(blk_id, intra_lb_pb_pin_lookup);
         if (error >= ERROR_THRESHOLD) {
             VPR_ERROR(VPR_ERROR_OTHER,
                       "Too many errors in netlist, exiting.\n");
@@ -158,14 +161,14 @@ static int check_clb_conn(ClusterBlockId iblk, int num_conn) {
 }
 
 /* Check that internal-to-logic-block connectivity is continuous and logically consistent */
-static int check_clb_internal_nets(ClusterBlockId iblk) {
+static int check_clb_internal_nets(ClusterBlockId iblk, const IntraLbPbPinLookup& pb_graph_pin_lookup) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
     int error = 0;
     const auto& pb_route = cluster_ctx.clb_nlist.block_pb(iblk)->pb_route;
     int num_pins_in_block = cluster_ctx.clb_nlist.block_pb(iblk)->pb_graph_node->total_pb_pins;
 
-    t_pb_graph_pin** pb_graph_pin_lookup = alloc_and_load_pb_graph_pin_lookup_from_index(cluster_ctx.clb_nlist.block_type(iblk));
+    t_logical_block_type_ptr type = cluster_ctx.clb_nlist.block_type(iblk);
 
     for (int i = 0; i < num_pins_in_block; i++) {
         if (!pb_route.count(i)) continue;
@@ -173,8 +176,9 @@ static int check_clb_internal_nets(ClusterBlockId iblk) {
         VTR_ASSERT(pb_route.count(i));
 
         if (pb_route[i].atom_net_id || pb_route[i].driver_pb_pin_id != OPEN) {
-            if ((pb_graph_pin_lookup[i]->port->type == IN_PORT && pb_graph_pin_lookup[i]->is_root_block_pin())
-                || (pb_graph_pin_lookup[i]->port->type == OUT_PORT && pb_graph_pin_lookup[i]->parent_node->is_primitive())) {
+            const t_pb_graph_pin* pb_gpin = pb_graph_pin_lookup.pb_gpin(type->index, i);
+            if ((pb_gpin->port->type == IN_PORT && pb_gpin->is_root_block_pin())
+                || (pb_gpin->port->type == OUT_PORT && pb_gpin->parent_node->is_primitive())) {
                 if (pb_route[i].driver_pb_pin_id != OPEN) {
                     VTR_LOG_ERROR(
                         "Internal connectivity error in logic block #%d with output %s."
@@ -202,8 +206,6 @@ static int check_clb_internal_nets(ClusterBlockId iblk) {
             }
         }
     }
-
-    free_pb_graph_pin_lookup_from_index(pb_graph_pin_lookup);
     return error;
 }
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1152,14 +1152,6 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
         VPR_FATAL_ERROR(VPR_ERROR_ANALYSIS, "No routing loaded -- can not perform post-routing analysis");
     }
 
-    vtr::vector<ClusterNetId, float*> net_delay;
-    vtr::t_chunk net_delay_ch;
-    if (vpr_setup.TimingEnabled) {
-        //Load the net delays
-        net_delay = alloc_net_delay(&net_delay_ch);
-        load_net_delay_from_routing(net_delay);
-    }
-
     routing_stats(vpr_setup.RouterOpts.full_stats, vpr_setup.RouterOpts.route_type,
                   vpr_setup.Segments,
                   vpr_setup.RoutingArch.R_minW_nmos,
@@ -1169,6 +1161,13 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
                   vpr_setup.RoutingArch.wire_to_rr_ipin_switch);
 
     if (vpr_setup.TimingEnabled) {
+        vtr::vector<ClusterNetId, float*> net_delay;
+        vtr::t_chunk net_delay_ch;
+
+        //Load the net delays
+        net_delay = alloc_net_delay(&net_delay_ch);
+        load_net_delay_from_routing(net_delay);
+
         //Do final timing analysis
         auto analysis_delay_calc = std::make_shared<AnalysisDelayCalculator>(atom_ctx.nlist, atom_ctx.lookup, net_delay);
         auto timing_info = make_setup_hold_timing_info(analysis_delay_calc);

--- a/vpr/src/main.cpp
+++ b/vpr/src/main.cpp
@@ -55,12 +55,14 @@ int main(int argc, const char** argv) {
         vpr_init(argc, argv, &Options, &vpr_setup, &Arch);
 
         if (Options.show_version) {
+            vpr_free_all(Arch, vpr_setup);
             return SUCCESS_EXIT_CODE;
         }
 
         bool flow_succeeded = vpr_flow(vpr_setup, Arch);
         if (!flow_succeeded) {
             VTR_LOG("VPR failed to implement circuit\n");
+            vpr_free_all(Arch, vpr_setup);
             return UNIMPLEMENTABLE_EXIT_CODE;
         }
 
@@ -81,6 +83,7 @@ int main(int argc, const char** argv) {
 
     } catch (const tatum::Error& tatum_error) {
         VTR_LOG_ERROR("%s\n", format_tatum_error(tatum_error).c_str());
+        vpr_free_all(Arch, vpr_setup);
 
         return ERROR_EXIT_CODE;
 
@@ -88,13 +91,16 @@ int main(int argc, const char** argv) {
         vpr_print_error(vpr_error);
 
         if (vpr_error.type() == VPR_ERROR_INTERRUPTED) {
+            vpr_free_all(Arch, vpr_setup);
             return INTERRUPTED_EXIT_CODE;
         } else {
+            vpr_free_all(Arch, vpr_setup);
             return ERROR_EXIT_CODE;
         }
 
     } catch (const vtr::VtrError& vtr_error) {
         VTR_LOG_ERROR("%s:%d %s\n", vtr_error.filename_c_str(), vtr_error.line(), vtr_error.what());
+        vpr_free_all(Arch, vpr_setup);
 
         return ERROR_EXIT_CODE;
     }

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -30,10 +30,6 @@
 #define LINELENGTH 1024
 #define TAB_LENGTH 4
 
-/****************** Static variables local to this module ************************/
-
-static t_pb_graph_pin*** pb_graph_pin_lookup_from_index_by_type = nullptr; /* [0..device_ctx.logical_block_types.size()-1][0..num_pb_graph_pins-1] lookup pointer to pb_graph_pin from pb_graph_pin index */
-
 /**************** Subroutine definitions ************************************/
 
 /* Prints out one cluster (clb).  Both the external pins and the *
@@ -143,7 +139,7 @@ static const char* clustering_xml_net_text(AtomNetId net_id) {
     }
 }
 
-static std::string clustering_xml_interconnect_text(t_logical_block_type_ptr type, int inode, const t_pb_routes& pb_route) {
+static std::string clustering_xml_interconnect_text(t_logical_block_type_ptr type, const IntraLbPbPinLookup& pb_graph_pin_lookup_from_index_by_type, int inode, const t_pb_routes& pb_route) {
     if (!pb_route.count(inode) || !pb_route[inode].atom_net_id) {
         return "open";
     }
@@ -152,12 +148,12 @@ static std::string clustering_xml_interconnect_text(t_logical_block_type_ptr typ
     int prev_edge;
     if (prev_node == OPEN) {
         /* No previous driver implies that this is either a top-level input pin or a primitive output pin */
-        t_pb_graph_pin* cur_pin = pb_graph_pin_lookup_from_index_by_type[type->index][inode];
+        const t_pb_graph_pin* cur_pin = pb_graph_pin_lookup_from_index_by_type.pb_gpin(type->index, inode);
         VTR_ASSERT(cur_pin->parent_node->pb_type->parent_mode == nullptr || (cur_pin->is_primitive_pin() && cur_pin->port->type == OUT_PORT));
         return clustering_xml_net_text(pb_route[inode].atom_net_id);
     } else {
-        t_pb_graph_pin* cur_pin = pb_graph_pin_lookup_from_index_by_type[type->index][inode];
-        t_pb_graph_pin* prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
+        const t_pb_graph_pin* cur_pin = pb_graph_pin_lookup_from_index_by_type.pb_gpin(type->index, inode);
+        const t_pb_graph_pin* prev_pin = pb_graph_pin_lookup_from_index_by_type.pb_gpin(type->index, prev_node);
 
         for (prev_edge = 0; prev_edge < prev_pin->num_output_edges; prev_edge++) {
             VTR_ASSERT(prev_pin->output_edges[prev_edge]->num_output_pins == 1);
@@ -190,7 +186,7 @@ static std::string clustering_xml_interconnect_text(t_logical_block_type_ptr typ
  * cannot simply be marked open as that would lose the routing information. Instead, a block must be
  * output that reflects the routing resources used. This function handles both cases.
  */
-static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_block_type_ptr type, t_pb_graph_node* pb_graph_node, int pb_index, bool is_used, const t_pb_routes& pb_route) {
+static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_block_type_ptr type, const IntraLbPbPinLookup& pb_graph_pin_lookup_from_index_by_type, t_pb_graph_node* pb_graph_node, int pb_index, bool is_used, const t_pb_routes& pb_route) {
     int i, j, k, m;
     const t_pb_type *pb_type, *child_pb_type;
     t_mode* mode = nullptr;
@@ -217,7 +213,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_bloc
                     node_index = pin->pin_count_in_cluster;
                     if (pb_type->num_modes > 0 && pb_route.count(node_index) && pb_route[node_index].atom_net_id) {
                         prev_node = pb_route[node_index].driver_pb_pin_id;
-                        const t_pb_graph_pin* prev_pin = pb_graph_pin_lookup_from_index_by_type[type->index][prev_node];
+                        const t_pb_graph_pin* prev_pin = pb_graph_pin_lookup_from_index_by_type.pb_gpin(type->index, prev_node);
                         const t_pb_graph_edge* edge = get_edge_between_pins(prev_pin, pin);
 
                         VTR_ASSERT(edge != nullptr);
@@ -257,7 +253,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_bloc
                     if (pb_type->parent_mode == nullptr) {
                         pins.push_back(clustering_xml_net_text(pb_route[node_index].atom_net_id));
                     } else {
-                        pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+                        pins.push_back(clustering_xml_interconnect_text(type, pb_graph_pin_lookup_from_index_by_type, node_index, pb_route));
                     }
                 }
                 port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
@@ -277,7 +273,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_bloc
                 std::vector<std::string> pins;
                 for (j = 0; j < pb_type->ports[i].num_pins; j++) {
                     node_index = pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
-                    pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+                    pins.push_back(clustering_xml_interconnect_text(type, pb_graph_pin_lookup_from_index_by_type, node_index, pb_route));
                 }
                 port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
                 port_index++;
@@ -298,7 +294,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_bloc
                     if (pb_type->parent_mode == nullptr) {
                         pins.push_back(clustering_xml_net_text(pb_route[node_index].atom_net_id));
                     } else {
-                        pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+                        pins.push_back(clustering_xml_interconnect_text(type, pb_graph_pin_lookup_from_index_by_type, node_index, pb_route));
                     }
                 }
                 port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
@@ -324,7 +320,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_bloc
                             port_index++;
                         }
                     }
-                    clustering_xml_open_block(block_node, type,
+                    clustering_xml_open_block(block_node, type, pb_graph_pin_lookup_from_index_by_type,
                                               &pb_graph_node->child_pb_graph_nodes[mode_of_edge][i][j],
                                               j, is_used, pb_route);
                 }
@@ -334,7 +330,7 @@ static void clustering_xml_open_block(pugi::xml_node parent_node, t_logical_bloc
 }
 
 /* outputs a block that is used (i.e. has configuration) and all of its child blocks */
-static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_type_ptr type, t_pb* pb, int pb_index, const t_pb_routes& pb_route) {
+static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_type_ptr type, const IntraLbPbPinLookup& pb_graph_pin_lookup_from_index_by_type, t_pb* pb, int pb_index, const t_pb_routes& pb_route) {
     int i, j, k, m;
     const t_pb_type *pb_type, *child_pb_type;
     t_pb_graph_node* pb_graph_node;
@@ -391,7 +387,7 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_typ
                         pins.push_back(clustering_xml_net_text(AtomNetId::INVALID()));
                     }
                 } else {
-                    pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+                    pins.push_back(clustering_xml_interconnect_text(type, pb_graph_pin_lookup_from_index_by_type, node_index, pb_route));
                 }
             }
             port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
@@ -466,7 +462,7 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_typ
             std::vector<std::string> pins;
             for (j = 0; j < pb_type->ports[i].num_pins; j++) {
                 node_index = pb->pb_graph_node->output_pins[port_index][j].pin_count_in_cluster;
-                pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+                pins.push_back(clustering_xml_interconnect_text(type, pb_graph_pin_lookup_from_index_by_type, node_index, pb_route));
             }
             port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
             port_index++;
@@ -491,7 +487,7 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_typ
                         pins.push_back(clustering_xml_net_text(AtomNetId::INVALID()));
                     }
                 } else {
-                    pins.push_back(clustering_xml_interconnect_text(type, node_index, pb_route));
+                    pins.push_back(clustering_xml_interconnect_text(type, pb_graph_pin_lookup_from_index_by_type, node_index, pb_route));
                 }
             }
             port_node.text().set(vtr::join(pins.begin(), pins.end(), " ").c_str());
@@ -504,7 +500,7 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_typ
             for (j = 0; j < mode->pb_type_children[i].num_pb; j++) {
                 /* If child pb is not used but routing is used, I must print things differently */
                 if ((pb->child_pbs[i] != nullptr) && (pb->child_pbs[i][j].name != nullptr)) {
-                    clustering_xml_block(block_node, type, &pb->child_pbs[i][j], j, pb_route);
+                    clustering_xml_block(block_node, type, pb_graph_pin_lookup_from_index_by_type, &pb->child_pbs[i][j], j, pb_route);
                 } else {
                     is_used = false;
                     child_pb_type = &mode->pb_type_children[i];
@@ -522,7 +518,7 @@ static void clustering_xml_block(pugi::xml_node parent_node, t_logical_block_typ
                             port_index++;
                         }
                     }
-                    clustering_xml_open_block(block_node, type,
+                    clustering_xml_open_block(block_node, type, pb_graph_pin_lookup_from_index_by_type,
                                               &pb_graph_node->child_pb_graph_nodes[pb->mode][i][j],
                                               j, is_used, pb_route);
                 }
@@ -546,10 +542,7 @@ void output_clustering(const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_
         }
     }
 
-    pb_graph_pin_lookup_from_index_by_type = new t_pb_graph_pin**[device_ctx.logical_block_types.size()];
-    for (unsigned int itype = 0; itype < device_ctx.logical_block_types.size(); itype++) {
-        pb_graph_pin_lookup_from_index_by_type[itype] = alloc_and_load_pb_graph_pin_lookup_from_index(&device_ctx.logical_block_types[itype]);
-    }
+    IntraLbPbPinLookup pb_graph_pin_lookup_from_index_by_type(device_ctx.logical_block_types);
 
     pugi::xml_document out_xml;
 
@@ -608,7 +601,7 @@ void output_clustering(const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_
     if (skip_clustering == false) {
         for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
             /* TODO: Must do check that total CLB pins match top-level pb pins, perhaps check this earlier? */
-            clustering_xml_block(block_node, cluster_ctx.clb_nlist.block_type(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id), size_t(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id)->pb_route);
+            clustering_xml_block(block_node, cluster_ctx.clb_nlist.block_type(blk_id), pb_graph_pin_lookup_from_index_by_type, cluster_ctx.clb_nlist.block_pb(blk_id), size_t(blk_id), cluster_ctx.clb_nlist.block_pb(blk_id)->pb_route);
         }
     }
 
@@ -621,9 +614,4 @@ void output_clustering(const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_
             cluster_ctx.clb_nlist.block_pb(blk_id)->pb_route.clear();
         }
     }
-
-    for (unsigned int itype = 0; itype < device_ctx.logical_block_types.size(); itype++) {
-        free_pb_graph_pin_lookup_from_index(pb_graph_pin_lookup_from_index_by_type[itype]);
-    }
-    delete[] pb_graph_pin_lookup_from_index_by_type;
 }

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -2563,13 +2563,13 @@ static void print_route_status(int itry, double elapsed_sec, float pres_fac, int
     constexpr int OVERUSE_DIGITS = 7;
     constexpr int OVERUSE_SCI_PRECISION = 2;
     pretty_print_uint(" ", overuse_info.overused_nodes(), OVERUSE_DIGITS, OVERUSE_SCI_PRECISION);
-    VTR_LOG(" (%6.3f%)", overuse_info.overused_node_ratio() * 100);
+    VTR_LOG(" (%6.3f%%)", overuse_info.overused_node_ratio() * 100);
 
     //Wirelength
     constexpr int WL_DIGITS = 7;
     constexpr int WL_SCI_PRECISION = 2;
     pretty_print_uint(" ", wirelength_info.used_wirelength(), WL_DIGITS, WL_SCI_PRECISION);
-    VTR_LOG(" (%4.1f%)", wirelength_info.used_wirelength_ratio() * 100);
+    VTR_LOG(" (%4.1f%%)", wirelength_info.used_wirelength_ratio() * 100);
 
     //CPD
     if (timing_info) {

--- a/vpr/src/util/histogram.cpp
+++ b/vpr/src/util/histogram.cpp
@@ -91,7 +91,7 @@ std::vector<std::string> format_histogram(std::vector<HistogramBucket> histogram
 
         float pct = histogram[ibucket].count / float(total_count) * 100;
 
-        line += vtr::string_fmt("[% 9.2g:% 9.2g) %*zu (%5.1f%) |", histogram[ibucket].min_value, histogram[ibucket].max_value, count_digits, histogram[ibucket].count, pct);
+        line += vtr::string_fmt("[% 9.2g:% 9.2g) %*zu (%5.1f%%) |", histogram[ibucket].min_value, histogram[ibucket].max_value, count_digits, histogram[ibucket].count, pct);
 
         size_t num_chars = std::round((double(histogram[ibucket].count) / max_count) * bar_len);
         for (size_t i = 0; i < num_chars; ++i) {

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -293,8 +293,7 @@ IntraLbPbPinLookup& IntraLbPbPinLookup::operator=(IntraLbPbPinLookup rhs) {
 }
 
 IntraLbPbPinLookup::~IntraLbPbPinLookup() {
-    auto& device_ctx = g_vpr_ctx.device();
-    for (unsigned int itype = 0; itype < device_ctx.logical_block_types.size(); itype++) {
+    for (unsigned int itype = 0; itype < intra_lb_pb_pin_lookup_.size(); ++itype) {
         free_pb_graph_pin_lookup_from_index(intra_lb_pb_pin_lookup_[itype]);
     }
 }

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -73,6 +73,9 @@ static AtomPinId find_atom_pin_for_pb_route_id(ClusterBlockId clb, int pb_route_
 static bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::regex& blif_model_regex);
 static bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::regex& blif_model_regex);
 
+static t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type);
+static void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type);
+
 /******************** Subroutine definitions *********************************/
 
 const t_model* find_model(const t_model* models, const std::string& name, bool required) {
@@ -1246,7 +1249,7 @@ static void load_pb_graph_pin_lookup_from_index_rec(t_pb_graph_pin** pb_graph_pi
 }
 
 /* Create a lookup that returns a pb_graph_pin pointer given the pb_graph_pin index */
-t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type) {
+static t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type) {
     t_pb_graph_pin** pb_graph_pin_lookup_from_type = nullptr;
 
     t_pb_graph_node* pb_graph_head = type->pb_graph_head;
@@ -1274,7 +1277,7 @@ t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_t
 }
 
 /* Free pb_graph_pin lookup array */
-void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type) {
+static void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type) {
     if (pb_graph_pin_lookup_from_type == nullptr) {
         return;
     }

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -270,8 +270,8 @@ std::string rr_node_arch_name(int inode) {
 }
 
 IntraLbPbPinLookup::IntraLbPbPinLookup(const std::vector<t_logical_block_type>& block_types)
-    : block_types_(block_types) {
-    intra_lb_pb_pin_lookup_ = new t_pb_graph_pin**[block_types_.size()];
+    : block_types_(block_types)
+    , intra_lb_pb_pin_lookup_(block_types.size(), nullptr) {
     for (unsigned int itype = 0; itype < block_types_.size(); ++itype) {
         intra_lb_pb_pin_lookup_[itype] = alloc_and_load_pb_graph_pin_lookup_from_index(&block_types[itype]);
     }
@@ -294,8 +294,6 @@ IntraLbPbPinLookup::~IntraLbPbPinLookup() {
     for (unsigned int itype = 0; itype < device_ctx.logical_block_types.size(); itype++) {
         free_pb_graph_pin_lookup_from_index(intra_lb_pb_pin_lookup_[itype]);
     }
-
-    delete[] intra_lb_pb_pin_lookup_;
 }
 
 const t_pb_graph_pin* IntraLbPbPinLookup::pb_gpin(unsigned int itype, int ipin) const {

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -126,8 +126,6 @@ bool primitive_type_feasible(AtomBlockId blk_id, const t_pb_type* cur_pb_type);
 t_pb_graph_pin* get_pb_graph_node_pin_from_model_port_pin(const t_model_ports* model_port, const int model_pin, const t_pb_graph_node* pb_graph_node);
 const t_pb_graph_pin* find_pb_graph_pin(const AtomNetlist& netlist, const AtomLookup& netlist_lookup, const AtomPinId pin_id);
 t_pb_graph_pin* get_pb_graph_node_pin_from_block_pin(ClusterBlockId iblock, int ipin);
-t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type);
-void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type);
 vtr::vector<ClusterBlockId, t_pb**> alloc_and_load_pin_id_to_pb_mapping();
 void free_pin_id_to_pb_mapping(vtr::vector<ClusterBlockId, t_pb**>& pin_id_to_pb_mapping);
 

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -71,7 +71,7 @@ class IntraLbPbPinLookup {
   private:
     std::vector<t_logical_block_type> block_types_;
 
-    t_pb_graph_pin*** intra_lb_pb_pin_lookup_;
+    std::vector<t_pb_graph_pin**> intra_lb_pb_pin_lookup_;
 };
 
 //Find the atom pins (driver or sinks) connected to the specified top-level CLB pin

--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -203,7 +203,7 @@ while ( scalar(@ARGV) != 0 ) { #While non-empty
             $expect_fail = 1;
     }
     elsif ( $token eq "-verbose"){
-            $expect_fail = shift(@ARGV);
+            $verbosity = 1;
     }
 	elsif ( $token eq "-adder_type"){
 		$odin_adder_config_path = shift(@ARGV);
@@ -1196,10 +1196,11 @@ close(RESULTS);
 if ($expect_fail) {
     if ($error_code != 0) {
         #Failed as expected, invert message
+        my $old_error_status = $error_status;
         $error_code = 0;
         $error_status = "OK";
         if ($verbosity > 0) {
-            $error_status .= "(as expected " . $error_status . ")";
+            $error_status .= " (as expected " . $old_error_status . ")";
         } else {
             $error_status .= "*";
         }

--- a/vtr_flow/scripts/run_vtr_task.pl
+++ b/vtr_flow/scripts/run_vtr_task.pl
@@ -440,7 +440,7 @@ sub generate_single_task_actions {
                 my $expect_fail = "";
                 my $expected_vpr_status = ret_expected_vpr_status($circuit, $arch, $full_params_dirname, $golden_results_file);
                 if ($expected_vpr_status ne "success" and $expected_vpr_status ne "Unkown") {
-                    $expect_fail = "-expect_fail";
+                    $expect_fail = "-expect_fail '$expected_vpr_status'";
                 }
 
                 my $show_failure_args = "";


### PR DESCRIPTION
These build set VTR_ENABLE_SANTIZE=on which compiles VTR with sanitizers
to check for invalid memory accesses, undefined behaviour etc.

For motivation see #1130
