### PR TITLE
Change default router initial timing to lookahead

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1057,6 +1057,21 @@ The following options are only valid when the router is in timing-driven mode (t
     
      **Default:** ``0.99``
 
+.. option:: --router_initial_timing {all_critical | lookahead}
+
+    Controls how criticality is determined at the start of the first routing iteration.
+
+     * ``all_critical``: All connections are considered timing critical.
+     * ``lookahead``: Connection criticalities are determined from timing analysis assuming (best-case) connection delays as estimated by the router's lookahead.
+
+     **Default:** ``all_critical`` for the classic :option:`--router_lookahead`, otherwise ``lookahead``
+
+.. option:: --router_update_lower_bound_delays {on | off}
+
+    Controls whether the router updates lower bound connection delays after the 1st routing iteration.
+
+    **Default:** ``on``
+
 .. option:: --router_first_iter_timing_report <file>
 
     Name of the timing report file to generate after the first routing iteration completes (not generated if unspecfied).

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1763,7 +1763,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
             "                 from timing analysis assuming best-case\n"
             "                 connection delays as estimated by the\n"
             "                 router's lookahead.\n")
-        .default_value("all_critical")
+        .default_value("lookahead")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_timing_grp.add_argument<e_heap_type, ParseRouterHeap>(args.router_heap, "--router_heap")
@@ -1779,7 +1779,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     route_timing_grp.add_argument<bool, ParseOnOff>(args.router_update_lower_bound_delays, "--router_update_lower_bound_delays")
         .help("Controls whether the router updates lower bound connection delays after the 1st routing iteration.")
-        .default_value("off")
+        .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_timing_grp.add_argument(args.router_first_iteration_timing_report_file, "--router_first_iter_timing_report")

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -324,10 +324,14 @@ float get_lookahead_map_cost(RRNodeId from_node, RRNodeId to_node, float critica
             //Such RR graphs are of course unroutable, but that should be determined by the
             //router. So just return an arbitrary value here rather than error.
 
-            //We choose to return the largest (non-infinite) value possible.
-            //This should ensure that the router de-prioritizes exploring it,
-            //but does not forbid the router from trying.
-            expected_cost = std::numeric_limits<float>::max();
+            //We choose to return the largest (non-infinite) value possible, but scaled
+            //down by a large factor to maintain some dynaimc range in case this value ends
+            //up being processed (e.g. by the timing analyzer).
+            //
+            //The cost estimate should still be *extremely* large compared to a typical delay, and
+            //so should ensure that the router de-prioritizes exploring this path, but does not
+            //forbid the router from trying.
+            expected_cost = std::numeric_limits<float>::max() / 1e12;
         } else {
             //From the current SOURCE/OPIN we look-up the wiretypes which are reachable
             //and then add the estimates from those wire types for the distance of interest.
@@ -576,7 +580,6 @@ static void compute_router_src_opin_lookahead() {
                 ptcs_with_no_reachable_wires = false;
 
                 sample_loc = pick_sample_tile(&device_ctx.physical_tile_types[itile], sample_loc);
-
 
                 if (sample_loc.x() == -1 && sample_loc.y() == -1) {
                     //No untried instances of the current tile type left

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -577,6 +577,7 @@ static void compute_router_src_opin_lookahead() {
 
                 sample_loc = pick_sample_tile(&device_ctx.physical_tile_types[itile], sample_loc);
 
+
                 if (sample_loc.x() == -1 && sample_loc.y() == -1) {
                     //No untried instances of the current tile type left
                     VTR_LOG_WARN("Found no %ssample locations for %s in %s\n",
@@ -585,6 +586,8 @@ static void compute_router_src_opin_lookahead() {
                                  device_ctx.physical_tile_types[itile].name);
                     break;
                 }
+
+                //VTR_LOG("Sampling %s at (%d,%d)\n", device_ctx.physical_tile_types[itile].name, sample_loc.x(), sample_loc.y());
 
                 rr_nodes_at_loc.clear();
 
@@ -628,20 +631,36 @@ static vtr::Point<int> pick_sample_tile(t_physical_tile_type_ptr tile_type, vtr:
     //Very simple for now, just pick the fist matching tile found
     vtr::Point<int> loc(OPEN, OPEN);
 
+    //VTR_LOG("Prev: %d,%d\n", prev.x(), prev.y());
+
     auto& device_ctx = g_vpr_ctx.device();
     auto& grid = device_ctx.grid;
+
+    int y_init = prev.y() + 1; //Start searching next element above prev
+
     for (int x = prev.x(); x < int(grid.width()); ++x) {
         if (x < 0) continue;
 
-        for (int y = prev.y() + 1; y < int(grid.height()); ++y) {
+        //VTR_LOG("  x: %d\n", x);
+
+        for (int y = y_init; y < int(grid.height()); ++y) {
             if (y < 0) continue;
 
+            //VTR_LOG("   y: %d\n", y);
             if (grid[x][y].type == tile_type) {
                 loc.set_x(x);
                 loc.set_y(y);
+                break;
             }
         }
+
+        if (loc.x() != OPEN && loc.y() != OPEN) {
+            break;
+        } else {
+            y_init = 0; //Prepare to search next column
+        }
     }
+    //VTR_LOG("Next: %d,%d\n", loc.x(), loc.y());
 
     return loc;
 }

--- a/vpr/src/timing/slack_evaluation.cpp
+++ b/vpr/src/timing/slack_evaluation.cpp
@@ -89,6 +89,10 @@ void SetupSlackCrit::update_criticalities(const tatum::TimingGraph& timing_graph
             auto domain_pair = DomainPair(tag.launch_clock_domain(), tag.capture_clock_domain());
 
             float slack = tag.time().value();
+
+            VTR_ASSERT_SAFE_MSG(!std::isnan(slack), "Slack should not be nan");
+            VTR_ASSERT_SAFE_MSG(std::isfinite(slack), "Slack should not be infinite");
+
             if (!worst_slack.count(domain_pair) || slack < worst_slack[domain_pair]) {
                 worst_slack[domain_pair] = slack;
             }

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -601,6 +601,9 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
         VTR_ASSERT_MSG(iter != domains_worst_slack.end(), "Require the worst slack for clock domain pair");
         float worst_slack = iter->second;
 
+        VTR_ASSERT_SAFE_MSG(!std::isnan(worst_slack), "Worst slack should not be nan");
+        VTR_ASSERT_SAFE_MSG(std::isfinite(worst_slack), "Worst slack should not be infinite");
+
         if (worst_slack < 0.) {
             //We shift slacks and required time by the most negative slack
             //**in the domain**, to ensure criticality is bounded within [0., 1.]
@@ -612,6 +615,10 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
             slack += shift;
             max_req += shift;
         }
+        VTR_ASSERT_SAFE_MSG(!std::isnan(slack), "Slack should not be nan");
+        VTR_ASSERT_SAFE_MSG(!std::isnan(max_req), "Max required time should not be nan");
+        VTR_ASSERT_SAFE_MSG(std::isfinite(slack), "Slack should not be infinite");
+        VTR_ASSERT_SAFE_MSG(std::isfinite(max_req), "Max required time should not be infinite");
 
         float crit = std::numeric_limits<float>::quiet_NaN();
         if (max_req > 0.) {
@@ -627,6 +634,8 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
         }
 
         //Soft check for reasonable criticality values
+        VTR_ASSERT_SAFE_MSG(!std::isnan(crit), "Criticality not be nan");
+        VTR_ASSERT_SAFE_MSG(std::isfinite(crit), "Criticality should not be infinite");
         VTR_ASSERT_MSG(crit >= 0. - CRITICALITY_ROUND_OFF_TOLERANCE, "Criticality should never be negative");
         VTR_ASSERT_MSG(crit <= 1. + CRITICALITY_ROUND_OFF_TOLERANCE, "Criticality should never be greather than one");
 

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_router_update_lb_delays/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_router_update_lb_delays/config/config.txt
@@ -24,6 +24,6 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements_fixed_chan_width.txt
 
 # Script parameters
-script_params_common = -starting_stage vpr --route_chan_width 60
+script_params_common = -starting_stage vpr --route_chan_width 70
 script_params_list_add = --router_update_lower_bound_delays off
 script_params_list_add = --router_update_lower_bound_delays on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Builds on #1216 and #1109 to use lookahead based initial timing estimates during the first routing iteration. This PR enables this feature (and updating of lower bound delays) by default. 

This PR requires #1216 so the map lookahead is used by default.