### PR TITLE
Verify RR Node Indicies are Consistent with RR Graph

### DIFF
--- a/vpr/src/device/rr_graph_fwd.h
+++ b/vpr/src/device/rr_graph_fwd.h
@@ -8,6 +8,9 @@
  * please refer to rr_graph_obj.h
  ***************************************************************/
 
+//Forward declaration
+class t_rr_graph_storage;
+
 class RRGraph;
 
 struct rr_node_id_tag;

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -98,6 +98,20 @@ int RoutingToClockConnection::create_virtual_clock_network_sink_node(
     rr_nodes.emplace_back();
     auto node_index = rr_nodes.size() - 1;
 
+    //Determine the a valid PTC
+    std::vector<int> nodes_at_loc;
+    get_rr_node_indices(device_ctx.rr_node_indices,
+                        x, y,
+                        SINK,
+                        &nodes_at_loc);
+
+    int max_ptc = 0;
+    for (int inode : nodes_at_loc) {
+        max_ptc = std::max<int>(max_ptc, device_ctx.rr_nodes[inode].ptc_num());
+    }
+    int ptc = max_ptc + 1;
+
+    rr_nodes[node_index].set_ptc_num(ptc);
     rr_nodes[node_index].set_coordinates(x, y, x, y);
     rr_nodes[node_index].set_capacity(1);
     rr_nodes[node_index].set_cost_index(SINK_COST_INDEX);
@@ -105,6 +119,8 @@ int RoutingToClockConnection::create_virtual_clock_network_sink_node(
     float R = 0.;
     float C = 0.;
     rr_nodes[node_index].set_rc_index(find_create_rr_rc_data(R, C));
+
+    add_to_rr_node_indices(device_ctx.rr_node_indices, rr_nodes, node_index);
 
     return node_index;
 }

--- a/vpr/src/route/clock_network_builders.h
+++ b/vpr/src/route/clock_network_builders.h
@@ -104,14 +104,15 @@ class ClockNetwork {
      * in ClockRRGraphBuilder. The reverse lookup maps the nodes to their switch point locations */
     void create_rr_nodes_for_clock_network_wires(ClockRRGraphBuilder& clock_graph,
                                                  t_rr_graph_storage* rr_nodes,
+                                                 t_rr_node_indices* rr_node_indices,
                                                  t_rr_edge_info_set* rr_edges_to_create,
                                                  int num_segments);
     virtual void create_segments(std::vector<t_segment_inf>& segment_inf) = 0;
-    virtual void create_rr_nodes_and_internal_edges_for_one_instance(
-        ClockRRGraphBuilder& clock_graph,
-        t_rr_graph_storage* rr_nodes,
-        t_rr_edge_info_set* rr_edges_to_create,
-        int num_segments)
+    virtual void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
+                                                                     t_rr_graph_storage* rr_nodes,
+                                                                     t_rr_node_indices* rr_node_indices,
+                                                                     t_rr_edge_info_set* rr_edges_to_create,
+                                                                     int num_segments)
         = 0;
     virtual size_t estimate_additional_nodes(const DeviceGrid& grid) = 0;
 };
@@ -165,6 +166,7 @@ class ClockRib : public ClockNetwork {
     void create_segments(std::vector<t_segment_inf>& segment_inf) override;
     void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                              t_rr_graph_storage* rr_nodes,
+                                                             t_rr_node_indices* rr_node_indices,
                                                              t_rr_edge_info_set* rr_edges_to_create,
                                                              int num_segments) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;
@@ -173,7 +175,8 @@ class ClockRib : public ClockNetwork {
                           int y,
                           int ptc_num,
                           e_direction direction,
-                          t_rr_graph_storage* rr_nodes);
+                          t_rr_graph_storage* rr_nodes,
+                          t_rr_node_indices* rr_node_indices);
     void record_tap_locations(unsigned x_start,
                               unsigned x_end,
                               unsigned y,
@@ -224,6 +227,7 @@ class ClockSpine : public ClockNetwork {
     void create_segments(std::vector<t_segment_inf>& segment_inf) override;
     void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                              t_rr_graph_storage* rr_nodes,
+                                                             t_rr_node_indices* rr_node_indices,
                                                              t_rr_edge_info_set* rr_edges_to_create,
                                                              int num_segments) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;
@@ -233,6 +237,7 @@ class ClockSpine : public ClockNetwork {
                           int ptc_num,
                           e_direction direction,
                           t_rr_graph_storage* rr_nodes,
+                          t_rr_node_indices* rr_node_indices,
                           int num_segments);
     void record_tap_locations(unsigned y_start,
                               unsigned y_end,
@@ -259,6 +264,7 @@ class ClockHTree : private ClockNetwork {
     void create_segments(std::vector<t_segment_inf>& segment_inf) override;
     void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                              t_rr_graph_storage* rr_nodes,
+                                                             t_rr_node_indices* rr_node_indices,
                                                              t_rr_edge_info_set* rr_edges_to_create,
                                                              int num_segments) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -374,6 +374,8 @@ void create_rr_graph(const t_graph_type graph_type,
 
     process_non_config_sets();
 
+    verify_rr_node_indices(grid, device_ctx.rr_node_indices, device_ctx.rr_nodes);
+
     print_rr_graph_stats();
 
     //Write out rr graph file if needed

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -163,7 +163,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(t_rr_graph_sto
                                                                   const std::vector<vtr::Matrix<int>>& Fc_out,
                                                                   vtr::NdMatrix<int, 3>& Fc_xofs,
                                                                   vtr::NdMatrix<int, 3>& Fc_yofs,
-                                                                  const t_rr_node_indices& L_rr_node_indices,
+                                                                  t_rr_node_indices& L_rr_node_indices,
                                                                   const int max_chan_width,
                                                                   const t_chan_width& chan_width,
                                                                   const int wire_to_ipin_switch,
@@ -1153,7 +1153,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(t_rr_graph_sto
                                                                   const std::vector<vtr::Matrix<int>>& Fc_out,
                                                                   vtr::NdMatrix<int, 3>& Fc_xofs,
                                                                   vtr::NdMatrix<int, 3>& Fc_yofs,
-                                                                  const t_rr_node_indices& L_rr_node_indices,
+                                                                  t_rr_node_indices& L_rr_node_indices,
                                                                   const int max_chan_width,
                                                                   const t_chan_width& chan_width,
                                                                   const int wire_to_ipin_switch,
@@ -1267,11 +1267,8 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(t_rr_graph_sto
     std::function<void(t_chan_width*)> update_chan_width = [](t_chan_width*) {
     };
     if (clock_modeling == DEDICATED_NETWORK) {
-        ClockRRGraphBuilder builder(
-            chan_width, grid, &L_rr_node);
-        builder.create_and_append_clock_rr_graph(
-            num_seg_types,
-            &rr_edges_to_create);
+        ClockRRGraphBuilder builder(chan_width, grid, &L_rr_node, &L_rr_node_indices);
+        builder.create_and_append_clock_rr_graph(num_seg_types, &rr_edges_to_create);
         uniquify_edges(rr_edges_to_create);
         alloc_and_load_edges(L_rr_node, rr_edges_to_create);
         rr_edges_to_create.clear();

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1392,6 +1392,11 @@ void get_rr_node_indices(const t_rr_node_indices& L_rr_node_indices,
                          t_rr_type rr_type,
                          std::vector<int>* indices,
                          e_side side) {
+    //Comparison predicate
+    auto is_valid_id = [](int id) { return id != OPEN; };
+
+    indices->resize(0);
+
     if (rr_type == SOURCE
         || rr_type == SINK
         || rr_type == CHANX
@@ -1402,11 +1407,12 @@ void get_rr_node_indices(const t_rr_node_indices& L_rr_node_indices,
         }
 
         VTR_ASSERT_MSG(side == NUM_SIDES, "Non-IPINs/OPINs must not specify side");
-        indices->resize(L_rr_node_indices[rr_type][x][y][0].size());
-        std::copy(
+        indices->reserve(L_rr_node_indices[rr_type][x][y][0].size());
+        std::copy_if(
             L_rr_node_indices[rr_type][x][y][0].begin(),
             L_rr_node_indices[rr_type][x][y][0].end(),
-            indices->begin());
+            std::back_inserter(*indices),
+            is_valid_id);
     } else {
         VTR_ASSERT(rr_type == OPIN || rr_type == IPIN);
         if (side == NUM_SIDES) {
@@ -1416,21 +1422,22 @@ void get_rr_node_indices(const t_rr_node_indices& L_rr_node_indices,
                 capacity_needed += L_rr_node_indices[rr_type][x][y][tmp_side].size();
             }
 
-            indices->resize(0);
             indices->reserve(capacity_needed);
             for (e_side tmp_side : SIDES) {
-                std::copy(
+                std::copy_if(
                     L_rr_node_indices[rr_type][x][y][tmp_side].begin(),
                     L_rr_node_indices[rr_type][x][y][tmp_side].end(),
-                    std::back_inserter(*indices));
+                    std::back_inserter(*indices),
+                    is_valid_id);
             }
         } else {
             //Side specified
-            indices->resize(L_rr_node_indices[rr_type][x][y][side].size());
-            std::copy(
+            indices->reserve(L_rr_node_indices[rr_type][x][y][side].size());
+            std::copy_if(
                 L_rr_node_indices[rr_type][x][y][side].begin(),
                 L_rr_node_indices[rr_type][x][y][side].end(),
-                indices->begin());
+                std::back_inserter(*indices),
+                is_valid_id);
         }
     }
 }

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -2756,3 +2756,37 @@ static bool should_apply_switch_override(int switch_override) {
     }
     return false;
 }
+
+/*
+ * Utility
+ */
+void add_to_rr_node_indices(t_rr_node_indices& rr_node_indices, const t_rr_graph_storage& rr_nodes, int inode) {
+    const t_rr_node& rr_node = rr_nodes[inode];
+
+    for (int x = rr_node.xlow(); x <= rr_node.xhigh(); ++x) {
+        for (int y = rr_node.ylow(); y <= rr_node.yhigh(); ++y) {
+            auto rr_type = rr_node.type();
+            if (rr_type == IPIN || rr_type == OPIN) {
+                insert_at_ptc_index(rr_node_indices[rr_node.type()][x][y][rr_node.side()], rr_node.ptc_num(), inode);
+            } else if (rr_type == CHANX) {
+                //CHANX uses odd swapped x/y indices....
+                insert_at_ptc_index(rr_node_indices[rr_node.type()][y][x][0], rr_node.ptc_num(), inode);
+            } else {
+                insert_at_ptc_index(rr_node_indices[rr_node.type()][x][y][0], rr_node.ptc_num(), inode);
+            }
+        }
+    }
+}
+
+void insert_at_ptc_index(std::vector<int>& rr_indices, int ptc, int inode) {
+    if (ptc >= int(rr_indices.size())) {
+        rr_indices.resize(ptc + 1, OPEN); //Functional, but inefficient allocations...
+    }
+
+    if (rr_indices[ptc] == inode) {
+        return;
+    }
+
+    VTR_ASSERT(rr_indices[ptc] == OPEN);
+    rr_indices[ptc] = inode;
+}

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -3,11 +3,10 @@
 #include <vector>
 
 #include "build_switchblocks.h"
+#include "rr_graph_fwd.h"
 #include "rr_graph_util.h"
 #include "rr_types.h"
 #include "device_grid.h"
-
-struct t_rr_graph_storage; //Forward declaration
 
 /******************* Types shared by rr_graph2 functions *********************/
 

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -7,6 +7,8 @@
 #include "rr_types.h"
 #include "device_grid.h"
 
+struct t_rr_graph_storage; //Forward declaration
+
 /******************* Types shared by rr_graph2 functions *********************/
 
 enum e_seg_details_type {
@@ -48,6 +50,8 @@ t_rr_node_indices alloc_and_load_rr_node_indices(const int max_chan_width,
                                                  int* index,
                                                  const t_chan_details& chan_details_x,
                                                  const t_chan_details& chan_details_y);
+
+bool verify_rr_node_indices(const DeviceGrid& grid, const t_rr_node_indices& rr_node_indices, const t_rr_graph_storage& rr_nodes);
 
 int get_rr_node_index(int x,
                       int y,

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -253,4 +253,6 @@ void dump_sblock_pattern(const t_sblock_pattern& sblock_pattern,
                          const DeviceGrid& grid,
                          const char* fname);
 
+void add_to_rr_node_indices(t_rr_node_indices& rr_node_indices, const t_rr_graph_storage& rr_nodes, int inode);
+void insert_at_ptc_index(std::vector<int>& rr_indices, int ptc, int inode);
 #endif

--- a/vpr/src/route/rr_graph_clock.cpp
+++ b/vpr/src/route/rr_graph_clock.cpp
@@ -30,7 +30,7 @@ void ClockRRGraphBuilder::create_clock_networks_wires(const std::vector<std::uni
                                                       t_rr_edge_info_set* rr_edges_to_create) {
     // Add rr_nodes for each clock network wire
     for (auto& clock_network : clock_networks) {
-        clock_network->create_rr_nodes_for_clock_network_wires(*this, rr_nodes_, rr_edges_to_create, num_segments);
+        clock_network->create_rr_nodes_for_clock_network_wires(*this, rr_nodes_, rr_node_indices_, rr_edges_to_create, num_segments);
     }
 
     // Reduce the capacity of rr_nodes for performance

--- a/vpr/src/route/rr_graph_clock.h
+++ b/vpr/src/route/rr_graph_clock.h
@@ -77,10 +77,12 @@ class ClockRRGraphBuilder {
     ClockRRGraphBuilder(
         const t_chan_width& chan_width,
         const DeviceGrid& grid,
-        t_rr_graph_storage* rr_nodes)
+        t_rr_graph_storage* rr_nodes,
+        t_rr_node_indices* rr_node_indices)
         : chan_width_(chan_width)
         , grid_(grid)
         , rr_nodes_(rr_nodes)
+        , rr_node_indices_(rr_node_indices)
         , chanx_ptc_idx_(0)
         , chany_ptc_idx_(0) {
     }
@@ -134,6 +136,7 @@ class ClockRRGraphBuilder {
     const t_chan_width& chan_width_;
     const DeviceGrid& grid_;
     t_rr_graph_storage* rr_nodes_;
+    t_rr_node_indices* rr_node_indices_;
 
     int chanx_ptc_idx_;
     int chany_ptc_idx_;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
While debugging other issues I found inconsistencies with the rr_node_indices reverse RR graph look-up.

This PR adds:
 * A verification routine which sanity checks RR node indices against the current RR graph (this also has the added benefit of codifying exactly what is stored in rr_node_indicies which hasn't always been clear).
 * Fixes several bugs (mostly in the clock RR graph construction code) which were causing the inconsistencies