### PR TITLE
Prune the heap

### DIFF
--- a/vpr/src/route/binary_heap.cpp
+++ b/vpr/src/route/binary_heap.cpp
@@ -9,7 +9,9 @@ static size_t right(size_t i) { return (i << 1) + 1; }
 BinaryHeap::BinaryHeap()
     : heap_(nullptr)
     , heap_size_(0)
-    , heap_tail_(0) {}
+    , heap_tail_(0)
+    , max_index_(std::numeric_limits<size_t>::max())
+    , prune_limit_(std::numeric_limits<size_t>::max()) {}
 
 BinaryHeap::~BinaryHeap() {
     free_all_memory();
@@ -26,7 +28,7 @@ void BinaryHeap::free(t_heap* hptr) {
 //       or realloc() must be eliminated from add_to_heap()
 //       because there is no C++ equivalent.
 void BinaryHeap::init_heap(const DeviceGrid& grid) {
-    ssize_t target_heap_size = (grid.width() - 1) * (grid.height() - 1);
+    size_t target_heap_size = (grid.width() - 1) * (grid.height() - 1);
     if (heap_ == nullptr || heap_size_ < target_heap_size) {
         if (heap_ != nullptr) {
             // coverity[offset_free : Intentional]
@@ -45,6 +47,11 @@ void BinaryHeap::add_to_heap(t_heap* hptr) {
     // start with undefined hole
     ++heap_tail_;
     sift_up(heap_tail_ - 1, hptr);
+
+    // If we have pruned, rebuild the heap now.
+    if (check_prune_limit()) {
+        build_heap();
+    }
 }
 
 bool BinaryHeap::is_empty_heap() const {
@@ -70,7 +77,7 @@ t_heap* BinaryHeap::get_heap_head() {
         hole = 1;
         child = 2;
         --heap_tail_;
-        while ((int)child < heap_tail_) {
+        while (child < heap_tail_) {
             if (heap_[child + 1]->cost < heap_[child]->cost)
                 ++child; // become right child
             heap_[hole] = heap_[child];
@@ -85,20 +92,20 @@ t_heap* BinaryHeap::get_heap_head() {
 }
 
 void BinaryHeap::empty_heap() {
-    for (int i = 1; i < heap_tail_; i++)
+    for (size_t i = 1; i < heap_tail_; i++)
         free(heap_[i]);
 
     heap_tail_ = 1;
 }
 
-size_t BinaryHeap::size() const { return static_cast<size_t>(heap_tail_ - 1); } // heap[0] is not valid element
+size_t BinaryHeap::size() const { return heap_tail_ - 1; } // heap[0] is not valid element
 
 // make a heap rooted at index hole by **sifting down** in O(lgn) time
 void BinaryHeap::sift_down(size_t hole) {
     t_heap* head{heap_[hole]};
     size_t child{left(hole)};
-    while ((int)child < heap_tail_) {
-        if ((int)child + 1 < heap_tail_ && heap_[child + 1]->cost < heap_[child]->cost)
+    while (child < heap_tail_) {
+        if (child + 1 < heap_tail_ && heap_[child + 1]->cost < heap_[child]->cost)
             ++child;
         if (heap_[child]->cost < head->cost) {
             heap_[hole] = heap_[child];
@@ -116,6 +123,14 @@ void BinaryHeap::build_heap() {
     // second half of heap are leaves
     for (size_t i = heap_tail_ >> 1; i != 0; --i)
         sift_down(i);
+}
+
+void BinaryHeap::set_prune_limit(size_t max_index, size_t prune_limit) {
+    if (prune_limit != std::numeric_limits<size_t>::max()) {
+        VTR_ASSERT(max_index < prune_limit);
+    }
+    max_index_ = max_index;
+    prune_limit_ = prune_limit;
 }
 
 // O(lgn) sifting up to maintain heap property after insertion (should sift down when building heap)
@@ -142,6 +157,8 @@ void BinaryHeap::push_back(t_heap* const hptr) {
     expand_heap_if_full();
     heap_[heap_tail_] = hptr;
     ++heap_tail_;
+
+    check_prune_limit();
 }
 
 bool BinaryHeap::is_valid() const {
@@ -149,9 +166,9 @@ bool BinaryHeap::is_valid() const {
         return false;
     }
 
-    for (size_t i = 1; (int)i <= heap_tail_ >> 1; ++i) {
-        if ((int)left(i) < heap_tail_ && heap_[left(i)]->cost < heap_[i]->cost) return false;
-        if ((int)right(i) < heap_tail_ && heap_[right(i)]->cost < heap_[i]->cost) return false;
+    for (size_t i = 1; i <= heap_tail_ >> 1; ++i) {
+        if (left(i) < heap_tail_ && heap_[left(i)]->cost < heap_[i]->cost) return false;
+        if (right(i) < heap_tail_ && heap_[right(i)]->cost < heap_[i]->cost) return false;
     }
     return true;
 }
@@ -166,7 +183,7 @@ void BinaryHeap::invalidate_heap_entries(int sink_node, int ipin_node) {
      * architectures.
      * */
 
-    for (int i = 1; i < heap_tail_; i++) {
+    for (size_t i = 1; i < heap_tail_; i++) {
         if (heap_[i]->index == sink_node) {
             if (heap_[i]->prev_node() == ipin_node) {
                 heap_[i]->index = OPEN; /* Invalid. */
@@ -187,4 +204,58 @@ void BinaryHeap::free_all_memory() {
     heap_ = nullptr; /* Defensive coding:  crash hard if I use these. */
 
     storage_.free_all_memory();
+}
+
+bool BinaryHeap::check_prune_limit() {
+    if (heap_tail_ > prune_limit_) {
+        prune_heap();
+        return true;
+    }
+
+    return false;
+}
+
+void BinaryHeap::prune_heap() {
+    VTR_ASSERT(max_index_ < prune_limit_);
+
+    std::vector<t_heap*> best_heap_item(max_index_, nullptr);
+
+    // Find the cheapest instance of each index and store it.
+    for (size_t i = 1; i < heap_tail_; i++) {
+        if (heap_[i] == nullptr) {
+            continue;
+        }
+
+        if (heap_[i]->index == OPEN) {
+            free(heap_[i]);
+            heap_[i] = nullptr;
+            continue;
+        }
+
+        VTR_ASSERT(static_cast<size_t>(heap_[i]->index) < max_index_);
+
+        if (best_heap_item[heap_[i]->index] == nullptr || best_heap_item[heap_[i]->index]->cost > heap_[i]->cost) {
+            best_heap_item[heap_[i]->index] = heap_[i];
+        }
+    }
+
+    // Free unused nodes.
+    for (size_t i = 1; i < heap_tail_; i++) {
+        if (heap_[i] == nullptr) {
+            continue;
+        }
+
+        if (best_heap_item[heap_[i]->index] != heap_[i]) {
+            free(heap_[i]);
+            heap_[i] = nullptr;
+        }
+    }
+
+    heap_tail_ = 1;
+
+    for (size_t i = 0; i < max_index_; ++i) {
+        if (best_heap_item[i] != nullptr) {
+            heap_[heap_tail_++] = best_heap_item[i];
+        }
+    }
 }

--- a/vpr/src/route/binary_heap.h
+++ b/vpr/src/route/binary_heap.h
@@ -19,6 +19,7 @@ class BinaryHeap : public HeapInterface {
     void empty_heap() final;
     t_heap* get_heap_head() final;
     void build_heap() final;
+    void set_prune_limit(size_t max_index, size_t prune_limit) final;
 
     void invalidate_heap_entries(int sink_node, int ipin_node) final;
 
@@ -29,11 +30,16 @@ class BinaryHeap : public HeapInterface {
     void sift_up(size_t leaf, t_heap* const node);
     void sift_down(size_t hole);
     void expand_heap_if_full();
+    bool check_prune_limit();
+    void prune_heap();
 
     HeapStorage storage_;
-    t_heap** heap_; /* Indexed from [1..heap_size] */
-    int heap_size_; /* Number of slots in the heap array */
-    int heap_tail_; /* Index of first unused slot in the heap array */
+    t_heap** heap_;    /* Indexed from [1..heap_size] */
+    size_t heap_size_; /* Number of slots in the heap array */
+    size_t heap_tail_; /* Index of first unused slot in the heap array */
+
+    size_t max_index_;
+    size_t prune_limit_;
 };
 
 #endif /* _BINARY_HEAP_H */

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -197,6 +197,8 @@ class Bucket : public HeapInterface {
     void build_heap() final {
     }
 
+    void set_prune_limit(size_t max_index, size_t prune_limit) final;
+
     // Pop an item from the cheapest non-empty bucket.
     //
     // Returns nullptr if empty.
@@ -226,7 +228,7 @@ class Bucket : public HeapInterface {
     static constexpr float kDefaultConvFactor = 1e12;
 
     // Convert cost from float to integer bucket id.
-    int cost_to_int(float cost) {
+    int cost_to_int(float cost) const {
         return (int)(cost * conv_factor_);
     }
 
@@ -237,11 +239,15 @@ class Bucket : public HeapInterface {
     }
 
     void check_scaling();
+    float rescale_func() const;
+    void check_conv_factor() const;
 
     // Expand the number of buckets.
     //
     // Only call if insufficient buckets exist.
     void expand(size_t required_number_of_buckets);
+
+    void prune_heap();
 
     BucketItems items_; /* Item storage */
 
@@ -259,6 +265,10 @@ class Bucket : public HeapInterface {
 
     float min_cost_; /* Smallest cost seen */
     float max_cost_; /* Large cost seen */
+
+    size_t num_items_;
+    size_t max_index_;
+    size_t prune_limit_;
 };
 
 #endif /* _BUCKET_H */

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -10,6 +10,9 @@
 #include "router_stats.h"
 #include "spatial_route_tree_lookup.h"
 
+// Prune the heap when it contains 4x the number of nodes in the RR graph.
+constexpr size_t kHeapPruneFactor = 4;
+
 // This class encapsolates the timing driven connection router. This class
 // routes from some initial set of sources (via the input rt tree) to a
 // particular sink.
@@ -37,6 +40,7 @@ class ConnectionRouter : public ConnectionRouterInterface {
         , router_stats_(nullptr)
         , router_debug_(false) {
         heap_.init_heap(grid);
+        heap_.set_prune_limit(rr_nodes_.size(), kHeapPruneFactor * rr_nodes_.size());
     }
 
     // Clear's the modified list.  Should be called after reset_path_costs

--- a/vpr/src/route/heap_type.h
+++ b/vpr/src/route/heap_type.h
@@ -191,6 +191,34 @@ class HeapInterface {
     // Note: Only invoke this method if all objects returned from this
     // HeapInterface instace have been free'd.
     virtual void free_all_memory() = 0;
+
+    // Set maximum number of elements that the heap should contain
+    // (the prune_limit).  If the prune limit is hit, then the heap should
+    // kick out duplicate index entries.
+    //
+    // The prune limit exists to provide a maximum bound on memory usage in
+    // the heap.  In some pathological cases, the router may explore
+    // incrementally better paths, resulting in many duplicate entries for
+    // RR nodes.  To handle this edge case, if the number of heap items
+    // exceeds the prune_limit, then the heap will compacts itself.
+    //
+    // The heap compaction process simply means taking the lowest cost entry
+    // for each index (e.g. RR node).  All nodes with higher costs can safely
+    // be dropped.
+    //
+    // The pruning process is intended to bound the memory usage the heap can
+    // consume based on the prune_limit, which is expected to be a function of
+    // the graph size.
+    //
+    // max_index should be the highest index possible in the heap.
+    // prune_limit is the maximuming number of heap entries before pruning
+    // should take place.
+    //
+    // The prune_limit should always be higher than max_index, likely by a
+    // significant amount.  The pruning process has some overhead, so
+    // prune_limit should be ~2-4x the max_index to prevent excess pruning
+    // when not required.
+    virtual void set_prune_limit(size_t max_index, size_t prune_limit) = 0;
 };
 
 enum class e_heap_type {


### PR DESCRIPTION
#### Description

VPR currently has unbounded memory usage as a result of #1032.  This PR caps the heap memory usage at 4x the number of nodes in the entire graph.  This is likely overkill for non-RCV routers.  For RCV based routers, this pruning will be problematic, but there likely needs to be a bounded memory limit for RCV based routers too.

#### Related Issue

#1032

#### Motivation and Context

The current heap implementations (both BinaryHeap and Bucket) can consume an unbounded amount of memory if the router is exploring bad paths that have incrementally better costs.  This has been observed to allow memory usage to grow to consume the entire RAM of ~128 GB machines in pathological cases.  Based on analysis, this memory usage around ~1000 heap entries for each node in the graph.

In #1032 other optimizations were identified, such as updating the best cost to node during insertion, rather than node pop, but even in that case the pathological behavior can result in unbounded memory usage.  This PR bounds the memory usage even in that pathological case.

#### How Has This Been Tested?

- [ ] Exists tests pass
- [ ] Failing unbounded memory case no longer consumes unbounded memory

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
