### PR TITLE
Remove traversal limits from capnp reading.

### DIFF
--- a/libs/libvtrcapnproto/serdes_utils.h
+++ b/libs/libvtrcapnproto/serdes_utils.h
@@ -1,6 +1,7 @@
 #ifndef SERDES_UTILS_H_
 #define SERDES_UTILS_H_
 
+#include <limits>
 #include <string>
 #include "capnp/serialize.h"
 
@@ -11,8 +12,8 @@ void writeMessageToFile(const std::string& file,
 inline ::capnp::ReaderOptions default_large_capnp_opts() {
     ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
 
-    /* Increase reader limit to 1G words to allow for large files. */
-    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    /* Remove traversal limit */
+    opts.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
     return opts;
 }
 

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <vector>
 #include <sstream>
+#include <limits>
 #include "capnp/serialize.h"
 #include "rr_graph_uxsdcxx.capnp.h"
 #include "rr_graph_uxsdcxx_interface.h"
@@ -296,9 +297,9 @@ inline ucap::LocSide conv_to_enum_loc_side(enum_loc_side e) {
 /* Load function for the root element. */
 template<class T, typename Context>
 inline void load_rr_graph_capnp(T& out, kj::ArrayPtr<const ::capnp::word> data, Context& context, const char* filename) {
-    /* Increase reader limit to 1G words. */
+    /* Remove traversal limits. */
     ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
-    opts.traversalLimitInWords = 1024 * 1024 * 1024;
+    opts.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
     ::capnp::FlatArrayMessageReader reader(data, opts);
     auto root = reader.getRoot<ucap::RrGraph>();
     std::vector<std::pair<const char*, size_t>> stack;


### PR DESCRIPTION
#### Description

Capnp's traversal limits are not helpful, so disable them.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

The traversal limit is easy to violate once graphs get big!

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
