### PR TITLE
Placement bb cost computation fix

### DIFF
--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2348,6 +2348,11 @@ static void alloc_and_load_for_fast_cost_update(float place_cost_exp) {
 
     for (size_t high = 0; high < device_ctx.grid.height(); high++)
         for (size_t low = 0; low <= high; low++) {
+            if (chanx_place_cost_fac[high][low] == 0.0f) {
+                VTR_LOG_WARN("CHANX place cost fac is 0 at %d %d\n", high, low);
+                chanx_place_cost_fac[high][low] = 1.0f;
+            }
+
             chanx_place_cost_fac[high][low] = (high - low + 1.)
                                               / chanx_place_cost_fac[high][low];
             chanx_place_cost_fac[high][low] = pow((double)chanx_place_cost_fac[high][low], (double)place_cost_exp);
@@ -2370,6 +2375,11 @@ static void alloc_and_load_for_fast_cost_update(float place_cost_exp) {
 
     for (size_t high = 0; high < device_ctx.grid.width(); high++)
         for (size_t low = 0; low <= high; low++) {
+            if (chany_place_cost_fac[high][low] == 0.0f) {
+                VTR_LOG_WARN("CHANY place cost fac is 0 at %d %d\n", high, low);
+                chany_place_cost_fac[high][low] = 1.0f;
+            }
+
             chany_place_cost_fac[high][low] = (high - low + 1.)
                                               / chany_place_cost_fac[high][low];
             chany_place_cost_fac[high][low] = pow((double)chany_place_cost_fac[high][low], (double)place_cost_exp);

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2348,6 +2348,11 @@ static void alloc_and_load_for_fast_cost_update(float place_cost_exp) {
 
     for (size_t high = 0; high < device_ctx.grid.height(); high++)
         for (size_t low = 0; low <= high; low++) {
+            /* Since we will divide the wiring cost by the average channel *
+             * capacity between high and low, having only 0 width channels *
+             * will result in infinite wiring capacity normalization       *
+             * factor, and extremely bad placer behaviour. Hence we change *
+             * this to a small (1 track) channel capacity instead.         */
             if (chanx_place_cost_fac[high][low] == 0.0f) {
                 VTR_LOG_WARN("CHANX place cost fac is 0 at %d %d\n", high, low);
                 chanx_place_cost_fac[high][low] = 1.0f;
@@ -2375,6 +2380,11 @@ static void alloc_and_load_for_fast_cost_update(float place_cost_exp) {
 
     for (size_t high = 0; high < device_ctx.grid.width(); high++)
         for (size_t low = 0; low <= high; low++) {
+            /* Since we will divide the wiring cost by the average channel *
+             * capacity between high and low, having only 0 width channels *
+             * will result in infinite wiring capacity normalization       *
+             * factor, and extremely bad placer behaviour. Hence we change *
+             * this to a small (1 track) channel capacity instead.         */
             if (chany_place_cost_fac[high][low] == 0.0f) {
                 VTR_LOG_WARN("CHANY place cost fac is 0 at %d %d\n", high, low);
                 chany_place_cost_fac[high][low] = 1.0f;


### PR DESCRIPTION
#### Description
If it happens that a routing graph contains zero-capacity channels then the computation of bounding-box placement cost yields in +infs. This may happen when VPR operates on a rr graph provided by a user. This makes the placement optimizer not optimize anything.

The cost is computed as inverse of a channel capacity. This PR adds a condition which catches zeros, logs a warnings and substitutes them with ones. This way channels of capacity 0 and 1 will have the same placement cost.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
Solves poor timing-driven placement results in SymbiFlow on the Artix 200T architecture.

#### How Has This Been Tested?
The placement algorithm was run twice: first in its unmodified version, second with the proposed modification. Each time using the same packed netlist. The results were assessed through the worst critical path delay estimated after placement:

| Design | Original | Proposed |
| --- | --- | --- |
| picosoc | 62.61ns | 22.75ns |
| murax | 36.90ns | 15.53ns |
| LiteX SoC (VexRiscv + DDR) | 41.83ns | 19.49ns |
| LiteX SoC (Linux capable VexRiscv + DDR) | 60.66ns | 20.41ns |

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
