### PR TITLE
WIP: Update Travis PPA sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ dist: trusty
 addons:
   apt:
     sources:
-    - george-edison55-precise-backports # For cmake
-    - llvm-toolchain-precise-3.6
-    - llvm-toolchain-trusty-6.0
-    - llvm-toolchain-trusty-7 # For clang-format-7
-    - llvm-toolchain-trusty-8
-    - ubuntu-toolchain-r-test
+    - sourceline: 'ppa:george-edison55/precise-backports' # For cmake
+    - sourceline: 'deb http://apt.llvm.org/precise llvm-toolchain-precise-3.6 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb http://apt.llvm.org/trusty llvm-toolchain-trusty-6.0 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb http://apt.llvm.org/trusty llvm-toolchain-trusty-7 main' # For clang-format-7
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb http://apt.llvm.org/trusty llvm-toolchain-trusty-8 main'
+      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
     - autoconf
     - automake


### PR DESCRIPTION
It appears Travis no longer includes various cmake/gcc/llvm PPA sources
in its whitelist, so we must change how they are specified.

Example build issues: https://travis-ci.com/github/verilog-to-routing/vtr-verilog-to-routing/jobs/313260700
