### PR TITLE
Detect missing name attribute on model port declaration.

### DIFF
--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -2503,6 +2503,11 @@ static void ProcessModelPorts(pugi::xml_node port_group, t_model* model, std::se
                            "Model port '%s' cannot be both a clock and a non-clock signal simultaneously", model_port->name);
         }
 
+        if (model_port->name == nullptr) {
+            archfpga_throw(loc_data.filename_c_str(), loc_data.line(port),
+                           "Model port is missing a name");
+        }
+
         if (port_names.count(model_port->name)) {
             archfpga_throw(loc_data.filename_c_str(), loc_data.line(port),
                            "Duplicate model port named '%s'", model_port->name);


### PR DESCRIPTION
#### Description

Previously this would cause a std::logic_error to be thrown from
std::string.

This is a good example of something that would be caught using the uxsdcxx parser generator, rather than hand writing parsing.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

Previous logic just reported:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
