### PR TITLE
Improve valgrind vtr flow

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -110,7 +110,7 @@ my @memory_tracker_args     = ("time", "-v");
 my $limit_memory_usage      = -1;
 my $timeout                 = 14 * 24 * 60 * 60;         # 14 day execution timeout
 my $valgrind 		        = 0;
-my @valgrind_args	        = ("--leak-check=full", "--suppressions=$vtr_flow_path/../vpr/valgrind.supp", "--error-exitcode=22", "--errors-for-leak-kinds=none", "--track-origins=yes", "--error-limit=no");
+my @valgrind_args	        = ("--leak-check=full", "--suppressions=$vtr_flow_path/../vpr/valgrind.supp", "--error-exitcode=22", "--track-origins=yes", "--error-limit=no");
 my $abc_quote_addition      = 0;
 my @forwarded_vpr_args;   # VPR arguments that pass through the script
 my $verify_rr_graph         = 0;

--- a/vtr_flow/scripts/run_vtr_flow.pl
+++ b/vtr_flow/scripts/run_vtr_flow.pl
@@ -110,7 +110,7 @@ my @memory_tracker_args     = ("time", "-v");
 my $limit_memory_usage      = -1;
 my $timeout                 = 14 * 24 * 60 * 60;         # 14 day execution timeout
 my $valgrind 		        = 0;
-my @valgrind_args	        = ("--leak-check=full", "--suppressions=$vtr_flow_path/../vpr/valgrind.supp", "--error-exitcode=1", "--errors-for-leak-kinds=none", "--track-origins=yes", "--log-file=valgrind.log","--error-limit=no");
+my @valgrind_args	        = ("--leak-check=full", "--suppressions=$vtr_flow_path/../vpr/valgrind.supp", "--error-exitcode=22", "--errors-for-leak-kinds=none", "--track-origins=yes", "--error-limit=no");
 my $abc_quote_addition      = 0;
 my @forwarded_vpr_args;   # VPR arguments that pass through the script
 my $verify_rr_graph         = 0;
@@ -1304,9 +1304,7 @@ sub system_with_timeout {
 
 
 		open( STDOUT, "> $_[1]" );
-		if (!$valgrind) {
-			open( STDERR, ">&STDOUT" );
-		}
+        open( STDERR, ">&STDOUT" );
 
 		# Copy the args and cut out first four
 		my @VPRARGS = @_;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Improves valgrind integration in run_vtr_flow.pl, specifically:

- Uses a unique exit code for valgrind failures (22) which is distinct from normal exit codes
- Includes the valgrind log in the regular tool log files, which ensures they show up when a failure log is printed (e.g. on TravisCI). Previously the vaglrind output was placed in a separate valgrind.log file which was rather mysterious.
- Treats detected memory leaks as errors, since most VTR tools are now leak-free in regular usage. This should detect new leak regressions.