### PR TITLE
Add vtr::StrongIdRange and use it within ConnectionRouter.

### DIFF
--- a/libs/libvtrutil/src/vtr_strong_id_range.h
+++ b/libs/libvtrutil/src/vtr_strong_id_range.h
@@ -1,0 +1,153 @@
+#ifndef _VTR_STRONG_ID_RANGE_H
+#define _VTR_STRONG_ID_RANGE_H
+
+#include <algorithm>
+#include "vtr_assert.h"
+
+namespace vtr {
+
+/*
+ * This header defines a utility class for StrongId's.  StrongId's are
+ * described in vtr_strong_id.h.  In some cases, StrongId's be considered
+ * like random access iterators, but not all StrongId's have this property.
+ * In addition, there is utility in refering to a range of id's, and being able
+ * to iterator over that range.
+ *
+ * StrongIdIterator allows a StrongId to be treated like a random access
+ * iterator.  Whether this is a correct use of the abstraction is up to the
+ * called.
+ *
+ * StrongIdRange allows a pair of StrongId's to defines a continguous range of
+ * ids.  The "end" StrongId is excluded from this range.
+ */
+template<typename StrongId>
+class StrongIdIterator {
+  public:
+    StrongIdIterator() = default;
+    StrongIdIterator& operator=(const StrongIdIterator& other) = default;
+    StrongIdIterator(const StrongIdIterator& other) = default;
+    explicit StrongIdIterator(StrongId id)
+        : id_(id) {
+        VTR_ASSERT(bool(id));
+    }
+
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = StrongId;
+    using reference = StrongId&;
+    using pointer = StrongId*;
+    using difference_type = ssize_t;
+
+    StrongId& operator*() {
+        VTR_ASSERT_SAFE(bool(id_));
+        return this->id_;
+    }
+
+    StrongIdIterator& operator+=(ssize_t n) {
+        VTR_ASSERT_SAFE(bool(id_));
+        id_ = StrongId(size_t(id_) + n);
+        VTR_ASSERT_SAFE(bool(id_));
+        return *this;
+    }
+
+    StrongIdIterator& operator-=(ssize_t n) {
+        VTR_ASSERT_SAFE(bool(id_));
+        id_ = StrongId(size_t(id_) - n);
+        VTR_ASSERT_SAFE(bool(id_));
+        return *this;
+    }
+
+    StrongIdIterator& operator++() {
+        VTR_ASSERT_SAFE(bool(id_));
+        *this += 1;
+        VTR_ASSERT_SAFE(bool(id_));
+        return *this;
+    }
+
+    StrongIdIterator& operator--() {
+        VTR_ASSERT_SAFE(bool(id_));
+        *this -= 1;
+        VTR_ASSERT_SAFE(bool(id_));
+        return *this;
+    }
+
+    StrongId operator[](ssize_t offset) const {
+        return StrongId(size_t(id_) + offset);
+    }
+
+    template<typename IdType>
+    friend StrongIdIterator<IdType> operator+(
+        const StrongIdIterator<IdType>& lhs,
+        ssize_t n) {
+        StrongIdIterator ret = lhs;
+        ret += n;
+        return ret;
+    }
+
+    template<typename IdType>
+    friend StrongIdIterator<IdType> operator-(
+        const StrongIdIterator<IdType>& lhs,
+        ssize_t n) {
+        StrongIdIterator ret = lhs;
+        ret -= n;
+        return ret;
+    }
+
+    template<typename IdType>
+    friend ssize_t operator-(
+        const StrongIdIterator<IdType>& lhs,
+        const StrongIdIterator<IdType>& rhs) {
+        VTR_ASSERT_SAFE(bool(lhs.id_));
+        VTR_ASSERT_SAFE(bool(rhs.id_));
+
+        ssize_t ret = size_t(lhs.id_);
+        ret -= size_t(rhs.id_);
+        return ret;
+    }
+
+    template<typename IdType>
+    friend bool operator==(const StrongIdIterator<IdType>& lhs, const StrongIdIterator<IdType>& rhs) {
+        return lhs.id_ == rhs.id_;
+    }
+
+    template<typename IdType>
+    friend bool operator!=(const StrongIdIterator<IdType>& lhs, const StrongIdIterator<IdType>& rhs) {
+        return lhs.id_ != rhs.id_;
+    }
+
+    template<typename IdType>
+    friend bool operator<(const StrongIdIterator<IdType>& lhs, const StrongIdIterator<IdType>& rhs) {
+        return lhs.id_ < rhs.id_;
+    }
+
+  private:
+    StrongId id_;
+};
+
+template<typename StrongId>
+class StrongIdRange {
+  public:
+    StrongIdRange(StrongId b, StrongId e)
+        : begin_(b)
+        , end_(e) {
+        VTR_ASSERT(begin_ < end_ || begin_ == end_);
+    }
+    StrongIdIterator<StrongId> begin() const {
+        return StrongIdIterator<StrongId>(begin_);
+    }
+    StrongIdIterator<StrongId> end() const {
+        return StrongIdIterator<StrongId>(end_);
+    }
+
+    bool empty() { return begin_ == end_; }
+    size_t size() {
+        return std::distance(begin(), end());
+    }
+
+  private:
+    StrongId begin_;
+    StrongId end_;
+};
+
+} //namespace vtr
+
+#endif /* _VTR_STRONG_ID_RANGE_H */

--- a/libs/libvtrutil/test/test_strong_id.cpp
+++ b/libs/libvtrutil/test/test_strong_id.cpp
@@ -1,0 +1,129 @@
+#include "catch.hpp"
+
+#include "vtr_strong_id.h"
+#include "vtr_strong_id_range.h"
+
+struct t_test_tag;
+using TestStrongId = vtr::StrongId<t_test_tag>;
+
+TEST_CASE("StrongId", "[StrongId/StrongId]") {
+    TestStrongId a;
+    TestStrongId b;
+    TestStrongId c(0);
+    TestStrongId d(0);
+    TestStrongId e(1);
+    TestStrongId f(2);
+
+    REQUIRE(!bool(a));
+    REQUIRE(!bool(b));
+    REQUIRE(bool(c));
+    REQUIRE(bool(d));
+    REQUIRE(bool(e));
+    REQUIRE(bool(f));
+
+    REQUIRE(a == b);
+    REQUIRE(a == TestStrongId::INVALID());
+
+    REQUIRE(c == d);
+    REQUIRE(c != a);
+    REQUIRE(c != TestStrongId::INVALID());
+    REQUIRE(d != TestStrongId::INVALID());
+
+    REQUIRE(c != e);
+    REQUIRE(c != f);
+    REQUIRE(e != f);
+
+    REQUIRE(c < e);
+    REQUIRE(c < f);
+    REQUIRE(e < f);
+    REQUIRE(!(e < c));
+    REQUIRE(!(f < c));
+    REQUIRE(!(f < e));
+}
+
+TEST_CASE("StrongIdIterator", "[StrongId/StrongIdIterator]") {
+    TestStrongId a(0);
+    TestStrongId b(1);
+    TestStrongId c(5);
+    TestStrongId d(5);
+
+    vtr::StrongIdIterator<TestStrongId> a_iter(a);
+    vtr::StrongIdIterator<TestStrongId> b_iter(b);
+    vtr::StrongIdIterator<TestStrongId> c_iter(c);
+    vtr::StrongIdIterator<TestStrongId> d_iter(d);
+
+    REQUIRE(*a_iter == a);
+    REQUIRE(*b_iter == b);
+    REQUIRE(*c_iter == c);
+    REQUIRE(*c_iter == d);
+    REQUIRE(*d_iter == c);
+    REQUIRE(*d_iter == d);
+
+    REQUIRE(a_iter != b_iter);
+    REQUIRE(a_iter != c_iter);
+    REQUIRE(a_iter != d_iter);
+
+    REQUIRE(c_iter == d_iter);
+    REQUIRE(c_iter != a_iter);
+    REQUIRE(c_iter != b_iter);
+
+    REQUIRE(std::distance(a_iter, b_iter) == 1);
+    REQUIRE(std::distance(c_iter, d_iter) == 0);
+    REQUIRE(std::distance(d_iter, a_iter) == -5);
+
+    REQUIRE(a_iter < b_iter);
+    REQUIRE(b_iter < c_iter);
+    REQUIRE(!(c_iter < b_iter));
+
+    REQUIRE(a_iter[0] == a);
+    REQUIRE(a_iter[1] == b);
+    REQUIRE(a_iter[5] == c);
+    REQUIRE(c_iter[0] == c);
+    REQUIRE(c_iter[-4] == b);
+    REQUIRE(c_iter[-5] == a);
+
+    REQUIRE((a_iter + 5) == c_iter);
+    REQUIRE(a_iter == (c_iter - 5));
+    a_iter += 5;
+    REQUIRE(a_iter == c_iter);
+    a_iter -= 4;
+    REQUIRE(a_iter == b_iter);
+}
+
+TEST_CASE("StrongIdRange", "[StrongId/StrongIdRange]") {
+    TestStrongId a(0);
+    TestStrongId b(0);
+    TestStrongId c(5);
+    TestStrongId d(1);
+
+    vtr::StrongIdRange<TestStrongId> r1(a, b);
+    REQUIRE(r1.size() == 0);
+    REQUIRE(r1.empty());
+
+    vtr::StrongIdRange<TestStrongId> r2(a, c);
+    REQUIRE(r2.size() == 5);
+    REQUIRE(!r2.empty());
+
+    vtr::StrongIdRange<TestStrongId> r3(d, c);
+    REQUIRE(r3.size() == 4);
+    REQUIRE(!r3.empty());
+
+    int count = 0;
+    for (TestStrongId id : r1) {
+        count += 1;
+    }
+    REQUIRE(count == 0);
+
+    for (TestStrongId id : r2) {
+        REQUIRE(TestStrongId(count) == id);
+        count += 1;
+    }
+    REQUIRE(count == 5);
+
+    count = 0;
+    for (TestStrongId id : r3) {
+        REQUIRE(TestStrongId(count + 1) == id);
+        count += 1;
+    }
+    REQUIRE(count == 4);
+}

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -363,9 +363,7 @@ void ConnectionRouter::timing_driven_expand_neighbours(t_heap* current,
     //For each node associated with the current heap element, expand all of it's neighbors
     int from_node_int = current->index;
     RRNodeId from_node(from_node_int);
-    RREdgeId first_edge = rr_nodes_->first_edge(from_node);
-    RREdgeId last_edge = rr_nodes_->last_edge(from_node);
-    int num_edges = size_t(last_edge) - size_t(first_edge);
+    auto edges = rr_nodes_->edge_range(from_node);
 
     // This is a simple prefetch that prefetches:
     //  - RR node data reachable from this node
@@ -384,9 +382,7 @@ void ConnectionRouter::timing_driven_expand_neighbours(t_heap* current,
     //  - directrf_stratixiv_arch_timing.blif
     //  - gsm_switch_stratixiv_arch_timing.blif
     //
-    for (int iconn = 0; iconn < num_edges; iconn++) {
-        RREdgeId from_edge(size_t(first_edge) + iconn);
-
+    for (RREdgeId from_edge : edges) {
         RRNodeId to_node = rr_nodes_->edge_sink_node(from_edge);
         rr_nodes_->prefetch_node(to_node);
 
@@ -394,13 +390,13 @@ void ConnectionRouter::timing_driven_expand_neighbours(t_heap* current,
         VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
     }
 
-    for (int iconn = 0; iconn < num_edges; iconn++) {
-        RREdgeId from_edge(size_t(first_edge) + iconn);
+    int iconn = 0;
+    for (RREdgeId from_edge : edges) {
         RRNodeId to_node = rr_nodes_->edge_sink_node(from_edge);
         timing_driven_expand_neighbour(current,
                                        from_node_int,
                                        from_edge,
-                                       iconn,
+                                       iconn++,
                                        size_t(to_node),
                                        cost_params,
                                        bounding_box,

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -8,6 +8,7 @@
 #include "vtr_log.h"
 #include "vtr_memory.h"
 #include "vpr_utils.h"
+#include "vtr_strong_id_range.h"
 
 /* Main structure describing one routing resource node.  Everything in       *
  * this structure should describe the graph -- information needed only       *
@@ -202,6 +203,7 @@ class t_rr_graph_storage {
      * Preferred access methods:
      * - first_edge(RRNodeId)
      * - last_edge(RRNodeId)
+     * - edge_range(RRNodeId)
      * - edge_sink_node(RREdgeId)
      * - edge_switch(RREdgeId)
      *
@@ -251,6 +253,13 @@ class t_rr_graph_storage {
     // been sorted by rr_node, which is true after partition_edges().
     RREdgeId last_edge(const RRNodeId& id) const {
         return (&node_first_edge_[id])[1];
+    }
+
+    // Returns a range of RREdgeId's belonging to RRNodeId id.
+    //
+    // If this range is empty, then RRNodeId id has no edges.
+    vtr::StrongIdRange<RREdgeId> edge_range(const RRNodeId id) const {
+        return vtr::StrongIdRange<RREdgeId>(first_edge(id), last_edge(id));
     }
 
     // Retrieve the RREdgeId for iedge'th edge in RRNodeId.


### PR DESCRIPTION
#### Description

vtr::StrongIdRange and vtr::StrongIdIterator are useful utility classes
for ranges of vtr::StrongId's (e.g. edges belonging to a node).

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
