### PR TITLE
Add t_rr_graph_view and have ConnectionRouter use it

### DIFF
--- a/libs/libvtrutil/src/vtr_array_view.h
+++ b/libs/libvtrutil/src/vtr_array_view.h
@@ -203,6 +203,12 @@ class array_view_id : private array_view<V> {
     key_iterator key_end() const { return key_iterator(key_type(size())); }
 };
 
+template<typename Container>
+array_view_id<typename Container::key_type, const typename Container::value_type> make_const_array_view_id(Container& container) {
+    return array_view_id<typename Container::key_type, const typename Container::value_type>(
+        container.data(), container.size());
+}
+
 } // namespace vtr
 
 #endif /* _VTR_ARRAY_VIEW_H */

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -50,10 +50,10 @@ class ConnectionRouter {
         std::vector<t_rr_node_route_inf>& rr_node_route_inf)
         : grid_(grid)
         , router_lookahead_(router_lookahead)
-        , rr_nodes_(&rr_nodes)
-        , rr_rc_data_(rr_rc_data.data())
-        , rr_switch_inf_(rr_switch_inf.data())
-        , rr_node_route_inf_(rr_node_route_inf.data())
+        , rr_nodes_(rr_nodes.view())
+        , rr_rc_data_(rr_rc_data.data(), rr_rc_data.size())
+        , rr_switch_inf_(rr_switch_inf.data(), rr_switch_inf.size())
+        , rr_node_route_inf_(rr_node_route_inf.data(), rr_node_route_inf.size())
         , router_stats_(nullptr)
         , router_debug_(false) {
         heap_.init_heap(grid);
@@ -242,10 +242,10 @@ class ConnectionRouter {
 
     const DeviceGrid& grid_;
     const RouterLookahead& router_lookahead_;
-    const t_rr_graph_storage* rr_nodes_;
-    const t_rr_rc_data* rr_rc_data_;
-    const t_rr_switch_inf* rr_switch_inf_;
-    t_rr_node_route_inf* rr_node_route_inf_;
+    const t_rr_graph_view rr_nodes_;
+    vtr::array_view<const t_rr_rc_data> rr_rc_data_;
+    vtr::array_view<const t_rr_switch_inf> rr_switch_inf_;
+    vtr::array_view<t_rr_node_route_inf> rr_node_route_inf_;
     std::vector<int> modified_rr_node_inf_;
     RouterStats* router_stats_;
     BinaryHeap heap_;

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -600,26 +600,20 @@ static short get_node_class_num(
 
 short t_rr_graph_storage::node_pin_num(RRNodeId id) const {
     return get_node_pin_num(
-        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
-            node_storage_.data(), node_storage_.size()),
-        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
-            node_ptc_.data(), node_ptc_.size()),
+        vtr::make_const_array_view_id(node_storage_),
+        vtr::make_const_array_view_id(node_ptc_),
         id);
 }
 short t_rr_graph_storage::node_track_num(RRNodeId id) const {
     return get_node_track_num(
-        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
-            node_storage_.data(), node_storage_.size()),
-        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
-            node_ptc_.data(), node_ptc_.size()),
+        vtr::make_const_array_view_id(node_storage_),
+        vtr::make_const_array_view_id(node_ptc_),
         id);
 }
 short t_rr_graph_storage::node_class_num(RRNodeId id) const {
     return get_node_class_num(
-        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
-            node_storage_.data(), node_storage_.size()),
-        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
-            node_ptc_.data(), node_ptc_.size()),
+        vtr::make_const_array_view_id(node_storage_),
+        vtr::make_const_array_view_id(node_ptc_),
         id);
 }
 
@@ -695,25 +689,11 @@ t_rr_graph_view t_rr_graph_storage::view() const {
     VTR_ASSERT(partitioned_);
     VTR_ASSERT(node_storage_.size() == node_fan_in_.size());
     return t_rr_graph_view(
-        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
-            node_storage_.data(),
-            node_storage_.size()),
-        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
-            node_ptc_.data(),
-            node_ptc_.size()),
-        vtr::array_view_id<RRNodeId, const RREdgeId>(
-            node_first_edge_.data(),
-            node_first_edge_.size()),
-        vtr::array_view_id<RRNodeId, const t_edge_size>(
-            node_fan_in_.data(),
-            node_fan_in_.size()),
-        vtr::array_view_id<RREdgeId, const RRNodeId>(
-            edge_src_node_.data(),
-            edge_src_node_.size()),
-        vtr::array_view_id<RREdgeId, const RRNodeId>(
-            edge_dest_node_.data(),
-            edge_dest_node_.size()),
-        vtr::array_view_id<RREdgeId, const short>(
-            edge_switch_.data(),
-            edge_switch_.size()));
+        vtr::make_const_array_view_id(node_storage_),
+        vtr::make_const_array_view_id(node_ptc_),
+        vtr::make_const_array_view_id(node_first_edge_),
+        vtr::make_const_array_view_id(node_fan_in_),
+        vtr::make_const_array_view_id(edge_src_node_),
+        vtr::make_const_array_view_id(edge_dest_node_),
+        vtr::make_const_array_view_id(edge_switch_));
 }

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -533,6 +533,9 @@ bool t_rr_graph_storage::validate() const {
 const char* t_rr_graph_storage::node_type_string(RRNodeId id) const {
     return rr_node_typename[node_type(id)];
 }
+const char* t_rr_graph_view::node_type_string(RRNodeId id) const {
+    return rr_node_typename[node_type(id)];
+}
 
 void t_rr_graph_storage::set_node_ptc_num(RRNodeId id, short new_ptc_num) {
     node_ptc_[id].ptc_.pin_num = new_ptc_num; //TODO: eventually remove
@@ -633,4 +636,53 @@ void t_rr_graph_storage::set_node_side(RRNodeId id, e_side new_side) {
         VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to set RR node 'side' for non-channel type '%s'", node_type_string(id));
     }
     node_storage_[id].dir_side_.side = new_side;
+}
+
+short t_rr_graph_view::node_ptc_num(RRNodeId id) const {
+    return node_ptc_[id].ptc_.pin_num;
+}
+short t_rr_graph_view::node_pin_num(RRNodeId id) const {
+    if (node_type(id) != IPIN && node_type(id) != OPIN) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'pin_num' for non-IPIN/OPIN type '%s'", node_type_string(id));
+    }
+    return node_ptc_[id].ptc_.pin_num;
+}
+short t_rr_graph_view::node_track_num(RRNodeId id) const {
+    if (node_type(id) != CHANX && node_type(id) != CHANY) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'track_num' for non-CHANX/CHANY type '%s'", node_type_string(id));
+    }
+    return node_ptc_[id].ptc_.track_num;
+}
+short t_rr_graph_view::node_class_num(RRNodeId id) const {
+    if (node_type(id) != SOURCE && node_type(id) != SINK) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'class_num' for non-SOURCE/SINK type '%s'", node_type_string(id));
+    }
+    return node_ptc_[id].ptc_.class_num;
+}
+
+t_rr_graph_view t_rr_graph_storage::view() const {
+    VTR_ASSERT(partitioned_);
+    VTR_ASSERT(node_storage_.size() == node_fan_in_.size());
+    return t_rr_graph_view(
+        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
+            node_storage_.data(),
+            node_storage_.size()),
+        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
+            node_ptc_.data(),
+            node_ptc_.size()),
+        vtr::array_view_id<RRNodeId, const RREdgeId>(
+            node_first_edge_.data(),
+            node_first_edge_.size()),
+        vtr::array_view_id<RRNodeId, const t_edge_size>(
+            node_fan_in_.data(),
+            node_fan_in_.size()),
+        vtr::array_view_id<RREdgeId, const RRNodeId>(
+            edge_src_node_.data(),
+            edge_src_node_.size()),
+        vtr::array_view_id<RREdgeId, const RRNodeId>(
+            edge_dest_node_.data(),
+            edge_dest_node_.size()),
+        vtr::array_view_id<RREdgeId, const short>(
+            edge_switch_.data(),
+            edge_switch_.size()));
 }

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -564,23 +564,63 @@ void t_rr_graph_storage::set_node_class_num(RRNodeId id, short new_class_num) {
 short t_rr_graph_storage::node_ptc_num(RRNodeId id) const {
     return node_ptc_[id].ptc_.pin_num;
 }
-short t_rr_graph_storage::node_pin_num(RRNodeId id) const {
-    if (node_type(id) != IPIN && node_type(id) != OPIN) {
-        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'pin_num' for non-IPIN/OPIN type '%s'", node_type_string(id));
+
+static short get_node_pin_num(
+    vtr::array_view_id<RRNodeId, const t_rr_node_data> node_storage,
+    vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data> node_ptc,
+    RRNodeId id) {
+    auto node_type = node_storage[id].type_;
+    if (node_type != IPIN && node_type != OPIN) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'pin_num' for non-IPIN/OPIN type '%s'", rr_node_typename[node_type]);
     }
-    return node_ptc_[id].ptc_.pin_num;
+    return node_ptc[id].ptc_.pin_num;
+}
+
+static short get_node_track_num(
+    vtr::array_view_id<RRNodeId, const t_rr_node_data> node_storage,
+    vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data> node_ptc,
+    RRNodeId id) {
+    auto node_type = node_storage[id].type_;
+    if (node_type != CHANX && node_type != CHANY) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'track_num' for non-CHANX/CHANY type '%s'", rr_node_typename[node_type]);
+    }
+    return node_ptc[id].ptc_.track_num;
+}
+
+static short get_node_class_num(
+    vtr::array_view_id<RRNodeId, const t_rr_node_data> node_storage,
+    vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data> node_ptc,
+    RRNodeId id) {
+    auto node_type = node_storage[id].type_;
+    if (node_type != SOURCE && node_type != SINK) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'class_num' for non-SOURCE/SINK type '%s'", rr_node_typename[node_type]);
+    }
+    return node_ptc[id].ptc_.class_num;
+}
+
+short t_rr_graph_storage::node_pin_num(RRNodeId id) const {
+    return get_node_pin_num(
+        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
+            node_storage_.data(), node_storage_.size()),
+        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
+            node_ptc_.data(), node_ptc_.size()),
+        id);
 }
 short t_rr_graph_storage::node_track_num(RRNodeId id) const {
-    if (node_type(id) != CHANX && node_type(id) != CHANY) {
-        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'track_num' for non-CHANX/CHANY type '%s'", node_type_string(id));
-    }
-    return node_ptc_[id].ptc_.track_num;
+    return get_node_track_num(
+        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
+            node_storage_.data(), node_storage_.size()),
+        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
+            node_ptc_.data(), node_ptc_.size()),
+        id);
 }
 short t_rr_graph_storage::node_class_num(RRNodeId id) const {
-    if (node_type(id) != SOURCE && node_type(id) != SINK) {
-        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'class_num' for non-SOURCE/SINK type '%s'", node_type_string(id));
-    }
-    return node_ptc_[id].ptc_.class_num;
+    return get_node_class_num(
+        vtr::array_view_id<RRNodeId, const t_rr_node_data>(
+            node_storage_.data(), node_storage_.size()),
+        vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data>(
+            node_ptc_.data(), node_ptc_.size()),
+        id);
 }
 
 void t_rr_graph_storage::set_node_type(RRNodeId id, t_rr_type new_type) {
@@ -642,22 +682,13 @@ short t_rr_graph_view::node_ptc_num(RRNodeId id) const {
     return node_ptc_[id].ptc_.pin_num;
 }
 short t_rr_graph_view::node_pin_num(RRNodeId id) const {
-    if (node_type(id) != IPIN && node_type(id) != OPIN) {
-        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'pin_num' for non-IPIN/OPIN type '%s'", node_type_string(id));
-    }
-    return node_ptc_[id].ptc_.pin_num;
+    return get_node_pin_num(node_storage_, node_ptc_, id);
 }
 short t_rr_graph_view::node_track_num(RRNodeId id) const {
-    if (node_type(id) != CHANX && node_type(id) != CHANY) {
-        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'track_num' for non-CHANX/CHANY type '%s'", node_type_string(id));
-    }
-    return node_ptc_[id].ptc_.track_num;
+    return get_node_track_num(node_storage_, node_ptc_, id);
 }
 short t_rr_graph_view::node_class_num(RRNodeId id) const {
-    if (node_type(id) != SOURCE && node_type(id) != SINK) {
-        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'class_num' for non-SOURCE/SINK type '%s'", node_type_string(id));
-    }
-    return node_ptc_[id].ptc_.class_num;
+    return get_node_class_num(node_storage_, node_ptc_, id);
 }
 
 t_rr_graph_view t_rr_graph_storage::view() const {

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -620,6 +620,14 @@ class t_rr_graph_storage {
     bool partitioned_;
 };
 
+// t_rr_graph_view is a read-only version of t_rr_graph_storage that only
+// uses pointers and sizes to rr graph data.
+//
+// t_rr_graph_view enables efficient access to RR graph storage without owning
+// the underlying storage.
+//
+// Because t_rr_graph_view only uses pointers and sizes, it is suitable for
+// use with purely mmap'd data.
 class t_rr_graph_view {
   public:
     t_rr_graph_view();
@@ -696,6 +704,11 @@ class t_rr_graph_view {
     short node_track_num(RRNodeId id) const; //Same as ptc_num() but checks that type() is consistent
     short node_class_num(RRNodeId id) const; //Same as ptc_num() but checks that type() is consistent
 
+    /* Retrieve fan_in for RRNodeId. */
+    t_edge_size fan_in(RRNodeId id) const {
+        return node_fan_in_[id];
+    }
+
     // This prefetechs hot RR node data required for optimization.
     //
     // Note: This is optional, but may lower time spent on memory stalls in
@@ -721,11 +734,6 @@ class t_rr_graph_view {
     // Get the switch used for the specified edge.
     short edge_switch(RREdgeId edge) const {
         return edge_switch_[edge];
-    }
-
-    /* Retrieve fan_in for RRNodeId. */
-    t_edge_size fan_in(RRNodeId id) const {
-        return node_fan_in_[id];
     }
 
   private:

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -177,17 +177,17 @@ class t_rr_graph_storage {
     }
 
     e_direction node_direction(RRNodeId id) const {
-        if (node_type(id) != CHANX && node_type(id) != CHANY) {
-            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'direction' for non-channel type '%s'", node_type_string(id));
-        }
-        return node_storage_[id].dir_side_.direction;
+        return get_node_direction(
+            vtr::array_view_id<RRNodeId, const t_rr_node_data>(
+                node_storage_.data(), node_storage_.size()),
+            id);
     }
 
     e_side node_side(RRNodeId id) const {
-        if (node_type(id) != IPIN && node_type(id) != OPIN) {
-            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'side' for non-IPIN/OPIN type '%s'", node_type_string(id));
-        }
-        return node_storage_[id].dir_side_.side;
+        return get_node_side(
+            vtr::array_view_id<RRNodeId, const t_rr_node_data>(
+                node_storage_.data(), node_storage_.size()),
+            id);
     }
 
     /* PTC get methods */
@@ -544,6 +544,30 @@ class t_rr_graph_storage {
      * have a complete rr-graph and not called often.*/
     void init_fan_in();
 
+    static inline e_direction get_node_direction(
+        vtr::array_view_id<RRNodeId, const t_rr_node_data> node_storage,
+        RRNodeId id) {
+        auto& node_data = node_storage[id];
+        if (node_data.type_ != CHANX && node_data.type_ != CHANY) {
+            VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
+                            "Attempted to access RR node 'direction' for non-channel type '%s'",
+                            rr_node_typename[node_data.type_]);
+        }
+        return node_storage[id].dir_side_.direction;
+    }
+
+    static inline e_side get_node_side(
+        vtr::array_view_id<RRNodeId, const t_rr_node_data> node_storage,
+        RRNodeId id) {
+        auto& node_data = node_storage[id];
+        if (node_data.type_ != IPIN && node_data.type_ != OPIN) {
+            VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
+                            "Attempted to access RR node 'side' for non-IPIN/OPIN type '%s'",
+                            rr_node_typename[node_data.type_]);
+        }
+        return node_storage[id].dir_side_.side;
+    }
+
   private:
     friend struct edge_swapper;
     friend class edge_sort_iterator;
@@ -685,17 +709,11 @@ class t_rr_graph_view {
     }
 
     e_direction node_direction(RRNodeId id) const {
-        if (node_type(id) != CHANX && node_type(id) != CHANY) {
-            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'direction' for non-channel type '%s'", node_type_string(id));
-        }
-        return node_storage_[id].dir_side_.direction;
+        return t_rr_graph_storage::get_node_direction(node_storage_, id);
     }
 
     e_side node_side(RRNodeId id) const {
-        if (node_type(id) != IPIN && node_type(id) != OPIN) {
-            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Attempted to access RR node 'side' for non-IPIN/OPIN type '%s'", node_type_string(id));
-        }
-        return node_storage_[id].dir_side_.side;
+        return t_rr_graph_storage::get_node_side(node_storage_, id);
     }
 
     /* PTC get methods */


### PR DESCRIPTION
#### Description

t_rr_graph_view is a purely read-only view into the RR graph object.  The justification for the view class is two fold:
 - Remove indirection overhead present in using a reference to `t_rr_graph_storage`
 - Pave the way for a fully const copy of the RR graph to be read from disk via mmap.  This would enable 0 overhead for loading rr graphs.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
