### PR TITLE
Enable CONFLICTED routing mode based on routing predictor.

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -365,6 +365,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->clock_modeling = Options.clock_modeling;
     RouterOpts->two_stage_clock_routing = Options.two_stage_clock_routing;
     RouterOpts->high_fanout_threshold = Options.router_high_fanout_threshold;
+    RouterOpts->congested_routing_slope_threshold = Options.router_congested_routing_slope_threshold;
     RouterOpts->router_debug_net = Options.router_debug_net;
     RouterOpts->router_debug_sink_rr = Options.router_debug_sink_rr;
     RouterOpts->router_debug_iteration = Options.router_debug_iteration;

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1612,6 +1612,13 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("1.0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<float>(args.router_congested_routing_slope_threshold, "--router_congested_routing_slope_threshold")
+        .help(
+            "Routing predictor slope where router enters a high effort mode to resolve lingering routing congestion.\n"
+            " -1.0 is normal progress, 0 is no progress.")
+        .default_value("-0.05")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument<e_route_bb_update, ParseRouteBBUpdate>(args.route_bb_update, "--route_bb_update")
         .help(
             "Controls how the router's net bounding boxes are updated:\n"

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -146,6 +146,7 @@ struct t_options {
     argparse::ArgValue<float> congested_routing_iteration_threshold_frac;
     argparse::ArgValue<e_route_bb_update> route_bb_update;
     argparse::ArgValue<int> router_high_fanout_threshold;
+    argparse::ArgValue<float> router_congested_routing_slope_threshold;
     argparse::ArgValue<int> router_debug_net;
     argparse::ArgValue<int> router_debug_sink_rr;
     argparse::ArgValue<int> router_debug_iteration;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -945,6 +945,7 @@ struct t_router_opts {
     enum e_clock_modeling clock_modeling; //How clock pins and nets should be handled
     bool two_stage_clock_routing;         //How clock nets on dedicated networks should be routed
     int high_fanout_threshold;
+    float congested_routing_slope_threshold;
     int router_debug_net;
     int router_debug_sink_rr;
     int router_debug_iteration;

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -648,10 +648,11 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
             num_net_bounding_boxes_updated = dynamic_update_bounding_boxes(rerouted_nets, router_opts.high_fanout_threshold);
         }
 
-        if (itry >= high_effort_congestion_mode_iteration_threshold) {
+        if (itry >= high_effort_congestion_mode_iteration_threshold || routing_predictor.get_slope() > router_opts.congested_routing_slope_threshold) {
             //We are approaching the maximum number of routing iterations,
             //and still do not have a legal routing. Switch to a mode which
             //focuses more on attempting to resolve routing conflicts.
+            VTR_LOG("Enabling CONFLICTED router congestion mode\n");
             router_congestion_mode = RouterCongestionMode::CONFLICTED;
         }
 


### PR DESCRIPTION
#### Description
Use the slope from the routing predictor to enable CONFLICTED routing mode.

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1132

#### Motivation and Context
This should enable CONFLICTED mode earlier when needed vs. the `--congested_routing_iteration_threshold` flag.

#### How Has This Been Tested?
All tests pass on Travis.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
