### PR TITLE
Add --quick_check_route to disable slow non-configurable edge check

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -379,6 +379,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
 
     RouterOpts->write_router_lookahead = Options.write_router_lookahead;
     RouterOpts->read_router_lookahead = Options.read_router_lookahead;
+    RouterOpts->quick_check_route = Options.quick_check_route;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1671,6 +1671,10 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
     route_timing_grp.add_argument(args.router_first_iteration_timing_report_file, "--router_first_iter_timing_report")
         .help("Name of the post first routing iteration timing report file (not generated if unspecfied)")
         .default_value("")
+
+            route_timing_grp.add_argument<bool, ParseOnOff>(args.quick_check_route, "--quick_check_route")
+        .help("Runs check_route, disabling slow checks, once routing step has finished or when routing file is loaded")
+        .default_value("off")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_timing_grp.add_argument(args.router_debug_net, "--router_debug_net")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -133,6 +133,7 @@ struct t_options {
     argparse::ArgValue<bool> verify_binary_search;
     argparse::ArgValue<e_router_algorithm> RouterAlgorithm;
     argparse::ArgValue<int> min_incremental_reroute_fanout;
+    argparse::ArgValue<bool> quick_check_route;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -688,7 +688,9 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         std::string graphics_msg;
         if (route_status.success()) {
             //Sanity check the routing
-            check_route(router_opts.route_type);
+            if (!router_opts.disable_check_route) {
+                check_route(router_opts.route_type, router_opts.quick_check_route);
+            }
             get_serial_num();
 
             //Update status

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -959,6 +959,7 @@ struct t_router_opts {
 
     std::string write_router_lookahead;
     std::string read_router_lookahead;
+    bool quick_check_route;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -3,6 +3,7 @@
 #include "vtr_assert.h"
 #include "vtr_log.h"
 #include "vtr_memory.h"
+#include "vtr_time.h"
 
 #include "vpr_types.h"
 #include "vpr_error.h"
@@ -628,18 +629,13 @@ static void check_node_and_range(int inode, enum e_route_type route_type) {
 //Checks that all non-configurable edges are in a legal configuration
 //This check is slow, so it has been moved out of check_route()
 static void check_all_non_configurable_edges() {
-    VTR_LOG("\n");
-    VTR_LOG("Checking to ensure non-configurable edges are legal...\n");
-
+    vtr::ScopedStartFinishTimer timer("Checking to ensure non-configurable edges are legal");
     auto non_configurable_rr_sets = identify_non_configurable_rr_sets();
-
     auto& cluster_ctx = g_vpr_ctx.clustering();
+
     for (auto net_id : cluster_ctx.clb_nlist.nets()) {
         check_non_configurable_edges(net_id, non_configurable_rr_sets);
     }
-
-    VTR_LOG("Completed non-configurable edge check successfully.\n");
-    VTR_LOG("\n");
 }
 
 //Checks that the specified routing is legal with respect to non-configurable edges

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -27,12 +27,13 @@ static void reset_flags(ClusterNetId inet, bool* connected_to_route);
 static void check_locally_used_clb_opins(const t_clb_opins_used& clb_opins_used_locally,
                                          enum e_route_type route_type);
 
+static void check_all_non_configurable_edges();
 static bool check_non_configurable_edges(ClusterNetId net, const t_non_configurable_rr_sets& non_configurable_rr_sets);
 static void check_net_for_stubs(ClusterNetId net);
 
 /************************ Subroutine definitions ****************************/
 
-void check_route(enum e_route_type route_type) {
+void check_route(enum e_route_type route_type, bool quick) {
     /* This routine checks that a routing:  (1) Describes a properly         *
      * connected path for each net, (2) this path connects all the           *
      * pins spanned by that net, and (3) that no routing resources are       *
@@ -154,13 +155,15 @@ void check_route(enum e_route_type route_type) {
             }
         }
 
-        check_non_configurable_edges(net_id, non_configurable_rr_sets);
-
         check_net_for_stubs(net_id);
 
-        reset_flags(net_id, connected_to_route.get());
+        reset_flags(net_id, connected_to_route);
 
     } /* End for each net */
+
+    if (!quick) {
+        check_all_non_configurable_edges();
+    }
 
     VTR_LOG("Completed routing consistency check successfully.\n");
     VTR_LOG("\n");
@@ -620,6 +623,23 @@ static void check_node_and_range(int inode, enum e_route_type route_type) {
                         "in check_node_and_range: rr_node #%d is out of legal, range (0 to %d).\n", inode, device_ctx.rr_nodes.size() - 1);
     }
     check_rr_node(inode, route_type, device_ctx);
+}
+
+//Checks that all non-configurable edges are in a legal configuration
+//This check is slow, so it has been moved out of check_route()
+static void check_all_non_configurable_edges() {
+    VTR_LOG("\n");
+    VTR_LOG("Checking to ensure non-configurable edges are legal...\n");
+
+    auto non_configurable_rr_sets = identify_non_configurable_rr_sets();
+
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    for (auto net_id : cluster_ctx.clb_nlist.nets()) {
+        check_non_configurable_edges(net_id, non_configurable_rr_sets);
+    }
+
+    VTR_LOG("Completed non-configurable edge check successfully.\n");
+    VTR_LOG("\n");
 }
 
 //Checks that the specified routing is legal with respect to non-configurable edges

--- a/vpr/src/route/check_route.h
+++ b/vpr/src/route/check_route.h
@@ -3,7 +3,7 @@
 #include "physical_types.h"
 #include "route_common.h"
 
-void check_route(enum e_route_type route_type);
+void check_route(enum e_route_type route_type, bool quick);
 
 void recompute_occupancy_from_scratch();
 


### PR DESCRIPTION
#### Description
The check in `check_non_configurable_edges()` is non-linear and takes a long time for the XC7 architecture in SymbiFlow.

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/537

#### Motivation and Context
This increases performance by making it possible to skip an expensive check.

#### How Has This Been Tested?
This flag has been tested and is currently being used in [symbiflow-arch-defs](https://github.com/SymbiFlow/symbiflow-arch-defs)

#### Types of changes
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
