### PR TITLE
Odin: add third party benchmark build step

### DIFF
--- a/ODIN_II/regression_test/benchmark/third_party/.gitignore
+++ b/ODIN_II/regression_test/benchmark/third_party/.gitignore
@@ -1,0 +1,2 @@
+task_list.conf
+sv-tests

--- a/ODIN_II/regression_test/benchmark/third_party/SymbiFlow/build.sh
+++ b/ODIN_II/regression_test/benchmark/third_party/SymbiFlow/build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -xe
+
+PATH_FROM_ODIN_ROOT="regression_test/benchmark/third_party/SymbiFlow"
+
+# init the output directory
+if [ ! -d sv-tests ];
+then
+    mkdir sv-tests
+    pushd sv-tests
+
+    # sparse checkout the tests directory
+    git init .
+    git remote add -f origin https://github.com/SymbiFlow/sv-tests.git
+    git config core.sparseCheckout true
+    echo "tests" >> .git/info/sparse-checkout
+    popd
+fi
+
+# fetch changes
+cd sv-tests; git pull --depth=1 origin master; cd ..
+
+# generate the tasks and the tasklist
+printf "" > task_list.conf
+for dir in sv-tests/tests/chapter-*
+do 
+    cat << EOF > ${dir}/task.conf
+########################
+# large benchmarks config
+########################
+
+regression_params=--disable_simulation
+script_synthesis_params=--limit_ressource --time_limit 3600s
+synthesis_params=--permissive
+
+# setup the architecture
+arch_dir=../vtr_flow/arch/timing
+
+# one arch allows it to run faster
+arch_list_add=k6_frac_N10_frac_chain_mem32K_40nm.xml
+
+circuit_dir=${PATH_FROM_ODIN_ROOT}/${dir}
+
+# glob all the benchmark!
+circuit_list_add=*.sv
+EOF
+    echo "${PATH_FROM_ODIN_ROOT}/${dir}" >> task_list.conf
+done

--- a/ODIN_II/regression_test/benchmark/third_party/SymbiFlow/task.mk
+++ b/ODIN_II/regression_test/benchmark/third_party/SymbiFlow/task.mk
@@ -1,0 +1,4 @@
+# This is called by the main script and must 
+# be implemented 
+build:
+	./build.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This add symbiflow as a third-party BM and add build step to odin regression if the third party bm are not found yet

#### Motivation and Context
Have the ability to run external BM without having to store them in the repository 

#### How Has This Been Tested?
make -f ODIN_II/Makefile pre_merge

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
