### PR TITLE
Travis & gcc10 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ addons:
     - qt5-default
     - clang-format-7
     # All the compilers!
-    - g++-4.9
-    - gcc-4.9
     - g++-5
     - gcc-5
     - g++-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+version: ~> 1.0
 language: cpp
 
 dist: trusty
@@ -133,6 +134,7 @@ jobs:
       script:
         - ./.github/travis/build.sh
         - travis_wait 30 ./run_reg_test.pl vtr_reg_valgrind_small -show_failures -j2
+    - stage: Test
       name: "Sanitized Basic Regression Tests"
       env:
         - CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on"

--- a/ODIN_II/SRC/include/Hashtable.hpp
+++ b/ODIN_II/SRC/include/Hashtable.hpp
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <unordered_map>
+#include <string>
 
 class Hashtable {
   private:

--- a/libs/libvtrutil/src/vtr_ndmatrix.h
+++ b/libs/libvtrutil/src/vtr_ndmatrix.h
@@ -36,7 +36,6 @@ class NdMatrixProxy {
     NdMatrixProxy<T, N>& operator=(const NdMatrixProxy<T, N>& other) = delete;
 
     const NdMatrixProxy<T, N - 1> operator[](size_t index) const {
-        VTR_ASSERT_SAFE_MSG(index >= 0, "Index out of range (below dimension minimum)");
         VTR_ASSERT_SAFE_MSG(index < dim_sizes_[0], "Index out of range (above dimension maximum)");
         VTR_ASSERT_SAFE_MSG(dim_sizes_[1] > 0, "Can not index into zero-sized dimension");
 
@@ -71,7 +70,6 @@ class NdMatrixProxy<T, 1> {
 
     const T& operator[](size_t index) const {
         VTR_ASSERT_SAFE_MSG(dim_strides_[0] == 1, "Final dimension must have stride 1");
-        VTR_ASSERT_SAFE_MSG(index >= 0, "Index out of range (below dimension minimum)");
         VTR_ASSERT_SAFE_MSG(index < dim_sizes_[0], "Index out of range (above dimension maximum)");
 
         //Base case
@@ -319,7 +317,6 @@ class NdMatrix : public NdMatrixBase<T, N> {
     const NdMatrixProxy<T, N - 1> operator[](size_t index) const {
         VTR_ASSERT_SAFE_MSG(this->dim_size(0) > 0, "Can not index into size zero dimension");
         VTR_ASSERT_SAFE_MSG(this->dim_size(1) > 0, "Can not index into size zero dimension");
-        VTR_ASSERT_SAFE_MSG(index >= 0, "Index out of range (below dimension minimum)");
         VTR_ASSERT_SAFE_MSG(index < this->dim_sizes_[0], "Index out of range (above dimension maximum)");
 
         //Peel off the first dimension


### PR DESCRIPTION
* Fixes for building with gcc-10
* Fixes for Travis infrastructure (should close #1263)
* ~~Add Travis gcc-10 and clang-9/10 build tests~~
  * Turns out gcc-10 and clang-9/clang-10  aren't available with the OS version we're using in Travis