### PR TITLE
Improve compatibility graph storage with various compilers.

### DIFF
--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -1,4 +1,7 @@
 #include "rr_graph_storage.h"
+
+#include <algorithm>
+
 #include "globals.h"
 
 void t_rr_graph_storage::reserve_edges(size_t num_edges) {
@@ -120,6 +123,7 @@ struct edge_swapper {
 
 class edge_sort_iterator {
   public:
+    edge_sort_iterator() : swapper_(nullptr, 0) {}
     edge_sort_iterator(t_rr_graph_storage* storage, size_t idx)
         : swapper_(storage, idx) {}
 


### PR DESCRIPTION
o make sure to include <algorithm>
o Provide default constructor for edge_sort_iterator as
  the implementation of std::stable_sort might need it.

Signed-off-by: Henner Zeller <h.zeller@acm.org>