### PR TITLE
vpr: Prime router lookahead for placement

### DIFF
--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -602,6 +602,16 @@ bool vpr_place_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
 }
 
 void vpr_place(t_vpr_setup& vpr_setup, const t_arch& arch) {
+    if (placer_needs_lookahead(vpr_setup)) {
+        // Prime lookahead cache to avoid adding lookahead computation cost to
+        // the placer timer.
+        get_cached_router_lookahead(
+            vpr_setup.RouterOpts.lookahead_type,
+            vpr_setup.RouterOpts.write_router_lookahead,
+            vpr_setup.RouterOpts.read_router_lookahead,
+            vpr_setup.Segments);
+    }
+
     vtr::ScopedStartFinishTimer timer("Placement");
 
     try_place(vpr_setup.PlacerOpts,

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2609,3 +2609,7 @@ static void print_resources_utilization() {
     }
     VTR_LOG("\n");
 }
+
+bool placer_needs_lookahead(const t_vpr_setup& vpr_setup) {
+    return (vpr_setup.PlacerOpts.place_algorithm == PATH_TIMING_DRIVEN_PLACE);
+}

--- a/vpr/src/place/place.h
+++ b/vpr/src/place/place.h
@@ -12,4 +12,5 @@ void try_place(const t_placer_opts& placer_opts,
                t_direct_inf* directs,
                int num_directs);
 
+bool placer_needs_lookahead(const t_vpr_setup& vpr_setup);
 #endif


### PR DESCRIPTION
This should ensure lookahead construction time is not attributed to the
placer (since it is also re-used by the router).