### PR TITLE
Remove stable sort by defining full element order.

### DIFF
--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -215,44 +215,52 @@ class edge_compare_src_node_and_configurable_first {
 
     bool operator()(const t_rr_edge_info& lhs, const edge_swapper& rhs) {
         auto lhs_src_node = RRNodeId(lhs.from_node);
+        auto lhs_dest_node = RRNodeId(lhs.to_node);
         auto lhs_is_configurable = rr_switch_inf_[lhs.switch_type].configurable();
 
         auto rhs_edge = RREdgeId(rhs.idx_);
         auto rhs_src_node = rhs.storage_->edge_src_node_[rhs_edge];
+        auto rhs_dest_node = rhs.storage_->edge_dest_node_[rhs_edge];
         auto rhs_is_configurable = rr_switch_inf_[rhs.storage_->edge_switch_[rhs_edge]].configurable();
 
-        return std::make_pair(lhs_src_node, !lhs_is_configurable) < std::make_pair(rhs_src_node, !rhs_is_configurable);
+        return std::make_tuple(lhs_src_node, !lhs_is_configurable, lhs_dest_node, lhs.switch_type) < std::make_tuple(rhs_src_node, !rhs_is_configurable, rhs_dest_node, rhs.storage_->edge_switch_[rhs_edge]);
     }
 
     bool operator()(const t_rr_edge_info& lhs, const t_rr_edge_info& rhs) {
         auto lhs_src_node = lhs.from_node;
+        auto lhs_dest_node = lhs.to_node;
         auto lhs_is_configurable = rr_switch_inf_[lhs.switch_type].configurable();
 
         auto rhs_src_node = rhs.from_node;
+        auto rhs_dest_node = rhs.to_node;
         auto rhs_is_configurable = rr_switch_inf_[rhs.switch_type].configurable();
 
-        return std::make_pair(lhs_src_node, !lhs_is_configurable) < std::make_pair(rhs_src_node, !rhs_is_configurable);
+        return std::make_tuple(lhs_src_node, !lhs_is_configurable, lhs_dest_node, lhs.switch_type) < std::make_tuple(rhs_src_node, !rhs_is_configurable, rhs_dest_node, rhs.switch_type);
     }
     bool operator()(const edge_swapper& lhs, const t_rr_edge_info& rhs) {
         auto lhs_edge = RREdgeId(lhs.idx_);
         auto lhs_src_node = lhs.storage_->edge_src_node_[lhs_edge];
+        auto lhs_dest_node = lhs.storage_->edge_dest_node_[lhs_edge];
         auto lhs_is_configurable = rr_switch_inf_[lhs.storage_->edge_switch_[lhs_edge]].configurable();
 
         auto rhs_src_node = RRNodeId(rhs.from_node);
+        auto rhs_dest_node = RRNodeId(rhs.to_node);
         auto rhs_is_configurable = rr_switch_inf_[rhs.switch_type].configurable();
 
-        return std::make_pair(lhs_src_node, !lhs_is_configurable) < std::make_pair(rhs_src_node, !rhs_is_configurable);
+        return std::make_tuple(lhs_src_node, !lhs_is_configurable, lhs_dest_node, lhs.storage_->edge_switch_[lhs_edge]) < std::make_tuple(rhs_src_node, !rhs_is_configurable, rhs_dest_node, rhs.switch_type);
     }
     bool operator()(const edge_swapper& lhs, const edge_swapper& rhs) {
         auto lhs_edge = RREdgeId(lhs.idx_);
         auto lhs_src_node = lhs.storage_->edge_src_node_[lhs_edge];
+        auto lhs_dest_node = lhs.storage_->edge_dest_node_[lhs_edge];
         auto lhs_is_configurable = rr_switch_inf_[lhs.storage_->edge_switch_[lhs_edge]].configurable();
 
         auto rhs_edge = RREdgeId(rhs.idx_);
         auto rhs_src_node = rhs.storage_->edge_src_node_[rhs_edge];
+        auto rhs_dest_node = rhs.storage_->edge_dest_node_[rhs_edge];
         auto rhs_is_configurable = rr_switch_inf_[rhs.storage_->edge_switch_[rhs_edge]].configurable();
 
-        return std::make_pair(lhs_src_node, !lhs_is_configurable) < std::make_pair(rhs_src_node, !rhs_is_configurable);
+        return std::make_tuple(lhs_src_node, !lhs_is_configurable, lhs_dest_node, lhs.storage_->edge_switch_[lhs_edge]) < std::make_tuple(rhs_src_node, !rhs_is_configurable, rhs_dest_node, rhs.storage_->edge_switch_[rhs_edge]);
     }
 
   private:
@@ -387,7 +395,7 @@ size_t t_rr_graph_storage::count_rr_switches(
     // values.
     //
     // This sort is safe to do because partition_edges() has not been invoked yet.
-    std::stable_sort(
+    std::sort(
         edge_sort_iterator(this, 0),
         edge_sort_iterator(this, edge_dest_node_.size()),
         edge_compare_dest_node());
@@ -482,7 +490,7 @@ void t_rr_graph_storage::partition_edges() {
     //    by assign_first_edges()
     //  - Edges within a source node have the configurable edges before the
     //    non-configurable edges.
-    std::stable_sort(
+    std::sort(
         edge_sort_iterator(this, 0),
         edge_sort_iterator(this, edge_src_node_.size()),
         edge_compare_src_node_and_configurable_first(device_ctx.rr_switch_inf));


### PR DESCRIPTION
#### Description

The stable sort requires additional memory, so this avoids using the stable sort.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
