### PR TITLE
Update file_formats.rst

### DIFF
--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -594,17 +594,15 @@ This information is used to ensure you are warned if you accidentally route this
 The second line of the file gives the size of the logic block array used by this placement.
 All the following lines have the format::
 
-    block_name    x        y   subblock_number
+    block_name    x        y   subtile_number
 
 The ``block_name`` is the name of this block, as given in the input .net formatted netlist.
 ``x`` and ``y`` are the row and column in which the block is placed, respectively.
 
 .. note:: The blocks in a placement file can be listed in any order.
 
-The ``subblock number`` is meaningful only for I/O pads.
-Since we can have more than one pad in a row or column when io_rat is set to be greater than 1 in the architecture file, the subblock number specifies which of the several possible pad locations in row x and column y contains this pad.
-Note that the first pads occupied at some (x, y) location are always those with the lowest subblock numbers -- i.e. if only one pad at (x, y) is used, the subblock number of the I/O placed there will be zero.
-For CLBs, the subblock number is always zero.
+Since we can have more than one block in a row or column when the block capacity is set to be greater than 1 in the architecture file, the subtile number specifies which of the several possible subtile locations in row x and column y contains this block.
+Note that the first blocks occupied at some (x, y) location are always those with the lowest subtile numbers -- i.e. if only one block at (x, y) is used, the subtile number of the block placed there will be zero.
 
 The placement files output by VPR also include (as a comment) a fifth field:  the block number.
 This is the internal index used by VPR to identify a block -- it may be useful to know this index if you are modifying VPR and trying to debug something.


### PR DESCRIPTION
I had made some changes to the documentation previously on another branch, but further changes were needed so I closed the pull request for that branch and created this one. 
The changes to the file formats documentation were made to reflect that now any block can have its location specified by x, y, subtile numbers - not just I/O blocks as it said previously.
