### PR TITLE
vpr: Fix crashes when freeing un-initialized data structures

### DIFF
--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -988,7 +988,7 @@ void free_device(const t_det_routing_arch& routing_arch) {
     device_ctx.chan_width.max = device_ctx.chan_width.x_max = device_ctx.chan_width.y_max = device_ctx.chan_width.x_min = device_ctx.chan_width.y_min = 0;
 
     for (int iswitch : {routing_arch.delayless_switch, routing_arch.global_route_switch}) {
-        if (device_ctx.arch_switch_inf[iswitch].name) {
+        if (device_ctx.arch_switch_inf != nullptr && device_ctx.arch_switch_inf[iswitch].name) {
             vtr::free(device_ctx.arch_switch_inf[iswitch].name);
             device_ctx.arch_switch_inf[iswitch].name = nullptr;
         }

--- a/vpr/src/pack/lb_type_rr_graph.cpp
+++ b/vpr/src/pack/lb_type_rr_graph.cpp
@@ -71,6 +71,10 @@ std::vector<t_lb_type_rr_node>* alloc_and_load_all_lb_type_rr_graph() {
 
 /* Free routing resource graph for all logic block types */
 void free_all_lb_type_rr_graph(std::vector<t_lb_type_rr_node>* lb_type_rr_graphs) {
+    if (lb_type_rr_graphs == nullptr) {
+        return;
+    }
+
     auto& device_ctx = g_vpr_ctx.device();
 
     for (const auto& type : device_ctx.logical_block_types) {


### PR DESCRIPTION
Crashes occurred when an early error means some data structures are uninitialized when things are cleaned up.
