### PR TITLE
odin: fix assignment to index 0 in array

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -1340,7 +1340,7 @@ void create_symbol_table_for_scope(ast_node_t* module_items, sc_hierarchy* local
                         sc_spot = sc_lookup_string(local_symbol_table_sc, temp_string);
                         if (sc_spot == -1) {
                             implicit_declarations = (ast_node_t**)vtr::realloc(implicit_declarations, sizeof(ast_node_t*) * (num_implicit_declarations + 1));
-                            implicit_declarations[0] = module_items->children[i]->children[0]->children[0];
+                            implicit_declarations[num_implicit_declarations] = module_items->children[i]->children[0]->children[0];
                             num_implicit_declarations++;
                         }
                         vtr::free(temp_string);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
invalid indexing for dynamic array

#### Related Issue
N/A (implicit ports)

#### Motivation and Context
bug during implicit port initilaization

#### How Has This Been Tested?
make -f ODIN_II/Makefile pre_merge

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
