### PR TITLE
Fixed non iopads

### DIFF
--- a/vpr/src/base/read_place.cpp
+++ b/vpr/src/base/read_place.cpp
@@ -146,6 +146,7 @@ void read_user_pad_loc(const char* pad_loc_file) {
     int xtmp, ytmp;
     FILE* fp;
     char buf[vtr::bufsize], bname[vtr::bufsize], *ptr;
+    std::unordered_set<ClusterBlockId> constrained_blocks;
 
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& device_ctx = g_vpr_ctx.device();
@@ -160,17 +161,14 @@ void read_user_pad_loc(const char* pad_loc_file) {
 
     hash_table = alloc_hash_table();
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
-        auto logical_block = cluster_ctx.clb_nlist.block_type(blk_id);
-        if (is_io_type(pick_best_physical_type(logical_block))) {
-            insert_in_hash_table(hash_table, cluster_ctx.clb_nlist.block_name(blk_id).c_str(), size_t(blk_id));
-            place_ctx.block_locs[blk_id].loc.x = OPEN; /* Mark as not seen yet. */
-        }
+        insert_in_hash_table(hash_table, cluster_ctx.clb_nlist.block_name(blk_id).c_str(), size_t(blk_id));
+        place_ctx.block_locs[blk_id].loc.x = OPEN; /* Mark as not seen yet. */
     }
 
     for (size_t i = 0; i < device_ctx.grid.width(); i++) {
         for (size_t j = 0; j < device_ctx.grid.height(); j++) {
             auto type = device_ctx.grid[i][j].type;
-            if (is_io_type(type)) {
+            if (!is_empty_type(type)) {
                 for (int k = 0; k < type->capacity; k++) {
                     if (place_ctx.grid_blocks[i][j].blocks[k] != INVALID_BLOCK_ID) {
                         place_ctx.grid_blocks[i][j].blocks[k] = EMPTY_BLOCK_ID; /* Flag for err. check */
@@ -236,12 +234,12 @@ void read_user_pad_loc(const char* pad_loc_file) {
         int j = ytmp;
 
         if (place_ctx.block_locs[bnum].loc.x != OPEN) {
-            vpr_throw(VPR_ERROR_PLACE_F, pad_loc_file, vtr::get_file_line_number_of_last_opened_file(),
+            VPR_THROW(VPR_ERROR_PLACE_F, pad_loc_file, vtr::get_file_line_number_of_last_opened_file(),
                       "Block %s is listed twice in pad file.\n", bname);
         }
 
         if (i < 0 || i > int(device_ctx.grid.width() - 1) || j < 0 || j > int(device_ctx.grid.height() - 1)) {
-            vpr_throw(VPR_ERROR_PLACE_F, pad_loc_file, 0,
+            VPR_THROW(VPR_ERROR_PLACE_F, pad_loc_file, 0,
                       "Block #%zu (%s) location, (%d,%d) is out of range.\n", size_t(bnum), bname, i, j);
         }
 
@@ -250,27 +248,33 @@ void read_user_pad_loc(const char* pad_loc_file) {
         place_ctx.block_locs[bnum].loc.z = k;
         place_ctx.block_locs[bnum].is_fixed = true;
 
-        auto type = device_ctx.grid[i][j].type;
-        if (!is_io_type(type)) {
-            vpr_throw(VPR_ERROR_PLACE_F, pad_loc_file, 0,
-                      "Attempt to place IO block %s at illegal location (%d, %d).\n", bname, i, j);
+        auto physical_tile = device_ctx.grid[i][j].type;
+        auto logical_block = cluster_ctx.clb_nlist.block_type(bnum);
+        if (!is_tile_compatible(physical_tile, logical_block)) {
+            VPR_THROW(VPR_ERROR_PLACE_F, pad_loc_file, 0,
+                      "Attempt to place block %s at illegal location (%d, %d).\n", bname, i, j);
         }
 
-        if (k >= type->capacity || k < 0) {
-            vpr_throw(VPR_ERROR_PLACE_F, pad_loc_file, vtr::get_file_line_number_of_last_opened_file(),
+        if (k >= physical_tile->capacity || k < 0) {
+            VPR_THROW(VPR_ERROR_PLACE_F, pad_loc_file, vtr::get_file_line_number_of_last_opened_file(),
                       "Block %s subblock number (%d) is out of range.\n", bname, k);
         }
         place_ctx.grid_blocks[i][j].blocks[k] = bnum;
         place_ctx.grid_blocks[i][j].usage++;
 
+        constrained_blocks.insert(bnum);
+
         ptr = vtr::fgets(buf, vtr::bufsize, fp);
     }
 
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
-        auto logical_block = cluster_ctx.clb_nlist.block_type(blk_id);
-        auto type = pick_best_physical_type(logical_block);
-        if (is_io_type(type) && place_ctx.block_locs[blk_id].loc.x == OPEN) {
-            vpr_throw(VPR_ERROR_PLACE_F, pad_loc_file, 0,
+        auto result = constrained_blocks.find(blk_id);
+        if (result == constrained_blocks.end()) {
+            continue;
+        }
+
+        if (place_ctx.block_locs[blk_id].loc.x == OPEN) {
+            VPR_THROW(VPR_ERROR_PLACE_F, pad_loc_file, 0,
                       "IO block %s location was not specified in the pad file.\n", cluster_ctx.clb_nlist.block_name(blk_id).c_str());
         }
     }

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -124,7 +124,7 @@ e_block_move_result record_single_block_swap(t_pl_blocks_to_be_moved& blocks_aff
     } else if (b_to != INVALID_BLOCK_ID) {
         // Check whether block to is compatible with from location
         if (b_to != EMPTY_BLOCK_ID && b_to != INVALID_BLOCK_ID) {
-            if (!(is_legal_swap_to_location(b_to, curr_from))) {
+            if (!(is_legal_swap_to_location(b_to, curr_from)) || place_ctx.block_locs[b_to].is_fixed) {
                 return e_block_move_result::ABORT;
             }
         }
@@ -434,6 +434,7 @@ bool is_legal_swap_to_location(ClusterBlockId blk, t_pl_loc to) {
 
     auto& device_ctx = g_vpr_ctx.device();
     auto& cluster_ctx = g_vpr_ctx.clustering();
+    auto& place_ctx = g_vpr_ctx.placement();
 
     if (to.x < 0 || to.x >= int(device_ctx.grid.width())
         || to.y < 0 || to.y >= int(device_ctx.grid.height())
@@ -441,6 +442,15 @@ bool is_legal_swap_to_location(ClusterBlockId blk, t_pl_loc to) {
         || !is_tile_compatible(device_ctx.grid[to.x][to.y].type, cluster_ctx.clb_nlist.block_type(blk))) {
         return false;
     }
+
+    // If the destination block is user constrained, abort this swap
+    auto b_to = place_ctx.grid_blocks[to.x][to.y].blocks[to.z];
+    if (b_to != INVALID_BLOCK_ID && b_to != EMPTY_BLOCK_ID) {
+        if (place_ctx.block_locs[b_to].is_fixed) {
+            return false;
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
#### Description

This PR was developed by @acomodi.

This PR allows VPR to place clusters other than IO pads, which is useful for placing clock elements explicitly.

#### Related Issue

#1045

#### Motivation and Context

In fabrics with specialized clocking networks, clock elements within the network may have specific requirements.  See #1045 for discussion.  For example, in the 7-series fabric, there are top global buffers and bottom global buffers.  In order to use the dedicated clock path between an input pad and the global clock buffer, if the input pad is in the bottom half of the fabric, it needs to use a "bottom" global buffer, top half of the fabric, it needs to use a "top" global buffer.

Rather than finding a general solution to this problem, for now these elements are given fixed placements *prior* to running VPR via the IO fixing code.  This PR enables that pathway to be more general, and fix any cluster, rather than just IO pads.

#### How Has This Been Tested?

Symbiflow has been using this code since December to place non-IO cluster instances.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
