### PR TITLE
Fixed post-synthesis netlist writing

### DIFF
--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -1603,14 +1603,16 @@ class NetlistWriterVisitor : public NetlistVisitor {
                 const t_port* port = pin->port;
 
                 int cluster_pin_idx = pin->pin_count_in_cluster;
-                auto atom_net_id = top_pb_route[cluster_pin_idx].atom_net_id;
 
                 std::string net;
-                if (!atom_net_id) {
+                if (!top_pb_route.count(cluster_pin_idx)) {
                     //Disconnected
 
                 } else {
                     //Connected
+                    auto atom_net_id = top_pb_route[cluster_pin_idx].atom_net_id;
+                    VTR_ASSERT(atom_net_id);
+
                     auto src_tnode = find_tnode(atom, cluster_pin_idx);
                     net = make_inst_wire(atom_net_id, src_tnode, inst_name, PortType::INPUT, iport, ipin);
                 }
@@ -1626,14 +1628,16 @@ class NetlistWriterVisitor : public NetlistVisitor {
                 const t_port* port = pin->port;
 
                 int cluster_pin_idx = pin->pin_count_in_cluster;
-                auto atom_net_id = top_pb_route[cluster_pin_idx].atom_net_id;
 
                 std::string net;
-                if (!atom_net_id) {
+                if (!top_pb_route.count(cluster_pin_idx)) {
                     //Disconnected
                     net = "";
                 } else {
                     //Connected
+                    auto atom_net_id = top_pb_route[cluster_pin_idx].atom_net_id;
+                    VTR_ASSERT(atom_net_id);
+
                     auto inode = find_tnode(atom, cluster_pin_idx);
                     net = make_inst_wire(atom_net_id, inode, inst_name, PortType::OUTPUT, iport, ipin);
                 }
@@ -1649,16 +1653,16 @@ class NetlistWriterVisitor : public NetlistVisitor {
                 const t_port* port = pin->port;
 
                 int cluster_pin_idx = pin->pin_count_in_cluster;
-                auto atom_net_id = top_pb_route[cluster_pin_idx].atom_net_id;
-
-                VTR_ASSERT(atom_net_id); //Must have a clock
 
                 std::string net;
-                if (!atom_net_id) {
+                if (!top_pb_route.count(cluster_pin_idx)) {
                     //Disconnected
                     net = "";
                 } else {
                     //Connected
+                    auto atom_net_id = top_pb_route[cluster_pin_idx].atom_net_id;
+                    VTR_ASSERT(atom_net_id); //Must have a clock
+
                     auto src_tnode = find_tnode(atom, cluster_pin_idx);
                     net = make_inst_wire(atom_net_id, src_tnode, inst_name, PortType::CLOCK, iport, ipin);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#### Description

VPR crashes when run with `--analysis` and `--gen_post_synthesis_netlist`. It turned out that the crash was caused by unconnected pins not having assigned nets in the `t_pb->pb_route` map.

I fixed that by checking whether a key is present in the map instead of retrieving its value and checking if it corresponds to a valid net. 

#### Related Issue
https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1467

#### Motivation and Context
This is a bugfix that allows to get a post-synthesis netlist from VPR.

#### How Has This Been Tested?
Locally by enabling the `--gen_post_synthesis_netlist` and seeing it not crash.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
