### PR TITLE
Fixed a typo in vtr quick start

### DIFF
--- a/doc/src/quickstart/index.rst
+++ b/doc/src/quickstart/index.rst
@@ -130,7 +130,7 @@ and various report files describing the characteristics of the implementation:
     pre_pack.report_timing.setup.rpt  report_timing.setup.rpt  report_unconstrained_timing.setup.rpt
 
 
-Visualizaing Circuit Implementation
+Visualizing Circuit Implementation
 -----------------------------------
 
 .. note:: This section requires that VPR was compiled with graphic support. See :ref:`VPR Graphics <vpr_graphics>` for details.


### PR DESCRIPTION
Visualization was misspelt (trivial fix)