### PR TITLE
Use grid_ reference in ConnectionRouter.

### DIFF
--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -65,13 +65,11 @@ t_heap* ConnectionRouter::timing_driven_route_connection_common_setup(
         //found with the bounding box) remains fast and never re-tries .
         VTR_LOG_WARN("No routing path for connection to sink_rr %d, retrying with full device bounding box\n", sink_node);
 
-        auto& device_ctx = g_vpr_ctx.device();
-
         t_bb full_device_bounding_box;
         full_device_bounding_box.xmin = 0;
         full_device_bounding_box.ymin = 0;
-        full_device_bounding_box.xmax = device_ctx.grid.width() - 1;
-        full_device_bounding_box.ymax = device_ctx.grid.height() - 1;
+        full_device_bounding_box.xmax = grid_.width() - 1;
+        full_device_bounding_box.ymax = grid_.height() - 1;
 
         //
         //TODO: potential future optimization


### PR DESCRIPTION
#### Description

This is a small cleanup removing a use of `g_vpr_ctx` from `ConnectionRouter`.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

**All** use of global data should be mediated through the `ConnectionRouter` construct, or arguments to it's methods.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
