### PR TITLE
Change VPR place WL estimate fun to linear

### DIFF
--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2242,14 +2242,14 @@ static void get_bb_from_scratch(ClusterNetId net_id, t_bb* coords, t_bb* num_on_
 }
 
 static double wirelength_crossing_count(size_t fanout) {
-	/* Get the expected "crossing count" of a net, based on its number *
+    /* Get the expected "crossing count" of a net, based on its number *
      * of pins.  Extrapolate for very large nets.                      */
 
-	if (fanout > 50) {
-		return 2.7933 + 0.02616 * (fanout - 50);
-	} else {
-		return cross_count[fanout - 1];
-	}
+    if (fanout > 50) {
+        return 2.7933 + 0.02616 * (fanout - 50);
+    } else {
+        return cross_count[fanout - 1];
+    }
 }
 
 static double get_net_wirelength_estimate(ClusterNetId net_id, t_bb* bbptr) {
@@ -2260,7 +2260,6 @@ static double get_net_wirelength_estimate(ClusterNetId net_id, t_bb* bbptr) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
     crossing = wirelength_crossing_count(cluster_ctx.clb_nlist.net_pins(net_id).size());
-
 
     /* Could insert a check for xmin == xmax.  In that case, assume  *
      * connection will be made with no bends and hence no x-cost.    *

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2241,6 +2241,17 @@ static void get_bb_from_scratch(ClusterNetId net_id, t_bb* coords, t_bb* num_on_
     num_on_edges->ymax = ymax_edge;
 }
 
+static double wirelength_crossing_count(size_t fanout) {
+	/* Get the expected "crossing count" of a net, based on its number *
+     * of pins.  Extrapolate for very large nets.                      */
+
+	if (fanout > 50) {
+		return 2.7933 + 0.02616 * (fanout - 50);
+	} else {
+		return cross_count[fanout - 1];
+	}
+}
+
 static double get_net_wirelength_estimate(ClusterNetId net_id, t_bb* bbptr) {
     /* WMF: Finds the estimate of wirelength due to one net by looking at   *
      * its coordinate bounding box.                                         */
@@ -2248,19 +2259,7 @@ static double get_net_wirelength_estimate(ClusterNetId net_id, t_bb* bbptr) {
     double ncost, crossing;
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
-    /* Get the expected "crossing count" of a net, based on its number *
-     * of pins.  Extrapolate for very large nets.                      */
-
-    if (((cluster_ctx.clb_nlist.net_pins(net_id).size()) > 50)
-        && ((cluster_ctx.clb_nlist.net_pins(net_id).size()) < 85)) {
-        crossing = 2.7933 + 0.02616 * ((cluster_ctx.clb_nlist.net_pins(net_id).size()) - 50);
-    } else if ((cluster_ctx.clb_nlist.net_pins(net_id).size()) >= 85) {
-        crossing = 2.7933 + 0.011 * (cluster_ctx.clb_nlist.net_pins(net_id).size())
-                   - 0.0000018 * (cluster_ctx.clb_nlist.net_pins(net_id).size())
-                         * (cluster_ctx.clb_nlist.net_pins(net_id).size());
-    } else {
-        crossing = cross_count[cluster_ctx.clb_nlist.net_pins(net_id).size() - 1];
-    }
+    crossing = wirelength_crossing_count(cluster_ctx.clb_nlist.net_pins(net_id).size());
 
     /* Could insert a check for xmin == xmax.  In that case, assume  *
      * connection will be made with no bends and hence no x-cost.    *
@@ -2283,15 +2282,7 @@ static double get_net_cost(ClusterNetId net_id, t_bb* bbptr) {
     double ncost, crossing;
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
-    /* Get the expected "crossing count" of a net, based on its number *
-     * of pins.  Extrapolate for very large nets.                      */
-
-    if ((cluster_ctx.clb_nlist.net_pins(net_id).size()) > 50) {
-        crossing = 2.7933 + 0.02616 * ((cluster_ctx.clb_nlist.net_pins(net_id).size()) - 50);
-        /*    crossing = 3.0;    Old value  */
-    } else {
-        crossing = cross_count[(cluster_ctx.clb_nlist.net_pins(net_id).size()) - 1];
-    }
+    crossing = wirelength_crossing_count(cluster_ctx.clb_nlist.net_pins(net_id).size());
 
     /* Could insert a check for xmin == xmax.  In that case, assume  *
      * connection will be made with no bends and hence no x-cost.    *


### PR DESCRIPTION
Changed get_net_wirelength_estimate() in vpr/src/place/place.cpp to
use linear equation, as in get_net_cost(). Original quadratic formula
offers no advantage over the linear one: similar runtime and QoR.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
VTR_benchmarks & titan_benchmarks
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x ] All new and existing tests passed
