### PR TITLE
Add support for drawing RR SOURCE and SINK nodes

### DIFF
--- a/doc/src/vpr/graphics.rst
+++ b/doc/src/vpr/graphics.rst
@@ -104,6 +104,7 @@ When a routing is on-screen, clicking on **Toggle RR** lets you to choose betwee
 The routing resource view can be very useful in ensuring that you have correctly described your FPGA in the architecture description file -- if you see switches where they shouldn’t be or pins on the wrong side of a clb, your architecture description needs to be revised.
 
 Wiring segments are drawn in black, input pins are drawn in sky blue, and output pins are drawn in pink.
+Sinks are drawn in dark slate blue, and sources in plum.
 Direct connections between output and input pins are shown in medium purple.
 Connections from wiring segments to input pins are shown in sky blue, connections from output pins to wiring segments are shown in pink, and connections between wiring segments are shown in green.
 The points at which wiring segments connect to clb pins (connection box switches) are marked with an ``x``.

--- a/vpr/src/draw/buttons.cpp
+++ b/vpr/src/draw/buttons.cpp
@@ -253,7 +253,8 @@ void button_for_toggle_rr() {
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "None");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes SBox");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All but Buffers");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes SBox CBox");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes SBox CBox Internal");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All");
     gtk_combo_box_set_active((GtkComboBox*)toggle_rr_widget, 0); // default set to None which has an index 0
     gtk_widget_set_name(toggle_rr_widget, "toggle_rr");

--- a/vpr/src/draw/buttons.cpp
+++ b/vpr/src/draw/buttons.cpp
@@ -251,10 +251,10 @@ void button_for_toggle_rr() {
     GtkWidget* toggle_rr_widget = gtk_combo_box_text_new();
     GtkWidget* toggle_rr_label = gtk_label_new("Toggle RR:");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "None");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes RR");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes SBox RR");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All but Buffers RR");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All RR");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes SBox");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All but Buffers");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All");
     gtk_combo_box_set_active((GtkComboBox*)toggle_rr_widget, 0); // default set to None which has an index 0
     gtk_widget_set_name(toggle_rr_widget, "toggle_rr");
 

--- a/vpr/src/draw/buttons.cpp
+++ b/vpr/src/draw/buttons.cpp
@@ -252,7 +252,7 @@ void button_for_toggle_rr() {
     GtkWidget* toggle_rr_label = gtk_label_new("Toggle RR:");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "None");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes RR");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes and SBox RR");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "Nodes SBox RR");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All but Buffers RR");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(toggle_rr_widget), "All RR");
     gtk_combo_box_set_active((GtkComboBox*)toggle_rr_widget, 0); // default set to None which has an index 0

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -576,11 +576,11 @@ void toggle_rr(GtkWidget* /*widget*/, gint /*response_id*/, gpointer /*data*/) {
     gchar* combo_box_content = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(toggle_rr));
     if (strcmp(combo_box_content, "None") == 0)
         new_state = DRAW_NO_RR;
-    else if (strcmp(combo_box_content, "Nodes RR") == 0)
+    else if (strcmp(combo_box_content, "Nodes") == 0)
         new_state = DRAW_NODES_RR;
-    else if (strcmp(combo_box_content, "Nodes SBox RR") == 0)
+    else if (strcmp(combo_box_content, "Nodes SBox") == 0)
         new_state = DRAW_NODES_SBOX_RR;
-    else if (strcmp(combo_box_content, "All but Buffers RR") == 0)
+    else if (strcmp(combo_box_content, "All but Buffers") == 0)
         new_state = DRAW_ALL_BUT_BUFFERS_RR;
     else // all rr
         new_state = DRAW_ALL_RR;

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -580,8 +580,10 @@ void toggle_rr(GtkWidget* /*widget*/, gint /*response_id*/, gpointer /*data*/) {
         new_state = DRAW_NODES_RR;
     else if (strcmp(combo_box_content, "Nodes SBox") == 0)
         new_state = DRAW_NODES_SBOX_RR;
-    else if (strcmp(combo_box_content, "All but Buffers") == 0)
-        new_state = DRAW_ALL_BUT_BUFFERS_RR;
+    else if (strcmp(combo_box_content, "Nodes SBox CBox") == 0)
+        new_state = DRAW_NODES_SBOX_CBOX_RR;
+    else if (strcmp(combo_box_content, "Nodes SBox CBox Internal") == 0)
+        new_state = DRAW_NODES_SBOX_CBOX_INTERNAL_RR;
     else // all rr
         new_state = DRAW_ALL_RR;
 
@@ -1542,7 +1544,8 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
     from_type = device_ctx.rr_nodes[inode].type();
 
     if ((draw_state->draw_rr_toggle == DRAW_NODES_RR)
-        || (draw_state->draw_rr_toggle == DRAW_NODES_SBOX_RR && from_type == OPIN)) {
+        || (draw_state->draw_rr_toggle == DRAW_NODES_SBOX_RR && (from_type == OPIN || from_type == SOURCE || from_type == IPIN))
+        || (draw_state->draw_rr_toggle == DRAW_NODES_SBOX_CBOX_RR && (from_type == SOURCE || from_type == IPIN))) {
         return; /* Nothing to draw. */
     }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2194,18 +2194,31 @@ static void draw_rr_src_sink(int inode, ezgl::color color, ezgl::renderer* g) {
 static void draw_get_rr_src_sink_coords(const t_rr_node& node, float* xcen, float* ycen) {
     t_draw_coords* draw_coords = get_draw_coords_vars();
 
-
-    float xc = draw_coords->tile_x[node.xlow()];
-    float yc = draw_coords->tile_y[node.ylow()];
-
     auto& device_ctx = g_vpr_ctx.device();
     t_physical_tile_type_ptr tile_type = device_ctx.grid[node.xlow()][node.ylow()].type;
 
+    //Number of classes (i.e. src/sinks) we need to draw
     float num_class = tile_type->class_inf.size();
+
+    int height = tile_type->height; //Height in blocks
+
+    //How many classes to draw per unit block height
+    int class_per_height = num_class;
+    if (height > 1) {
+        class_per_height = num_class / (height - 1);
+    }
+
+    int class_height_offset = node.class_num() / class_per_height; //Offset wrt block height
+    int class_height_shift = node.class_num() % class_per_height;  //Offset within unit block
+
+    float xc = draw_coords->tile_x[node.xlow()];
+    float yc = draw_coords->tile_y[node.ylow() + class_height_offset];
 
     *xcen = xc + 0.5 * draw_coords->get_tile_width();
 
-    float ypos = ((node.class_num() + 1) / (num_class + 1));
+    float class_section_height = class_per_height + 1;
+
+    float ypos = (class_height_shift + 1) / class_section_height;
     *ycen = yc + ypos * draw_coords->get_tile_height();
 }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2582,6 +2582,18 @@ static int draw_check_rr_node_hit(float click_x, float click_y) {
                 }
                 break;
             }
+            case SOURCE:
+            case SINK: {
+                float xcen, ycen;
+                draw_get_rr_src_sink_coords(device_ctx.rr_nodes[inode], &xcen, &ycen);
+
+                // Now check if we clicked on this pin
+                if (click_x >= xcen - draw_coords->pin_size && click_x <= xcen + draw_coords->pin_size && click_y >= ycen - draw_coords->pin_size && click_y <= ycen + draw_coords->pin_size) {
+                    hit_node = inode;
+                    return hit_node;
+                }
+                break;
+            }
             case CHANX:
             case CHANY: {
                 bound_box = draw_get_rr_chan_bbox(inode);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -578,8 +578,8 @@ void toggle_rr(GtkWidget* /*widget*/, gint /*response_id*/, gpointer /*data*/) {
         new_state = DRAW_NO_RR;
     else if (strcmp(combo_box_content, "Nodes RR") == 0)
         new_state = DRAW_NODES_RR;
-    else if (strcmp(combo_box_content, "Nodes and SBox RR") == 0)
-        new_state = DRAW_NODES_AND_SBOX_RR;
+    else if (strcmp(combo_box_content, "Nodes SBox RR") == 0)
+        new_state = DRAW_NODES_SBOX_RR;
     else if (strcmp(combo_box_content, "All but Buffers RR") == 0)
         new_state = DRAW_ALL_BUT_BUFFERS_RR;
     else // all rr
@@ -1542,7 +1542,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
     from_type = device_ctx.rr_nodes[inode].type();
 
     if ((draw_state->draw_rr_toggle == DRAW_NODES_RR)
-        || (draw_state->draw_rr_toggle == DRAW_NODES_AND_SBOX_RR && from_type == OPIN)) {
+        || (draw_state->draw_rr_toggle == DRAW_NODES_SBOX_RR && from_type == OPIN)) {
         return; /* Nothing to draw. */
     }
 
@@ -1595,7 +1595,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
             case CHANX: /* from_type */
                 switch (to_type) {
                     case IPIN:
-                        if (draw_state->draw_rr_toggle == DRAW_NODES_AND_SBOX_RR) {
+                        if (draw_state->draw_rr_toggle == DRAW_NODES_SBOX_RR) {
                             break;
                         }
 
@@ -1665,7 +1665,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
             case CHANY: /* from_type */
                 switch (to_type) {
                     case IPIN:
-                        if (draw_state->draw_rr_toggle == DRAW_NODES_AND_SBOX_RR) {
+                        if (draw_state->draw_rr_toggle == DRAW_NODES_SBOX_RR) {
                             break;
                         }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2205,7 +2205,7 @@ static void draw_get_rr_src_sink_coords(const t_rr_node& node, float* xcen, floa
 
     *xcen = xc + 0.5 * draw_coords->get_tile_width();
 
-    float ypos = ((node.class_num() + 1) / (num_class + 2));
+    float ypos = ((node.class_num() + 1) / (num_class + 1));
     *ycen = yc + ypos * draw_coords->get_tile_height();
 }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2073,7 +2073,7 @@ void draw_get_rr_pin_coords(int inode, float* xcen, float* ycen) {
     draw_get_rr_pin_coords(device_ctx.rr_nodes[inode], xcen, ycen);
 }
 
-void draw_get_rr_pin_coords(const t_rr_node node, float* xcen, float* ycen) {
+void draw_get_rr_pin_coords(const t_rr_node& node, float* xcen, float* ycen) {
     t_draw_coords* draw_coords = get_draw_coords_vars();
 
     int i, j, k, ipin, pins_per_sub_tile;

--- a/vpr/src/draw/draw.h
+++ b/vpr/src/draw/draw.h
@@ -32,7 +32,7 @@ void free_draw_structs();
 #ifndef NO_GRAPHICS
 
 void draw_get_rr_pin_coords(int inode, float* xcen, float* ycen);
-void draw_get_rr_pin_coords(const t_rr_node node, float* xcen, float* ycen);
+void draw_get_rr_pin_coords(const t_rr_node& node, float* xcen, float* ycen);
 
 void draw_triangle_along_line(ezgl::renderer* g, ezgl::point2d start, ezgl::point2d end, float relative_position = 1., float arrow_size = DEFAULT_ARROW_SIZE);
 void draw_triangle_along_line(ezgl::renderer* g, ezgl::point2d loc, ezgl::point2d start, ezgl::point2d end, float arrow_size = DEFAULT_ARROW_SIZE);

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -52,7 +52,7 @@ enum e_draw_nets {
 enum e_draw_rr_toggle {
     DRAW_NO_RR = 0,
     DRAW_NODES_RR,
-    DRAW_NODES_AND_SBOX_RR,
+    DRAW_NODES_SBOX_RR,
     DRAW_ALL_BUT_BUFFERS_RR,
     DRAW_ALL_RR,
 };

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -53,7 +53,8 @@ enum e_draw_rr_toggle {
     DRAW_NO_RR = 0,
     DRAW_NODES_RR,
     DRAW_NODES_SBOX_RR,
-    DRAW_ALL_BUT_BUFFERS_RR,
+    DRAW_NODES_SBOX_CBOX_RR,
+    DRAW_NODES_SBOX_CBOX_INTERNAL_RR,
     DRAW_ALL_RR,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Adds support for drawing SOURCE and SINK RR nodes in VPR graphics.

Also cleans-up RR drawing combobox options, and avoid expensive copying of RR nodes in pin drawing.