### PR TITLE
Add penalty cost attribute to switches

### DIFF
--- a/doc/src/arch/reference.rst
+++ b/doc/src/arch/reference.rst
@@ -631,7 +631,7 @@ The tags within the ``<switchlist>`` tag specifies the switches used to connect 
 
     .. code-block:: xml
 
-        <switch type="mux" name="my_awesome_mux" R="551" Cin=".77e-15" Cout="4e-15" Cinternal="5e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+        <switch type="mux" name="my_awesome_mux" R="551" Cin=".77e-15" Cout="4e-15" Cinternal="5e-15" Tdel="58e-12" penalty_cost="1e-8" mux_trans_size="2.630740" buf_size="27.645901"/>
 
 
     :req_param type:
@@ -698,6 +698,14 @@ The tags within the ``<switchlist>`` tag specifies the switches used to connect 
         .. note:: Required if no ``<Tdel>`` tags are specified
 
         .. note:: A ``<switch>``'s resistance (``R``) and output capacitance (``Cout``) have no effect on delay when used for the input connection block, since VPR does not model the resistance/capacitance of block internal wires.
+
+    :opt_param penalty_cost:
+
+        Penalty cost added to the switch.
+        This cost is not related to the physical properties of the switch. It adds an additional cost to it for the router to avoid its usage.
+        This can be useful for switches that should not be used in general, but that are necessary for certain types of designs that need to route through them.
+
+        .. note:: The addition of this attribute to the switch does not affect Timing Analysis
 
     :opt_param buf_size:
 

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1384,6 +1384,7 @@ struct t_arch_switch_inf {
     float Cin = 0.;
     float Cout = 0.;
     float Cinternal = 0.;
+    float penalty_cost = 0.;
     float mux_trans_size = 1.;
     BufferSize buf_size_type = BufferSize::AUTO;
     float buf_size = 0.;
@@ -1448,6 +1449,7 @@ struct t_rr_switch_inf {
     float Cout = 0.;
     float Cinternal = 0.;
     float Tdel = 0.;
+    float penalty_cost = 0.;
     float mux_trans_size = 0.;
     float buf_size = 0.;
     const char* name = nullptr;

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -3779,23 +3779,23 @@ static void ProcessSwitches(pugi::xml_node Parent,
         SwitchType type = SwitchType::MUX;
         if (0 == strcmp(type_name, "mux")) {
             type = SwitchType::MUX;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Cinternal", "Tdel", "buf_size", "power_buf_size", "mux_trans_size"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Cinternal", "Tdel", "penalty_cost", "buf_size", "power_buf_size", "mux_trans_size"}, " with type '"s + type_name + "'"s, loc_data);
 
         } else if (0 == strcmp(type_name, "tristate")) {
             type = SwitchType::TRISTATE;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Cinternal", "Tdel", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Cinternal", "Tdel", "penalty_cost", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data);
 
         } else if (0 == strcmp(type_name, "buffer")) {
             type = SwitchType::BUFFER;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "penalty_cost", "buf_size", "power_buf_size"}, " with type '"s + type_name + "'"s, loc_data);
 
         } else if (0 == strcmp(type_name, "pass_gate")) {
             type = SwitchType::PASS_GATE;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel"}, " with type '"s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "penalty_cost"}, " with type '"s + type_name + "'"s, loc_data);
 
         } else if (0 == strcmp(type_name, "short")) {
             type = SwitchType::SHORT;
-            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel"}, " with type "s + type_name + "'"s, loc_data);
+            expect_only_attributes(Node, {"type", "name", "R", "Cin", "Cout", "Tdel", "penalty_cost"}, " with type "s + type_name + "'"s, loc_data);
         } else {
             archfpga_throw(loc_data.filename_c_str(), loc_data.line(Node),
                            "Invalid switch type '%s'.\n", type_name);
@@ -3818,6 +3818,7 @@ static void ProcessSwitches(pugi::xml_node Parent,
         arch_switch.Cin = get_attribute(Node, "Cin", loc_data, CIN_REQD).as_float(0);
         arch_switch.Cout = get_attribute(Node, "Cout", loc_data, COUT_REQD).as_float(0);
         arch_switch.Cinternal = get_attribute(Node, "Cinternal", loc_data, CINTERNAL_REQD).as_float(0);
+        arch_switch.penalty_cost = get_attribute(Node, "penalty_cost", loc_data, ReqOpt::OPTIONAL).as_float(0);
 
         if (arch_switch.type() == SwitchType::MUX) {
             //Only muxes have mux transistors

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -4,9 +4,9 @@
 #
 # Cmdline: uxsdcxx/uxsdcap.py rr_graph.xsd
 # Input file: rr_graph.xsd
-# md5sum of input file: 40e83d2ea6556761d4e29f21324b1871
+# md5sum of input file: c4f47394efd27f5819c943829c111204
 
-@0xc18a82ddfa10808b;
+@0x9e90feddf132e6a8;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -81,6 +81,7 @@ struct Timing {
 	cout @2 :Float32;
 	r @3 :Float32;
 	tdel @4 :Float32;
+	penaltyCost @5 :Float32;
 }
 
 struct Sizing {

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -279,6 +279,7 @@ static void SetupSwitches(const t_arch& Arch,
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].R = 0.;
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].Cin = 0.;
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].Cout = 0.;
+    device_ctx.arch_switch_inf[RoutingArch->delayless_switch].penalty_cost = 0.;
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].set_Tdel(t_arch_switch_inf::UNDEFINED_FANIN, 0.);
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].power_buffer_type = POWER_BUFFER_TYPE_NONE;
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].mux_trans_size = 0.;

--- a/vpr/src/route/gen/rr_graph_uxsdcxx.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py rr_graph.xsd
  * Input file: rr_graph.xsd
- * md5sum of input file: 40e83d2ea6556761d4e29f21324b1871
+ * md5sum of input file: c4f47394efd27f5819c943829c111204
  */
 
 #include <functional>
@@ -237,8 +237,9 @@ enum class atok_t_timing { CIN,
                            CINTERNAL,
                            COUT,
                            R,
-                           TDEL };
-constexpr const char* atok_lookup_t_timing[] = {"Cin", "Cinternal", "Cout", "R", "Tdel"};
+                           TDEL,
+                           PENALTY_COST };
+constexpr const char* atok_lookup_t_timing[] = {"Cin", "Cinternal", "Cout", "R", "Tdel", "penalty_cost"};
 
 enum class atok_t_sizing { BUF_SIZE,
                            MUX_TRANS_SIZE };
@@ -620,6 +621,21 @@ inline atok_t_timing lex_attr_t_timing(const char* in, const std::function<void(
                     switch (in[8]) {
                         case onechar('l', 0, 8):
                             return atok_t_timing::CINTERNAL;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 12:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('p', 0, 64) | onechar('e', 8, 64) | onechar('n', 16, 64) | onechar('a', 24, 64) | onechar('l', 32, 64) | onechar('t', 40, 64) | onechar('y', 48, 64) | onechar('_', 56, 64):
+                    switch (*((triehash_uu32*)&in[8])) {
+                        case onechar('c', 0, 32) | onechar('o', 8, 32) | onechar('s', 16, 32) | onechar('t', 24, 32):
+                            return atok_t_timing::PENALTY_COST;
                             break;
                         default:
                             break;
@@ -2710,6 +2726,9 @@ inline void load_timing(const pugi::xml_node& root, T& out, Context& context, co
             case atok_t_timing::TDEL:
                 out.set_timing_Tdel(load_float(attr.value(), report_error), context);
                 break;
+            case atok_t_timing::PENALTY_COST:
+                out.set_timing_penalty_cost(load_float(attr.value(), report_error), context);
+                break;
             default:
                 break; /* Not possible. */
         }
@@ -3834,6 +3853,8 @@ inline void write_switch(T& in, std::ostream& os, Context& context) {
                 os << " R=\"" << in.get_timing_R(child_context) << "\"";
             if ((bool)in.get_timing_Tdel(child_context))
                 os << " Tdel=\"" << in.get_timing_Tdel(child_context) << "\"";
+            if ((bool)in.get_timing_penalty_cost(child_context))
+                os << " penalty_cost=\"" << in.get_timing_penalty_cost(child_context) << "\"";
             os << "/>\n";
         }
     }

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcap.py rr_graph.xsd
  * Input file: rr_graph.xsd
- * md5sum of input file: 40e83d2ea6556761d4e29f21324b1871
+ * md5sum of input file: c4f47394efd27f5819c943829c111204
  */
 
 #include <functional>
@@ -420,6 +420,7 @@ inline void load_timing_capnp_type(const ucap::Timing::Reader& root, T& out, Con
     out.set_timing_Cout(root.getCout(), context);
     out.set_timing_R(root.getR(), context);
     out.set_timing_Tdel(root.getTdel(), context);
+    out.set_timing_penalty_cost(root.getPenaltyCost(), context);
 }
 
 template<class T, typename Context>
@@ -937,6 +938,8 @@ inline void write_switch_capnp_type(T& in, ucap::Switch::Builder& root, Context&
             switch_timing.setR(in.get_timing_R(child_context));
         if ((bool)in.get_timing_Tdel(child_context))
             switch_timing.setTdel(in.get_timing_Tdel(child_context));
+        if ((bool)in.get_timing_penalty_cost(child_context))
+            switch_timing.setPenaltyCost(in.get_timing_penalty_cost(child_context));
     }
 
     {

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_interface.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_interface.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py rr_graph.xsd
  * Input file: rr_graph.xsd
- * md5sum of input file: 40e83d2ea6556761d4e29f21324b1871
+ * md5sum of input file: c4f47394efd27f5819c943829c111204
  */
 
 #include <functional>
@@ -183,6 +183,7 @@ class RrGraphBase {
      *   <xs:attribute name="Cinternal" type="xs:float" />
      *   <xs:attribute name="Cout" type="xs:float" />
      *   <xs:attribute name="Tdel" type="xs:float" />
+     *   <xs:attribute name="penalty_cost" type="xs:float" />
      * </xs:complexType>
      */
     virtual inline float get_timing_Cin(typename ContextTypes::TimingReadContext& ctx) = 0;
@@ -195,6 +196,8 @@ class RrGraphBase {
     virtual inline void set_timing_R(float R, typename ContextTypes::TimingWriteContext& ctx) = 0;
     virtual inline float get_timing_Tdel(typename ContextTypes::TimingReadContext& ctx) = 0;
     virtual inline void set_timing_Tdel(float Tdel, typename ContextTypes::TimingWriteContext& ctx) = 0;
+    virtual inline float get_timing_penalty_cost(typename ContextTypes::TimingReadContext& ctx) = 0;
+    virtual inline void set_timing_penalty_cost(float penalty_cost, typename ContextTypes::TimingWriteContext& ctx) = 0;
 
     /** Generated for complex type "sizing":
      * <xs:complexType name="sizing">

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -76,6 +76,11 @@ float ClassicLookahead::classic_wire_lookahead_cost(int inode, int target_node, 
                       + ipin_data.base_cost
                       + sink_data.base_cost;
 
+    float penalty_cost = num_segs_same_dir * same_data.penalty_cost
+                         + num_segs_ortho_dir * ortho_data.penalty_cost
+                         + ipin_data.penalty_cost
+                         + sink_data.penalty_cost;
+
     float Tdel = num_segs_same_dir * same_data.T_linear
                  + num_segs_ortho_dir * ortho_data.T_linear
                  + num_segs_same_dir * num_segs_same_dir * same_data.T_quadratic
@@ -83,7 +88,7 @@ float ClassicLookahead::classic_wire_lookahead_cost(int inode, int target_node, 
                  + R_upstream * (num_segs_same_dir * same_data.C_load + num_segs_ortho_dir * ortho_data.C_load)
                  + ipin_data.T_linear;
 
-    float expected_cost = criticality * Tdel + (1. - criticality) * cong_cost;
+    float expected_cost = criticality * penalty_cost + criticality * Tdel + (1. - criticality) * cong_cost;
     return (expected_cost);
 }
 

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -88,7 +88,7 @@ float ClassicLookahead::classic_wire_lookahead_cost(int inode, int target_node, 
                  + R_upstream * (num_segs_same_dir * same_data.C_load + num_segs_ortho_dir * ortho_data.C_load)
                  + ipin_data.T_linear;
 
-    float expected_cost = criticality * penalty_cost + criticality * Tdel + (1. - criticality) * cong_cost;
+    float expected_cost = penalty_cost + criticality * Tdel + (1. - criticality) * cong_cost;
     return (expected_cost);
 }
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -881,6 +881,7 @@ void load_rr_switch_from_arch_switch(int arch_switch_idx,
     device_ctx.rr_switch_inf[rr_switch_idx].Cin = device_ctx.arch_switch_inf[arch_switch_idx].Cin;
     device_ctx.rr_switch_inf[rr_switch_idx].Cinternal = device_ctx.arch_switch_inf[arch_switch_idx].Cinternal;
     device_ctx.rr_switch_inf[rr_switch_idx].Cout = device_ctx.arch_switch_inf[arch_switch_idx].Cout;
+    device_ctx.rr_switch_inf[rr_switch_idx].penalty_cost = device_ctx.arch_switch_inf[arch_switch_idx].penalty_cost;
     device_ctx.rr_switch_inf[rr_switch_idx].Tdel = rr_switch_Tdel;
     device_ctx.rr_switch_inf[rr_switch_idx].mux_trans_size = device_ctx.arch_switch_inf[arch_switch_idx].mux_trans_size;
     if (device_ctx.arch_switch_inf[arch_switch_idx].buf_size_type == BufferSize::AUTO) {

--- a/vpr/src/route/rr_graph.xsd
+++ b/vpr/src/route/rr_graph.xsd
@@ -101,6 +101,7 @@
     <xs:attribute name="Cinternal" type="xs:float"/>
     <xs:attribute name="Cout" type="xs:float"/>
     <xs:attribute name="Tdel" type="xs:float"/>
+    <xs:attribute name="penalty_cost" type="xs:float"/>
   </xs:complexType>
 
   <xs:complexType name="sizing">

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -355,6 +355,13 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         return sw->Tdel;
     }
 
+    inline void set_timing_penalty_cost(float penalty_cost, t_rr_switch_inf*& sw) final {
+        sw->penalty_cost = penalty_cost;
+    }
+    inline float get_timing_penalty_cost(const t_rr_switch_inf*& sw) final {
+        return sw->penalty_cost;
+    }
+
     /** Generated for complex type "switch":
      * <xs:complexType name="switch">
      *   <xs:all>

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -185,6 +185,7 @@ struct t_rr_indexed_data {
     float T_linear;
     float T_quadratic;
     float C_load;
+    float penalty_cost;
 };
 
 #include "rr_node_impl.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds an additional attribute to the switches, namely the `penalty_cost`. There are some situations for which the router chooses some paths that are allowed, but only for special reasons, and shouldn't be generally chosen.

To give an example, regarding a known SymbiFlow issue, the clock nets should always be routed through the dedicated clock network.
The architecture, though, is designed in a way that the clock nets can "escape" from the clock network through a switch and enter in the general interconnect, resulting in a possible increase in the clock skew and timing violations.
It is necessary though to have the switch, as some logic designs still should have the freedom (even though it is highly discouraged), to use the clock net within logic cells. If the problematic switch that allows clock nets to enter general interconnect were removed, such designs would not be implementable.

To limit the issue, a `penalty_cost` is added with this PR. This cost is not related to any physical property, but is a way for the architecture, to instruct the router to avoid using the problematic switch if there is no need to use it.
This has the benefit of not compromising the timing analysis, as the penalty cost is not taken into account when running STA.

#### Related Issue

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
vtr_reg_basic
vtr_reg_strong

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
