### PR TITLE
Adding .gitattributes to fix GitHub language detection.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,31 @@
 abc/**                  -text
 abc_with_bb_support/**  -text
 libs/EXTERNAL/**        -text
+
+# Settings to improve linguist data reporting (used by GitHub)
+#-------------------------------------------------------------------------
+*.v                     linguist-language=Verilog
+*.vh                    linguist-language=Verilog
+*.pv                    linguist-language=Verilog
+*.pl                    linguist-language=Perl
+*.sp                    linguist-language=Spice
+*.pm                    linguist-language=Spice
+
+# External ABC
+abc/**                  linguist-vendored
+abc_with_bb_support/**  linguist-vendored
+# External libraries
+libs/EXTERNAL/**        linguist-vendored
+# External benchmarks imported into vtr_flow benchmark suite.
+vtr_flow/benchmarks/**  linguist-vendored
+vtr_flow/scripts/perl_libs/** linguist-vendored
+# External benchmarks imported into ODIN_II benchmark suite.
+ODIN_II/regression_test/benchmark/verilog/large/** linguist-vendored
+ODIN_II/regression_test/benchmark/verilog/full/** linguist-vendored
+ODIN_II/regression_test/benchmark/verilog/FIR/** linguist-vendored
+
+# Documentation
+doc/**                  linguist-documentation
+*.txt                   linguist-documentation
+*.md                    linguist-documentation
+*.rst                   linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -48,3 +48,6 @@ doc/**                  linguist-documentation
 *.txt                   linguist-documentation
 *.md                    linguist-documentation
 *.rst                   linguist-documentation
+
+# Generated files
+vpr/src/route/gen/**    linguist-generated


### PR DESCRIPTION
#### Description

GitHub uses https://github.com/github/linguist to do language stats. linguist however mis-detects a bunch of things in this repo. It also needs to be told about the "vendored" files in the repo.

This can be fixed by setting values via `.gitattributes` file which is done here.

##### Before
```
53.46%  C         	 # This mostly comes from ABC
24.03%  C++
18.32%  Verilog  	 # This is the various imported regression tests / benchmarks
1.24%   HTML
0.85%   Perl
0.63%   Python
0.28%   Shell
0.28%   Cap'n Proto
0.27%   CMake
0.15%   Makefile
0.13%   Yacc
0.10%   JavaScript
0.07%   Lex
0.06%   Raku   		 # Misdetection
0.04%   M4
0.03%   CSS
0.03%   Objective-C
0.01%   Coq              # Misdetection
0.01%   Dockerfile
0.01%   SourcePawn    	 # Misdetection
0.00%   Lua
0.00%   Emacs Lisp
0.00%   Batchfile
0.00%   SystemVerilog
```

##### After
```
80.92%  C++
5.47%   Verilog
4.42%   Python
3.76%   C
2.45%   Perl
0.97%   Shell
0.70%   JavaScript
0.44%   Yacc
0.27%   Lex
0.23%   CMake
0.17%   Makefile
0.08%   HTML
0.05%   Cap'n Proto
0.05%   Dockerfile
0.04%   CSS
```
