### PR TITLE
Reserve VPR delayless switch name

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1390,6 +1390,17 @@ enum class SwitchType {
 };
 constexpr std::array<const char*, size_t(SwitchType::NUM_SWITCH_TYPES)> SWITCH_TYPE_STRINGS = {{"MUX", "TRISTATE", "PASS_GATE", "SHORT", "BUFFER", "INVALID"}};
 
+/* Constant/Reserved names for switches in architecture XML
+ * Delayless switch:
+ *   The zero-delay switch created by VPR internally 
+ *   This is a special switch just to ease CAD algorithms
+ *   It is mainly used in
+ *     - the edges between SOURCE and SINK nodes in routing resource graphs  
+ *     - the edges in CLB-to-CLB connections (defined by <directlist> in arch XML)
+ *   
+ */
+constexpr const char* VPR_DELAYLESS_SWITCH_NAME = "__vpr_delayless_switch__";
+
 enum class BufferSize {
     AUTO,
     ABSOLUTE

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -3931,6 +3931,14 @@ static void ProcessSwitches(pugi::xml_node Parent,
         t_arch_switch_inf& arch_switch = (*Switches)[i];
 
         switch_name = get_attribute(Node, "name", loc_data).value();
+
+        /* Check if the switch has conflicts with any reserved names */
+        if (0 == strcmp(switch_name, VPR_DELAYLESS_SWITCH_NAME)) {
+            archfpga_throw(loc_data.filename_c_str(), loc_data.line(Node),
+                           "Switch name '%s' is a reserved name for VPR internal usage! Please use another  name.\n",
+                           switch_name);
+        }
+
         type_name = get_attribute(Node, "type", loc_data).value();
 
         /* Check for switch name collisions */

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -277,7 +277,7 @@ static void SetupSwitches(const t_arch& Arch,
 
     /* Delayless switch for connecting sinks and sources with their pins. */
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].set_type(SwitchType::MUX);
-    device_ctx.arch_switch_inf[RoutingArch->delayless_switch].name = vtr::strdup("__vpr_delayless_switch__");
+    device_ctx.arch_switch_inf[RoutingArch->delayless_switch].name = vtr::strdup(VPR_DELAYLESS_SWITCH_NAME);
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].R = 0.;
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].Cin = 0.;
     device_ctx.arch_switch_inf[RoutingArch->delayless_switch].Cout = 0.;


### PR DESCRIPTION
This pull request aims to solve the following problem: 

  - Keep the VPR delayless switch name in a constant string and can be used easily in later functions
  - Avoid users to define a switch in the reserved names, which may crash the software.
 
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Modify the readarch library to add a constant string for delayless switches.
Check codes are added to error out `read_arch`  when users try to define a switch in the same name as the delayless switch.
VPR setup code has been adapted to use the delayless switch constant.

#### Related Issue
<!--- Pull requests should be related to open issues -->
This issue has been discussed during the VTR developer's meeting at FPGA'2020

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Delayless switch is a special switch created by VPR internally.
It is the switch that is used by edges between SOURCE and OPIN, IPIN and SINK, or direct connection between CLBs in VPR's routing resource graphs.
It has a special name and users are not allowed to define it.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Passed the regression tests in CI without QoR changes.
Tested with XML sample, to ensure that read_arch will error out when reserved names are used.

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
No impact on the rest of VPR codes. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X ] All new and existing tests passed
