### PR TITLE
Increase width of cost_index to support more segment types.

### DIFF
--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -48,7 +48,7 @@
  *       This field is valid only for IPINs and OPINs and should be ignored  *
  *       otherwise.                                                          */
 struct alignas(16) t_rr_node_data {
-    int8_t cost_index_ = -1;
+    int16_t cost_index_ = -1;
     int16_t rc_index_ = -1;
 
     int16_t xlow_ = -1;


### PR DESCRIPTION
### Description

The maximux value of cost_index limits the number of segments to max
~(count / 2), because CHANX and CHANY segments each get a cost index.

At int8, the maximum number of segments is ~64, which can easily be
exceeded.  The 7-series arch has ~100 segment types.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

The 7-series arch uses ~100 segment types, which cannot be stored in an `int8_t`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
