### PR TITLE
[WIP] Odin: get verbose output out of bison

### DIFF
--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -42,6 +42,8 @@ int yywrap(){	return 1;}
 int yylex(void);
 
 %}
+/* give detailed errors */
+%define parse.error verbose
 
 %locations
 


### PR DESCRIPTION
#### Description
Get verbosity back from bison, since the macro YYERROR_VERBOSE seems to not provide detailed output as of bison v:3.6.4

#### Motivation and Context
The parser errors where uninsightful with the newer bison

#### How Has This Been Tested?
odin full regression test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
