### PR TITLE
Fix couple small bugs in vtr_string_view.h

### DIFF
--- a/libs/libvtrutil/src/vtr_string_view.h
+++ b/libs/libvtrutil/src/vtr_string_view.h
@@ -65,7 +65,7 @@ class string_view {
     }
 
     constexpr bool empty() const noexcept {
-        return size_ != 0;
+        return size_ == 0;
     }
 
     constexpr const char* begin() const noexcept {
@@ -107,7 +107,7 @@ class string_view {
 
 inline bool operator==(string_view lhs,
                        string_view rhs) noexcept {
-    return lhs.size() == rhs.size() && strncmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size())) == 0;
+    return lhs.size() == rhs.size() && (lhs.empty() || rhs.empty() || (strncmp(lhs.data(), rhs.data(), std::min(lhs.size(), rhs.size())) == 0));
 }
 inline bool operator!=(string_view lhs,
                        string_view rhs) noexcept {


### PR DESCRIPTION
#### Description

- strncpy cannot handle nullptr (e.g. empty strings), so special case comparisons with empty strings to avoid calling into strncpy
- Fixed incorrect `empty` method

This was discovered by running with sanitizers.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
