### PR TITLE
infra: Fix Kokoro nightly run-time failures

### DIFF
--- a/.github/kokoro/continuous/nightly.cfg
+++ b/.github/kokoro/continuous/nightly.cfg
@@ -49,5 +49,5 @@ env_vars {
 
 env_vars {
   key: "NUM_CORES"
-  value: "6"
+  value: "5"
 }

--- a/.github/kokoro/continuous/nightly.cfg
+++ b/.github/kokoro/continuous/nightly.cfg
@@ -35,6 +35,12 @@ env_vars {
   value: "vtr-verilog-to-routing"
 }
 
+#Use default build configuration
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: ""
+}
+
 env_vars {
   key: "VTR_TEST"
   value: "vtr_reg_nightly"

--- a/.github/kokoro/continuous/strong.cfg
+++ b/.github/kokoro/continuous/strong.cfg
@@ -35,6 +35,12 @@ env_vars {
   value: "vtr-verilog-to-routing"
 }
 
+#Enable extra assertion checking for strong test
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: "-DVTR_ASSERT_LEVEL=3"
+}
+
 env_vars {
   key: "VTR_TEST"
   value: "vtr_reg_strong"

--- a/.github/kokoro/continuous/weekly.cfg
+++ b/.github/kokoro/continuous/weekly.cfg
@@ -35,6 +35,12 @@ env_vars {
   value: "vtr-verilog-to-routing"
 }
 
+#Use default build configuration
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: ""
+}
+
 env_vars {
   key: "VTR_TEST"
   value: "vtr_reg_weekly"

--- a/.github/kokoro/presubmit/nightly.cfg
+++ b/.github/kokoro/presubmit/nightly.cfg
@@ -49,5 +49,5 @@ env_vars {
 
 env_vars {
   key: "NUM_CORES"
-  value: "6"
+  value: "5"
 }

--- a/.github/kokoro/presubmit/nightly.cfg
+++ b/.github/kokoro/presubmit/nightly.cfg
@@ -35,6 +35,12 @@ env_vars {
   value: "vtr-verilog-to-routing"
 }
 
+#Use default build configuration
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: ""
+}
+
 env_vars {
   key: "VTR_TEST"
   value: "vtr_reg_nightly"

--- a/.github/kokoro/presubmit/strong.cfg
+++ b/.github/kokoro/presubmit/strong.cfg
@@ -35,6 +35,12 @@ env_vars {
   value: "vtr-verilog-to-routing"
 }
 
+#Enable extra assertion checking for strong test
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: "-DVTR_ASSERT_LEVEL=3"
+}
+
 env_vars {
   key: "VTR_TEST"
   value: "vtr_reg_strong"

--- a/.github/kokoro/steps/hostinfo.sh
+++ b/.github/kokoro/steps/hostinfo.sh
@@ -13,20 +13,30 @@ echo
 echo "========================================"
 echo "Host CPU"
 echo "----------------------------------------"
-export CORES=$(nproc --all)
-echo "Cores: $CORES"
+
+export LOGICAL_CORES=$(nproc --all)
+echo "Logical Cores (counting SMT/HT): $LOGICAL_CORES"
+
+#The 2nd column of lscpu -p contains the core ID, with each physical
+# core having 1 or (in the case of SMT/hyperthreading) more logical
+# CPUs. Counting the *unique* core IDs across lines tells us the number
+# of *physical* CPUs (cores).
+export PHYSICAL_CORES=$(lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l)
+echo "Physical Cores (ignoring SMT/HT): $PHYSICAL_CORES"
+
+export MEM_GB=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)/(1024*1024)))
+echo "Memory (GB): $MEM_GB"
+
+echo
+echo "CPU Details"
+echo "----------------------------------------"
+lscpu
+echo "----------------------------------------"
 echo
 echo "Memory"
 echo "----------------------------------------"
 cat /proc/meminfo
 echo "----------------------------------------"
-export MEM_GB=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)/(1024*1024)))
-echo "Memory (GB): $CORES"
-export MEM_CORES=$(($MEM_GB/4))
-echo "Cores (4 GB per): $MEM_CORES"
-export MAX_CORES_NO_MIN=$(($MEM_CORES>$CORES?$CORES:$MEM_CORES))
-export MAX_CORES=$(($MAX_CORES_NO_MIN<1?1:$MAX_CORES_NO_MIN))
-echo "Max cores: $MAX_CORES"
 echo "----------------------------------------"
 echo "Process limits:"
 echo "----------------------------------------"

--- a/.github/kokoro/steps/vtr-build.sh
+++ b/.github/kokoro/steps/vtr-build.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
+if [ -z $VTR_CMAKE_PARAMS ]; then
+	echo "Missing $$VTR_CMAKE_PARAMS value"
+	exit 1
+fi
+
+if [ -z $LOGICAL_CORES ]; then
+	echo "Missing $$LOGICAL_CORES value"
+	exit 1
+fi
+
 export FAILURE=0
-make -k CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3" -j$MAX_CORES || export FAILURE=1
+make -k CMAKE_PARAMS="$VTR_CMAKE_PARAMS" -j$LOGICAL_CORES || export FAILURE=1
 
 echo
 echo
@@ -10,6 +20,6 @@ echo
 
 # When the build fails, produce the failure output in a clear way
 if [ $FAILURE -ne 0 ]; then
-        make CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3" -j1
+        make CMAKE_PARAMS="$VTR_CMAKE_PARAMS" -j1
         exit 1
 fi

--- a/.github/kokoro/steps/vtr-build.sh
+++ b/.github/kokoro/steps/vtr-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z $VTR_CMAKE_PARAMS ]; then
+if [ -z ${VTR_CMAKE_PARAMS+x} ]; then
 	echo "Missing $$VTR_CMAKE_PARAMS value"
 	exit 1
 fi

--- a/.github/kokoro/steps/vtr-test.sh
+++ b/.github/kokoro/steps/vtr-test.sh
@@ -5,11 +5,6 @@ if [ -z ${VTR_TEST+x} ]; then
 	exit 1
 fi
 
-if [ -z $MAX_CORES ]; then
-	echo "Missing $$MAX_CORES value"
-	exit 1
-fi
-
 if [ -z ${VTR_TEST_OPTIONS+x} ]; then
 	echo "Missing $$VTR_TEST_OPTIONS value"
 	exit 1

--- a/.github/kokoro/steps/vtr-test.sh
+++ b/.github/kokoro/steps/vtr-test.sh
@@ -36,6 +36,14 @@ pwd -P
 ) &
 MONITOR=$!
 
+echo "========================================"
+echo "VPR Build Info"
+echo "========================================"
+./vpr/vpr --version
+
+echo "========================================"
+echo "Running Tests"
+echo "========================================"
 export VPR_NUM_WORKERS=1
 ./run_reg_test.pl $VTR_TEST $VTR_TEST_OPTIONS -j$NUM_CORES
 kill $MONITOR


### PR DESCRIPTION
I've observed a number of run-time failures on the Kokoro nightly regression test, despite having fully updated the nightly regression test results, and the same tests passing when run locally.

For example see: https://source.cloud.google.com/results/invocations/354130ae-411d-454b-bdb0-6d66751a702e/targets/foss-fpga-tools%2Fverilog-to-routing%2Fupstream%2Fpresubmit%2Fnightly/log
where we see everything passes run-time and quality except for route time on some tests:
```
regression_tests/vtr_reg_nightly/complex_switch...[Fail]
 k4_N8_topology-0.85sL2-0.15gL4-on-cb-off-sb_22nm_22nm.xml/mcml.v/common crit_path_route_time: golden = 81.87 result = 2124.87
```

Diffing the offending [VPR on Kokoro log file](https://storage.cloud.google.com/vtr-verilog-to-routing/artifacts/prod/foss-fpga-tools/verilog-to-routing/upstream/presubmit/nightly/577/20200413-122350/vtr_flow/tasks/regression_tests/vtr_reg_nightly/complex_switch/run001/k4_N8_topology-0.85sL2-0.15gL4-on-cb-off-sb_22nm_22nm.xml/mcml.v/common/vpr.out) with one run locally 
([vpr.out.txt](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/4475704/vpr.out.txt)) shows identical results and router operations, but significantly longer run-times on Kokoro.

Checking the amount of free memory as the tests run shows:
```
$ grep 'Mem:' kokoro-sisyphus_resultstore_prod_foss-fpga-tools_verilog-to-routing_upstream_presubmit_nightly_354130ae-411d-454b-bdb0-6d66751a702e_build.log | awk '{print $4}' | sort -h | uniq -c
      1 512M
      1 516M
      1 547M
      1 592M
      2 595M
      1 596M
      1 599M
      3 600M
      1 602M
      1 641M
      1 836M
      1 837M
      1 838M
      3 1.1G
      1 1.2G
[...]
     12 35G
     15 36G
      2 37G
     16 38G
[...]
      1 85G
      2 86G
      1 88G
```
Indicating that at points the machine is nearing memory exhaustion (<1G free).

And begins swapping to disk, which shows up as a non-zero amount of swap usage:
```
grep 'Swap:' kokoro-sisyphus_resultstore_prod_foss-fpga-tools_verilog-to-routing_upstream_presubmit_nightly_354130ae-411d-454b-bdb0-6d66751a702e_build.log | awk '{print $3}' | sort -h | uniq -c
     52 0B
      5 4.4M
      1 22M
      9 23M
     59 28M
     12 29M
      1 57M
      4 58M
     43 63M
      4 64M
```

This PR reduces the number of parallel instances of VPR being run during Kokoro nightly, in order to avoid swapping to disk, and prevent run-times from being effected by it.

