### PR TITLE
Fix Serialization of ptcs

### DIFF
--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -1569,27 +1569,25 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             if (node.type() == SOURCE || node.type() == SINK) {
                 for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                     for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                        if (node.type() == SOURCE) {
-                            indices[SOURCE][ix][iy][0].push_back(inode);
-                            indices[SINK][ix][iy][0].push_back(OPEN);
-                        } else {
-                            VTR_ASSERT(node.type() == SINK);
-                            indices[SINK][ix][iy][0].push_back(inode);
-                            indices[SOURCE][ix][iy][0].push_back(OPEN);
+                        if (node.ptc_num() >= (int)indices[SOURCE][ix][iy][0].size()) {
+                            indices[SOURCE][ix][iy][0].resize(node.ptc_num() + 1, OPEN);
                         }
+                        if (node.ptc_num() >= (int)indices[SINK][ix][iy][0].size()) {
+                            indices[SINK][ix][iy][0].resize(node.ptc_num() + 1, OPEN);
+                        }
+                        indices[node.type()][ix][iy][0][node.ptc_num()] = inode;
                     }
                 }
             } else if (node.type() == IPIN || node.type() == OPIN) {
                 for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                     for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                        if (node.type() == OPIN) {
-                            indices[OPIN][ix][iy][node.side()].push_back(inode);
-                            indices[IPIN][ix][iy][node.side()].push_back(OPEN);
-                        } else {
-                            VTR_ASSERT(node.type() == IPIN);
-                            indices[IPIN][ix][iy][node.side()].push_back(inode);
-                            indices[OPIN][ix][iy][node.side()].push_back(OPEN);
+                        if (node.ptc_num() >= (int)indices[OPIN][ix][iy][node.side()].size()) {
+                            indices[OPIN][ix][iy][node.side()].resize(node.ptc_num() + 1, OPEN);
                         }
+                        if (node.ptc_num() >= (int)indices[IPIN][ix][iy][node.side()].size()) {
+                            indices[IPIN][ix][iy][node.side()].resize(node.ptc_num() + 1, OPEN);
+                        }
+                        indices[node.type()][ix][iy][node.side()][node.ptc_num()] = inode;
                     }
                 }
             } else if (node.type() == CHANX) {


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1161
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1079

#### Motivation and Context
This bug prevents testing different graph ordering algorithms, which could benefit VPR runtime.

#### How Has This Been Tested?
It has been tested with random and specific orderings using https://github.com/HackerFoo/Gorder in symbiflow-arch-defs.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
