### PR TITLE
Update libblifparse

### DIFF
--- a/libs/EXTERNAL/libblifparse/.travis.yml
+++ b/libs/EXTERNAL/libblifparse/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+dist: trusty #Ubuntu 14.04 by default
+sudo: false #Use container based infrastructure
+
+matrix:
+    include:
+        #Extensive testing for base compiler
+        - env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5"
+          addons: { apt: { packages: ["cmake", "g++-5", "libtbb-dev", "flex", "bison"], sources: ["ubuntu-toolchain-r-test"] } }
+before_install:
+    - eval "${MATRIX_EVAL}" #Set compiler versions
+    - echo $CC
+    - echo $CXX
+
+script:
+    #Build
+    - mkdir -p build
+    - pushd build 
+    - cmake .. 
+    - make -j2
+
+    #Test
+    - ../test/test_parser.sh ../test

--- a/libs/EXTERNAL/libblifparse/src/blif_lexer.l
+++ b/libs/EXTERNAL/libblifparse/src/blif_lexer.l
@@ -15,7 +15,7 @@
  */
 
 /* track line numbers*/
-%option yylineno 
+%option yylineno
 
 /* No lexing accross files */
 %option noyywrap
@@ -42,10 +42,10 @@
  * Use a prefix to avoid name clashes with other
  * flex lexers
  */
-%option prefix="blifparse_" 
+%option prefix="blifparse_"
 
 /* Common character classes */
-ID_SET [^ \t\r\n\\=]
+ID_SET [^ \t\r\n\\="]
 BACK_SLASH [\\]
 WS [ \t]
 ENDL (\n|\n\r|\r\n)
@@ -63,37 +63,37 @@ ENDL (\n|\n\r|\r\n)
                                   return blifparse::Parser::make_EOL();
                                 }
 ^{WS}*{ENDL}                    { /* Ignore blank lines. */ }
-\\{ENDL}{WS}*{ENDL}             { 
-                                  /* 
-                                   * Do forward end of line if the last line was a continuation. 
+\\{ENDL}{WS}*{ENDL}             {
+                                  /*
+                                   * Do forward end of line if the last line was a continuation.
                                    *
-                                   * Some times line continuations are followed by blank lines (which 
-                                   * are otherwise ignored). In these cases we *do* want to 
-                                   * forward EOL, so the parser knows the continued line has finished 
-                                   */ 
-                                  return blifparse::Parser::make_EOL(); 
+                                   * Some times line continuations are followed by blank lines (which
+                                   * are otherwise ignored). In these cases we *do* want to
+                                   * forward EOL, so the parser knows the continued line has finished
+                                   */
+                                  return blifparse::Parser::make_EOL();
                                 }
 <*>\\{ENDL}                     { /* line continuation (don't forward EOL to parser) */ }
-{ENDL}                          { 
-                                  return blifparse::Parser::make_EOL(); 
+{ENDL}                          {
+                                  return blifparse::Parser::make_EOL();
                                 }
 <*>{WS}+                        { /* skip white space */ }
-<*>\.names                      { 
+<*>\.names                      {
                                   /*
                                    * To process the single output cover rows of the names directly as symbols
                                    * (rather than as strings) we use a special lexer state.
                                    */
                                   BEGIN(NAMES);
-                                  return blifparse::Parser::make_DOT_NAMES(); 
+                                  return blifparse::Parser::make_DOT_NAMES();
                                 }
-<*>\.latch                      { 
+<*>\.latch                      {
                                   /*
-                                   * The initial state value of a latch is ambiguous (it chould be 
+                                   * The initial state value of a latch is ambiguous (it chould be
                                    * interpreted as a string or logic value string). So we use
                                    * a special lexer state to capture it.
                                    */
-                                  BEGIN(LATCH); 
-                                  return blifparse::Parser::make_DOT_LATCH(); 
+                                  BEGIN(LATCH);
+                                  return blifparse::Parser::make_DOT_LATCH();
                                 }
 <*>\.model                      { BEGIN(INITIAL); return blifparse::Parser::make_DOT_MODEL(); }
 <*>\.subckt                     { BEGIN(INITIAL); return blifparse::Parser::make_DOT_SUBCKT(); }
@@ -107,6 +107,7 @@ ENDL (\n|\n\r|\r\n)
 <*>\.param                      { BEGIN(INITIAL); return blifparse::Parser::make_DOT_PARAM(); /*BLIF extension */}
 <*>\.cname                      { BEGIN(INITIAL); return blifparse::Parser::make_DOT_CNAME(); /*BLIF extension */}
 
+
 =                               { return blifparse::Parser::make_EQ();}
 <LATCH>fe                       { return blifparse::Parser::make_LATCH_FE(); }
 <LATCH>re                       { return blifparse::Parser::make_LATCH_RE(); }
@@ -118,43 +119,51 @@ ENDL (\n|\n\r|\r\n)
 <LATCH>1                        { return blifparse::Parser::make_LOGIC_TRUE(); }
 <LATCH>2                        { return blifparse::Parser::make_LATCH_INIT_2(); }
 <LATCH>3                        { return blifparse::Parser::make_LATCH_INIT_3(); }
-<LATCH>{ENDL}                   { 
+<LATCH>{ENDL}                   {
                                   /*
                                    * Latches are only every defined on a single line,
                                    * so when we see the end of a line while in the LATCH
                                    * state we can go back to the regular (INITIAL) state.
                                    */
-                                  BEGIN(INITIAL); return blifparse::Parser::make_EOL(); 
+                                  BEGIN(INITIAL); return blifparse::Parser::make_EOL();
                                 }
 <SO_COVER>0                     { return blifparse::Parser::make_LOGIC_FALSE(); }
 <SO_COVER>1                     { return blifparse::Parser::make_LOGIC_TRUE(); }
 <SO_COVER>\-                    { return blifparse::Parser::make_LOGIC_DONT_CARE(); }
 <SO_COVER>{ENDL}                { return blifparse::Parser::make_EOL(); }
-<NAMES>{ENDL}                   { 
+<NAMES>{ENDL}                   {
                                   /*
                                    * Once we reach the end of a line in NAMES state (i.e. the end of a .names line)
                                    * we expect the truth table (in single output cover format) to follow, so we enter
                                    * the SO_COVER state.
                                    */
-                                  BEGIN(SO_COVER); 
-                                  return blifparse::Parser::make_EOL(); 
+                                  BEGIN(SO_COVER);
+                                  return blifparse::Parser::make_EOL();
                                 }
-<INITIAL,NAMES,LATCH>(({ID_SET}|{BACK_SLASH})*{ID_SET}) {
+<INITIAL,NAMES,LATCH>([\"][^\r\n\"]*[\"])|(({ID_SET}|{BACK_SLASH})*{ID_SET}) {
                                     /*
-                                     * We allow all sorts of characters in regular strings.
+                                     * There two types of STRING's this
+                                     * expression recognizes:
+                                     *  - Quoted strings, with no string
+                                     *    escape allowed, no line continuation
+                                     *    allowed.
+                                     *  - Unquoted strings.
+                                     *
+                                     * For the unquoted strings, we allow all
+                                     * sorts of characters in regular strings.
                                      * However we need to be careful about line continuations
-                                     * in particular, it is possible that we could have a string 
-                                     * followed by a continuation with no space for this reason, 
-                                     * we do not allow a continuation (backslash, \\ in escaped 
+                                     * in particular, it is possible that we could have a string
+                                     * followed by a continuation with no space for this reason,
+                                     * we do not allow a continuation (backslash, \\ in escaped
                                      * form in the regex) in the last character of the string.
                                      */
-                                    return blifparse::Parser::make_STRING(blifparse_get_text(yyscanner)); 
+                                    return blifparse::Parser::make_STRING(blifparse_get_text(yyscanner));
                                 }
 <<EOF>>                         { /* If the file has no blank line at the end there will
-                                     not be the expected EOL following the last command. 
-                                     So first time through, return EOL, and subsequently 
+                                     not be the expected EOL following the last command.
+                                     So first time through, return EOL, and subsequently
                                      return 0 (which indicated end of file). This ensures
-                                     there will always be an EOL provided to the parser. 
+                                     there will always be an EOL provided to the parser.
                                      However it may also generate a stray EOL if the last
                                      line IS blank - so the parser must handle those correclty. */
                                   static bool once; return (once = !once) ? blifparse::Parser::make_EOL() : blifparse::Parser::make_EOF();

--- a/libs/EXTERNAL/libblifparse/test/eblif/test.eblif
+++ b/libs/EXTERNAL/libblifparse/test/eblif/test.eblif
@@ -2,7 +2,7 @@
 .inputs a b clk
 .outputs o_dff
 
-.names 1\a 3 a_-1234567890~|:*/\[\]\.\{\}^+$;'"?<>
+.names 1\a 3 a_-1234567890~|:*/\[\]\.\{\}^+$;'?<>
 
 .names a b \
   a_and_b
@@ -16,6 +16,8 @@
 .cname my_dff
 .param parama param_valuea
 .param attra attr_valuea
+.param paramb " A  B "
+.attr attrb "I have a space"
 
 .conn dff_q o_dff
 

--- a/libs/EXTERNAL/libblifparse/test/test_parser.sh
+++ b/libs/EXTERNAL/libblifparse/test/test_parser.sh
@@ -13,7 +13,7 @@ do
         echo
         echo "File: $blif_file"
         #valgrind --leak-check=full --track-origins=yes ./blifparse_test $blif_file
-        ./blifparse_test $blif_file 
+        ./blifparse_test $blif_file > blif_parse_test.log
         exit_code=$?
         if [[ $exit_code -ne 0 ]]; then
             echo "Error" >&2 


### PR DESCRIPTION
#### Description

Update libblifparse git subtree.

#### Related Issue

#### Motivation and Context

eblif extensions for .attr and .param have support for string parameters, which may be contain strings which contain spaces.  libblifparse has been updated to support a simple string quote, with escaping character support initially. 

#### How Has This Been Tested?

libblifparse has new tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
