### PR TITLE
edge_sort_iterator: also add operator> and >=.

### DIFF
--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -208,6 +208,10 @@ class edge_sort_iterator {
         return lhs.swapper_.idx_ >= rhs.swapper_.idx_;
     }
 
+    friend bool operator<=(const edge_sort_iterator& lhs, const edge_sort_iterator& rhs) {
+        return lhs.swapper_.idx_ <= rhs.swapper_.idx_;
+    }
+
     RREdgeId edge() const {
         return RREdgeId(swapper_.idx_);
     }

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -200,6 +200,14 @@ class edge_sort_iterator {
         return lhs.swapper_.idx_ < rhs.swapper_.idx_;
     }
 
+    friend bool operator>(const edge_sort_iterator& lhs, const edge_sort_iterator& rhs) {
+        return lhs.swapper_.idx_ > rhs.swapper_.idx_;
+    }
+
+    friend bool operator>=(const edge_sort_iterator& lhs, const edge_sort_iterator& rhs) {
+        return lhs.swapper_.idx_ >= rhs.swapper_.idx_;
+    }
+
     RREdgeId edge() const {
         return RREdgeId(swapper_.idx_);
     }


### PR DESCRIPTION
Some system implementations of sort are not really good in
only using the equality and less-than operators on iterators; add
operators observed to be needed.

Signed-off-by: Henner Zeller <h.zeller@acm.org>

CC: @litghost 