### PR TITLE
Odin: don't glob for memory architectures in arch_sweep

### DIFF
--- a/ODIN_II/regression_test/benchmark/task/arch_sweep/task.conf
+++ b/ODIN_II/regression_test/benchmark/task/arch_sweep/task.conf
@@ -8,9 +8,21 @@ regression_params=--disable_simulation
 # setup the architecture
 archs_dir=../vtr_flow/arch
 
-# bug in ram
+arch_list_add=timing/k6_frac_N10_4add_2chains_tie_off_depop50_mem20K_22nm.xml
+arch_list_add=timing/k6_frac_N10_4add_2chains_depop50_mem20K_22nm.xml
+arch_list_add=timing/k6_frac_N10_4add_2chains_tie_off_depop50_mem20K_22nm.xml
+arch_list_add=timing/k6_frac_N10_frac_chain_depop50_mem32K_40nm.xml
+arch_list_add=timing/k6_frac_N10_frac_chain_mem32K_40nm.xml
+arch_list_add=timing/k6_frac_N10_frac_chain_mem32K_htree0_routedCLK_40nm.xml
+arch_list_add=timing/k6_frac_N10_frac_chain_mem32K_htree0_40nm.xml
+arch_list_add=custom_pins/k6_frac_N10_mem32K_40nm_custom_pins.xml
+arch_list_add=timing/k6_frac_N10_frac_chain_mem32K_htree0short_40nm.xml
 arch_list_add=timing/k6_N10_40nm.xml
-arch_list_add=*/*mem*.xml
+arch_list_add=timing/k6_frac_N10_mem32K_40nm.xml
+arch_list_add=timing/k6_N10_mem32K_40nm_fc_abs.xml
+arch_list_add=nonuniform_chan_width/k6_N10_mem32K_40nm_nonuniform.xml
+arch_list_add=nonuniform_chan_width/k6_N10_mem32K_40nm_pulse.xml
+arch_list_add=timing/k6_N10_mem32K_40nm.xml
 
 # setup the circuits
 circuits_dir=regression_test/benchmark/verilog/syntax


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Stop using glob for regression tests architecttures in odin

#### Related Issue
PR #1436 added a new architecture and the regresssion test added it due to globbing

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
