### PR TITLE
Options to enable faster rr graph reading

### DIFF
--- a/utils/fasm/src/main.cpp
+++ b/utils/fasm/src/main.cpp
@@ -73,6 +73,7 @@ int main(int argc, const char **argv) {
         vpr_setup.PackerOpts.doPacking    = STAGE_LOAD;
         vpr_setup.PlacerOpts.doPlacement  = STAGE_LOAD;
         vpr_setup.RouterOpts.doRouting    = STAGE_LOAD;
+        vpr_setup.RouterOpts.read_edge_metadata = true;
         vpr_setup.AnalysisOpts.doAnalysis = STAGE_SKIP;
 
         bool flow_succeeded = false;

--- a/utils/fasm/src/main.cpp
+++ b/utils/fasm/src/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, const char **argv) {
         vpr_setup.PackerOpts.doPacking    = STAGE_LOAD;
         vpr_setup.PlacerOpts.doPlacement  = STAGE_LOAD;
         vpr_setup.RouterOpts.doRouting    = STAGE_LOAD;
-        vpr_setup.RouterOpts.read_edge_metadata = true;
+        vpr_setup.RouterOpts.read_rr_edge_metadata = true;
         vpr_setup.AnalysisOpts.doAnalysis = STAGE_SKIP;
 
         bool flow_succeeded = false;

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -182,6 +182,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
         };
         vpr_init(sizeof(argv)/sizeof(argv[0]), argv,
                 &options, &vpr_setup, &arch);
+        vpr_setup.RouterOpts.read_edge_metadata = true;
         bool flow_succeeded = vpr_flow(vpr_setup, arch);
         REQUIRE(flow_succeeded == true);
 
@@ -220,6 +221,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     vpr_setup.PackerOpts.doPacking    = STAGE_LOAD;
     vpr_setup.PlacerOpts.doPlacement  = STAGE_LOAD;
     vpr_setup.RouterOpts.doRouting    = STAGE_LOAD;
+    vpr_setup.RouterOpts.read_edge_metadata = true;
     vpr_setup.AnalysisOpts.doAnalysis = STAGE_SKIP;
 
     bool flow_succeeded = vpr_flow(vpr_setup, arch);

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -182,7 +182,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
         };
         vpr_init(sizeof(argv)/sizeof(argv[0]), argv,
                 &options, &vpr_setup, &arch);
-        vpr_setup.RouterOpts.read_edge_metadata = true;
+        vpr_setup.RouterOpts.read_rr_edge_metadata = true;
         bool flow_succeeded = vpr_flow(vpr_setup, arch);
         REQUIRE(flow_succeeded == true);
 
@@ -221,7 +221,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     vpr_setup.PackerOpts.doPacking    = STAGE_LOAD;
     vpr_setup.PlacerOpts.doPlacement  = STAGE_LOAD;
     vpr_setup.RouterOpts.doRouting    = STAGE_LOAD;
-    vpr_setup.RouterOpts.read_edge_metadata = true;
+    vpr_setup.RouterOpts.read_rr_edge_metadata = true;
     vpr_setup.AnalysisOpts.doAnalysis = STAGE_SKIP;
 
     bool flow_succeeded = vpr_flow(vpr_setup, arch);

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -322,6 +322,7 @@ static void SetupRoutingArch(const t_arch& Arch,
 }
 
 static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts) {
+    RouterOpts->do_check_rr_graph = Options.check_rr_graph;
     RouterOpts->astar_fac = Options.astar_fac;
     RouterOpts->bb_factor = Options.bb_factor;
     RouterOpts->criticality_exp = Options.criticality_exp;

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -345,6 +345,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->router_algorithm = Options.RouterAlgorithm;
     RouterOpts->fixed_channel_width = Options.RouteChanWidth;
     RouterOpts->min_channel_width_hint = Options.min_route_chan_width_hint;
+    RouterOpts->read_rr_edge_metadata = Options.read_rr_edge_metadata;
 
     //TODO document these?
     RouterOpts->trim_empty_channels = false; /* DEFAULT */

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -357,7 +357,9 @@ int binary_search_place_and_route(const t_placer_opts& placer_opts_ref,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
                     arch->Directs, arch->num_directs,
-                    &warnings);
+                    &warnings,
+                    router_opts.read_edge_metadata,
+                    router_opts.do_check_rr_graph);
 
     init_draw_coords(final);
     restore_routing(best_routing, route_ctx.clb_opins_used_locally, saved_clb_opins_used_locally);

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -358,7 +358,7 @@ int binary_search_place_and_route(const t_placer_opts& placer_opts_ref,
                     router_opts.clock_modeling,
                     arch->Directs, arch->num_directs,
                     &warnings,
-                    router_opts.read_edge_metadata,
+                    router_opts.read_rr_edge_metadata,
                     router_opts.do_check_rr_graph);
 
     init_draw_coords(final);

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1673,6 +1673,11 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<bool, ParseOnOff>(args.read_rr_edge_metadata, "--read_rr_edge_metadata")
+        .help("Read RR edge metadata from --read_rr_graph.  RR edge metadata is not used in core VPR algorithms, and is typically not read to save runtime and memory. (Default: off).")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.router_debug_net, "--router_debug_net")
         .help(
             "Controls when router debugging is enabled for nets.\n"

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1705,6 +1705,11 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("-2")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<bool, ParseOnOff>(args.check_rr_graph, "--check_rr_graph")
+        .help("Controls whether to check the rr graph when reading from disk.")
+        .default_value("on")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& analysis_grp = parser.add_argument_group("analysis options");
 
     analysis_grp.add_argument<bool, ParseOnOff>(args.full_stats, "--full_stats")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -119,6 +119,7 @@ struct t_options {
     argparse::ArgValue<std::string> allowed_tiles_for_delay_model;
 
     /* Router Options */
+    argparse::ArgValue<bool> check_rr_graph;
     argparse::ArgValue<int> max_router_iterations;
     argparse::ArgValue<float> first_iter_pres_fac;
     argparse::ArgValue<float> initial_pres_fac;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -134,6 +134,7 @@ struct t_options {
     argparse::ArgValue<bool> verify_binary_search;
     argparse::ArgValue<e_router_algorithm> RouterAlgorithm;
     argparse::ArgValue<int> min_incremental_reroute_fanout;
+    argparse::ArgValue<bool> read_rr_edge_metadata;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -859,7 +859,9 @@ void vpr_create_rr_graph(t_vpr_setup& vpr_setup, const t_arch& arch, int chan_wi
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
                     arch.Directs, arch.num_directs,
-                    &warnings);
+                    &warnings,
+                    router_opts.read_edge_metadata,
+                    router_opts.do_check_rr_graph);
     //Initialize drawing, now that we have an RR graph
     init_draw_coords(chan_width_fac);
 }

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -860,7 +860,7 @@ void vpr_create_rr_graph(t_vpr_setup& vpr_setup, const t_arch& arch, int chan_wi
                     router_opts.clock_modeling,
                     arch.Directs, arch.num_directs,
                     &warnings,
-                    router_opts.read_edge_metadata,
+                    router_opts.read_rr_edge_metadata,
                     router_opts.do_check_rr_graph);
     //Initialize drawing, now that we have an RR graph
     init_draw_coords(chan_width_fac);

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -912,7 +912,7 @@ enum class e_incr_reroute_delay_ripup {
 constexpr int NO_FIXED_CHANNEL_WIDTH = -1;
 
 struct t_router_opts {
-    bool read_edge_metadata = false;
+    bool read_rr_edge_metadata = false;
     bool do_check_rr_graph = true;
     float first_iter_pres_fac;
     float initial_pres_fac;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -912,6 +912,8 @@ enum class e_incr_reroute_delay_ripup {
 constexpr int NO_FIXED_CHANNEL_WIDTH = -1;
 
 struct t_router_opts {
+    bool read_edge_metadata = false;
+    bool do_check_rr_graph = true;
     float first_iter_pres_fac;
     float initial_pres_fac;
     float pres_fac_mult;

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -232,7 +232,7 @@ void try_graph(int width_fac, const t_router_opts& router_opts, t_det_routing_ar
                     router_opts.clock_modeling,
                     directs, num_directs,
                     &warning_count,
-                    router_opts.read_edge_metadata,
+                    router_opts.read_rr_edge_metadata,
                     router_opts.do_check_rr_graph);
 }
 
@@ -284,7 +284,7 @@ bool try_route(int width_fac,
                     router_opts.clock_modeling,
                     directs, num_directs,
                     &warning_count,
-                    router_opts.read_edge_metadata,
+                    router_opts.read_rr_edge_metadata,
                     router_opts.do_check_rr_graph);
 
     //Initialize drawing, now that we have an RR graph

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -231,7 +231,9 @@ void try_graph(int width_fac, const t_router_opts& router_opts, t_det_routing_ar
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
                     directs, num_directs,
-                    &warning_count);
+                    &warning_count,
+                    router_opts.read_edge_metadata,
+                    router_opts.do_check_rr_graph);
 }
 
 bool try_route(int width_fac,
@@ -281,7 +283,9 @@ bool try_route(int width_fac,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
                     directs, num_directs,
-                    &warning_count);
+                    &warning_count,
+                    router_opts.read_edge_metadata,
+                    router_opts.do_check_rr_graph);
 
     //Initialize drawing, now that we have an RR graph
     init_draw_coords(width_fac);

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -213,7 +213,9 @@ void alloc_routing_structs(t_chan_width chan_width,
                     router_opts.trim_obs_channels,
                     router_opts.clock_modeling,
                     directs, num_directs,
-                    &warnings);
+                    &warnings,
+                    router_opts.read_edge_metadata,
+                    router_opts.do_check_rr_graph);
 
     alloc_and_load_rr_node_route_structs();
 

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -214,7 +214,7 @@ void alloc_routing_structs(t_chan_width chan_width,
                     router_opts.clock_modeling,
                     directs, num_directs,
                     &warnings,
-                    router_opts.read_edge_metadata,
+                    router_opts.read_rr_edge_metadata,
                     router_opts.do_check_rr_graph);
 
     alloc_and_load_rr_node_route_structs();

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -323,7 +323,7 @@ void create_rr_graph(const t_graph_type graph_type,
                      const t_direct_inf* directs,
                      const int num_directs,
                      int* Warnings,
-                     bool read_edge_metadata,
+                     bool read_rr_edge_metadata,
                      bool do_check_rr_graph) {
     const auto& device_ctx = g_vpr_ctx.device();
 
@@ -337,7 +337,7 @@ void create_rr_graph(const t_graph_type graph_type,
                          base_cost_type,
                          &det_routing_arch->wire_to_rr_ipin_switch,
                          det_routing_arch->read_rr_graph_filename.c_str(),
-                         read_edge_metadata,
+                         read_rr_edge_metadata,
                          do_check_rr_graph);
         }
     } else {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -322,7 +322,9 @@ void create_rr_graph(const t_graph_type graph_type,
                      const enum e_clock_modeling clock_modeling,
                      const t_direct_inf* directs,
                      const int num_directs,
-                     int* Warnings) {
+                     int* Warnings,
+                     bool read_edge_metadata,
+                     bool do_check_rr_graph) {
     const auto& device_ctx = g_vpr_ctx.device();
 
     if (!det_routing_arch->read_rr_graph_filename.empty()) {
@@ -335,8 +337,8 @@ void create_rr_graph(const t_graph_type graph_type,
                          base_cost_type,
                          &det_routing_arch->wire_to_rr_ipin_switch,
                          det_routing_arch->read_rr_graph_filename.c_str(),
-                         /*read_edge_metadata=*/true,
-                         /*do_check_rr_graph=*/true);
+                         read_edge_metadata,
+                         do_check_rr_graph);
         }
     } else {
         if (channel_widths_unchanged(device_ctx.chan_width, nodes_per_chan) && !device_ctx.rr_nodes.empty()) {

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -38,7 +38,9 @@ void create_rr_graph(const t_graph_type graph_type,
                      const enum e_clock_modeling clock_modeling,
                      const t_direct_inf* directs,
                      const int num_directs,
-                     int* Warnings);
+                     int* Warnings,
+                     bool read_edge_metadata,
+                     bool do_check_rr_graph);
 
 void free_rr_graph();
 

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -39,7 +39,7 @@ void create_rr_graph(const t_graph_type graph_type,
                      const t_direct_inf* directs,
                      const int num_directs,
                      int* Warnings,
-                     bool read_edge_metadata,
+                     bool read_rr_edge_metadata,
                      bool do_check_rr_graph);
 
 void free_rr_graph();

--- a/vpr/test/test_vpr.cpp
+++ b/vpr/test/test_vpr.cpp
@@ -129,6 +129,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
         };
         vpr_init(sizeof(argv) / sizeof(argv[0]), argv,
                  &options, &vpr_setup, &arch);
+        vpr_setup.RouterOpts.read_edge_metadata = true;
         vpr_create_device(vpr_setup, arch);
 
         const auto& device_ctx = g_vpr_ctx.device();
@@ -170,6 +171,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
 
     vpr_init(sizeof(argv) / sizeof(argv[0]), argv,
              &options, &vpr_setup, &arch);
+    vpr_setup.RouterOpts.read_edge_metadata = true;
     vpr_create_device(vpr_setup, arch);
 
     const auto& device_ctx = g_vpr_ctx.device();

--- a/vpr/test/test_vpr.cpp
+++ b/vpr/test/test_vpr.cpp
@@ -129,7 +129,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
         };
         vpr_init(sizeof(argv) / sizeof(argv[0]), argv,
                  &options, &vpr_setup, &arch);
-        vpr_setup.RouterOpts.read_edge_metadata = true;
+        vpr_setup.RouterOpts.read_rr_edge_metadata = true;
         vpr_create_device(vpr_setup, arch);
 
         const auto& device_ctx = g_vpr_ctx.device();
@@ -171,7 +171,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
 
     vpr_init(sizeof(argv) / sizeof(argv[0]), argv,
              &options, &vpr_setup, &arch);
-    vpr_setup.RouterOpts.read_edge_metadata = true;
+    vpr_setup.RouterOpts.read_rr_edge_metadata = true;
     vpr_create_device(vpr_setup, arch);
 
     const auto& device_ctx = g_vpr_ctx.device();


### PR DESCRIPTION
#### Description

This PR adds two options that enable faster reading of RR graphs from disk.

Option 1 enables the ability to disable calling `check_rr_graph`.  This is takes ~12 seconds on the A50T graph, and if the entire flow is otherwise taking ~60 seconds, this is a significant fraction of runtime.  The idea here is that when the RR graph was first created, `check_rr_graph` can be called, and then once the graph is written to disk, future instance of VPR do not need to call it again.

Option 2 is a two part change.  By default VPR doesn't use edge metadata, so by default the RR graph reader will no longer read edge metadata.  However there are reasons to read the edge metadata (e.g. format conversion, profiling, etc), so an option is being added to re-enable reading of edge metadata from disk.  The default is reasonable, delivering the performance boost, and the option exists to retain a full read if needed.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

This enables a faster RR graph read, and is fully controllable via flags.

#### How Has This Been Tested?

Tests have been updated, and symbiflow has been using these flags for a while.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
