### PR TITLE
Odin: resolve coverity errors

### DIFF
--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -1106,10 +1106,10 @@ ast_node_t* build_hierarchy(ast_node_t* node, ast_node_t* parent, int index, sc_
                 break;
             }
         }
+    }
 
-        if (child_skip_list) {
-            child_skip_list = (short*)vtr::free(child_skip_list);
-        }
+    if (child_skip_list) {
+        child_skip_list = (short*)vtr::free(child_skip_list);
     }
 
     return node;

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1322,12 +1322,12 @@ void assert_constant_positionnal_args(ast_node_t* node, long arg_count) {
                       "%s node expects arguments\n", ast_node_name_based_on_ids(node));
     } else if (node->num_children < arg_count) {
         error_message(AST, node->line_number, node->file_number,
-                      "%s node expects %d positional arguments\n", ast_node_name_based_on_ids(node), arg_count);
+                      "%s node expects %ld positional arguments\n", ast_node_name_based_on_ids(node), arg_count);
     } else {
         for (long i = 0; i < arg_count; i += 1) {
             if (!node_is_constant(node->children[i])) {
                 error_message(AST, node->line_number, node->file_number,
-                              "%s node expects a constant at positional arguments [%d]\n", ast_node_name_based_on_ids(node), i);
+                              "%s node expects a constant at positional arguments [%ld]\n", ast_node_name_based_on_ids(node), i);
             }
         }
     }
@@ -1401,7 +1401,7 @@ void c_display(ast_node_t* node) {
                 printf("%%");
             } else if (!argv_nodes || argc_node >= argv_nodes->num_children || argv_nodes->children[argc_node] == NULL) {
                 error_message(AST, node->children[0]->line_number, node->children[0]->file_number,
-                              "specifier character [%d] has no argument associated with it", argc_node);
+                              "specifier character [%ld] has no argument associated with it", argc_node);
             } else {
                 ast_node_t* argv = argv_nodes->children[argc_node];
                 switch (tolower(format_input[1])) {
@@ -1414,7 +1414,7 @@ void c_display(ast_node_t* node) {
                     case 'b': {
                         if (!node_is_constant(argv)) {
                             error_message(AST, argv->line_number, argv->file_number,
-                                          "specifier character [%d] is not associated with a constant, node is %s",
+                                          "specifier character [%ld] is not associated with a constant, node is %s",
                                           argc_node, ast_node_name_based_on_ids(argv));
                         }
                         printf("%s", argv->types.vnumber->to_vstring(format_input[1]).c_str());
@@ -1440,7 +1440,7 @@ void c_display(ast_node_t* node) {
                     case 't': {
                         if (!node_is_constant(argv)) {
                             error_message(AST, argv->line_number, argv->file_number,
-                                          "specifier character [%d] is not associated with a constant, node is %s",
+                                          "specifier character [%ld] is not associated with a constant, node is %s",
                                           argc_node, ast_node_name_based_on_ids(argv));
                         }
                         // TODO: for now we just print as is


### PR DESCRIPTION
### CID 210518:  API usage errors  (PRINTF_ARGS)
```
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/ast_util.cpp: 1329 in assert_constant_positionnal_args(ast_node_t *, long)()
>>>     CID 210518:  API usage errors  (PRINTF_ARGS)
>>>     Argument "i" to format specifier "%d" was expected to have type "int" but has type "long".
1329                     error_message(AST, node->line_number, node->file_number,
1330                                   "%s node expects a constant at positional arguments [%d]\n", ast_node_name_based_on_ids(node), i);
```
### CID 210517:  Resource leaks  (RESOURCE_LEAK)
```
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/ast_elaborate.cpp: 1115 in build_hierarchy(ast_node_t *, ast_node_t *, int, sc_hierarchy *, bool, bool, e_data *)()
1110             if (child_skip_list) {
1111                 child_skip_list = (short*)vtr::free(child_skip_list);
1112             }
1113         }
1114    
>>>     CID 210517:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "child_skip_list" going out of scope leaks the storage it points to.
1115         return node;
```
### CID 210516:  API usage errors  (PRINTF_ARGS)
```
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/ast_util.cpp: 1324 in assert_constant_positionnal_args(ast_node_t *, long)()
>>>     CID 210516:  API usage errors  (PRINTF_ARGS)
>>>     Argument "arg_count" to format specifier "%d" was expected to have type "int" but has type "long".
1324             error_message(AST, node->line_number, node->file_number,
1325                           "%s node expects %d positional arguments\n", ast_node_name_based_on_ids(node), arg_count);
```
## CID 210515:    (PRINTF_ARGS)
```
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/ast_util.cpp: 1442 in c_display(ast_node_t *)()
>>>     CID 210515:    (PRINTF_ARGS)
>>>     Argument "argc_node" to format specifier "%d" was expected to have type "int" but has type "long".
1442                                 error_message(AST, argv->line_number, argv->file_number,
1443                                               "specifier character [%d] is not associated with a constant, node is %s",
1444                                               argc_node, ast_node_name_based_on_ids(argv));
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/ast_util.cpp: 1416 in c_display(ast_node_t *)()
>>>     CID 210515:    (PRINTF_ARGS)
>>>     Argument "argc_node" to format specifier "%d" was expected to have type "int" but has type "long".
1416                                 error_message(AST, argv->line_number, argv->file_number,
1417                                               "specifier character [%d] is not associated with a constant, node is %s",
1418                                               argc_node, ast_node_name_based_on_ids(argv));
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/ast_util.cpp: 1403 in c_display(ast_node_t *)()
>>>     CID 210515:    (PRINTF_ARGS)
>>>     Argument "argc_node" to format specifier "%d" was expected to have type "int" but has type "long".
1403                     error_message(AST, node->children[0]->line_number, node->children[0]->file_number,
1404                                   "specifier character [%d] has no argument associated with it", argc_node);
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
