### PR TITLE
Add vtr_reg_strong with sanitizers to Kokoro

### DIFF
--- a/.github/kokoro/continuous/nightly.cfg
+++ b/.github/kokoro/continuous/nightly.cfg
@@ -40,6 +40,13 @@ env_vars {
   value: "vtr_reg_nightly"
 }
 
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
 env_vars {
   key: "NUM_CORES"
   value: "6"

--- a/.github/kokoro/continuous/strong.cfg
+++ b/.github/kokoro/continuous/strong.cfg
@@ -40,6 +40,13 @@ env_vars {
   value: "vtr_reg_strong"
 }
 
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
 env_vars {
   key: "NUM_CORES"
   value: "8"

--- a/.github/kokoro/continuous/strong_sanitized.cfg
+++ b/.github/kokoro/continuous/strong_sanitized.cfg
@@ -1,0 +1,62 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "vtr-verilog-to-routing/.github/kokoro/run-vtr.sh"
+
+# 1 hour
+timeout_mins: 60
+
+action {
+  define_artifacts {
+    # File types
+    regex: "**/*.out"
+    regex: "**/vpr_stdout.log"
+    regex: "**/parse_results.txt"
+    regex: "**/qor_results.txt"
+    regex: "**/pack.log"
+    regex: "**/place.log"
+    regex: "**/route.log"
+    regex: "**/*_qor.csv"
+    strip_prefix: "github/vtr-verilog-to-routing/"
+  }
+}
+
+env_vars {
+  key: "KOKORO_TYPE"
+  value: "continuous"
+}
+
+env_vars {
+  key: "KOKORO_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+env_vars {
+  key: "VTR_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+#VTR build configuration options:
+# -DVTR_ASSERT_LEVEL=3: Enable extra assertion checking
+# -DVTR_ENABLE_SANITIZE=ON: Enable compiler sanitizers (check for memory issues, undefined behaviour, etc.)
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: "-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=ON"
+}
+
+env_vars {
+  key: "VTR_TEST"
+  value: "vtr_reg_strong"
+}
+
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+# -skip_qor: Skip QoR checks (since we expect run-time failures due to sanitizers)
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures -skip_qor"
+}
+
+env_vars {
+  key: "NUM_CORES"
+  value: "8"
+}

--- a/.github/kokoro/continuous/weekly.cfg
+++ b/.github/kokoro/continuous/weekly.cfg
@@ -40,6 +40,13 @@ env_vars {
   value: "vtr_reg_weekly"
 }
 
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
 env_vars {
   key: "NUM_CORES"
   value: "3"

--- a/.github/kokoro/presubmit/nightly.cfg
+++ b/.github/kokoro/presubmit/nightly.cfg
@@ -40,6 +40,13 @@ env_vars {
   value: "vtr_reg_nightly"
 }
 
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
 env_vars {
   key: "NUM_CORES"
   value: "6"

--- a/.github/kokoro/presubmit/strong.cfg
+++ b/.github/kokoro/presubmit/strong.cfg
@@ -40,6 +40,13 @@ env_vars {
   value: "vtr_reg_strong"
 }
 
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
 env_vars {
   key: "NUM_CORES"
   value: "8"

--- a/.github/kokoro/presubmit/strong_sanitized.cfg
+++ b/.github/kokoro/presubmit/strong_sanitized.cfg
@@ -1,0 +1,62 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "vtr-verilog-to-routing/.github/kokoro/run-vtr.sh"
+
+# 1 hour
+timeout_mins: 60
+
+action {
+  define_artifacts {
+    # File types
+    regex: "**/*.out"
+    regex: "**/vpr_stdout.log"
+    regex: "**/parse_results.txt"
+    regex: "**/qor_results.txt"
+    regex: "**/pack.log"
+    regex: "**/place.log"
+    regex: "**/route.log"
+    regex: "**/*_qor.csv"
+    strip_prefix: "github/vtr-verilog-to-routing/"
+  }
+}
+
+env_vars {
+  key: "KOKORO_TYPE"
+  value: "presubmit"
+}
+
+env_vars {
+  key: "KOKORO_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+env_vars {
+  key: "VTR_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+#VTR build configuration options:
+# -DVTR_ASSERT_LEVEL=3: Enable extra assertion checking
+# -DVTR_ENABLE_SANITIZE=ON: Enable compiler sanitizers (check for memory issues, undefined behaviour, etc.)
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: "-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=ON"
+}
+
+env_vars {
+  key: "VTR_TEST"
+  value: "vtr_reg_strong"
+}
+
+#Options for run_reg_test.pl
+# -show_failures: show tool failures in main log output
+# -skip_qor: Skip QoR checks (since we expect run-time failures due to sanitizers)
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures -skip_qor"
+}
+
+env_vars {
+  key: "NUM_CORES"
+  value: "8"
+}

--- a/.github/kokoro/steps/vtr-test.sh
+++ b/.github/kokoro/steps/vtr-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z $VTR_TEST ]; then
+if [ -z ${VTR_TEST+x} ]; then
 	echo "Missing $$VTR_TEST value"
 	exit 1
 fi
@@ -10,7 +10,7 @@ if [ -z $MAX_CORES ]; then
 	exit 1
 fi
 
-if [ -z $VTR_TEST_OPTIONS ]; then
+if [ -z ${VTR_TEST_OPTIONS+x} ]; then
 	echo "Missing $$VTR_TEST_OPTIONS value"
 	exit 1
 fi

--- a/.github/kokoro/steps/vtr-test.sh
+++ b/.github/kokoro/steps/vtr-test.sh
@@ -10,6 +10,11 @@ if [ -z $MAX_CORES ]; then
 	exit 1
 fi
 
+if [ -z $VTR_TEST_OPTIONS ]; then
+	echo "Missing $$VTR_TEST_OPTIONS value"
+	exit 1
+fi
+
 if [ -z $NUM_CORES ]; then
 	echo "Missing $$NUM_CORES value"
 	exit 1
@@ -37,5 +42,5 @@ pwd -P
 MONITOR=$!
 
 export VPR_NUM_WORKERS=1
-./run_reg_test.pl $VTR_TEST -show_failures -j$NUM_CORES
+./run_reg_test.pl $VTR_TEST $VTR_TEST_OPTIONS -j$NUM_CORES
 kill $MONITOR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Building on PR #1276, this adds an additional Kokoro test, which runs vtr_reg_strong with a [sanitizer enabled](https://docs.verilogtorouting.org/en/latest/dev/developing/#sanitizers) build of VTR.

Since vtr_reg_strong is out main 'feature check' test it would be good to have it checked with sanitizers for memory issues/leaks etc.

We already have a sanitized version of the vtr_reg_basic test running in TravisCI, but the combination of longer compilation times with sanitizers enabled, and longer test time make it impossible to run vtr_reg_strong with sanitizers on TravisCI.