### PR TITLE
Fix some bugs in generating non-configurable edge sets.

### DIFF
--- a/vpr/src/route/edge_groups.cpp
+++ b/vpr/src/route/edge_groups.cpp
@@ -1,0 +1,107 @@
+#include "edge_groups.h"
+
+#include <stack>
+
+// Adds non-configurable (undirected) edge to be grouped.
+//
+// Returns true if this is a new edge.
+bool EdgeGroups::add_non_config_edge(int from_node, int to_node) {
+    return graph_[from_node].edges.insert(to_node).second && graph_[to_node].edges.insert(from_node).second;
+}
+
+// After add_non_config_edge has been called for all edges, create_sets
+// will form groups of nodes that are connected via non-configurable
+// edges.
+void EdgeGroups::create_sets() {
+    rr_non_config_node_sets_map_.clear();
+
+    // https://en.wikipedia.org/wiki/Component_(graph_theory)#Algorithms
+    std::vector<size_t> group_size;
+    for (auto& node : graph_) {
+        if (node.second.set == OPEN) {
+            node.second.set = group_size.size();
+            group_size.push_back(add_connected_group(node.second));
+        }
+    }
+
+    // Sanity check the node sets.
+    for (const auto& node : graph_) {
+        VTR_ASSERT(node.second.set != OPEN);
+        for (const auto& e : node.second.edges) {
+            int set = graph_[e].set;
+            VTR_ASSERT(set == node.second.set);
+        }
+    }
+
+    // Create compact set of sets.
+    rr_non_config_node_sets_map_.resize(group_size.size());
+    for (size_t i = 0; i < group_size.size(); i++) {
+        rr_non_config_node_sets_map_[i].reserve(group_size[i]);
+    }
+    for (const auto& node : graph_) {
+        rr_non_config_node_sets_map_[node.second.set].push_back(node.first);
+    }
+}
+
+// Create t_non_configurable_rr_sets from set data.
+// NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
+t_non_configurable_rr_sets EdgeGroups::output_sets() {
+    t_non_configurable_rr_sets sets;
+    for (const auto& nodes : rr_non_config_node_sets_map_) {
+        std::set<t_node_edge> edge_set;
+        std::set<int> node_set(nodes.begin(), nodes.end());
+
+        for (const auto& src : node_set) {
+            for (const auto& dest : graph_[src].edges) {
+                edge_set.emplace(t_node_edge(src, dest));
+            }
+        }
+
+        sets.node_sets.emplace(std::move(node_set));
+        sets.edge_sets.emplace(std::move(edge_set));
+    }
+
+    return sets;
+}
+
+// Set device context structures for non-configurable node sets.
+void EdgeGroups::set_device_context(DeviceContext& device_ctx) {
+    std::vector<std::vector<int>> rr_non_config_node_sets;
+    for (const auto& item : rr_non_config_node_sets_map_) {
+        rr_non_config_node_sets.emplace_back(std::move(item));
+    }
+
+    std::unordered_map<int, int> rr_node_to_non_config_node_set;
+    for (size_t set = 0; set < rr_non_config_node_sets.size(); ++set) {
+        for (const auto inode : rr_non_config_node_sets[set]) {
+            rr_node_to_non_config_node_set.insert(
+                std::make_pair(inode, set));
+        }
+    }
+
+    device_ctx.rr_non_config_node_sets = std::move(rr_non_config_node_sets);
+    device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_to_non_config_node_set);
+}
+
+// Perform a DFS traversal marking everything reachable with the same set id
+size_t EdgeGroups::add_connected_group(const node_data& node) {
+    // stack contains nodes with edges to mark with node.set
+    // The set for each node must be set before pushing it onto the stack
+    std::stack<const node_data*> stack;
+    stack.push(&node);
+    size_t n = 1;
+    while (!stack.empty()) {
+        auto top = stack.top();
+        stack.pop();
+        for (auto e : top->edges) {
+            auto& next = graph_[e];
+            if (next.set != node.set) {
+                VTR_ASSERT(next.set == OPEN);
+                n++;
+                next.set = node.set;
+                stack.push(&next);
+            }
+        }
+    }
+    return n;
+}

--- a/vpr/src/route/edge_groups.h
+++ b/vpr/src/route/edge_groups.h
@@ -1,0 +1,50 @@
+#ifndef EDGE_GROUPS_H
+#define EDGE_GROUPS_H
+
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+#include <cstddef>
+
+#include "vpr_types.h"
+#include "vpr_context.h"
+
+// Class for building a group of connected edges.
+class EdgeGroups {
+  public:
+    EdgeGroups() {}
+
+    // Adds non-configurable (undirected) edge to be grouped.
+    //
+    // Returns true if this is a new edge.
+    bool add_non_config_edge(int from_node, int to_node);
+
+    // After add_non_config_edge has been called for all edges, create_sets
+    // will form groups of nodes that are connected via non-configurable
+    // edges.
+    void create_sets();
+
+    // Create t_non_configurable_rr_sets from set data.
+    // NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
+    t_non_configurable_rr_sets output_sets();
+
+    // Set device context structures for non-configurable node sets.
+    void set_device_context(DeviceContext& device_ctx);
+
+  private:
+    struct node_data {
+        std::unordered_set<int> edges;
+        int set = OPEN;
+    };
+
+    // Perform a DFS traversal marking everything reachable with the same set id
+    size_t add_connected_group(const node_data& node);
+
+    // Set of non-configurable edges.
+    std::unordered_map<int, node_data> graph_;
+
+    // Compact set of node sets. Map key is arbitrary.
+    std::vector<std::vector<int>> rr_non_config_node_sets_map_;
+};
+
+#endif

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -3084,12 +3084,12 @@ static void create_edge_groups(EdgeGroups* groups) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& rr_nodes = device_ctx.rr_nodes;
 
-    for (size_t iedge = 0; iedge < rr_nodes.edges_size(); ++iedge) {
-        RREdgeId edge(iedge);
-        if (!device_ctx.rr_switch_inf[rr_nodes.edge_switch(edge)].configurable()) {
-            groups->add_non_config_edge(size_t(rr_nodes.edge_source_node(edge)), size_t(rr_nodes.edge_sink_node(edge)));
-        }
-    }
+    rr_nodes.for_each_edge(
+        [&](RREdgeId edge, RRNodeId src, RRNodeId sink) {
+            if (!device_ctx.rr_switch_inf[rr_nodes.edge_switch(edge)].configurable()) {
+                groups->add_non_config_edge(size_t(src), size_t(sink));
+            }
+        });
 
     groups->create_sets();
 }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2956,128 +2956,110 @@ static int pick_best_direct_connect_target_rr_node(const t_rr_graph_storage& rr_
     return best_rr;
 }
 
-// Class for building a group of connected edges.
-class EdgeGroups {
-  public:
-    EdgeGroups() {}
+// Adds non-configurable (undirected) edge to be grouped.
+//
+// Returns true if this is a new edge.
+bool EdgeGroups::add_non_config_edge(int from_node, int to_node) {
+    return graph_[from_node].edges.insert(to_node).second && graph_[to_node].edges.insert(from_node).second;
+}
 
-    // Adds non-configurable (undirected) edge to be grouped.
-    //
-    // Returns true if this is a new edge.
-    bool add_non_config_edge(int from_node, int to_node) {
-        return graph_[from_node].edges.insert(to_node).second && graph_[to_node].edges.insert(from_node).second;
-    }
+// After add_non_config_edge has been called for all edges, create_sets
+// will form groups of nodes that are connected via non-configurable
+// edges.
+void EdgeGroups::create_sets() {
+    rr_non_config_node_sets_map_.clear();
 
-    // After add_non_config_edge has been called for all edges, create_sets
-    // will form groups of nodes that are connected via non-configurable
-    // edges.
-    void create_sets() {
-        rr_non_config_node_sets_map_.clear();
-
-        // https://en.wikipedia.org/wiki/Component_(graph_theory)#Algorithms
-        std::vector<size_t> group_size;
-        for (auto& node : graph_) {
-            if (node.second.set == OPEN) {
-                node.second.set = group_size.size();
-                group_size.push_back(add_connected_group(node.second));
-            }
-        }
-
-        // Sanity check the node sets.
-        for (const auto& node : graph_) {
-            VTR_ASSERT(node.second.set != OPEN);
-            for (const auto& e : node.second.edges) {
-                int set = graph_[e].set;
-                VTR_ASSERT(set == node.second.set);
-            }
-        }
-
-        // Create compact set of sets.
-        rr_non_config_node_sets_map_.resize(group_size.size());
-        for (size_t i = 0; i < group_size.size(); i++) {
-            rr_non_config_node_sets_map_[i].reserve(group_size[i]);
-        }
-        for (const auto& node : graph_) {
-            rr_non_config_node_sets_map_[node.second.set].push_back(node.first);
+    // https://en.wikipedia.org/wiki/Component_(graph_theory)#Algorithms
+    std::vector<size_t> group_size;
+    for (auto& node : graph_) {
+        if (node.second.set == OPEN) {
+            node.second.set = group_size.size();
+            group_size.push_back(add_connected_group(node.second));
         }
     }
 
-    // Create t_non_configurable_rr_sets from set data.
-    // NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
-    t_non_configurable_rr_sets output_sets() {
-        t_non_configurable_rr_sets sets;
-        for (const auto& nodes : rr_non_config_node_sets_map_) {
-            std::set<t_node_edge> edge_set;
-            std::set<int> node_set(nodes.begin(), nodes.end());
-
-            for (const auto& src : node_set) {
-                for (const auto& dest : graph_[src].edges) {
-                    edge_set.emplace(t_node_edge(src, dest));
-                }
-            }
-
-            sets.node_sets.emplace(std::move(node_set));
-            sets.edge_sets.emplace(std::move(edge_set));
+    // Sanity check the node sets.
+    for (const auto& node : graph_) {
+        VTR_ASSERT(node.second.set != OPEN);
+        for (const auto& e : node.second.edges) {
+            int set = graph_[e].set;
+            VTR_ASSERT(set == node.second.set);
         }
-
-        return sets;
     }
 
-    // Set device context structures for non-configurable node sets.
-    void set_device_context() {
-        std::vector<std::vector<int>> rr_non_config_node_sets;
-        for (const auto& item : rr_non_config_node_sets_map_) {
-            rr_non_config_node_sets.emplace_back(std::move(item));
-        }
+    // Create compact set of sets.
+    rr_non_config_node_sets_map_.resize(group_size.size());
+    for (size_t i = 0; i < group_size.size(); i++) {
+        rr_non_config_node_sets_map_[i].reserve(group_size[i]);
+    }
+    for (const auto& node : graph_) {
+        rr_non_config_node_sets_map_[node.second.set].push_back(node.first);
+    }
+}
 
-        std::unordered_map<int, int> rr_node_to_non_config_node_set;
-        for (size_t set = 0; set < rr_non_config_node_sets.size(); ++set) {
-            for (const auto inode : rr_non_config_node_sets[set]) {
-                rr_node_to_non_config_node_set.insert(
-                    std::make_pair(inode, set));
+// Create t_non_configurable_rr_sets from set data.
+// NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
+t_non_configurable_rr_sets EdgeGroups::output_sets() {
+    t_non_configurable_rr_sets sets;
+    for (const auto& nodes : rr_non_config_node_sets_map_) {
+        std::set<t_node_edge> edge_set;
+        std::set<int> node_set(nodes.begin(), nodes.end());
+
+        for (const auto& src : node_set) {
+            for (const auto& dest : graph_[src].edges) {
+                edge_set.emplace(t_node_edge(src, dest));
             }
         }
 
-        auto& device_ctx = g_vpr_ctx.mutable_device();
-        device_ctx.rr_non_config_node_sets = std::move(rr_non_config_node_sets);
-        device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_to_non_config_node_set);
+        sets.node_sets.emplace(std::move(node_set));
+        sets.edge_sets.emplace(std::move(edge_set));
     }
 
-  private:
-    struct node_data {
-        std::unordered_set<int> edges;
-        int set = OPEN;
-    };
+    return sets;
+}
 
-    // Perform a DFS traversal marking everything reachable with the same set id
-    size_t add_connected_group(const node_data& node) {
-        // stack contains nodes with edges to mark with node.set
-        // The set for each node must be set before pushing it onto the stack
-        std::stack<const node_data*> stack;
-        stack.push(&node);
-        size_t n = 1;
-        while (!stack.empty()) {
-            auto top = stack.top();
-            stack.pop();
-            for (auto e : top->edges) {
-                auto& next = graph_[e];
-                if (next.set != node.set) {
-                    VTR_ASSERT(next.set == OPEN);
-                    n++;
-                    next.set = node.set;
-                    stack.push(&next);
-                }
+// Set device context structures for non-configurable node sets.
+void EdgeGroups::set_device_context() {
+    std::vector<std::vector<int>> rr_non_config_node_sets;
+    for (const auto& item : rr_non_config_node_sets_map_) {
+        rr_non_config_node_sets.emplace_back(std::move(item));
+    }
+
+    std::unordered_map<int, int> rr_node_to_non_config_node_set;
+    for (size_t set = 0; set < rr_non_config_node_sets.size(); ++set) {
+        for (const auto inode : rr_non_config_node_sets[set]) {
+            rr_node_to_non_config_node_set.insert(
+                std::make_pair(inode, set));
+        }
+    }
+
+    auto& device_ctx = g_vpr_ctx.mutable_device();
+    device_ctx.rr_non_config_node_sets = std::move(rr_non_config_node_sets);
+    device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_to_non_config_node_set);
+}
+
+// Perform a DFS traversal marking everything reachable with the same set id
+size_t EdgeGroups::add_connected_group(const node_data& node) {
+    // stack contains nodes with edges to mark with node.set
+    // The set for each node must be set before pushing it onto the stack
+    std::stack<const node_data*> stack;
+    stack.push(&node);
+    size_t n = 1;
+    while (!stack.empty()) {
+        auto top = stack.top();
+        stack.pop();
+        for (auto e : top->edges) {
+            auto& next = graph_[e];
+            if (next.set != node.set) {
+                VTR_ASSERT(next.set == OPEN);
+                n++;
+                next.set = node.set;
+                stack.push(&next);
             }
         }
-        return n;
     }
-
-    // Set of non-configurable edges.
-    std::unordered_map<int, node_data> graph_;
-
-    // Compact set of node sets. Map key is arbitrary.
-    std::vector<std::vector<int>> rr_non_config_node_sets_map_;
-};
+    return n;
+}
 
 //Collects the sets of connected non-configurable edges in the RR graph
 static void create_edge_groups(EdgeGroups* groups) {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -4,7 +4,6 @@
 #include <ctime>
 #include <algorithm>
 #include <vector>
-#include <stack>
 #include "vtr_assert.h"
 
 #include "vtr_util.h"
@@ -34,6 +33,7 @@
 #include "rr_graph_reader.h"
 #include "router_lookahead_map.h"
 #include "rr_graph_clock.h"
+#include "edge_groups.h"
 
 #include "rr_types.h"
 
@@ -2956,111 +2956,6 @@ static int pick_best_direct_connect_target_rr_node(const t_rr_graph_storage& rr_
     return best_rr;
 }
 
-// Adds non-configurable (undirected) edge to be grouped.
-//
-// Returns true if this is a new edge.
-bool EdgeGroups::add_non_config_edge(int from_node, int to_node) {
-    return graph_[from_node].edges.insert(to_node).second && graph_[to_node].edges.insert(from_node).second;
-}
-
-// After add_non_config_edge has been called for all edges, create_sets
-// will form groups of nodes that are connected via non-configurable
-// edges.
-void EdgeGroups::create_sets() {
-    rr_non_config_node_sets_map_.clear();
-
-    // https://en.wikipedia.org/wiki/Component_(graph_theory)#Algorithms
-    std::vector<size_t> group_size;
-    for (auto& node : graph_) {
-        if (node.second.set == OPEN) {
-            node.second.set = group_size.size();
-            group_size.push_back(add_connected_group(node.second));
-        }
-    }
-
-    // Sanity check the node sets.
-    for (const auto& node : graph_) {
-        VTR_ASSERT(node.second.set != OPEN);
-        for (const auto& e : node.second.edges) {
-            int set = graph_[e].set;
-            VTR_ASSERT(set == node.second.set);
-        }
-    }
-
-    // Create compact set of sets.
-    rr_non_config_node_sets_map_.resize(group_size.size());
-    for (size_t i = 0; i < group_size.size(); i++) {
-        rr_non_config_node_sets_map_[i].reserve(group_size[i]);
-    }
-    for (const auto& node : graph_) {
-        rr_non_config_node_sets_map_[node.second.set].push_back(node.first);
-    }
-}
-
-// Create t_non_configurable_rr_sets from set data.
-// NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
-t_non_configurable_rr_sets EdgeGroups::output_sets() {
-    t_non_configurable_rr_sets sets;
-    for (const auto& nodes : rr_non_config_node_sets_map_) {
-        std::set<t_node_edge> edge_set;
-        std::set<int> node_set(nodes.begin(), nodes.end());
-
-        for (const auto& src : node_set) {
-            for (const auto& dest : graph_[src].edges) {
-                edge_set.emplace(t_node_edge(src, dest));
-            }
-        }
-
-        sets.node_sets.emplace(std::move(node_set));
-        sets.edge_sets.emplace(std::move(edge_set));
-    }
-
-    return sets;
-}
-
-// Set device context structures for non-configurable node sets.
-void EdgeGroups::set_device_context() {
-    std::vector<std::vector<int>> rr_non_config_node_sets;
-    for (const auto& item : rr_non_config_node_sets_map_) {
-        rr_non_config_node_sets.emplace_back(std::move(item));
-    }
-
-    std::unordered_map<int, int> rr_node_to_non_config_node_set;
-    for (size_t set = 0; set < rr_non_config_node_sets.size(); ++set) {
-        for (const auto inode : rr_non_config_node_sets[set]) {
-            rr_node_to_non_config_node_set.insert(
-                std::make_pair(inode, set));
-        }
-    }
-
-    auto& device_ctx = g_vpr_ctx.mutable_device();
-    device_ctx.rr_non_config_node_sets = std::move(rr_non_config_node_sets);
-    device_ctx.rr_node_to_non_config_node_set = std::move(rr_node_to_non_config_node_set);
-}
-
-// Perform a DFS traversal marking everything reachable with the same set id
-size_t EdgeGroups::add_connected_group(const node_data& node) {
-    // stack contains nodes with edges to mark with node.set
-    // The set for each node must be set before pushing it onto the stack
-    std::stack<const node_data*> stack;
-    stack.push(&node);
-    size_t n = 1;
-    while (!stack.empty()) {
-        auto top = stack.top();
-        stack.pop();
-        for (auto e : top->edges) {
-            auto& next = graph_[e];
-            if (next.set != node.set) {
-                VTR_ASSERT(next.set == OPEN);
-                n++;
-                next.set = node.set;
-                stack.push(&next);
-            }
-        }
-    }
-    return n;
-}
-
 //Collects the sets of connected non-configurable edges in the RR graph
 static void create_edge_groups(EdgeGroups* groups) {
     auto& device_ctx = g_vpr_ctx.device();
@@ -3084,7 +2979,8 @@ t_non_configurable_rr_sets identify_non_configurable_rr_sets() {
 }
 
 static void process_non_config_sets() {
+    auto& device_ctx = g_vpr_ctx.mutable_device();
     EdgeGroups groups;
     create_edge_groups(&groups);
-    groups.set_device_context();
+    groups.set_device_context(device_ctx);
 }

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -55,44 +55,6 @@ void load_rr_switch_from_arch_switch(int arch_switch_idx,
                                      const float R_minW_nmos,
                                      const float R_minW_pmos);
 
-// Class for building a group of connected edges.
-class EdgeGroups {
-  public:
-    EdgeGroups() {}
-
-    // Adds non-configurable (undirected) edge to be grouped.
-    //
-    // Returns true if this is a new edge.
-    bool add_non_config_edge(int from_node, int to_node);
-
-    // After add_non_config_edge has been called for all edges, create_sets
-    // will form groups of nodes that are connected via non-configurable
-    // edges.
-    void create_sets();
-
-    // Create t_non_configurable_rr_sets from set data.
-    // NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
-    t_non_configurable_rr_sets output_sets();
-
-    // Set device context structures for non-configurable node sets.
-    void set_device_context();
-
-  private:
-    struct node_data {
-        std::unordered_set<int> edges;
-        int set = OPEN;
-    };
-
-    // Perform a DFS traversal marking everything reachable with the same set id
-    size_t add_connected_group(const node_data& node);
-
-    // Set of non-configurable edges.
-    std::unordered_map<int, node_data> graph_;
-
-    // Compact set of node sets. Map key is arbitrary.
-    std::vector<std::vector<int>> rr_non_config_node_sets_map_;
-};
-
 t_non_configurable_rr_sets identify_non_configurable_rr_sets();
 
 #endif

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -55,6 +55,44 @@ void load_rr_switch_from_arch_switch(int arch_switch_idx,
                                      const float R_minW_nmos,
                                      const float R_minW_pmos);
 
+// Class for building a group of connected edges.
+class EdgeGroups {
+  public:
+    EdgeGroups() {}
+
+    // Adds non-configurable (undirected) edge to be grouped.
+    //
+    // Returns true if this is a new edge.
+    bool add_non_config_edge(int from_node, int to_node);
+
+    // After add_non_config_edge has been called for all edges, create_sets
+    // will form groups of nodes that are connected via non-configurable
+    // edges.
+    void create_sets();
+
+    // Create t_non_configurable_rr_sets from set data.
+    // NOTE: The stored graph is undirected, so this may generate reverse edges that don't exist.
+    t_non_configurable_rr_sets output_sets();
+
+    // Set device context structures for non-configurable node sets.
+    void set_device_context();
+
+  private:
+    struct node_data {
+        std::unordered_set<int> edges;
+        int set = OPEN;
+    };
+
+    // Perform a DFS traversal marking everything reachable with the same set id
+    size_t add_connected_group(const node_data& node);
+
+    // Set of non-configurable edges.
+    std::unordered_map<int, node_data> graph_;
+
+    // Compact set of node sets. Map key is arbitrary.
+    std::vector<std::vector<int>> rr_non_config_node_sets_map_;
+};
+
 t_non_configurable_rr_sets identify_non_configurable_rr_sets();
 
 #endif

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -293,6 +293,11 @@ class t_rr_graph_storage {
         return edge_dest_node_[edge];
     }
 
+    // Get the source node for the specified edge.
+    RRNodeId edge_source_node(const RREdgeId& edge) const {
+        return edge_src_node_[edge];
+    }
+
     // Get the destination node for the iedge'th edge from specified RRNodeId.
     //
     // This method should generally not be used, and instead first_edge and
@@ -383,6 +388,11 @@ class t_rr_graph_storage {
     // Number of RR nodes that can be accessed.
     size_t size() const {
         return node_storage_.size();
+    }
+
+    // Number of RR nodes that can be accessed.
+    size_t edges_size() const {
+        return edge_dest_node_.size();
     }
 
     // Is the RR graph currently empty?

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -293,9 +293,12 @@ class t_rr_graph_storage {
         return edge_dest_node_[edge];
     }
 
-    // Get the source node for the specified edge.
-    RRNodeId edge_source_node(const RREdgeId& edge) const {
-        return edge_src_node_[edge];
+    // Call the `apply` function with the edge id, source, and sink nodes of every edge.
+    void for_each_edge(std::function<void(RREdgeId, RRNodeId, RRNodeId)> apply) const {
+        for (size_t i = 0; i < edge_dest_node_.size(); i++) {
+            RREdgeId edge(i);
+            apply(edge, edge_src_node_[edge], edge_dest_node_[edge]);
+        }
     }
 
     // Get the destination node for the iedge'th edge from specified RRNodeId.
@@ -388,11 +391,6 @@ class t_rr_graph_storage {
     // Number of RR nodes that can be accessed.
     size_t size() const {
         return node_storage_.size();
-    }
-
-    // Number of RR nodes that can be accessed.
-    size_t edges_size() const {
-        return edge_dest_node_.size();
     }
 
     // Is the RR graph currently empty?

--- a/vpr/test/test_edge_groups.cpp
+++ b/vpr/test/test_edge_groups.cpp
@@ -31,10 +31,9 @@ TEST_CASE("edge_groups_create_sets", "[vpr]") {
     // Build the id map for node IDs
     std::vector<int> nodes(max_node_id + 1);
     std::iota(nodes.begin(), nodes.end(), 0);
-    std::random_device rd;
-    std::mt19937 g(rd());
+    std::mt19937 g(1);
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 1000; i++) {
         // Shuffle node IDs
         auto random_nodes = nodes;
         std::shuffle(random_nodes.begin(), random_nodes.end(), g);

--- a/vpr/test/test_edge_groups.cpp
+++ b/vpr/test/test_edge_groups.cpp
@@ -1,0 +1,73 @@
+#include <vector>
+#include <utility>
+#include <cstddef>
+#include <set>
+#include <random>
+#include <algorithm>
+
+#include "catch.hpp"
+
+#include "rr_graph.h"
+
+namespace {
+
+TEST_CASE("edge_groups_create_sets", "[vpr]") {
+    // Construct a set of edges that result in these connected sets
+    std::vector<std::set<int>> connected_sets{{{1, 2, 3, 4, 5, 6, 7, 8},
+                                               {9, 0}}};
+    int max_node_id = 0;
+    std::vector<std::pair<int, int>> edges;
+    for (auto set : connected_sets) {
+        int last = *set.cbegin();
+        std::for_each(std::next(set.cbegin()),
+                      set.cend(),
+                      [&](int node) {
+                          edges.push_back(std::make_pair(last, node));
+                          last = node;
+                          max_node_id = std::max(max_node_id, node);
+                      });
+    }
+
+    // Build the id map for node IDs
+    std::vector<int> nodes(max_node_id + 1);
+    std::iota(nodes.begin(), nodes.end(), 0);
+    std::random_device rd;
+    std::mt19937 g(rd());
+
+    for (int i = 0; i < 100; i++) {
+        // Shuffle node IDs
+        auto random_nodes = nodes;
+        std::shuffle(random_nodes.begin(), random_nodes.end(), g);
+
+        // Apply shuffled IDs to edges
+        auto random_edges = edges;
+        for (auto& edge : random_edges) {
+            edge.first = random_nodes[edge.first];
+            edge.second = random_nodes[edge.second];
+        }
+
+        // Shuffle edges
+        std::shuffle(random_edges.begin(), random_edges.end(), g);
+
+        // Add edges to the EdgeGroups object
+        EdgeGroups groups;
+        for (auto edge : random_edges) {
+            groups.add_non_config_edge(edge.first, edge.second);
+        }
+
+        // The algorithm to test
+        groups.create_sets();
+        t_non_configurable_rr_sets sets = groups.output_sets();
+
+        // Check for the expected sets
+        for (auto set : connected_sets) {
+            std::set<int> random_set;
+            for (auto elem : set) {
+                random_set.insert(random_nodes[elem]);
+            }
+            REQUIRE(sets.node_sets.find(random_set) != sets.node_sets.end());
+        }
+    }
+}
+
+} // namespace

--- a/vpr/test/test_edge_groups.cpp
+++ b/vpr/test/test_edge_groups.cpp
@@ -7,7 +7,7 @@
 
 #include "catch.hpp"
 
-#include "rr_graph.h"
+#include "edge_groups.h"
 
 namespace {
 


### PR DESCRIPTION
#### Description
Depending on the node and edge order, the previous algorithm could result in an inconsistent group assignment, failing the following assertion:

https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/d4ea40548ee30aa13e27df5268760a86e38ad289/vpr/src/route/rr_graph.cpp#L3051

#### Related Issue
#1288 

#### Motivation and Context
These bugs were found while implementing #1271

#### How Has This Been Tested?
A unit test has been added that fails with the previous algorithm, and also been tested with `random_shuffle` in #1271

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
