### PR TITLE
A New Simulated Annealing Schedule

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -680,46 +680,6 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
 
     **Default:** ``0.8``
 
-.. option:: --alpha_min <float>
-
-    The minimum (starting) update factor (alpha) used.
-    Ranges between 0 and alpha_max.
-    Setting this flag selects Dusty's annealing schedule.
-
-    **Default:** ``0.2``
-
-.. option:: --alpha_max <float>
-
-    The maximum (stopping) update factor (alpha) used after which simulated annealing will complete.
-    Ranges between alpha_min and 1.
-    Setting this flag selects Dusty's annealing schedule.
-
-    **Default:** ``0.9``
-
-.. option:: --alpha_decay <float>
-
-    The rate at which alpha will approach 1: alpha(n) = 1 - (1 - alpha(n-1)) * alpha_decay
-    Ranges between 0 and 1.
-    Setting this flag selects Dusty's annealing schedule.
-
-    **Default:** ``0.7``
-
-.. option:: --anneal_success_min <float>
-
-   The minimum success ratio after which the temperature will reset to maintain the target success ratio.
-   Ranges between 0 and anneal_success_target.
-   Setting this flag selects Dusty's annealing schedule.
-
-    **Default:** ``0.1``
-
-.. option:: --anneal_success_target <float>
-
-   The temperature after each reset is selected to keep this target success ratio.
-   Ranges between anneal_success_target and 1.
-   Setting this flag selects Dusty's annealing schedule.
-
-    **Default:** ``0.25``
-
 .. option:: --fix_pins {free | random | <file.pads>}
 
     Controls how the placer handles I/O pads during placement.
@@ -756,6 +716,44 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
     For example, a value of 0.1 means 10% of moves are allowed to ignore the region limit.
 
     **Default:** ``0.0``
+
+.. _dusty_sa_options:
+Setting any of the following options selects `Dusty's annealing schedule <dusty_sa.rst>`_.
+
+.. option:: --alpha_min <float>
+
+    The minimum (starting) update factor (alpha) used.
+    Ranges between 0 and alpha_max.
+
+    **Default:** ``0.2``
+
+.. option:: --alpha_max <float>
+
+    The maximum (stopping) update factor (alpha) used after which simulated annealing will complete.
+    Ranges between alpha_min and 1.
+
+    **Default:** ``0.9``
+
+.. option:: --alpha_decay <float>
+
+    The rate at which alpha will approach 1: alpha(n) = 1 - (1 - alpha(n-1)) * alpha_decay
+    Ranges between 0 and 1.
+
+    **Default:** ``0.7``
+
+.. option:: --anneal_success_min <float>
+
+   The minimum success ratio after which the temperature will reset to maintain the target success ratio.
+   Ranges between 0 and anneal_success_target.
+
+    **Default:** ``0.1``
+
+.. option:: --anneal_success_target <float>
+
+   The temperature after each reset is selected to keep this target success ratio.
+   Ranges between anneal_success_target and 1.
+
+    **Default:** ``0.25``
 
 .. _timing_driven_placer_options:
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -680,6 +680,46 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
 
     **Default:** ``0.8``
 
+.. option:: --alpha_min <float>
+
+    The minimum (starting) update factor (alpha) used.
+    Ranges between 0 and alpha_max.
+    Setting this flag selects Dusty's annealing schedule.
+
+    **Default:** ``0.2``
+
+.. option:: --alpha_max <float>
+
+    The maximum (stopping) update factor (alpha) used after which simulated annealing will complete.
+    Ranges between alpha_min and 1.
+    Setting this flag selects Dusty's annealing schedule.
+
+    **Default:** ``0.9``
+
+.. option:: --alpha_decay <float>
+
+    The rate at which alpha will approach 1: alpha(n) = 1 - (1 - alpha(n-1)) * alpha_decay
+    Ranges between 0 and 1.
+    Setting this flag selects Dusty's annealing schedule.
+
+    **Default:** ``0.7``
+
+.. option:: --anneal_success_min <float>
+
+   The minimum success ratio after which the temperature will reset to maintain the target success ratio.
+   Ranges between 0 and anneal_success_target.
+   Setting this flag selects Dusty's annealing schedule.
+
+    **Default:** ``0.1``
+
+.. option:: --anneal_success_target <float>
+
+   The temperature after each reset is selected to keep this target success ratio.
+   Ranges between anneal_success_target and 1.
+   Setting this flag selects Dusty's annealing schedule.
+
+    **Default:** ``0.25``
+
 .. option:: --fix_pins {free | random | <file.pads>}
 
     Controls how the placer handles I/O pads during placement.

--- a/doc/src/vpr/dusty_sa.rst
+++ b/doc/src/vpr/dusty_sa.rst
@@ -1,0 +1,22 @@
+Dusty's Simulated Annealing Schedule
+====================================
+
+This simulated annealing schedule is designed to quickly characterize the search space and maintain a target success ratio (accepted moves.)
+
+It starts at the minimum alpha (``--alpha_min``) to allow it to quickly find the target.
+
+For each alpha, the temperature decays by a factor of alpha after each outer loop iteration.
+
+The temperature before which the success ratio drops below the target (``--anneal_success_target``) is recorded; after hitting the minimum success ratio (``--anneal_success_min``), the temperature resets to a little before recorded temperature, and alpha parameter itself decays according to ``--alpha_decay``.
+
+The effect of this is many fast, but slowing sweeps in temperature, focused where they can make the most effective progress. Unlike fixed and adaptive schedules that monotonically decrease temperature, this allows the global properties of the search space to affect the schedule.
+
+In addition, move_lim (which controls the number of iterations in the inner loop) is scaled with the target success ratio over the current success ratio, which reduces the time to reach the target ratio.
+
+The schedule terminates when the maximum alpha (``--alpha_max``) is reached. Termination is ensured by the narrowing range between the recorded upper temperature and the minimum success ratio, which will eventually cause alpha to reach its minimum.
+
+This algorithm was inspired by Lester Ingber's adaptive simulated annealing algorithm [ASA93]_.
+
+See ``update_state()`` in ``place.cpp`` for the algorithm details.
+
+.. [ASA93] Ingber, Lester. "Adaptive simulated annealing (ASA)." Global optimization C-code, Caltech Alumni Association, Pasadena, CA (1993).

--- a/doc/src/vpr/dusty_sa.rst
+++ b/doc/src/vpr/dusty_sa.rst
@@ -13,7 +13,7 @@ The effect of this is many fast, but slowing sweeps in temperature, focused wher
 
 In addition, move_lim (which controls the number of iterations in the inner loop) is scaled with the target success ratio over the current success ratio, which reduces the time to reach the target ratio.
 
-The schedule terminates when the maximum alpha (``--alpha_max``) is reached. Termination is ensured by the narrowing range between the recorded upper temperature and the minimum success ratio, which will eventually cause alpha to reach its minimum.
+The schedule terminates when the maximum alpha (``--alpha_max``) is reached. Termination is ensured by the narrowing range between the recorded upper temperature and the minimum success ratio, which will eventually cause alpha to reach its maximum.
 
 This algorithm was inspired by Lester Ingber's adaptive simulated annealing algorithm [ASA93]_.
 

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -420,6 +420,31 @@ static void SetupAnnealSched(const t_options& Options,
         VPR_FATAL_ERROR(VPR_ERROR_OTHER, "inner_num must be greater than 0.\n");
     }
 
+    AnnealSched->alpha_min = Options.PlaceAlphaMin;
+    if (AnnealSched->alpha_min >= 1 || AnnealSched->alpha_min <= 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "alpha_min must be between 0 and 1 exclusive.\n");
+    }
+
+    AnnealSched->alpha_max = Options.PlaceAlphaMax;
+    if (AnnealSched->alpha_max >= 1 || AnnealSched->alpha_max <= AnnealSched->alpha_min) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "alpha_max must be between alpha_min and 1 exclusive.\n");
+    }
+
+    AnnealSched->alpha_decay = Options.PlaceAlphaDecay;
+    if (AnnealSched->alpha_decay >= 1 || AnnealSched->alpha_decay <= 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "alpha_decay must be between 0 and 1 exclusive.\n");
+    }
+
+    AnnealSched->restart_filter = Options.PlaceRestartFilter;
+    if (AnnealSched->restart_filter >= 1 || AnnealSched->restart_filter <= 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "restart_filter must be between 0 and 1 exclusive.\n");
+    }
+
+    AnnealSched->wait = Options.PlaceWait;
+    if (AnnealSched->wait < 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "wait must not be negative.\n");
+    }
+
     AnnealSched->type = Options.anneal_sched_type;
 }
 

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -435,14 +435,14 @@ static void SetupAnnealSched(const t_options& Options,
         VPR_FATAL_ERROR(VPR_ERROR_OTHER, "alpha_decay must be between 0 and 1 exclusive.\n");
     }
 
-    AnnealSched->restart_filter = Options.PlaceRestartFilter;
-    if (AnnealSched->restart_filter >= 1 || AnnealSched->restart_filter <= 0) {
-        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "restart_filter must be between 0 and 1 exclusive.\n");
+    AnnealSched->success_min = Options.PlaceSuccessMin;
+    if (AnnealSched->success_min >= 1 || AnnealSched->success_min <= 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "success_min must be between 0 and 1 exclusive.\n");
     }
 
-    AnnealSched->wait = Options.PlaceWait;
-    if (AnnealSched->wait < 0) {
-        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "wait must not be negative.\n");
+    AnnealSched->success_target = Options.PlaceSuccessTarget;
+    if (AnnealSched->success_target >= 1 || AnnealSched->success_target <= 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "success_target must be between 0 and 1 exclusive.\n");
     }
 
     AnnealSched->type = Options.anneal_sched_type;

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -155,6 +155,9 @@ static void ShowAnnealSched(const t_annealing_sched& AnnealSched) {
         case USER_SCHED:
             VTR_LOG("USER_SCHED\n");
             break;
+        case DUSTY_SCHED:
+            VTR_LOG("DUSTY_SCHED\n");
+            break;
         default:
             VTR_LOG_ERROR("Unknown annealing schedule\n");
     }
@@ -165,6 +168,12 @@ static void ShowAnnealSched(const t_annealing_sched& AnnealSched) {
         VTR_LOG("AnnealSched.init_t: %f\n", AnnealSched.init_t);
         VTR_LOG("AnnealSched.alpha_t: %f\n", AnnealSched.alpha_t);
         VTR_LOG("AnnealSched.exit_t: %f\n", AnnealSched.exit_t);
+    } else if (DUSTY_SCHED == AnnealSched.type) {
+        VTR_LOG("AnnealSched.alpha_min: %f\n", AnnealSched.alpha_min);
+        VTR_LOG("AnnealSched.alpha_max: %f\n", AnnealSched.alpha_max);
+        VTR_LOG("AnnealSched.alpha_decay: %f\n", AnnealSched.alpha_decay);
+        VTR_LOG("AnnealSched.success_min: %f\n", AnnealSched.success_min);
+        VTR_LOG("AnnealSched.success_target: %f\n", AnnealSched.success_target);
     }
 }
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2222,19 +2222,19 @@ void set_conditional_defaults(t_options& args) {
         args.quench_recompute_divider.set(args.inner_loop_recompute_divider, Provenance::INFERRED);
     }
 
-    //Are we using the automatic, or user-specified annealing schedule?
-    if (args.PlaceAlphaMin.provenance() == Provenance::SPECIFIED
+    //Which schedule?
+    if (args.PlaceAlphaMin.provenance() == Provenance::SPECIFIED // Any of these flags select Dusty's schedule
         || args.PlaceAlphaMax.provenance() == Provenance::SPECIFIED
         || args.PlaceAlphaDecay.provenance() == Provenance::SPECIFIED
         || args.PlaceSuccessMin.provenance() == Provenance::SPECIFIED
         || args.PlaceSuccessTarget.provenance() == Provenance::SPECIFIED) {
         args.anneal_sched_type.set(DUSTY_SCHED, Provenance::INFERRED);
-    } else if (args.PlaceInitT.provenance() == Provenance::SPECIFIED
+    } else if (args.PlaceInitT.provenance() == Provenance::SPECIFIED // Any of these flags select a manual schedule
                || args.PlaceExitT.provenance() == Provenance::SPECIFIED
                || args.PlaceAlphaT.provenance() == Provenance::SPECIFIED) {
         args.anneal_sched_type.set(USER_SCHED, Provenance::INFERRED);
     } else {
-        args.anneal_sched_type.set(AUTO_SCHED, Provenance::INFERRED);
+        args.anneal_sched_type.set(AUTO_SCHED, Provenance::INFERRED); // Otherwise use the automatic schedule
     }
 
     //Are the pad locations specified?

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1580,20 +1580,20 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     place_grp.add_argument(args.PlaceAlphaDecay, "--alpha_decay")
         .help(
-            "The value that alpha is scaled by.")
+            "The value that alpha is scaled by when successful.")
         .default_value("0.9")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    place_grp.add_argument(args.PlaceRestartFilter, "--anneal_restart_filter")
+    place_grp.add_argument(args.PlaceSuccessMin, "--anneal_success_min")
         .help(
-            "Filters the selected restart temperature, ranges 0 (no update) to 1 (use last successful temperature.)")
-        .default_value("0.9")
+            "Minimum success ratio when annealing before restarting.")
+        .default_value("0.01")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    place_grp.add_argument(args.PlaceWait, "--anneal_wait")
+    place_grp.add_argument(args.PlaceSuccessTarget, "--anneal_success_target")
         .help(
-            "Number of unsuccessful iterations before restarting.")
-        .default_value("2")
+            "Target success ratio when annealing.")
+        .default_value("0.44")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.pad_loc_file, "--fix_pins")
@@ -2226,8 +2226,8 @@ void set_conditional_defaults(t_options& args) {
     if (args.PlaceAlphaMin.provenance() == Provenance::SPECIFIED
         || args.PlaceAlphaMax.provenance() == Provenance::SPECIFIED
         || args.PlaceAlphaDecay.provenance() == Provenance::SPECIFIED
-        || args.PlaceRestartFilter.provenance() == Provenance::SPECIFIED
-        || args.PlaceWait.provenance() == Provenance::SPECIFIED) {
+        || args.PlaceSuccessMin.provenance() == Provenance::SPECIFIED
+        || args.PlaceSuccessTarget.provenance() == Provenance::SPECIFIED) {
         args.anneal_sched_type.set(DUSTY_SCHED, Provenance::INFERRED);
     } else if (args.PlaceInitT.provenance() == Provenance::SPECIFIED
                || args.PlaceExitT.provenance() == Provenance::SPECIFIED

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1575,25 +1575,25 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
     place_grp.add_argument(args.PlaceAlphaMax, "--alpha_max")
         .help(
             "Maximum (stopping) value of alpha.")
-        .default_value("0.99")
+        .default_value("0.9")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceAlphaDecay, "--alpha_decay")
         .help(
             "The value that alpha is scaled by when successful.")
-        .default_value("0.9")
+        .default_value("0.7")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceSuccessMin, "--anneal_success_min")
         .help(
             "Minimum success ratio when annealing before restarting.")
-        .default_value("0.01")
+        .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceSuccessTarget, "--anneal_success_target")
         .help(
             "Target success ratio when annealing.")
-        .default_value("0.44")
+        .default_value("0.25")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.pad_loc_file, "--fix_pins")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1568,31 +1568,31 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     place_grp.add_argument(args.PlaceAlphaMin, "--alpha_min")
         .help(
-            "Minimum (starting) value of alpha.")
+            "For placement using Dusty's annealing schedule. Minimum (starting) value of alpha.")
         .default_value("0.2")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceAlphaMax, "--alpha_max")
         .help(
-            "Maximum (stopping) value of alpha.")
+            "For placement using Dusty's annealing schedule. Maximum (stopping) value of alpha.")
         .default_value("0.9")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceAlphaDecay, "--alpha_decay")
         .help(
-            "The value that alpha is scaled by after reset.")
+            "For placement using Dusty's annealing schedule. The value that alpha is scaled by after reset.")
         .default_value("0.7")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceSuccessMin, "--anneal_success_min")
         .help(
-            "Minimum success ratio when annealing before resetting the temperature to maintain the target success ratio.")
+            "For placement using Dusty's annealing schedule. Minimum success ratio when annealing before resetting the temperature to maintain the target success ratio.")
         .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceSuccessTarget, "--anneal_success_target")
         .help(
-            "Target success ratio when annealing.")
+            "For placement using Dusty's annealing schedule. Target success ratio when annealing.")
         .default_value("0.25")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1566,6 +1566,36 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("0.8")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    place_grp.add_argument(args.PlaceAlphaMin, "--alpha_min")
+        .help(
+            "Minimum (starting) value of alpha.")
+        .default_value("0.2")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    place_grp.add_argument(args.PlaceAlphaMax, "--alpha_max")
+        .help(
+            "Maximum (stopping) value of alpha.")
+        .default_value("0.99")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    place_grp.add_argument(args.PlaceAlphaDecay, "--alpha_decay")
+        .help(
+            "The value that alpha is scaled by.")
+        .default_value("0.9")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    place_grp.add_argument(args.PlaceRestartFilter, "--anneal_restart_filter")
+        .help(
+            "Filters the selected restart temperature, ranges 0 (no update) to 1 (use last successful temperature.)")
+        .default_value("0.9")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    place_grp.add_argument(args.PlaceWait, "--anneal_wait")
+        .help(
+            "Number of unsuccessful iterations before restarting.")
+        .default_value("2")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     place_grp.add_argument(args.pad_loc_file, "--fix_pins")
         .help(
             "Fixes I/O pad locations during placement. Valid options:\n"
@@ -2193,9 +2223,15 @@ void set_conditional_defaults(t_options& args) {
     }
 
     //Are we using the automatic, or user-specified annealing schedule?
-    if (args.PlaceInitT.provenance() == Provenance::SPECIFIED
-        || args.PlaceExitT.provenance() == Provenance::SPECIFIED
-        || args.PlaceAlphaT.provenance() == Provenance::SPECIFIED) {
+    if (args.PlaceAlphaMin.provenance() == Provenance::SPECIFIED
+        || args.PlaceAlphaMax.provenance() == Provenance::SPECIFIED
+        || args.PlaceAlphaDecay.provenance() == Provenance::SPECIFIED
+        || args.PlaceRestartFilter.provenance() == Provenance::SPECIFIED
+        || args.PlaceWait.provenance() == Provenance::SPECIFIED) {
+        args.anneal_sched_type.set(DUSTY_SCHED, Provenance::INFERRED);
+    } else if (args.PlaceInitT.provenance() == Provenance::SPECIFIED
+               || args.PlaceExitT.provenance() == Provenance::SPECIFIED
+               || args.PlaceAlphaT.provenance() == Provenance::SPECIFIED) {
         args.anneal_sched_type.set(USER_SCHED, Provenance::INFERRED);
     } else {
         args.anneal_sched_type.set(AUTO_SCHED, Provenance::INFERRED);

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1580,13 +1580,13 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     place_grp.add_argument(args.PlaceAlphaDecay, "--alpha_decay")
         .help(
-            "The value that alpha is scaled by when successful.")
+            "The value that alpha is scaled by after reset.")
         .default_value("0.7")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceSuccessMin, "--anneal_success_min")
         .help(
-            "Minimum success ratio when annealing before restarting.")
+            "Minimum success ratio when annealing before resetting the temperature to maintain the target success ratio.")
         .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -100,8 +100,8 @@ struct t_options {
     argparse::ArgValue<float> PlaceAlphaMin;
     argparse::ArgValue<float> PlaceAlphaMax;
     argparse::ArgValue<float> PlaceAlphaDecay;
-    argparse::ArgValue<float> PlaceRestartFilter;
-    argparse::ArgValue<int> PlaceWait;
+    argparse::ArgValue<float> PlaceSuccessMin;
+    argparse::ArgValue<float> PlaceSuccessTarget;
     argparse::ArgValue<sched_type> anneal_sched_type;
     argparse::ArgValue<e_place_algorithm> PlaceAlgorithm;
     argparse::ArgValue<e_pad_loc_type> pad_loc_type;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -97,6 +97,11 @@ struct t_options {
     argparse::ArgValue<float> PlaceInitT;
     argparse::ArgValue<float> PlaceExitT;
     argparse::ArgValue<float> PlaceAlphaT;
+    argparse::ArgValue<float> PlaceAlphaMin;
+    argparse::ArgValue<float> PlaceAlphaMax;
+    argparse::ArgValue<float> PlaceAlphaDecay;
+    argparse::ArgValue<float> PlaceRestartFilter;
+    argparse::ArgValue<int> PlaceWait;
     argparse::ArgValue<sched_type> anneal_sched_type;
     argparse::ArgValue<e_place_algorithm> PlaceAlgorithm;
     argparse::ArgValue<e_pad_loc_type> pad_loc_type;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -486,6 +486,7 @@ enum class e_timing_update_type {
 /* Timing data structures end */
 enum sched_type {
     AUTO_SCHED,
+    DUSTY_SCHED,
     USER_SCHED
 };
 /* Annealing schedule */
@@ -806,6 +807,18 @@ struct t_annealing_sched {
     float init_t;
     float alpha_t;
     float exit_t;
+
+    /* Parameters for DUSTY_SCHED                                         *
+     * The alpha ranges from alpha_min to alpha_max, decaying each        *
+     * iteration by `alpha_decay`.                                        *
+     * `restart_filter` is the low-pass coefficient (EWMA) for updating   *
+     * the new starting temperature for each alpha.                       *
+     * Give up after `wait` alphas.                                       */
+    float alpha_min;
+    float alpha_max;
+    float alpha_decay;
+    float restart_filter;
+    int wait;
 };
 
 /* Various options for the placer.                                           *

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -817,8 +817,8 @@ struct t_annealing_sched {
     float alpha_min;
     float alpha_max;
     float alpha_decay;
-    float restart_filter;
-    int wait;
+    float success_min;
+    float success_target;
 };
 
 /* Various options for the placer.                                           *

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -353,7 +353,7 @@ static float starting_t(t_placer_costs* costs,
                         t_pl_blocks_to_be_moved& blocks_affected,
                         const t_placer_opts& placer_opts);
 
-static bool update_state(t_annealing_state* state, float success_rat, const t_placer_opts& placer_opts, const t_placer_costs& costs, const t_annealing_sched& annealing_sched);
+static bool update_state(t_annealing_state* state, float success_rat, const t_placer_costs& costs, const t_annealing_sched& annealing_sched);
 
 static void update_rlim(float* rlim, float success_rat, const DeviceGrid& grid);
 
@@ -813,7 +813,7 @@ void try_place(const t_placer_opts& placer_opts,
             print_clb_placement("first_iteration_clb_placement.echo");
         }
 #endif
-    } while (update_state(&state, success_rat, placer_opts, costs, annealing_sched));
+    } while (update_state(&state, success_rat, costs, annealing_sched));
     /* Outer loop of the simmulated annealing ends */
 
     auto pre_quench_timing_stats = timing_ctx.stats;
@@ -1206,7 +1206,7 @@ static void update_rlim(float* rlim, float success_rat, const DeviceGrid& grid) 
 }
 
 /* Update the temperature according to the annealing schedule selected. */
-static bool update_state(t_annealing_state* state, float success_rat, const t_placer_opts& placer_opts, const t_placer_costs& costs, const t_annealing_sched& annealing_sched) {
+static bool update_state(t_annealing_state* state, float success_rat, const t_placer_costs& costs, const t_annealing_sched& annealing_sched) {
     /* Return `false` when the exit criterion is met. */
     if (annealing_sched.type == USER_SCHED) {
         state->t *= annealing_sched.alpha_t;

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1221,7 +1221,7 @@ static bool update_state(t_annealing_state* state, float success_rat, const t_pl
     bool restart_temp = state->t < t_exit || std::isnan(t_exit); //May get nan if there are no nets
 
     if (annealing_sched.type == DUSTY_SCHED) {
-        if (success_rat < annealing_sched.success_min) {
+        if (success_rat < annealing_sched.success_min || restart_temp) {
             if (state->alpha > annealing_sched.alpha_max) return false;
             state->t = state->restart_t / sqrt(state->alpha); // Take a half step from the restart temperature.
             state->alpha = 1.0 - ((1.0 - state->alpha) * annealing_sched.alpha_decay);

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -103,6 +103,17 @@ struct t_placer_prev_inverse_costs {
     double timing_cost;
 };
 
+struct t_annealing_state {
+    float t;
+    float rlim;
+    float rlim_initial;
+    float alpha;
+    float restart_t;
+    float best_cost;
+    int countdown;
+    t_annealing_sched sched;
+};
+
 constexpr float INVALID_DELAY = std::numeric_limits<float>::quiet_NaN();
 
 constexpr double MAX_INV_TIMING_COST = 1.e9;
@@ -344,11 +355,9 @@ static float starting_t(t_placer_costs* costs,
                         t_pl_blocks_to_be_moved& blocks_affected,
                         const t_placer_opts& placer_opts);
 
-static void update_t(float* t, float rlim, float success_rat, t_annealing_sched annealing_sched);
+static bool update_state(t_annealing_state* state, float success_rat, const t_placer_opts& placer_opts, const t_placer_costs& costs, const t_annealing_sched& annealing_sched);
 
 static void update_rlim(float* rlim, float success_rat, const DeviceGrid& grid);
-
-static int exit_crit(float t, float cost, t_annealing_sched annealing_sched);
 
 static int count_connections();
 
@@ -465,7 +474,7 @@ static void print_place_status_header();
 static void print_place_status(const size_t num_temps,
                                const float elapsed_sec,
                                const float t,
-                               const float oldt,
+                               const float alpha,
                                const t_placer_statistics& stats,
                                const float cpd,
                                const float sTNS,
@@ -498,11 +507,14 @@ void try_place(const t_placer_opts& placer_opts,
     auto& timing_ctx = g_vpr_ctx.timing();
     auto pre_place_timing_stats = timing_ctx.stats;
 
-    int tot_iter, move_lim = 0, moves_since_cost_recompute, width_fac, num_connections,
-                  outer_crit_iter_count, inner_recompute_limit;
-    float t, success_rat, rlim,
-        oldt = 0, crit_exponent,
+    int tot_iter, move_lim, moves_since_cost_recompute, width_fac, num_connections,
+        outer_crit_iter_count, inner_recompute_limit;
+    float success_rat, crit_exponent,
         first_rlim, final_rlim, inverse_delta_rlim;
+
+    t_annealing_state state;
+    state.alpha = annealing_sched.alpha_min;
+    state.best_cost = std::numeric_limits<float>::infinity();
 
     t_placer_costs costs;
     t_placer_prev_inverse_costs prev_inverse_costs;
@@ -711,24 +723,26 @@ void try_place(const t_placer_opts& placer_opts,
         quench_recompute_limit = move_lim + 1;
     }
 
-    rlim = (float)max(device_ctx.grid.width() - 1, device_ctx.grid.height() - 1);
+    state.rlim = (float)max(device_ctx.grid.width() - 1, device_ctx.grid.height() - 1);
+    state.rlim_initial = state.rlim;
 
-    first_rlim = rlim; /*used in timing-driven placement for exponent computation */
+    first_rlim = state.rlim; /*used in timing-driven placement for exponent computation */
     final_rlim = 1;
     inverse_delta_rlim = 1 / (first_rlim - final_rlim);
 
-    t = starting_t(&costs,
-                   &prev_inverse_costs,
-                   annealing_sched,
-                   move_lim,
-                   rlim,
-                   place_delay_model.get(),
-                   placer_criticalities.get(),
-                   timing_info.get(),
-                   *move_generator,
-                   pin_timing_invalidator.get(),
-                   blocks_affected,
-                   placer_opts);
+    state.t = starting_t(&costs,
+                         &prev_inverse_costs,
+                         annealing_sched,
+                         move_lim,
+                         state.rlim,
+                         place_delay_model.get(),
+                         placer_criticalities.get(),
+                         timing_info.get(),
+                         *move_generator,
+                         pin_timing_invalidator.get(),
+                         blocks_affected,
+                         placer_opts);
+    state.restart_t = state.t;
 
     if (!placer_opts.move_stats_file.empty()) {
         f_move_stats_file = std::unique_ptr<FILE, decltype(&vtr::fclose)>(vtr::fopen(placer_opts.move_stats_file.c_str(), "w"), vtr::fclose);
@@ -743,8 +757,8 @@ void try_place(const t_placer_opts& placer_opts,
     VTR_LOG("\n");
     print_place_status_header();
 
-    /* Outer loop of the simmulated annealing begins */
-    while (exit_crit(t, costs.cost, annealing_sched) == 0) {
+    /* Outer loop of the simulated annealing begins */
+    do {
         vtr::Timer temperature_timer;
         if (placer_opts.place_algorithm == PATH_TIMING_DRIVEN_PLACE) {
             costs.cost = 1;
@@ -759,7 +773,7 @@ void try_place(const t_placer_opts& placer_opts,
                                            pin_timing_invalidator.get(),
                                            timing_info.get());
 
-        placement_inner_loop(t, num_temps, rlim, placer_opts,
+        placement_inner_loop(state.t, num_temps, state.rlim, placer_opts,
                              move_lim, crit_exponent, inner_recompute_limit, &stats,
                              &costs,
                              &prev_inverse_costs,
@@ -775,8 +789,6 @@ void try_place(const t_placer_opts& placer_opts,
 
         calc_placer_stats(stats, success_rat, std_dev, costs, move_lim);
 
-        oldt = t; /* for finding and printing alpha. */
-        update_t(&t, rlim, success_rat, annealing_sched);
         ++num_temps;
 
         if (placer_opts.place_algorithm == PATH_TIMING_DRIVEN_PLACE) {
@@ -787,18 +799,18 @@ void try_place(const t_placer_opts& placer_opts,
 
         print_place_status(num_temps,
                            temperature_timer.elapsed_sec(),
-                           t, oldt,
+                           state.t, state.alpha,
                            stats,
                            critical_path.delay(), sTNS, sWNS,
-                           success_rat, std_dev, rlim, crit_exponent, tot_iter);
+                           success_rat, std_dev, state.rlim, crit_exponent, tot_iter);
 
         sprintf(msg, "Cost: %g  BB Cost %g  TD Cost %g  Temperature: %g",
-                costs.cost, costs.bb_cost, costs.timing_cost, t);
+                costs.cost, costs.bb_cost, costs.timing_cost, state.t);
         update_screen(ScreenUpdatePriority::MINOR, msg, PLACEMENT, timing_info);
-        update_rlim(&rlim, success_rat, device_ctx.grid);
+        update_rlim(&state.rlim, success_rat, device_ctx.grid);
 
         if (placer_opts.place_algorithm == PATH_TIMING_DRIVEN_PLACE) {
-            crit_exponent = (1 - (rlim - final_rlim) * inverse_delta_rlim)
+            crit_exponent = (1 - (state.rlim - final_rlim) * inverse_delta_rlim)
                                 * (placer_opts.td_place_exp_last - placer_opts.td_place_exp_first)
                             + placer_opts.td_place_exp_first;
         }
@@ -808,7 +820,8 @@ void try_place(const t_placer_opts& placer_opts,
             print_clb_placement("first_iteration_clb_placement.echo");
         }
 #endif
-    } /* Outer loop of the simmulated annealing ends */
+    } while (update_state(&state, success_rat, placer_opts, costs, annealing_sched));
+    /* Outer loop of the simmulated annealing ends */
 
     auto pre_quench_timing_stats = timing_ctx.stats;
     { /* Quench */
@@ -824,11 +837,11 @@ void try_place(const t_placer_opts& placer_opts,
                                            pin_timing_invalidator.get(),
                                            timing_info.get());
 
-        t = 0; /* freeze out */
+        state.t = 0; /* freeze out */
 
         /* Run inner loop again with temperature = 0 so as to accept only swaps
          * which reduce the cost of the placement */
-        placement_inner_loop(t, num_temps, rlim, placer_opts,
+        placement_inner_loop(state.t, num_temps, state.rlim, placer_opts,
                              move_lim, crit_exponent, quench_recompute_limit, &stats,
                              &costs,
                              &prev_inverse_costs,
@@ -839,7 +852,6 @@ void try_place(const t_placer_opts& placer_opts,
                              *move_generator,
                              blocks_affected,
                              timing_info.get());
-        oldt = t;
 
         tot_iter += move_lim;
         ++num_temps;
@@ -855,9 +867,9 @@ void try_place(const t_placer_opts& placer_opts,
         float quench_elapsed_sec = temperature_timer.elapsed_sec();
         print_place_status(num_temps,
                            quench_elapsed_sec,
-                           t, oldt, stats,
+                           state.t, state.alpha, stats,
                            critical_path.delay(), sTNS, sWNS,
-                           success_rat, std_dev, rlim, crit_exponent, tot_iter);
+                           success_rat, std_dev, state.rlim, crit_exponent, tot_iter);
     }
     auto post_quench_timing_stats = timing_ctx.stats;
 
@@ -1201,47 +1213,51 @@ static void update_rlim(float* rlim, float success_rat, const DeviceGrid& grid) 
 }
 
 /* Update the temperature according to the annealing schedule selected. */
-static void update_t(float* t, float rlim, float success_rat, t_annealing_sched annealing_sched) {
-    /*  float fac; */
-
+static bool update_state(t_annealing_state* state, float success_rat, const t_placer_opts& placer_opts, const t_placer_costs& costs, const t_annealing_sched& annealing_sched) {
+    /* Return `false` when the exit criterion is met. */
     if (annealing_sched.type == USER_SCHED) {
-        *t = annealing_sched.alpha_t * (*t);
-    } else { /* AUTO_SCHED */
-        if (success_rat > 0.96) {
-            *t = (*t) * 0.5;
-        } else if (success_rat > 0.8) {
-            *t = (*t) * 0.9;
-        } else if (success_rat > 0.15 || rlim > 1.) {
-            *t = (*t) * 0.95;
-        } else {
-            *t = (*t) * 0.8;
-        }
-    }
-}
-
-static int exit_crit(float t, float cost, t_annealing_sched annealing_sched) {
-    /* Return 1 when the exit criterion is met.                        */
-
-    if (annealing_sched.type == USER_SCHED) {
-        if (t < annealing_sched.exit_t) {
-            return (1);
-        } else {
-            return (0);
-        }
+        state->t *= annealing_sched.alpha_t;
+        return state->t >= annealing_sched.exit_t;
     }
 
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
     /* Automatic annealing schedule */
-    float t_exit = 0.005 * cost / cluster_ctx.clb_nlist.nets().size();
+    float t_exit = 0.005 * costs.cost / cluster_ctx.clb_nlist.nets().size();
 
-    if (t < t_exit) {
-        return (1);
-    } else if (std::isnan(t_exit)) {
-        //May get nan if there are no nets
-        return (1);
-    } else {
-        return (0);
+    bool restart = state->t < t_exit || std::isnan(t_exit); //May get nan if there are no nets
+
+    if (annealing_sched.type == DUSTY_SCHED) {
+        /* Timing driven cost is normalized */
+        float limit = placer_opts.place_algorithm == PATH_TIMING_DRIVEN_PLACE ? 0.9999 : state->best_cost;
+        if (restart) {
+            state->t = state->restart_t;
+            state->rlim = state->rlim_initial;
+            state->alpha = 1.0 - ((1.0 - state->alpha) * annealing_sched.alpha_decay);
+            if (state->countdown == 0 || state->alpha > annealing_sched.alpha_max) return false;
+            state->countdown--;
+        } else {
+            if (costs.cost < limit) {
+                state->restart_t = (1.0 - annealing_sched.restart_filter) * state->restart_t + annealing_sched.restart_filter * state->t;
+                state->rlim_initial = (1.0 - annealing_sched.restart_filter) * state->rlim_initial + annealing_sched.restart_filter * state->rlim;
+                state->best_cost = costs.cost;
+                state->countdown = annealing_sched.wait;
+            }
+            state->t *= state->alpha;
+        }
+        return true;
+    } else { /* annealing_sched.type == AUTO_SCHED */
+        if (success_rat > 0.96) {
+            state->alpha = 0.5;
+        } else if (success_rat > 0.8) {
+            state->alpha = 0.9;
+        } else if (success_rat > 0.15 || state->rlim > 1.) {
+            state->alpha = 0.95;
+        } else {
+            state->alpha = 0.8;
+        }
+        state->t *= state->alpha;
+        return !restart;
     }
 }
 
@@ -2889,7 +2905,7 @@ static void print_place_status_header() {
 static void print_place_status(const size_t num_temps,
                                const float elapsed_sec,
                                const float t,
-                               const float oldt,
+                               const float alpha,
                                const t_placer_statistics& stats,
                                const float cpd,
                                const float sTNS,
@@ -2908,19 +2924,13 @@ static void print_place_status(const size_t num_temps,
         "%7.3f %7.4f %6.1f %8.2f",
         num_temps,
         elapsed_sec,
-        oldt,
+        t,
         stats.av_cost, stats.av_bb_cost, stats.av_timing_cost,
         1e9 * cpd, 1e9 * sTNS, 1e9 * sWNS,
         acc_rate, std_dev, rlim, crit_exponent);
 
     pretty_print_uint(" ", tot_moves, 9, 3);
 
-    float alpha;
-    if (oldt == 0.) {
-        alpha = 0.;
-    } else {
-        alpha = t / oldt;
-    }
     VTR_LOG(" %6.3f\n", alpha);
     fflush(stdout);
 }

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -484,7 +484,7 @@ static void print_place_status(const size_t num_temps,
                                size_t tot_moves);
 static void print_resources_utilization();
 
-static void init_annealing_state(t_annealing_state *state, const t_annealing_sched &annealing_sched, float t, float rlim, int move_lim_max);
+static void init_annealing_state(t_annealing_state* state, const t_annealing_sched& annealing_sched, float t, float rlim, int move_lim_max);
 
 /*****************************************************************************/
 void try_place(const t_placer_opts& placer_opts,
@@ -725,14 +725,14 @@ void try_place(const t_placer_opts& placer_opts,
     inverse_delta_rlim = 1 / (first_rlim - final_rlim);
 
     float first_t = starting_t(&costs, &prev_inverse_costs,
-                         annealing_sched, move_lim, first_rlim,
-                         place_delay_model.get(),
-                         placer_criticalities.get(),
-                         timing_info.get(),
-                         *move_generator,
-                         pin_timing_invalidator.get(),
-                         blocks_affected,
-                         placer_opts);
+                               annealing_sched, move_lim, first_rlim,
+                               place_delay_model.get(),
+                               placer_criticalities.get(),
+                               timing_info.get(),
+                               *move_generator,
+                               pin_timing_invalidator.get(),
+                               blocks_affected,
+                               placer_opts);
 
     t_annealing_state state;
     init_annealing_state(&state, annealing_sched, first_t, first_rlim, move_lim);
@@ -2958,7 +2958,7 @@ static void print_resources_utilization() {
     VTR_LOG("\n");
 }
 
-static void init_annealing_state(t_annealing_state *state, const t_annealing_sched &annealing_sched, float t, float rlim, int move_lim_max) {
+static void init_annealing_state(t_annealing_state* state, const t_annealing_sched& annealing_sched, float t, float rlim, int move_lim_max) {
     state->alpha = annealing_sched.alpha_min;
     state->t = t;
     state->restart_t = t;

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -108,6 +108,8 @@ struct t_annealing_state {
     float rlim;
     float alpha;
     float restart_t;
+    int move_lim_max;
+    int move_lim;
 };
 
 constexpr float INVALID_DELAY = std::numeric_limits<float>::quiet_NaN();
@@ -482,7 +484,7 @@ static void print_place_status(const size_t num_temps,
                                size_t tot_moves);
 static void print_resources_utilization();
 
-static void init_annealing_state(t_annealing_state *state, const t_annealing_sched &annealing_sched, float t, float rlim);
+static void init_annealing_state(t_annealing_state *state, const t_annealing_sched &annealing_sched, float t, float rlim, int move_lim_max);
 
 /*****************************************************************************/
 void try_place(const t_placer_opts& placer_opts,
@@ -505,7 +507,7 @@ void try_place(const t_placer_opts& placer_opts,
     auto& timing_ctx = g_vpr_ctx.timing();
     auto pre_place_timing_stats = timing_ctx.stats;
 
-    int tot_iter, move_lim, moves_since_cost_recompute, width_fac, num_connections,
+    int tot_iter, moves_since_cost_recompute, width_fac, num_connections,
         outer_crit_iter_count, inner_recompute_limit;
     float success_rat, crit_exponent,
         first_rlim, final_rlim, inverse_delta_rlim;
@@ -675,6 +677,7 @@ void try_place(const t_placer_opts& placer_opts,
         print_place(nullptr, nullptr, filename.c_str());
     }
 
+    int move_lim = 1;
     if (placer_opts.effort_scaling == e_place_effort_scaling::CIRCUIT) {
         //This scales the move limit proportional to num_blocks ^ (4/3)
         move_lim = (int)(annealing_sched.inner_num * pow(cluster_ctx.clb_nlist.blocks().size(), 1.3333));
@@ -732,7 +735,7 @@ void try_place(const t_placer_opts& placer_opts,
                          placer_opts);
 
     t_annealing_state state;
-    init_annealing_state(&state, annealing_sched, first_t, first_rlim);
+    init_annealing_state(&state, annealing_sched, first_t, first_rlim, move_lim);
 
     if (!placer_opts.move_stats_file.empty()) {
         f_move_stats_file = std::unique_ptr<FILE, decltype(&vtr::fclose)>(vtr::fopen(placer_opts.move_stats_file.c_str(), "w"), vtr::fclose);
@@ -764,7 +767,7 @@ void try_place(const t_placer_opts& placer_opts,
                                            timing_info.get());
 
         placement_inner_loop(state.t, num_temps, state.rlim, placer_opts,
-                             move_lim, crit_exponent, inner_recompute_limit, &stats,
+                             state.move_lim, crit_exponent, inner_recompute_limit, &stats,
                              &costs,
                              &prev_inverse_costs,
                              &moves_since_cost_recompute,
@@ -775,9 +778,9 @@ void try_place(const t_placer_opts& placer_opts,
                              blocks_affected,
                              timing_info.get());
 
-        tot_iter += move_lim;
+        tot_iter += state.move_lim;
 
-        calc_placer_stats(stats, success_rat, std_dev, costs, move_lim);
+        calc_placer_stats(stats, success_rat, std_dev, costs, state.move_lim);
 
         ++num_temps;
 
@@ -1219,15 +1222,16 @@ static bool update_state(t_annealing_state* state, float success_rat, const t_pl
 
     if (annealing_sched.type == DUSTY_SCHED) {
         if (success_rat < annealing_sched.success_min) {
-            state->t = state->restart_t / state->alpha;
-            state->alpha = 1.0 - ((1.0 - state->alpha) * annealing_sched.alpha_decay);
             if (state->alpha > annealing_sched.alpha_max) return false;
+            state->t = state->restart_t / sqrt(state->alpha); // Take a half step from the restart temperature.
+            state->alpha = 1.0 - ((1.0 - state->alpha) * annealing_sched.alpha_decay);
         } else {
             if (success_rat > annealing_sched.success_target) {
                 state->restart_t = state->t;
             }
             state->t *= state->alpha;
         }
+        state->move_lim = std::max(1, std::min(state->move_lim_max, (int)(state->move_lim_max * (annealing_sched.success_target / success_rat))));
         return true;
     } else { /* annealing_sched.type == AUTO_SCHED */
         if (success_rat > 0.96) {
@@ -2954,11 +2958,17 @@ static void print_resources_utilization() {
     VTR_LOG("\n");
 }
 
-static void init_annealing_state(t_annealing_state *state, const t_annealing_sched &annealing_sched, float t, float rlim) {
+static void init_annealing_state(t_annealing_state *state, const t_annealing_sched &annealing_sched, float t, float rlim, int move_lim_max) {
     state->alpha = annealing_sched.alpha_min;
     state->t = t;
     state->restart_t = t;
     state->rlim = rlim;
+    state->move_lim_max = std::max(1, move_lim_max);
+    if (annealing_sched.type == DUSTY_SCHED) {
+        state->move_lim = std::max(1, (int)(state->move_lim_max * annealing_sched.success_target));
+    } else {
+        state->move_lim = state->move_lim_max;
+    }
 }
 
 bool placer_needs_lookahead(const t_vpr_setup& vpr_setup) {

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -58,6 +58,8 @@ using std::min;
  * cost computation. 0.01 means that there is a 1% error tolerance.       */
 #define ERROR_TOL .01
 
+/* The final rlim (range limit) is 1, which is the smallest value that can *
+ * still make progress, since an rlim of 0 wouldn't allow any swaps.       */
 #define FINAL_RLIM 1
 
 /* This defines the maximum number of swap attempts before invoking the   *
@@ -105,15 +107,16 @@ struct t_placer_prev_inverse_costs {
     double timing_cost;
 };
 
+// Used by update_state()
 struct t_annealing_state {
-    float t;
-    float rlim;
-    float inverse_delta_rlim;
-    float alpha;
-    float restart_t;
-    float crit_exponent;
-    int move_lim_max;
-    int move_lim;
+    float t;                  // Temperature
+    float rlim;               // Range limit for swaps
+    float inverse_delta_rlim; // used to calculate crit_exponent
+    float alpha;              // Temperature decays by this factor each outer iteration
+    float restart_t;          // Temperature used after restart due to minimum success ratio
+    float crit_exponent;      // Used by timing-driven placement to "sharpen" timing criticality
+    int move_lim_max;         // Maximum move limit
+    int move_lim;             // Current move limit
 };
 
 constexpr float INVALID_DELAY = std::numeric_limits<float>::quiet_NaN();

--- a/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_min_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_min_chan_width.txt
@@ -1,7 +1,7 @@
 #VPR metrics at minimum channel width
 
 #Routing Metrics
-min_chan_width;Range(0.80,1.30)
+min_chan_width;Range(0.25,1.30)
 routed_wirelength;RangeAbs(0.60,1.50,5)
 
 #Area metrics

--- a/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_pack_place.txt
+++ b/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_pack_place.txt
@@ -2,6 +2,6 @@
 %include "../common/pass_requirements.vpr_pack_place.txt"
 
 #Timing metrics
-placed_CPD_est;Range(0.80,1.40)
-placed_setup_TNS_est;Range(0.80,1.40)
-placed_setup_WNS_est;Range(0.80,1.40)
+placed_CPD_est;Range(0.50,1.40)
+placed_setup_TNS_est;Range(0.50,1.40)
+placed_setup_WNS_est;Range(0.50,1.40)

--- a/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_fixed_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_fixed_chan_width.txt
@@ -2,9 +2,9 @@
 %include "../common/pass_requirements.vpr_route_fixed_chan_width.txt"
 
 #Timing metrics
-critical_path_delay;Range(0.80,1.40)
-geomean_nonvirtual_intradomain_critical_path_delay;Range(0.80,1.40)
-setup_TNS;Range(0.80,1.40)
-setup_WNS;Range(0.80,1.40)
+critical_path_delay;Range(0.50,1.40)
+geomean_nonvirtual_intradomain_critical_path_delay;Range(0.50,1.40)
+setup_TNS;Range(0.50,1.40)
+setup_WNS;Range(0.50,1.40)
 #hold_TNS;Range(0.05,20.00)
 #hold_WNS;Range(0.05,20.00)

--- a/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_relaxed_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_relaxed_chan_width.txt
@@ -11,9 +11,9 @@ crit_path_routing_area_per_tile;Range(0.8,1.3)
 #Run-time Metrics
 crit_path_route_time;RangeAbs(0.10,10.0,2)
 #Timing Metrics
-critical_path_delay;Range(0.80,1.40)
-geomean_nonvirtual_intradomain_critical_path_delay;Range(0.80,1.40)
-setup_TNS;Range(0.80,1.40)
-setup_WNS;Range(0.80,1.40)
+critical_path_delay;Range(0.50,1.40)
+geomean_nonvirtual_intradomain_critical_path_delay;Range(0.50,1.40)
+setup_TNS;Range(0.50,1.40)
+setup_WNS;Range(0.50,1.40)
 #hold_TNS;Range(0.05,20.00)
 #hold_WNS;Range(0.05,20.00)

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly/titan_quick_qor/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly/titan_quick_qor/config/config.txt
@@ -66,4 +66,4 @@ pass_requirements_file=pass_requirements_vpr_titan.txt
 #A large number of routing iterations is set to ensure the router doesn't give up to easily on the larger benchmarks
 #To be more run-time comparable to commercial tools like Quartus, we run with higher placer effort (inner_num=2) and lower astar_fac (1.0)
 #Set a 24hr timeout so they don't run forever
-script_params=-starting_stage vpr --route_chan_width 300 --max_router_iterations 400 --router_lookahead map -timeout 86400
+script_params=-starting_stage vpr --route_chan_width 300 --max_router_iterations 400 --router_lookahead map -timeout 86400 --seed 197

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly/vtr_bidir/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly/vtr_bidir/config/config.txt
@@ -47,5 +47,5 @@ pass_requirements_file=pass_requirements.txt
 #We increase the critical path router iterations beyond the default 50, to avoid
 #spurrious routing failures at relaxed channel width (since we know they should 
 #be routable via the minimum channel width search)
-script_params=-starting_stage vpr -track_memory_usage -crit_path_router_iterations 60
+script_params=-starting_stage vpr -track_memory_usage -crit_path_router_iterations 60 --seed 250
 


### PR DESCRIPTION
#### Description
This change adds a new schedule designed to simultaneously optimize for variables of varying sensitivity by continually sweeping a narrow temperature band at increasing rates.

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1203

#### Motivation and Context
This change is to increase the performance (quality/runtime) of the placer.

#### How Has This Been Tested?
I've run a QoR comparison using `vtr_reg_nightly/vtr_reg_qor_chain`:

Metric | Relative to Baseline
--|--
vtr_flow_elapsed_time | 108.40%
placed_wirelength_est | 107.57%
place_time | **49.71%**
placed_CPD_est | 100.64%
min_chan_width | 105.69%
routed_wirelength | 106.89%
min_chan_width_route_time | 147.13%
crit_path_routed_wirelength | 105.72%
critical_path_delay | 101.79%
crit_path_route_time | 109.44%

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
