### PR TITLE
Sanitizer leak fixes

### DIFF
--- a/.github/kokoro/continuous/strong_sanitized.cfg
+++ b/.github/kokoro/continuous/strong_sanitized.cfg
@@ -2,8 +2,8 @@
 
 build_file: "vtr-verilog-to-routing/.github/kokoro/run-vtr.sh"
 
-# 1 hour
-timeout_mins: 60
+# 2 hour
+timeout_mins: 120
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit/strong_sanitized.cfg
+++ b/.github/kokoro/presubmit/strong_sanitized.cfg
@@ -2,8 +2,8 @@
 
 build_file: "vtr-verilog-to-routing/.github/kokoro/run-vtr.sh"
 
-# 1 hour
-timeout_mins: 60
+# 2 hour
+timeout_mins: 120
 
 action {
   define_artifacts {

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ jobs:
       script:
         - ./.github/travis/build.sh
         #We skip QoR since we are only checking for errors in sanitizer runs
-        - travis_wait 30 ./run_reg_test.pl vtr_reg_basic -show_failures -skip_qor -j2
+        - travis_wait 50 ./run_reg_test.pl vtr_reg_basic -show_failures -skip_qor -j2
     #Currently strong regression with sanitizers is disabled as it exceeds the maximum travis job run-time
     #- stage: Test
       #name: "Sanitized Strong Regression Tests"

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -142,33 +142,7 @@ void free_arch(t_arch* arch) {
     arch->Switches = nullptr;
     t_model* model = arch->models;
     while (model) {
-        t_model_ports* input_port = model->inputs;
-        while (input_port) {
-            t_model_ports* prev_port = input_port;
-            input_port = input_port->next;
-            vtr::free(prev_port->name);
-            delete prev_port;
-        }
-        t_model_ports* output_port = model->outputs;
-        while (output_port) {
-            t_model_ports* prev_port = output_port;
-            output_port = output_port->next;
-            vtr::free(prev_port->name);
-            delete prev_port;
-        }
-        vtr::t_linked_vptr* vptr = model->pb_types;
-        while (vptr) {
-            vtr::t_linked_vptr* vptr_prev = vptr;
-            vptr = vptr->next;
-            vtr::free(vptr_prev);
-        }
-        t_model* prev_model = model;
-
-        model = model->next;
-        if (prev_model->instances)
-            vtr::free(prev_model->instances);
-        vtr::free(prev_model->name);
-        delete prev_model;
+        model = free_arch_model(model);
     }
 
     for (int i = 0; i < arch->num_directs; ++i) {
@@ -213,6 +187,40 @@ void free_arch(t_arch* arch) {
     if (arch->clocks) {
         vtr::free(arch->clocks->clock_inf);
     }
+}
+
+//Frees the specified model, and returns the next model (if any) in the linked list
+t_model* free_arch_model(t_model* model) {
+    if (!model) return nullptr;
+
+    t_model_ports* input_port = model->inputs;
+    while (input_port) {
+        t_model_ports* prev_port = input_port;
+        input_port = input_port->next;
+        vtr::free(prev_port->name);
+        delete prev_port;
+    }
+    t_model_ports* output_port = model->outputs;
+    while (output_port) {
+        t_model_ports* prev_port = output_port;
+        output_port = output_port->next;
+        vtr::free(prev_port->name);
+        delete prev_port;
+    }
+    vtr::t_linked_vptr* vptr = model->pb_types;
+    while (vptr) {
+        vtr::t_linked_vptr* vptr_prev = vptr;
+        vptr = vptr->next;
+        vtr::free(vptr_prev);
+    }
+    t_model* next_model = model->next;
+
+    if (model->instances)
+        vtr::free(model->instances);
+    vtr::free(model->name);
+    delete model;
+
+    return next_model;
 }
 
 void free_type_descriptors(std::vector<t_physical_tile_type>& type_descriptors) {

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -193,14 +193,9 @@ void free_arch(t_arch* arch) {
 t_model* free_arch_model(t_model* model) {
     if (!model) return nullptr;
 
-    t_model_ports* input_port = model->inputs;
-    while (input_port) {
-        input_port = free_arch_model_port(input_port);
-    }
-    t_model_ports* output_port = model->outputs;
-    while (output_port) {
-        output_port = free_arch_model_port(output_port);
-    }
+    free_arch_model_ports(model->inputs);
+    free_arch_model_ports(model->outputs);
+
     vtr::t_linked_vptr* vptr = model->pb_types;
     while (vptr) {
         vtr::t_linked_vptr* vptr_prev = vptr;
@@ -215,6 +210,13 @@ t_model* free_arch_model(t_model* model) {
     delete model;
 
     return next_model;
+}
+
+void free_arch_model_ports(t_model_ports* model_ports) {
+    t_model_ports* model_port = model_ports;
+    while (model_port) {
+        model_port = free_arch_model_port(model_port);
+    }
 }
 
 t_model_ports* free_arch_model_port(t_model_ports* model_port) {

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -140,10 +140,8 @@ void free_arch(t_arch* arch) {
     }
     delete[] arch->Switches;
     arch->Switches = nullptr;
-    t_model* model = arch->models;
-    while (model) {
-        model = free_arch_model(model);
-    }
+
+    free_arch_models(arch->models);
 
     for (int i = 0; i < arch->num_directs; ++i) {
         vtr::free(arch->Directs[i].name);
@@ -189,9 +187,19 @@ void free_arch(t_arch* arch) {
     }
 }
 
+//Frees all models in the linked list
+void free_arch_models(t_model* models) {
+    t_model* model = models;
+    while (model) {
+        model = free_arch_model(model);
+    }
+}
+
 //Frees the specified model, and returns the next model (if any) in the linked list
 t_model* free_arch_model(t_model* model) {
     if (!model) return nullptr;
+
+    t_model* next_model = model->next;
 
     free_arch_model_ports(model->inputs);
     free_arch_model_ports(model->outputs);
@@ -202,7 +210,6 @@ t_model* free_arch_model(t_model* model) {
         vptr = vptr->next;
         vtr::free(vptr_prev);
     }
-    t_model* next_model = model->next;
 
     if (model->instances)
         vtr::free(model->instances);
@@ -212,6 +219,7 @@ t_model* free_arch_model(t_model* model) {
     return next_model;
 }
 
+//Frees all the model portss in a linked list
 void free_arch_model_ports(t_model_ports* model_ports) {
     t_model_ports* model_port = model_ports;
     while (model_port) {
@@ -219,6 +227,7 @@ void free_arch_model_ports(t_model_ports* model_ports) {
     }
 }
 
+//Frees the specified model_port, and returns the next model_port (if any) in the linked list
 t_model_ports* free_arch_model_port(t_model_ports* model_port) {
     if (!model_port) return nullptr;
 

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -195,17 +195,11 @@ t_model* free_arch_model(t_model* model) {
 
     t_model_ports* input_port = model->inputs;
     while (input_port) {
-        t_model_ports* prev_port = input_port;
-        input_port = input_port->next;
-        vtr::free(prev_port->name);
-        delete prev_port;
+        input_port = free_arch_model_port(input_port);
     }
     t_model_ports* output_port = model->outputs;
     while (output_port) {
-        t_model_ports* prev_port = output_port;
-        output_port = output_port->next;
-        vtr::free(prev_port->name);
-        delete prev_port;
+        output_port = free_arch_model_port(output_port);
     }
     vtr::t_linked_vptr* vptr = model->pb_types;
     while (vptr) {
@@ -221,6 +215,17 @@ t_model* free_arch_model(t_model* model) {
     delete model;
 
     return next_model;
+}
+
+t_model_ports* free_arch_model_port(t_model_ports* model_port) {
+    if (!model_port) return nullptr;
+
+    t_model_ports* next_port = model_port->next;
+
+    vtr::free(model_port->name);
+    delete model_port;
+
+    return next_port;
 }
 
 void free_type_descriptors(std::vector<t_physical_tile_type>& type_descriptors) {

--- a/libs/libarchfpga/src/arch_util.h
+++ b/libs/libarchfpga/src/arch_util.h
@@ -40,6 +40,7 @@ class InstPort {
 };
 
 void free_arch(t_arch* arch);
+t_model* free_arch_model(t_model* model);
 
 void free_type_descriptors(std::vector<t_logical_block_type>& type_descriptors);
 void free_type_descriptors(std::vector<t_physical_tile_type>& type_descriptors);

--- a/libs/libarchfpga/src/arch_util.h
+++ b/libs/libarchfpga/src/arch_util.h
@@ -41,6 +41,7 @@ class InstPort {
 
 void free_arch(t_arch* arch);
 t_model* free_arch_model(t_model* model);
+void free_arch_model_ports(t_model_ports* model_ports);
 t_model_ports* free_arch_model_port(t_model_ports* model_port);
 
 void free_type_descriptors(std::vector<t_logical_block_type>& type_descriptors);

--- a/libs/libarchfpga/src/arch_util.h
+++ b/libs/libarchfpga/src/arch_util.h
@@ -40,6 +40,7 @@ class InstPort {
 };
 
 void free_arch(t_arch* arch);
+void free_arch_models(t_model* models);
 t_model* free_arch_model(t_model* model);
 void free_arch_model_ports(t_model_ports* model_ports);
 t_model_ports* free_arch_model_port(t_model_ports* model_port);

--- a/libs/libarchfpga/src/arch_util.h
+++ b/libs/libarchfpga/src/arch_util.h
@@ -41,6 +41,7 @@ class InstPort {
 
 void free_arch(t_arch* arch);
 t_model* free_arch_model(t_model* model);
+t_model_ports* free_arch_model_port(t_model_ports* model_port);
 
 void free_type_descriptors(std::vector<t_logical_block_type>& type_descriptors);
 void free_type_descriptors(std::vector<t_physical_tile_type>& type_descriptors);

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1296,59 +1296,59 @@ void vpr_power_estimation(const t_vpr_setup& vpr_setup,
 
 void vpr_print_error(const VprError& vpr_error) {
     /* Determine the type of VPR error, To-do: can use some enum-to-string mechanism */
-    char* error_type = nullptr;
+    const char* error_type = nullptr;
     try {
         switch (vpr_error.type()) {
             case VPR_ERROR_UNKNOWN:
-                error_type = vtr::strdup("Unknown");
+                error_type = "Unknown";
                 break;
             case VPR_ERROR_ARCH:
-                error_type = vtr::strdup("Architecture file");
+                error_type = "Architecture file";
                 break;
             case VPR_ERROR_PACK:
-                error_type = vtr::strdup("Packing");
+                error_type = "Packing";
                 break;
             case VPR_ERROR_PLACE:
-                error_type = vtr::strdup("Placement");
+                error_type = "Placement";
                 break;
             case VPR_ERROR_ROUTE:
-                error_type = vtr::strdup("Routing");
+                error_type = "Routing";
                 break;
             case VPR_ERROR_TIMING:
-                error_type = vtr::strdup("Timing");
+                error_type = "Timing";
                 break;
             case VPR_ERROR_SDC:
-                error_type = vtr::strdup("SDC file");
+                error_type = "SDC file";
                 break;
             case VPR_ERROR_NET_F:
-                error_type = vtr::strdup("Netlist file");
+                error_type = "Netlist file";
                 break;
             case VPR_ERROR_BLIF_F:
-                error_type = vtr::strdup("Blif file");
+                error_type = "Blif file";
                 break;
             case VPR_ERROR_PLACE_F:
-                error_type = vtr::strdup("Placement file");
+                error_type = "Placement file";
                 break;
             case VPR_ERROR_IMPL_NETLIST_WRITER:
-                error_type = vtr::strdup("Implementation Netlist Writer");
+                error_type = "Implementation Netlist Writer";
                 break;
             case VPR_ERROR_ATOM_NETLIST:
-                error_type = vtr::strdup("Atom Netlist");
+                error_type = "Atom Netlist";
                 break;
             case VPR_ERROR_POWER:
-                error_type = vtr::strdup("Power");
+                error_type = "Power";
                 break;
             case VPR_ERROR_ANALYSIS:
-                error_type = vtr::strdup("Analysis");
+                error_type = "Analysis";
                 break;
             case VPR_ERROR_OTHER:
-                error_type = vtr::strdup("Other");
+                error_type = "Other";
                 break;
             case VPR_ERROR_INTERRUPTED:
-                error_type = vtr::strdup("Interrupted");
+                error_type = "Interrupted";
                 break;
             default:
-                error_type = vtr::strdup("Unrecognized Error");
+                error_type = "Unrecognized Error";
                 break;
         }
     } catch (const vtr::VtrError& e) {

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -49,7 +49,7 @@ bool try_pack(t_packer_opts* packer_opts,
     int num_models;
     t_pack_patterns* list_of_packing_patterns;
     int num_packing_patterns;
-    t_pack_molecule *list_of_pack_molecules, *cur_pack_molecule;
+    t_pack_molecule* list_of_pack_molecules;
     VTR_LOG("Begin packing '%s'.\n", packer_opts->blif_file_name.c_str());
 
     /* determine number of models in the architecture */
@@ -196,12 +196,7 @@ bool try_pack(t_packer_opts* packer_opts,
     /*free list_of_pack_molecules*/
     free_list_of_pack_patterns(list_of_packing_patterns, num_packing_patterns);
 
-    cur_pack_molecule = list_of_pack_molecules;
-    while (cur_pack_molecule != nullptr) {
-        cur_pack_molecule = list_of_pack_molecules->next;
-        delete list_of_pack_molecules;
-        list_of_pack_molecules = cur_pack_molecule;
-    }
+    free_pack_molecules(list_of_pack_molecules);
 
     VTR_LOG("\n");
     VTR_LOG("Netlist conversion complete.\n");

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -47,8 +47,7 @@ bool try_pack(t_packer_opts* packer_opts,
     std::unordered_map<AtomBlockId, t_pb_graph_node*> expected_lowest_cost_pb_gnode; //The molecules associated with each atom block
     const t_model* cur_model;
     int num_models;
-    t_pack_patterns* list_of_packing_patterns;
-    int num_packing_patterns;
+    std::vector<t_pack_patterns> list_of_packing_patterns;
     std::unique_ptr<t_pack_molecule, decltype(&free_pack_molecules)> list_of_pack_molecules(nullptr, free_pack_molecules);
     VTR_LOG("Begin packing '%s'.\n", packer_opts->blif_file_name.c_str());
 
@@ -86,12 +85,12 @@ bool try_pack(t_packer_opts* packer_opts,
             atom_ctx.nlist.blocks().size(), atom_ctx.nlist.nets().size(), num_p_inputs, num_p_outputs);
 
     VTR_LOG("Begin prepacking.\n");
-    list_of_packing_patterns = alloc_and_load_pack_patterns(&num_packing_patterns);
+    list_of_packing_patterns = alloc_and_load_pack_patterns();
 
-    list_of_pack_molecules.reset(alloc_and_load_pack_molecules(list_of_packing_patterns,
+    list_of_pack_molecules.reset(alloc_and_load_pack_molecules(list_of_packing_patterns.data(),
                                                                atom_molecules,
                                                                expected_lowest_cost_pb_gnode,
-                                                               num_packing_patterns));
+                                                               list_of_packing_patterns.size()));
     VTR_LOG("Finish prepacking.\n");
 
     if (packer_opts->auto_compute_inter_cluster_net_delay) {
@@ -195,7 +194,7 @@ bool try_pack(t_packer_opts* packer_opts,
     }
 
     /*free list_of_pack_molecules*/
-    free_list_of_pack_patterns(list_of_packing_patterns, num_packing_patterns);
+    free_list_of_pack_patterns(list_of_packing_patterns);
 
     VTR_LOG("\n");
     VTR_LOG("Netlist conversion complete.\n");

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -60,7 +60,7 @@ static void backward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expans
 
 static int compare_pack_pattern(const t_pack_patterns* pattern_a, const t_pack_patterns* pattern_b);
 
-static void free_pack_pattern(t_pack_pattern_block* pattern_block, t_pack_pattern_block** pattern_block_list);
+static void free_pack_pattern_block(t_pack_pattern_block* pattern_block, t_pack_pattern_block** pattern_block_list);
 
 static t_pack_molecule* try_create_molecule(t_pack_patterns* list_of_pack_patterns,
                                             std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules,
@@ -352,7 +352,7 @@ void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patte
         pattern_block_list = (t_pack_pattern_block**)vtr::calloc(num_pack_pattern_blocks, sizeof(t_pack_pattern_block*));
         free(list_of_pack_patterns[i].name);
         free(list_of_pack_patterns[i].is_block_optional);
-        free_pack_pattern(list_of_pack_patterns[i].root_block, pattern_block_list);
+        free_pack_pattern_block(list_of_pack_patterns[i].root_block, pattern_block_list);
         for (j = 0; j < num_pack_pattern_blocks; j++) {
             free(pattern_block_list[j]);
         }
@@ -877,7 +877,7 @@ void free_pack_molecules(t_pack_molecule* list_of_pack_molecules) {
     }
 }
 
-static void free_pack_pattern(t_pack_pattern_block* pattern_block, t_pack_pattern_block** pattern_block_list) {
+static void free_pack_pattern_block(t_pack_pattern_block* pattern_block, t_pack_pattern_block** pattern_block_list) {
     t_pack_pattern_connections *connection, *next;
     if (pattern_block == nullptr || pattern_block->block_id == OPEN) {
         /* already traversed, return */
@@ -887,8 +887,8 @@ static void free_pack_pattern(t_pack_pattern_block* pattern_block, t_pack_patter
     pattern_block->block_id = OPEN;
     connection = pattern_block->connections;
     while (connection) {
-        free_pack_pattern(connection->from_block, pattern_block_list);
-        free_pack_pattern(connection->to_block, pattern_block_list);
+        free_pack_pattern_block(connection->from_block, pattern_block_list);
+        free_pack_pattern_block(connection->to_block, pattern_block_list);
         next = connection->next;
         free(connection);
         connection = next;

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -345,15 +345,19 @@ static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::u
 }
 
 void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patterns) {
-    int j, num_pack_pattern_blocks;
-    t_pack_pattern_block** pattern_block_list;
     for (size_t i = 0; i < list_of_pack_patterns.size(); i++) {
-        num_pack_pattern_blocks = list_of_pack_patterns[i].num_blocks;
-        pattern_block_list = (t_pack_pattern_block**)vtr::calloc(num_pack_pattern_blocks, sizeof(t_pack_pattern_block*));
-        free(list_of_pack_patterns[i].name);
-        free(list_of_pack_patterns[i].is_block_optional);
-        free_pack_pattern_block(list_of_pack_patterns[i].root_block, pattern_block_list);
-        for (j = 0; j < num_pack_pattern_blocks; j++) {
+        free_pack_pattern(&list_of_pack_patterns[i]);
+    }
+}
+
+void free_pack_pattern(t_pack_patterns* pack_pattern) {
+    if (pack_pattern) {
+        int num_pack_pattern_blocks = pack_pattern->num_blocks;
+        t_pack_pattern_block** pattern_block_list = (t_pack_pattern_block**)vtr::calloc(num_pack_pattern_blocks, sizeof(t_pack_pattern_block*));
+        free(pack_pattern->name);
+        free(pack_pattern->is_block_optional);
+        free_pack_pattern_block(pack_pattern->root_block, pattern_block_list);
+        for (int j = 0; j < num_pack_pattern_blocks; j++) {
             free(pattern_block_list[j]);
         }
         free(pattern_block_list);

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -40,7 +40,7 @@ static void forward_infer_pattern(t_pb_graph_pin* pb_graph_pin);
 
 static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin);
 
-static t_pack_patterns* alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names);
+static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names);
 
 static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
                                                        const t_pb_graph_node* pb_graph_node);
@@ -117,9 +117,9 @@ static void print_chain_starting_points(t_pack_patterns* chain_pattern);
  * (general packing) or upstream (in tech mapping).
  * If this limitation is too constraining, code is designed so that this limitation can be removed.
  */
-t_pack_patterns* alloc_and_load_pack_patterns(int* num_packing_patterns) {
+std::vector<t_pack_patterns> alloc_and_load_pack_patterns() {
     int L_num_blocks;
-    t_pack_patterns* list_of_packing_patterns;
+    std::vector<t_pack_patterns> list_of_packing_patterns;
     t_pb_graph_edge* expansion_edge;
     auto& device_ctx = g_vpr_ctx.device();
 
@@ -144,7 +144,7 @@ t_pack_patterns* alloc_and_load_pack_patterns(int* num_packing_patterns) {
             list_of_packing_patterns[i].base_cost = 0;
             // use the found expansion edge to build the pack pattern
             backward_expand_pack_pattern_from_edge(expansion_edge,
-                                                   list_of_packing_patterns, i, nullptr, nullptr, &L_num_blocks);
+                                                   list_of_packing_patterns.data(), i, nullptr, nullptr, &L_num_blocks);
             list_of_packing_patterns[i].num_blocks = L_num_blocks;
 
             /* Default settings: A section of a netlist must match all blocks in a pack
@@ -178,8 +178,6 @@ t_pack_patterns* alloc_and_load_pack_patterns(int* num_packing_patterns) {
             VPR_FATAL_ERROR(VPR_ERROR_ARCH, "Failed to find root block for pack pattern %s", list_of_packing_patterns[i].name);
         }
     }
-
-    *num_packing_patterns = pattern_names.size();
 
     return list_of_packing_patterns;
 }
@@ -332,8 +330,8 @@ static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin) {
  * Allocates memory for models and loads the name of the packing pattern
  * so that it can be identified and loaded with more complete information later
  */
-static t_pack_patterns* alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names) {
-    t_pack_patterns* nlist = new t_pack_patterns[pattern_names.size()];
+static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names) {
+    std::vector<t_pack_patterns> nlist(pattern_names.size());
 
     for (const auto& curr_pattern : pattern_names) {
         VTR_ASSERT(nlist[curr_pattern.second].name == nullptr);
@@ -346,22 +344,19 @@ static t_pack_patterns* alloc_and_init_pattern_list_from_hash(std::unordered_map
     return nlist;
 }
 
-void free_list_of_pack_patterns(t_pack_patterns* list_of_pack_patterns, const int num_packing_patterns) {
-    int i, j, num_pack_pattern_blocks;
+void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patterns) {
+    int j, num_pack_pattern_blocks;
     t_pack_pattern_block** pattern_block_list;
-    if (list_of_pack_patterns != nullptr) {
-        for (i = 0; i < num_packing_patterns; i++) {
-            num_pack_pattern_blocks = list_of_pack_patterns[i].num_blocks;
-            pattern_block_list = (t_pack_pattern_block**)vtr::calloc(num_pack_pattern_blocks, sizeof(t_pack_pattern_block*));
-            free(list_of_pack_patterns[i].name);
-            free(list_of_pack_patterns[i].is_block_optional);
-            free_pack_pattern(list_of_pack_patterns[i].root_block, pattern_block_list);
-            for (j = 0; j < num_pack_pattern_blocks; j++) {
-                free(pattern_block_list[j]);
-            }
-            free(pattern_block_list);
+    for (size_t i = 0; i < list_of_pack_patterns.size(); i++) {
+        num_pack_pattern_blocks = list_of_pack_patterns[i].num_blocks;
+        pattern_block_list = (t_pack_pattern_block**)vtr::calloc(num_pack_pattern_blocks, sizeof(t_pack_pattern_block*));
+        free(list_of_pack_patterns[i].name);
+        free(list_of_pack_patterns[i].is_block_optional);
+        free_pack_pattern(list_of_pack_patterns[i].root_block, pattern_block_list);
+        for (j = 0; j < num_pack_pattern_blocks; j++) {
+            free(pattern_block_list[j]);
         }
-        delete[] list_of_pack_patterns;
+        free(pattern_block_list);
     }
 }
 

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -873,6 +873,15 @@ t_pack_molecule* alloc_and_load_pack_molecules(t_pack_patterns* list_of_pack_pat
     return list_of_molecules_head;
 }
 
+void free_pack_molecules(t_pack_molecule* list_of_pack_molecules) {
+    t_pack_molecule* cur_pack_molecule = list_of_pack_molecules;
+    while (cur_pack_molecule != nullptr) {
+        cur_pack_molecule = list_of_pack_molecules->next;
+        delete list_of_pack_molecules;
+        list_of_pack_molecules = cur_pack_molecule;
+    }
+}
+
 static void free_pack_pattern(t_pack_pattern_block* pattern_block, t_pack_pattern_block** pattern_block_list) {
     t_pack_pattern_connections *connection, *next;
     if (pattern_block == nullptr || pattern_block->block_id == OPEN) {

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -13,7 +13,6 @@
 
 std::vector<t_pack_patterns> alloc_and_load_pack_patterns();
 void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patterns);
-void free_pack_pattern(t_pack_patterns* pack_pattern);
 
 t_pack_molecule* alloc_and_load_pack_molecules(t_pack_patterns* list_of_pack_patterns,
                                                std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules,

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -19,4 +19,6 @@ t_pack_molecule* alloc_and_load_pack_molecules(t_pack_patterns* list_of_pack_pat
                                                std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
                                                const int num_packing_patterns);
 
+void free_pack_molecules(t_pack_molecule* list_of_pack_molecules);
+
 #endif

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -11,8 +11,9 @@
 #include "arch_types.h"
 #include "vpr_types.h"
 
-t_pack_patterns* alloc_and_load_pack_patterns(int* num_packing_patterns);
-void free_list_of_pack_patterns(t_pack_patterns* list_of_pack_patterns, const int num_packing_patterns);
+std::vector<t_pack_patterns> alloc_and_load_pack_patterns();
+void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patterns);
+void free_pack_pattern(t_pack_patterns* pack_pattern);
 
 t_pack_molecule* alloc_and_load_pack_molecules(t_pack_patterns* list_of_pack_patterns,
                                                std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules,

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -13,6 +13,7 @@
 
 std::vector<t_pack_patterns> alloc_and_load_pack_patterns();
 void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patterns);
+void free_pack_pattern(t_pack_patterns* pack_pattern);
 
 t_pack_molecule* alloc_and_load_pack_molecules(t_pack_patterns* list_of_pack_patterns,
                                                std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules,

--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -1643,8 +1643,12 @@ sub run_vpr {
         push(@vpr_args, @extra_vpr_args);
     }
 
-    #Add the LeakSanitizer (LSAN) suppression file
-    local $ENV{"LSAN_OPTIONS"} = "suppressions=$vtr_flow_path/../vpr/lsan.supp exitcode=23";
+    #Extra options to fine-tune LeakSanitizer (LSAN) behaviour.
+    #Note that if VPR was compiled without LSAN these have no effect
+    # 'suppressions=...' Add the LeakSanitizer (LSAN) suppression file
+    # 'exitcode=12' Use a consistent exitcode (on some systems LSAN don't use the default exit code of 23)
+    # 'fast_unwind_on_malloc=0' Provide more accurate leak stack traces
+    local $ENV{"LSAN_OPTIONS"} = "suppressions=$vtr_flow_path/../vpr/lsan.supp exitcode=23 fast_unwind_on_malloc=0";
 
     #Run the command
     $q = &system_with_timeout(

--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -1644,7 +1644,7 @@ sub run_vpr {
     }
 
     #Add the LeakSanitizer (LSAN) suppression file
-    local $ENV{"LSAN_OPTIONS"} = "suppressions=$vtr_flow_path/../vpr/lsan.supp";
+    local $ENV{"LSAN_OPTIONS"} = "suppressions=$vtr_flow_path/../vpr/lsan.supp exitcode=23";
 
     #Run the command
     $q = &system_with_timeout(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes various memory leaks which could occur when errors cause VPR to abort.

Also ensures LSAN uses a consistent exit code in case of leaks across different machines (for instance, ensuring consistent behavior on local developer and Kokoro machines).

This should fix the 'strong sanitized' Kokoro test, which was failing due to these leaks. We have some tests which check that VPR exits with an error in the case of invalid input. However some memory was leaked in these cases causing LSAN to exit with a different exit code (causing the test to fail).