### PR TITLE
Fix missing <sstream> include for use of std::istringstream

### DIFF
--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <sstream>
 
 #include "vtr_log.h"
 #include "vtr_assert.h"


### PR DESCRIPTION
in id_or_pin_name_to_tn()

Signed-off-by: Henner Zeller <h.zeller@acm.org>
