### PR TITLE
Speed up Router's calculation of OveruseInfo

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -192,7 +192,7 @@ struct more_sinks_than {
 
 static size_t calculate_wirelength_available();
 static WirelengthInfo calculate_wirelength_info(size_t available_wirelength);
-static OveruseInfo calculate_overuse_info(std::vector<ClusterNetId>& rerouted_nets);
+static OveruseInfo calculate_overuse_info(const std::vector<ClusterNetId>& rerouted_nets);
 
 static void print_route_status_header();
 static void print_route_status(int itry,
@@ -1608,9 +1608,8 @@ static bool early_exit_heuristic(const t_router_opts& router_opts, const Wirelen
     return false;
 }
 
-static OveruseInfo calculate_overuse_info(std::vector<ClusterNetId>& rerouted_nets) {
+static OveruseInfo calculate_overuse_info(const std::vector<ClusterNetId>& rerouted_nets) {
     auto& device_ctx = g_vpr_ctx.device();
-    auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& route_ctx = g_vpr_ctx.routing();
 
     std::unordered_set<int> checked_nodes;

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -192,7 +192,7 @@ struct more_sinks_than {
 
 static size_t calculate_wirelength_available();
 static WirelengthInfo calculate_wirelength_info(size_t available_wirelength);
-static OveruseInfo calculate_overuse_info();
+static OveruseInfo calculate_overuse_info(std::vector<ClusterNetId>& rerouted_nets);
 
 static void print_route_status_header();
 static void print_route_status(int itry,
@@ -503,7 +503,7 @@ bool try_timing_driven_route_tmpl(const t_router_opts& router_opts,
         bool routing_is_feasible = feasible_routing();
         float est_success_iteration = routing_predictor.estimate_success_iteration();
 
-        overuse_info = calculate_overuse_info();
+        overuse_info = calculate_overuse_info(rerouted_nets);
         wirelength_info = calculate_wirelength_info(available_wirelength);
         routing_predictor.add_iteration_overuse(itry, overuse_info.overused_nodes());
 
@@ -1608,7 +1608,7 @@ static bool early_exit_heuristic(const t_router_opts& router_opts, const Wirelen
     return false;
 }
 
-static OveruseInfo calculate_overuse_info() {
+static OveruseInfo calculate_overuse_info(std::vector<ClusterNetId>& rerouted_nets) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& route_ctx = g_vpr_ctx.routing();
@@ -1627,7 +1627,10 @@ static OveruseInfo calculate_overuse_info() {
     //Note that we walk through the entire routing and *not* the RR graph, which
     //should be more efficient (since usually only a portion of the RR graph is
     //used by routing, particularly on large devices).
-    for (auto net_id : cluster_ctx.clb_nlist.nets()) {
+    //
+    //We skip the nets that have not been rerouted, since if a net should
+    //be rerouted if it already has overused nodes (congestion problem).
+    for (auto net_id : rerouted_nets) {
         for (t_trace* tptr = route_ctx.trace[net_id].head; tptr != nullptr; tptr = tptr->next) {
             int inode = tptr->index;
 


### PR DESCRIPTION
#### Motivation and Context
Trying to speed up the VPR router by detecting its various performance bottlenecks and remove them by optimizations. This PR should not change any of the VPR router's functionalities.

This PR is still undergoing changes. I will update more commits if I manage to optimize other areas of the code.

#### What Has Already Been Optimized?
1. Optimized overused info calculation. Noticeable speed up when running very large titan benchmarks, where the number of nets is large and many router iterations are performed.

- Tested on the LU8+Flagship and Stereovision+Tian benchmarks. No significant speedup.
- Tested on the Bitcoin+Titan benchmark. Appreciable speedup.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Optimization (change which speeds up code)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
