### PR TITLE
Fix sanitizer failures in vtr_reg_strong

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -630,10 +630,10 @@ struct t_physical_tile_type {
     // https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1193
 
     // Does this t_physical_tile_type contain an inpad?
-    bool is_input_type;
+    bool is_input_type = false;
 
     // Does this t_physical_tile_type contain an outpad?
-    bool is_output_type;
+    bool is_output_type = false;
 };
 
 /* Holds the capacity range of a certain sub_tile block within the parent physical tile type.

--- a/vpr/lsan.supp
+++ b/vpr/lsan.supp
@@ -1,0 +1,5 @@
+#LeakSanitizer supporession file for VPR
+
+#Leak from graphics (ezgl/cairo) related to
+# text processing
+leak:libfontconfig.so

--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -1643,6 +1643,9 @@ sub run_vpr {
         push(@vpr_args, @extra_vpr_args);
     }
 
+    #Add the LeakSanitizer (LSAN) suppression file
+    local $ENV{"LSAN_OPTIONS"} = "suppressions=$vtr_flow_path/../vpr/lsan.supp";
+
     #Run the command
     $q = &system_with_timeout(
         $vpr_path, $args->{log_file},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
On some systems there are memory leaks caused by system libraries (e.g. related to VPR graphics) which get picked up by LSAN.

This change adds an LSAN suppression file to avoid such leaks causing test failures (since they are outside of VTR's control).

Also fixes an uninitialized member variable in t_physical_tile_type also detected by sanitizers.