### PR TITLE
doc: add Antmicro to contributing companies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Graduate Students: Kevin Murray, Jason Luu, Oleg Petelin, Mohamed Eldafrawy, Jef
 
 Summer Students: Opal Densmore, Ted Campbell, Cong Wang, Peter Milankov, Scott Whitty, Michael Wainberg, Suya Liu, Miad Nasr, Nooruddin Ahmed, Thien Yu, Long Yu Wang, Matthew J.P. Walker, Amer Hesson, Sheng Zhong, Hanqing Zeng, Vidya Sankaranarayanan, Jia Min Wang, Eugene Sha, Jean-Philippe Legault, Richard Ren, Dingyu Yang, Alexandrea Demmings, Hillary Soontiens, Julie Brown
 
-Companies: Intel, Huawei, Lattice, Altera Corporation, Texas Instruments, Google
+Companies: Intel, Huawei, Lattice, Altera Corporation, Texas Instruments, Google, Antmicro
 
 Funding Agencies: NSERC, Semiconductor Research Corporation
 


### PR DESCRIPTION
#### Description

Adding Antmicro to the contributing companies list in the README to reflect the commitment.

#### Related Issue

N/A

#### Motivation and Context

Antmicro have been contributing to VTR for quite a while, and expect to continue to do so for the foreseeable future related to our dedication to open source FPGA as well as customer projects. We want to raise prominence of the tool among the organizations we participate in - RISC-V and CHIPS, so showing commitment / contributions from more companies helps in this endeavor.

#### How Has This Been Tested?

N/A

#### Types of changes

N/A

#### Checklist:

N/A