### PR TITLE
Use RREdgeId in t_heap

### DIFF
--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -41,6 +41,7 @@
 #include "vtr_cache.h"
 #include "vtr_string_view.h"
 #include "vtr_dynamic_bitset.h"
+#include "rr_graph_fwd.h"
 
 /*******************************************************************************
  * Global data types and constants
@@ -211,6 +212,33 @@ class t_pack_high_fanout_thresholds {
 
 /* Type used to express rr_node edge index. */
 typedef uint16_t t_edge_size;
+
+//An iterator that dereferences to an edge index
+//
+//Used inconjunction with vtr::Range to return ranges of edge indices
+class edge_idx_iterator : public std::iterator<std::bidirectional_iterator_tag, t_edge_size> {
+  public:
+    edge_idx_iterator(value_type init)
+        : value_(init) {}
+    iterator operator++() {
+        value_ += 1;
+        return *this;
+    }
+    iterator operator--() {
+        value_ -= 1;
+        return *this;
+    }
+    reference operator*() { return value_; }
+    pointer operator->() { return &value_; }
+
+    friend bool operator==(const edge_idx_iterator lhs, const edge_idx_iterator rhs) { return lhs.value_ == rhs.value_; }
+    friend bool operator!=(const edge_idx_iterator lhs, const edge_idx_iterator rhs) { return !(lhs == rhs); }
+
+  private:
+    value_type value_;
+};
+
+typedef vtr::Range<edge_idx_iterator> edge_idx_range;
 
 /* these are defined later, but need to declare here because it is used */
 class t_rr_node;
@@ -1206,7 +1234,7 @@ struct t_trace {
  * occ:        The current occupancy of the associated rr node              */
 struct t_rr_node_route_inf {
     int prev_node;
-    t_edge_size prev_edge;
+    RREdgeId prev_edge;
 
     float pres_cost;
     float acc_cost;

--- a/vpr/src/device/rr_graph_fwd.h
+++ b/vpr/src/device/rr_graph_fwd.h
@@ -15,8 +15,8 @@ struct rr_edge_id_tag;
 struct rr_switch_id_tag;
 struct rr_segment_id_tag;
 
-typedef vtr::StrongId<rr_node_id_tag> RRNodeId;
-typedef vtr::StrongId<rr_edge_id_tag> RREdgeId;
+typedef vtr::StrongId<rr_node_id_tag, unsigned int> RRNodeId;
+typedef vtr::StrongId<rr_edge_id_tag, unsigned int> RREdgeId;
 typedef vtr::StrongId<rr_switch_id_tag, short> RRSwitchId;
 typedef vtr::StrongId<rr_segment_id_tag, short> RRSegmentId;
 

--- a/vpr/src/route/binary_heap.cpp
+++ b/vpr/src/route/binary_heap.cpp
@@ -168,7 +168,7 @@ void BinaryHeap::invalidate_heap_entries(int sink_node, int ipin_node) {
 
     for (int i = 1; i < heap_tail_; i++) {
         if (heap_[i]->index == sink_node) {
-            if (heap_[i]->u.prev.node == ipin_node) {
+            if (heap_[i]->prev_node() == ipin_node) {
                 heap_[i]->index = OPEN; /* Invalid. */
                 break;
             }

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -134,8 +134,8 @@ class ConnectionRouter {
         //Record final link to target
         add_to_mod_list(cheapest->index);
 
-        route_inf->prev_node = cheapest->u.prev.node;
-        route_inf->prev_edge = cheapest->u.prev.edge;
+        route_inf->prev_node = cheapest->prev_node();
+        route_inf->prev_edge = cheapest->prev_edge();
         route_inf->path_cost = cheapest->cost;
         route_inf->backward_path_cost = cheapest->backward_path_cost;
     }
@@ -186,7 +186,6 @@ class ConnectionRouter {
         t_heap* current,
         const int from_node,
         const RREdgeId from_edge,
-        const t_edge_size from_node_edge_idx,
         const int to_node,
         const t_conn_cost_params cost_params,
         const t_bb bounding_box,
@@ -201,7 +200,6 @@ class ConnectionRouter {
         const int from_node,
         const int to_node,
         const RREdgeId from_edge,
-        const int iconn,
         const int target_node);
 
     // Calculates the cost of reaching to_node

--- a/vpr/src/route/heap_type.cpp
+++ b/vpr/src/route/heap_type.cpp
@@ -12,23 +12,23 @@ HeapStorage::alloc() {
 
     //Extract the head
     t_heap* temp_ptr = heap_free_head_;
-    heap_free_head_ = heap_free_head_->u.next;
+    heap_free_head_ = heap_free_head_->next_heap_item();
 
     num_heap_allocated_++;
 
     //Reset
-    temp_ptr->u.next = nullptr;
+    temp_ptr->set_next_heap_item(nullptr);
     temp_ptr->cost = 0.;
     temp_ptr->backward_path_cost = 0.;
     temp_ptr->R_upstream = 0.;
     temp_ptr->index = OPEN;
-    temp_ptr->u.prev.node = NO_PREVIOUS;
-    temp_ptr->u.prev.edge = NO_PREVIOUS;
+    temp_ptr->set_prev_node(NO_PREVIOUS);
+    temp_ptr->set_prev_edge(RREdgeId::INVALID());
     return (temp_ptr);
 }
 
 void HeapStorage::free(t_heap* hptr) {
-    hptr->u.next = heap_free_head_;
+    hptr->set_next_heap_item(heap_free_head_);
     heap_free_head_ = hptr;
     num_heap_allocated_--;
 }
@@ -40,7 +40,7 @@ void HeapStorage::free_all_memory() {
         t_heap* curr = heap_free_head_;
         while (curr) {
             t_heap* tmp = curr;
-            curr = curr->u.next;
+            curr = curr->next_heap_item();
 
             vtr::chunk_delete(tmp, &heap_ch_);
         }

--- a/vpr/src/route/heap_type.h
+++ b/vpr/src/route/heap_type.h
@@ -43,11 +43,36 @@ struct t_heap {
 
     struct t_prev {
         int node;
-        int edge;
+        unsigned int edge;
     };
 
+    t_heap* next_heap_item() const {
+        return u.next;
+    }
+
+    void set_next_heap_item(t_heap* next) {
+        u.next = next;
+    }
+
+    int prev_node() const {
+        return u.prev.node;
+    }
+
+    void set_prev_node(int prev_node) {
+        u.prev.node = prev_node;
+    }
+
+    RREdgeId prev_edge() const {
+        return RREdgeId(u.prev.edge);
+    }
+
+    void set_prev_edge(RREdgeId edge) {
+        u.prev.edge = (size_t)edge;
+    }
+
+  private:
     union {
-        t_heap* next;
+        t_heap* next = nullptr;
         t_prev prev;
     } u;
 };

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -4,6 +4,7 @@
 #include "clustered_netlist.h"
 #include "vtr_vector.h"
 #include "heap_type.h"
+#include "rr_node_fwd.h"
 
 /******* Subroutines in route_common used only by other router modules ******/
 
@@ -77,7 +78,7 @@ t_heap* prepare_to_add_node_to_heap(
     int inode,
     float total_cost,
     int prev_node,
-    int prev_edge,
+    RREdgeId prev_edge,
     float backward_path_cost,
     float R_upstream) {
     if (total_cost >= rr_node_route_inf[inode].path_cost)
@@ -87,10 +88,8 @@ t_heap* prepare_to_add_node_to_heap(
 
     hptr->index = inode;
     hptr->cost = total_cost;
-    VTR_ASSERT_SAFE(hptr->u.prev.node == NO_PREVIOUS);
-    VTR_ASSERT_SAFE(hptr->u.prev.edge == NO_PREVIOUS);
-    hptr->u.prev.node = prev_node;
-    hptr->u.prev.edge = prev_edge;
+    hptr->set_prev_node(prev_node);
+    hptr->set_prev_edge(prev_edge);
     hptr->backward_path_cost = backward_path_cost;
     hptr->R_upstream = R_upstream;
     return hptr;
@@ -104,7 +103,7 @@ void add_node_to_heap(
     int inode,
     float total_cost,
     int prev_node,
-    int prev_edge,
+    RREdgeId prev_edge,
     float backward_path_cost,
     float R_upstream) {
     t_heap* hptr = prepare_to_add_node_to_heap(
@@ -126,7 +125,7 @@ void push_back_node(
     int inode,
     float total_cost,
     int prev_node,
-    int prev_edge,
+    RREdgeId prev_edge,
     float backward_path_cost,
     float R_upstream) {
     t_heap* hptr = prepare_to_add_node_to_heap(

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -288,9 +288,9 @@ add_subtree_to_route_tree(t_heap* hptr, t_rt_node** sink_rt_node_ptr) {
 
     std::unordered_set<int> main_branch_visited;
     std::unordered_set<int> all_visited;
-    inode = hptr->u.prev.node;
-    t_edge_size iedge = hptr->u.prev.edge;
-    short iswitch = device_ctx.rr_nodes[inode].edge_switch(iedge);
+    inode = hptr->prev_node();
+    RREdgeId edge = hptr->prev_edge();
+    short iswitch = device_ctx.rr_nodes.edge_switch(edge);
 
     /* For all "new" nodes in the main path */
     // inode is node index of previous node
@@ -326,9 +326,9 @@ add_subtree_to_route_tree(t_heap* hptr, t_rt_node** sink_rt_node_ptr) {
         }
 
         downstream_rt_node = rt_node;
-        iedge = route_ctx.rr_node_route_inf[inode].prev_edge;
+        edge = route_ctx.rr_node_route_inf[inode].prev_edge;
         inode = route_ctx.rr_node_route_inf[inode].prev_node;
-        iswitch = device_ctx.rr_nodes[inode].edge_switch(iedge);
+        iswitch = device_ctx.rr_nodes.edge_switch(edge);
     }
 
     //Inode is now the branch point to the old routing; do not need
@@ -583,7 +583,7 @@ void load_route_tree_rr_route_inf(t_rt_node* root) {
     for (;;) {
         int inode = root->inode;
         route_ctx.rr_node_route_inf[inode].prev_node = NO_PREVIOUS;
-        route_ctx.rr_node_route_inf[inode].prev_edge = NO_PREVIOUS;
+        route_ctx.rr_node_route_inf[inode].prev_edge = RREdgeId::INVALID();
         // path cost should be unset
         VTR_ASSERT(std::isinf(route_ctx.rr_node_route_inf[inode].path_cost));
         VTR_ASSERT(std::isinf(route_ctx.rr_node_route_inf[inode].backward_path_cost));

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -3,6 +3,7 @@
 
 #include <exception>
 
+#include "rr_graph_fwd.h"
 #include "rr_node_fwd.h"
 #include "rr_graph2.h"
 #include "vtr_log.h"

--- a/vpr/src/route/rr_node_fwd.h
+++ b/vpr/src/route/rr_node_fwd.h
@@ -3,52 +3,10 @@
 
 #include <iterator>
 #include "vpr_types.h"
-#include "vtr_strong_id.h"
 
 //Forward declaration
 class t_rr_node;
 class t_rr_graph_storage;
 class node_idx_iterator;
-
-/*
- * StrongId's for the t_rr_node class
- */
-
-//Type tags for Ids
-struct rr_node_id_tag;
-struct rr_edge_id_tag;
-
-//A unique identifier for a node in the rr graph
-typedef vtr::StrongId<rr_node_id_tag, unsigned int> RRNodeId;
-
-//A unique identifier for an edge in the rr graph
-typedef vtr::StrongId<rr_edge_id_tag, unsigned int> RREdgeId;
-
-//An iterator that dereferences to an edge index
-//
-//Used inconjunction with vtr::Range to return ranges of edge indices
-class edge_idx_iterator : public std::iterator<std::bidirectional_iterator_tag, t_edge_size> {
-  public:
-    edge_idx_iterator(value_type init)
-        : value_(init) {}
-    iterator operator++() {
-        value_ += 1;
-        return *this;
-    }
-    iterator operator--() {
-        value_ -= 1;
-        return *this;
-    }
-    reference operator*() { return value_; }
-    pointer operator->() { return &value_; }
-
-    friend bool operator==(const edge_idx_iterator lhs, const edge_idx_iterator rhs) { return lhs.value_ == rhs.value_; }
-    friend bool operator!=(const edge_idx_iterator lhs, const edge_idx_iterator rhs) { return !(lhs == rhs); }
-
-  private:
-    value_type value_;
-};
-
-typedef vtr::Range<edge_idx_iterator> edge_idx_range;
 
 #endif


### PR DESCRIPTION
#### Description

When reviewing https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1197#discussion_r389216334 @kmurray suggested removing `iconn` from the `ConnectionRouter` completely here: https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1197

I've made that change, but done it here, because removing `iconn` is more involved because of its usage in `t_heap`.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
