### PR TITLE
Print out info/report on overused rr-nodes at the end of a failed routing iteration

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1004,7 +1004,7 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
     Prints the information on overused RR nodes to the VPR log file after the each failed routing attempt.
 
-    This happens only when the number of overused nodes is below the given threshold.
+    If the number of overused nodes is above the given threshold ``N``, then only the first ``N`` entries are printed to the logfile.
 
     **Default:** ``20``
 
@@ -1014,7 +1014,7 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
     This report is generated only when the final routing attempt fails (i.e. the whole routing process has failed).
 
-    In addition to the information that can be seen via ``--max_logged_overused_rr_nodes``, this report prints out all the net ids that associated with each overused node. Also, this report does not place a threshold upon the number of RR nodes printed.
+    In addition to the information that can be seen via ``--max_logged_overused_rr_nodes``, this report prints out all the net ids that are associated with each overused RR node. Also, this report does not place a threshold upon the number of RR nodes printed.
 
     **Default:** ``off``
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1010,7 +1010,7 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
 .. option:: --generate_rr_node_overuse_report {on | off}
 
-    Generates a detailed report on the overused RR nodes' information.
+    Generates a detailed report on the overused RR nodes' information: **report_overused_nodes.rpt**.
 
     This report is generated only when the final routing attempt fails (i.e. the whole routing process has failed).
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1000,6 +1000,24 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
     **Default:** ``16``
 
+.. option:: --max_logged_overused_rr_nodes <int>
+
+    Prints the information on overused RR nodes to the VPR log file after the each failed routing attempt.
+
+    This happens only when the number of overused nodes is below the given threshold.
+
+    **Default:** ``20``
+
+.. option:: --generate_rr_node_overuse_report {on | off}
+
+    Generates a detailed report on the overused RR nodes' information.
+
+    This report is generated only when the final routing attempt fails (i.e. the whole routing process has failed).
+
+    In addition to the information that can be seen via ``--max_logged_overused_rr_nodes``, this report prints out all the net ids that associated with each overused node. Also, this report does not place a threshold upon the number of RR nodes printed.
+
+    **Default:** ``off``
+
 .. _timing_driven_router_options:
 
 Timing-Driven Router Options

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -394,6 +394,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->timing_update_type = Options.timing_update_type;
 
     RouterOpts->max_logged_overused_rr_nodes = Options.max_logged_overused_rr_nodes;
+    RouterOpts->generate_rr_node_overuse_report = Options.generate_rr_node_overuse_report;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -393,7 +393,7 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->check_route = Options.check_route;
     RouterOpts->timing_update_type = Options.timing_update_type;
 
-    RouterOpts->max_reported_overused_rr_nodes = Options.max_reported_overused_rr_nodes;
+    RouterOpts->max_logged_overused_rr_nodes = Options.max_logged_overused_rr_nodes;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -392,6 +392,8 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
 
     RouterOpts->check_route = Options.check_route;
     RouterOpts->timing_update_type = Options.timing_update_type;
+
+    RouterOpts->max_reported_overused_rr_nodes = Options.max_reported_overused_rr_nodes;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1849,6 +1849,12 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("off")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_grp.add_argument(args.max_reported_overused_rr_nodes, "--max_reported_overused_rr_nodes")
+        .help(
+            "Maximum number of overused RR nodes printed when the routing fails")
+        .default_value("20")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& route_timing_grp = parser.add_argument_group("timing-driven routing options");
 
     route_timing_grp.add_argument(args.astar_fac, "--astar_fac")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1850,9 +1850,13 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_grp.add_argument(args.max_logged_overused_rr_nodes, "--max_logged_overused_rr_nodes")
-        .help(
-            "Maximum number of overused RR nodes logged each time the routing fails")
+        .help("Maximum number of overused RR nodes logged each time the routing fails")
         .default_value("20")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    route_grp.add_argument<bool, ParseOnOff>(args.generate_rr_node_overuse_report, "--generate_rr_node_overuse_report")
+        .help("Generate detailed reports on overused rr nodes and congested nets should the routing fails")
+        .default_value("off")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     auto& route_timing_grp = parser.add_argument_group("timing-driven routing options");

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1849,9 +1849,9 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("off")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    route_grp.add_argument(args.max_reported_overused_rr_nodes, "--max_reported_overused_rr_nodes")
+    route_grp.add_argument(args.max_logged_overused_rr_nodes, "--max_logged_overused_rr_nodes")
         .help(
-            "Maximum number of overused RR nodes printed when the routing fails")
+            "Maximum number of overused RR nodes logged each time the routing fails")
         .default_value("20")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -148,7 +148,8 @@ struct t_options {
     argparse::ArgValue<bool> read_rr_edge_metadata;
     argparse::ArgValue<bool> exit_after_first_routing_iteration;
     argparse::ArgValue<e_check_route_option> check_route;
-    argparse::ArgValue<int> max_logged_overused_rr_nodes;
+    argparse::ArgValue<size_t> max_logged_overused_rr_nodes;
+    argparse::ArgValue<bool> generate_rr_node_overuse_report;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -148,6 +148,7 @@ struct t_options {
     argparse::ArgValue<bool> read_rr_edge_metadata;
     argparse::ArgValue<bool> exit_after_first_routing_iteration;
     argparse::ArgValue<e_check_route_option> check_route;
+    argparse::ArgValue<int> max_reported_overused_rr_nodes;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -148,7 +148,7 @@ struct t_options {
     argparse::ArgValue<bool> read_rr_edge_metadata;
     argparse::ArgValue<bool> exit_after_first_routing_iteration;
     argparse::ArgValue<e_check_route_option> check_route;
-    argparse::ArgValue<int> max_reported_overused_rr_nodes;
+    argparse::ArgValue<int> max_logged_overused_rr_nodes;
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -69,6 +69,7 @@
 #include "cluster.h"
 
 #include "pack_report.h"
+#include "overuse_report.h"
 
 #include "timing_graph_builder.h"
 #include "timing_reports.h"
@@ -731,6 +732,11 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
             //Update status
             VTR_LOG("Circuit is unroutable with a channel width factor of %d.\n", route_status.chan_width());
             graphics_msg = vtr::string_fmt("Routing failed with a channel width factor of %d. ILLEGAL routing shown.", route_status.chan_width());
+
+            //Generate a report on overused nodes if specified
+            if (router_opts.generate_rr_node_overuse_report) {
+                report_overused_nodes();
+            }
         }
 
         //Echo files

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -727,17 +727,23 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
 
             //Update status
             VTR_LOG("Circuit successfully routed with a channel width factor of %d.\n", route_status.chan_width());
-            graphics_msg = vtr::string_fmt("Routing succeeded with a channel width factor of %d.", route_status.chan_width());
+            graphics_msg = vtr::string_fmt("Routing succeeded with a channel width factor of %d.\n", route_status.chan_width());
         } else {
             //Update status
             VTR_LOG("Circuit is unroutable with a channel width factor of %d.\n", route_status.chan_width());
             graphics_msg = vtr::string_fmt("Routing failed with a channel width factor of %d. ILLEGAL routing shown.", route_status.chan_width());
 
             //Generate a report on overused nodes if specified
+            //Otherwise, remind the user of this possible report option
             if (router_opts.generate_rr_node_overuse_report) {
+                VTR_LOG("See report_overused_nodes.rpt for a detailed report on the RR node overuse information.\n");
                 report_overused_nodes();
+            } else {
+                VTR_LOG("For a detailed report on the RR node overuse information (report_overused_nodes.rpt), specify --generate_rr_node_overuse_report on.\n");
             }
         }
+
+        VTR_LOG("\n");
 
         //Echo files
         if (vpr_setup.Timing.timing_analysis_enabled) {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1091,7 +1091,7 @@ struct t_router_opts {
     e_check_route_option check_route;
     e_timing_update_type timing_update_type;
 
-    int max_reported_overused_rr_nodes;
+    size_t max_logged_overused_rr_nodes;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1092,6 +1092,7 @@ struct t_router_opts {
     e_timing_update_type timing_update_type;
 
     size_t max_logged_overused_rr_nodes;
+    bool generate_rr_node_overuse_report;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1090,6 +1090,8 @@ struct t_router_opts {
 
     e_check_route_option check_route;
     e_timing_update_type timing_update_type;
+
+    int max_reported_overused_rr_nodes;
 };
 
 struct t_analysis_opts {

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -1,0 +1,148 @@
+#include "overuse_report.h"
+
+#include <fstream>
+#include "globals.h"
+#include "vtr_log.h"
+
+static void log_overused_nodes_header();
+static void log_single_overused_node_status(int overuse_index, int inode);
+
+void log_overused_nodes_status() {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& route_ctx = g_vpr_ctx.routing();
+
+    //Print overuse info header
+    log_overused_nodes_header();
+
+    //Print overuse info body
+    int overuse_index = 0;
+    for (size_t inode = 0; inode < device_ctx.rr_nodes.size(); inode++) {
+        int overuse = route_ctx.rr_node_route_inf[inode].occ() - device_ctx.rr_nodes[inode].capacity();
+
+        if (overuse > 0) {
+            log_single_overused_node_status(overuse_index, inode);
+            overuse_index++;
+        }
+    }
+}
+
+static void log_overused_nodes_header() {
+    VTR_LOG("Routing Failure Diagnostics: Printing Overused Nodes Information\n");
+    VTR_LOG("------ ------- ---------- --------- -------- ------------ ------- ------- ------- ------- ------- -------\n");
+    VTR_LOG("   No.   Inode  Occupancy  Capacity  RR Node    Direction    Side     PTC    Xlow    Ylow   Xhigh   Yhigh\n");
+    VTR_LOG("                                        type                          NUM                                \n");
+    VTR_LOG("------ ------- ---------- --------- -------- ------------ ------- ------- ------- ------- ------- -------\n");
+}
+
+static void log_single_overused_node_status(int overuse_index, int inode) {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& route_ctx = g_vpr_ctx.routing();
+
+    //Determines if direction or side is available for printing
+    auto node_type = device_ctx.rr_nodes[inode].type();
+
+    //Overuse #
+    VTR_LOG("%6d", overuse_index);
+
+    //Inode
+    VTR_LOG(" %7d", inode);
+
+    //Occupancy
+    VTR_LOG(" %10d", route_ctx.rr_node_route_inf[inode].occ());
+
+    //Capacity
+    VTR_LOG(" %9d", device_ctx.rr_nodes[inode].capacity());
+
+    //RR node type
+    VTR_LOG(" %8s", device_ctx.rr_nodes[inode].type_string());
+
+    //Direction
+    if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
+        VTR_LOG(" %12s", device_ctx.rr_nodes[inode].direction_string());
+    } else {
+        VTR_LOG(" %12s", "N/A");
+    }
+
+    //Side
+    if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
+        VTR_LOG(" %7s", device_ctx.rr_nodes[inode].side_string());
+    } else {
+        VTR_LOG(" %7s", "N/A");
+    }
+
+    //PTC number
+    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].ptc_num());
+
+    //X_low
+    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].xlow());
+
+    //Y_low
+    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].ylow());
+
+    //X_high
+    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].xhigh());
+
+    //Y_high
+    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].yhigh());
+
+    VTR_LOG("\n");
+
+    fflush(stdout);
+}
+
+void report_overused_nodes() {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& route_ctx = g_vpr_ctx.routing();
+    const auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    //Create overused nodes to congested nets loop up
+    //by traversing through the net trackbacks
+    std::unordered_map<size_t, std::vector<ClusterNetId>> overused_nodes_to_net_lookup;
+    for (ClusterNetId net_id : cluster_ctx.clb_nlist.nets()) {
+        for (t_trace* tptr = route_ctx.trace[net_id].head; tptr != nullptr; tptr = tptr->next) {
+            size_t inode = size_t(tptr->index);
+
+            int overuse = route_ctx.rr_node_route_inf[inode].occ() - device_ctx.rr_nodes[inode].capacity();
+            if (overuse > 0) {
+                overused_nodes_to_net_lookup[inode].push_back(net_id);
+            }
+        }
+    }
+
+    //Append to the current report file
+    std::ofstream os("report_overused_nodes.rpt");
+
+    for (auto lookup_pair : overused_nodes_to_net_lookup) {
+        size_t inode = lookup_pair.first;
+        const auto& congested_nets = lookup_pair.second;
+
+        //Report Basic info
+        os << '\n';
+        os << "Overused RR node index #" << inode << '\n';
+        os << "Occupancy = " << route_ctx.rr_node_route_inf[inode].occ() << '\n';
+        os << "Capacity = " << device_ctx.rr_nodes[inode].capacity() << '\n';
+        os << "Node type = " << device_ctx.rr_nodes[inode].type_string() << '\n';
+        os << "PTC number = " << device_ctx.rr_nodes[inode].ptc_num() << '\n';
+        os << "Xlow = " << device_ctx.rr_nodes[inode].xlow() << ", Ylow = " << device_ctx.rr_nodes[inode].ylow() << '\n';
+        os << "Xhigh = " << device_ctx.rr_nodes[inode].xhigh() << ", Yhigh = " << device_ctx.rr_nodes[inode].yhigh() << '\n';
+
+        //Report Selective info
+        auto node_type = device_ctx.rr_nodes[inode].type();
+        if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
+            os << "Direction = " << device_ctx.rr_nodes[inode].direction_string() << '\n';
+            os << "Resistance = " << device_ctx.rr_nodes[inode].R() << '\n';
+            os << "Capacitance = " << device_ctx.rr_nodes[inode].C() << '\n';
+        } else if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
+            os << "Side = " << device_ctx.rr_nodes[inode].side_string() << '\n';
+        }
+
+        //Reported corresponding congested nets
+        os << "Number of nets passing through this RR node = " << congested_nets.size() << '\n';
+        os << "Net IDs:" << '\n';
+        for (auto net_id : congested_nets) {
+            os << size_t(net_id) << '\n';
+        }
+    }
+
+    os.close();
+}

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -97,20 +97,21 @@ void report_overused_nodes() {
 
     //Create overused nodes to congested nets loop up
     //by traversing through the net trackbacks
-    std::unordered_map<size_t, std::vector<ClusterNetId>> overused_nodes_to_net_lookup;
+    std::unordered_map<size_t, std::unordered_set<ClusterNetId>> overused_nodes_to_net_lookup;
     for (ClusterNetId net_id : cluster_ctx.clb_nlist.nets()) {
         for (t_trace* tptr = route_ctx.trace[net_id].head; tptr != nullptr; tptr = tptr->next) {
             size_t inode = size_t(tptr->index);
 
             int overuse = route_ctx.rr_node_route_inf[inode].occ() - device_ctx.rr_nodes[inode].capacity();
             if (overuse > 0) {
-                overused_nodes_to_net_lookup[inode].push_back(net_id);
+                overused_nodes_to_net_lookup[inode].insert(net_id);
             }
         }
     }
 
     //Append to the current report file
     std::ofstream os("report_overused_nodes.rpt");
+    os << "Overused nodes information report on the final failed routing attempt" << '\n';
 
     for (auto lookup_pair : overused_nodes_to_net_lookup) {
         size_t inode = lookup_pair.first;

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -5,7 +5,7 @@
 #include "vtr_log.h"
 
 static void log_overused_nodes_header();
-static void log_single_overused_node_status(int overuse_index, int inode);
+static void log_single_overused_node_status(int overuse_index, RRNodeId inode);
 
 void log_overused_nodes_status() {
     const auto& device_ctx = g_vpr_ctx.device();
@@ -20,8 +20,75 @@ void log_overused_nodes_status() {
         int overuse = route_ctx.rr_node_route_inf[inode].occ() - device_ctx.rr_nodes[inode].capacity();
 
         if (overuse > 0) {
-            log_single_overused_node_status(overuse_index, inode);
+            log_single_overused_node_status(overuse_index, RRNodeId(inode));
             overuse_index++;
+        }
+    }
+}
+
+void report_overused_nodes() {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& route_ctx = g_vpr_ctx.routing();
+
+    //Generate overuse infor lookup table
+    std::map<RRNodeId, std::set<ClusterNetId>> nodes_to_nets_lookup;
+    generate_overused_nodes_to_congested_net_lookup(nodes_to_nets_lookup);
+
+    //Open the report file
+    std::ofstream os("report_overused_nodes.rpt");
+    os << "Overused nodes information report on the final failed routing attempt" << '\n';
+
+    for (const auto& lookup_pair : nodes_to_nets_lookup) {
+        const RRNodeId inode = lookup_pair.first;
+        const auto& congested_nets = lookup_pair.second;
+
+        //Report Basic info
+        os << '\n';
+        os << "Overused RR node index #" << size_t(inode) << '\n';
+        os << "Occupancy = " << route_ctx.rr_node_route_inf[size_t(inode)].occ() << '\n';
+        os << "Capacity = " << device_ctx.rr_nodes.node_capacity(inode) << '\n';
+        os << "Node type = " << device_ctx.rr_nodes.node_type_string(inode) << '\n';
+        os << "PTC number = " << device_ctx.rr_nodes.node_ptc_num(inode) << '\n';
+        os << "Xlow = " << device_ctx.rr_nodes.node_xlow(inode) << ", Ylow = " << device_ctx.rr_nodes.node_ylow(inode) << '\n';
+        os << "Xhigh = " << device_ctx.rr_nodes.node_xhigh(inode) << ", Yhigh = " << device_ctx.rr_nodes.node_yhigh(inode) << '\n';
+
+        //Report Selective info
+        auto node_type = device_ctx.rr_nodes.node_type(inode);
+        if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
+            os << "Direction = " << device_ctx.rr_nodes.node_direction_string(inode) << '\n';
+            os << "Resistance = " << device_ctx.rr_nodes.node_R(inode) << '\n';
+            os << "Capacitance = " << device_ctx.rr_nodes.node_C(inode) << '\n';
+        } else if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
+            os << "Side = " << device_ctx.rr_nodes.node_side_string(inode) << '\n';
+        }
+
+        //Reported corresponding congested nets
+        os << "Number of nets passing through this RR node = " << congested_nets.size() << '\n';
+        os << "Net IDs:";
+        for (auto net_id : congested_nets) {
+            os << ' ' << size_t(net_id);
+        }
+        os << '\n';
+    }
+
+    os.close();
+}
+
+void generate_overused_nodes_to_congested_net_lookup(std::map<RRNodeId, std::set<ClusterNetId>>& nodes_to_nets_lookup) {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& route_ctx = g_vpr_ctx.routing();
+    const auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    //Create overused nodes to congested nets look up by
+    //traversing through the net trace backs linked lists
+    for (ClusterNetId net_id : cluster_ctx.clb_nlist.nets()) {
+        for (t_trace* tptr = route_ctx.trace[net_id].head; tptr != nullptr; tptr = tptr->next) {
+            int inode = tptr->index;
+
+            int overuse = route_ctx.rr_node_route_inf[inode].occ() - device_ctx.rr_nodes[inode].capacity();
+            if (overuse > 0) {
+                nodes_to_nets_lookup[RRNodeId(inode)].insert(net_id);
+            }
         }
     }
 }
@@ -34,116 +101,58 @@ static void log_overused_nodes_header() {
     VTR_LOG("------ ------- ---------- --------- -------- ------------ ------- ------- ------- ------- ------- -------\n");
 }
 
-static void log_single_overused_node_status(int overuse_index, int inode) {
+static void log_single_overused_node_status(int overuse_index, RRNodeId inode) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& route_ctx = g_vpr_ctx.routing();
 
     //Determines if direction or side is available for printing
-    auto node_type = device_ctx.rr_nodes[inode].type();
+    auto node_type = device_ctx.rr_nodes.node_type(inode);
 
     //Overuse #
     VTR_LOG("%6d", overuse_index);
 
     //Inode
-    VTR_LOG(" %7d", inode);
+    VTR_LOG(" %7d", size_t(inode));
 
     //Occupancy
-    VTR_LOG(" %10d", route_ctx.rr_node_route_inf[inode].occ());
+    VTR_LOG(" %10d", route_ctx.rr_node_route_inf[size_t(inode)].occ());
 
     //Capacity
-    VTR_LOG(" %9d", device_ctx.rr_nodes[inode].capacity());
+    VTR_LOG(" %9d", device_ctx.rr_nodes.node_capacity(inode));
 
     //RR node type
-    VTR_LOG(" %8s", device_ctx.rr_nodes[inode].type_string());
+    VTR_LOG(" %8s", device_ctx.rr_nodes.node_type_string(inode));
 
     //Direction
     if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
-        VTR_LOG(" %12s", device_ctx.rr_nodes[inode].direction_string());
+        VTR_LOG(" %12s", device_ctx.rr_nodes.node_direction_string(inode));
     } else {
         VTR_LOG(" %12s", "N/A");
     }
 
     //Side
     if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
-        VTR_LOG(" %7s", device_ctx.rr_nodes[inode].side_string());
+        VTR_LOG(" %7s", device_ctx.rr_nodes.node_side_string(inode));
     } else {
         VTR_LOG(" %7s", "N/A");
     }
 
     //PTC number
-    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].ptc_num());
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ptc_num(inode));
 
     //X_low
-    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].xlow());
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_xlow(inode));
 
     //Y_low
-    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].ylow());
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ylow(inode));
 
     //X_high
-    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].xhigh());
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_xhigh(inode));
 
     //Y_high
-    VTR_LOG(" %7d", device_ctx.rr_nodes[inode].yhigh());
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_yhigh(inode));
 
     VTR_LOG("\n");
 
     fflush(stdout);
-}
-
-void report_overused_nodes() {
-    const auto& device_ctx = g_vpr_ctx.device();
-    const auto& route_ctx = g_vpr_ctx.routing();
-    const auto& cluster_ctx = g_vpr_ctx.clustering();
-
-    //Create overused nodes to congested nets loop up
-    //by traversing through the net trackbacks
-    std::unordered_map<size_t, std::unordered_set<ClusterNetId>> overused_nodes_to_net_lookup;
-    for (ClusterNetId net_id : cluster_ctx.clb_nlist.nets()) {
-        for (t_trace* tptr = route_ctx.trace[net_id].head; tptr != nullptr; tptr = tptr->next) {
-            size_t inode = size_t(tptr->index);
-
-            int overuse = route_ctx.rr_node_route_inf[inode].occ() - device_ctx.rr_nodes[inode].capacity();
-            if (overuse > 0) {
-                overused_nodes_to_net_lookup[inode].insert(net_id);
-            }
-        }
-    }
-
-    //Append to the current report file
-    std::ofstream os("report_overused_nodes.rpt");
-    os << "Overused nodes information report on the final failed routing attempt" << '\n';
-
-    for (auto lookup_pair : overused_nodes_to_net_lookup) {
-        size_t inode = lookup_pair.first;
-        const auto& congested_nets = lookup_pair.second;
-
-        //Report Basic info
-        os << '\n';
-        os << "Overused RR node index #" << inode << '\n';
-        os << "Occupancy = " << route_ctx.rr_node_route_inf[inode].occ() << '\n';
-        os << "Capacity = " << device_ctx.rr_nodes[inode].capacity() << '\n';
-        os << "Node type = " << device_ctx.rr_nodes[inode].type_string() << '\n';
-        os << "PTC number = " << device_ctx.rr_nodes[inode].ptc_num() << '\n';
-        os << "Xlow = " << device_ctx.rr_nodes[inode].xlow() << ", Ylow = " << device_ctx.rr_nodes[inode].ylow() << '\n';
-        os << "Xhigh = " << device_ctx.rr_nodes[inode].xhigh() << ", Yhigh = " << device_ctx.rr_nodes[inode].yhigh() << '\n';
-
-        //Report Selective info
-        auto node_type = device_ctx.rr_nodes[inode].type();
-        if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
-            os << "Direction = " << device_ctx.rr_nodes[inode].direction_string() << '\n';
-            os << "Resistance = " << device_ctx.rr_nodes[inode].R() << '\n';
-            os << "Capacitance = " << device_ctx.rr_nodes[inode].C() << '\n';
-        } else if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
-            os << "Side = " << device_ctx.rr_nodes[inode].side_string() << '\n';
-        }
-
-        //Reported corresponding congested nets
-        os << "Number of nets passing through this RR node = " << congested_nets.size() << '\n';
-        os << "Net IDs:" << '\n';
-        for (auto net_id : congested_nets) {
-            os << size_t(net_id) << '\n';
-        }
-    }
-
-    os.close();
 }

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -29,6 +29,7 @@ void log_overused_nodes_status() {
 void report_overused_nodes() {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& route_ctx = g_vpr_ctx.routing();
+    const auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
 
     //Generate overuse infor lookup table
     std::map<RRNodeId, std::set<ClusterNetId>> nodes_to_nets_lookup;
@@ -37,38 +38,60 @@ void report_overused_nodes() {
     //Open the report file
     std::ofstream os("report_overused_nodes.rpt");
     os << "Overused nodes information report on the final failed routing attempt" << '\n';
+    os << "Total number of overused nodes = " << nodes_to_nets_lookup.size() << '\n';
+
+    int inode = 0;
 
     for (const auto& lookup_pair : nodes_to_nets_lookup) {
-        const RRNodeId inode = lookup_pair.first;
+        const RRNodeId node_id = lookup_pair.first;
         const auto& congested_nets = lookup_pair.second;
 
+        os << "************************************************\n\n"; //RR Node Separation line
+
         //Report Basic info
-        os << '\n';
-        os << "Overused RR node index #" << size_t(inode) << '\n';
-        os << "Occupancy = " << route_ctx.rr_node_route_inf[size_t(inode)].occ() << '\n';
-        os << "Capacity = " << device_ctx.rr_nodes.node_capacity(inode) << '\n';
-        os << "Node type = " << device_ctx.rr_nodes.node_type_string(inode) << '\n';
-        os << "PTC number = " << device_ctx.rr_nodes.node_ptc_num(inode) << '\n';
-        os << "Xlow = " << device_ctx.rr_nodes.node_xlow(inode) << ", Ylow = " << device_ctx.rr_nodes.node_ylow(inode) << '\n';
-        os << "Xhigh = " << device_ctx.rr_nodes.node_xhigh(inode) << ", Yhigh = " << device_ctx.rr_nodes.node_yhigh(inode) << '\n';
+        os << "Overused RR node #" << inode << '\n';
+        os << "Node id = " << size_t(node_id) << '\n';
+        os << "Occupancy = " << route_ctx.rr_node_route_inf[size_t(node_id)].occ() << '\n';
+        os << "Capacity = " << device_ctx.rr_nodes.node_capacity(node_id) << '\n';
+        os << "Node type = " << device_ctx.rr_nodes.node_type_string(node_id) << '\n';
+        os << "PTC number = " << device_ctx.rr_nodes.node_ptc_num(node_id) << '\n';
+        os << "Xlow = " << device_ctx.rr_nodes.node_xlow(node_id) << ", ";
+        os << "Ylow = " << device_ctx.rr_nodes.node_ylow(node_id) << '\n';
+        os << "Xhigh = " << device_ctx.rr_nodes.node_xhigh(node_id) << ", ";
+        os << "Yhigh = " << device_ctx.rr_nodes.node_yhigh(node_id) << '\n';
 
         //Report Selective info
-        auto node_type = device_ctx.rr_nodes.node_type(inode);
+        auto node_type = device_ctx.rr_nodes.node_type(node_id);
+
         if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
-            os << "Direction = " << device_ctx.rr_nodes.node_direction_string(inode) << '\n';
-            os << "Resistance = " << device_ctx.rr_nodes.node_R(inode) << '\n';
-            os << "Capacitance = " << device_ctx.rr_nodes.node_C(inode) << '\n';
+            os << "Direction = " << device_ctx.rr_nodes.node_direction_string(node_id) << '\n';
+
+            os << "Resistance = " << device_ctx.rr_nodes.node_R(node_id) << '\n';
+            os << "Capacitance = " << device_ctx.rr_nodes.node_C(node_id) << '\n';
         } else if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
-            os << "Side = " << device_ctx.rr_nodes.node_side_string(inode) << '\n';
+            os << "Side = " << device_ctx.rr_nodes.node_side_string(node_id) << '\n';
         }
 
+        os << "-----------------------------\n"; //Node/net info separation line
+
         //Reported corresponding congested nets
+        int inet = 0;
+
         os << "Number of nets passing through this RR node = " << congested_nets.size() << '\n';
-        os << "Net IDs:";
-        for (auto net_id : congested_nets) {
-            os << ' ' << size_t(net_id);
+        for (ClusterNetId net_id : congested_nets) {
+            ClusterBlockId block_id = clb_nlist.net_driver_block(net_id);
+
+            os << "Net #" << inet << ": ";
+            os << "Net ID = " << size_t(net_id) << ", ";
+            os << "Net name = " << clb_nlist.net_name(net_id) << ", ";
+            os << "Driving block name = " << clb_nlist.block_pb(block_id)->name << ", ";
+            os << "Driving block type = " << clb_nlist.block_type(block_id)->name << '\n';
+
+            ++inet;
         }
+
         os << '\n';
+        ++inode;
     }
 
     os.close();
@@ -96,61 +119,61 @@ void generate_overused_nodes_to_congested_net_lookup(std::map<RRNodeId, std::set
 static void log_overused_nodes_header() {
     VTR_LOG("Routing Failure Diagnostics: Printing Overused Nodes Information\n");
     VTR_LOG("------ ------- ---------- --------- -------- ------------ ------- ------- ------- ------- ------- -------\n");
-    VTR_LOG("   No.   Inode  Occupancy  Capacity  RR Node    Direction    Side     PTC    Xlow    Ylow   Xhigh   Yhigh\n");
+    VTR_LOG("   No.  NodeId  Occupancy  Capacity  RR Node    Direction    Side     PTC    Xlow    Ylow   Xhigh   Yhigh\n");
     VTR_LOG("                                        type                          NUM                                \n");
     VTR_LOG("------ ------- ---------- --------- -------- ------------ ------- ------- ------- ------- ------- -------\n");
 }
 
-static void log_single_overused_node_status(int overuse_index, RRNodeId inode) {
+static void log_single_overused_node_status(int overuse_index, RRNodeId node_id) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& route_ctx = g_vpr_ctx.routing();
 
     //Determines if direction or side is available for printing
-    auto node_type = device_ctx.rr_nodes.node_type(inode);
+    auto node_type = device_ctx.rr_nodes.node_type(node_id);
 
     //Overuse #
     VTR_LOG("%6d", overuse_index);
 
     //Inode
-    VTR_LOG(" %7d", size_t(inode));
+    VTR_LOG(" %7d", size_t(node_id));
 
     //Occupancy
-    VTR_LOG(" %10d", route_ctx.rr_node_route_inf[size_t(inode)].occ());
+    VTR_LOG(" %10d", route_ctx.rr_node_route_inf[size_t(node_id)].occ());
 
     //Capacity
-    VTR_LOG(" %9d", device_ctx.rr_nodes.node_capacity(inode));
+    VTR_LOG(" %9d", device_ctx.rr_nodes.node_capacity(node_id));
 
     //RR node type
-    VTR_LOG(" %8s", device_ctx.rr_nodes.node_type_string(inode));
+    VTR_LOG(" %8s", device_ctx.rr_nodes.node_type_string(node_id));
 
     //Direction
     if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
-        VTR_LOG(" %12s", device_ctx.rr_nodes.node_direction_string(inode));
+        VTR_LOG(" %12s", device_ctx.rr_nodes.node_direction_string(node_id));
     } else {
         VTR_LOG(" %12s", "N/A");
     }
 
     //Side
     if (node_type == e_rr_type::IPIN || node_type == e_rr_type::OPIN) {
-        VTR_LOG(" %7s", device_ctx.rr_nodes.node_side_string(inode));
+        VTR_LOG(" %7s", device_ctx.rr_nodes.node_side_string(node_id));
     } else {
         VTR_LOG(" %7s", "N/A");
     }
 
     //PTC number
-    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ptc_num(inode));
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ptc_num(node_id));
 
     //X_low
-    VTR_LOG(" %7d", device_ctx.rr_nodes.node_xlow(inode));
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_xlow(node_id));
 
     //Y_low
-    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ylow(inode));
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ylow(node_id));
 
     //X_high
-    VTR_LOG(" %7d", device_ctx.rr_nodes.node_xhigh(inode));
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_xhigh(node_id));
 
     //Y_high
-    VTR_LOG(" %7d", device_ctx.rr_nodes.node_yhigh(inode));
+    VTR_LOG(" %7d", device_ctx.rr_nodes.node_yhigh(node_id));
 
     VTR_LOG("\n");
 

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -7,7 +7,7 @@
 static void log_overused_nodes_header();
 static void log_single_overused_node_status(int overuse_index, RRNodeId inode);
 
-void log_overused_nodes_status() {
+void log_overused_nodes_status(int max_logged_overused_rr_nodes) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& route_ctx = g_vpr_ctx.routing();
 
@@ -21,7 +21,12 @@ void log_overused_nodes_status() {
 
         if (overuse > 0) {
             log_single_overused_node_status(overuse_index, RRNodeId(inode));
-            overuse_index++;
+            ++overuse_index;
+
+            //Reached the logging limit
+            if (overuse_index >= max_logged_overused_rr_nodes) {
+                return;
+            }
         }
     }
 }

--- a/vpr/src/route/overuse_report.h
+++ b/vpr/src/route/overuse_report.h
@@ -3,6 +3,6 @@
 #include "rr_graph_storage.h"
 #include <map>
 
-void log_overused_nodes_status();
+void log_overused_nodes_status(int max_logged_overused_rr_nodes);
 void report_overused_nodes();
 void generate_overused_nodes_to_congested_net_lookup(std::map<RRNodeId, std::set<ClusterNetId>>& nodes_to_nets_lookup);

--- a/vpr/src/route/overuse_report.h
+++ b/vpr/src/route/overuse_report.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void log_overused_nodes_status();
+void report_overused_nodes();

--- a/vpr/src/route/overuse_report.h
+++ b/vpr/src/route/overuse_report.h
@@ -1,4 +1,8 @@
 #pragma once
 
+#include "rr_graph_storage.h"
+#include <map>
+
 void log_overused_nodes_status();
 void report_overused_nodes();
+void generate_overused_nodes_to_congested_net_lookup(std::map<RRNodeId, std::set<ClusterNetId>>& nodes_to_nets_lookup);

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -131,7 +131,7 @@ static void print_route_status(int itry,
                                std::shared_ptr<const SetupHoldTimingInfo> timing_info,
                                float est_success_iteration);
 
-static void print_overused_nodes_status(const OveruseInfo& overuse_info);
+static void print_overused_nodes_status(const t_router_opts& router_opts, const OveruseInfo& overuse_info);
 static void print_overused_nodes_header();
 static void print_single_overused_node_status(int overuse_index, int inode);
 
@@ -720,7 +720,7 @@ bool try_timing_driven_route_tmpl(const t_router_opts& router_opts,
     } else {
         VTR_LOG("Routing failed.\n");
         //If the routing fails, print the overused info
-        print_overused_nodes_status(overuse_info);
+        print_overused_nodes_status(router_opts, overuse_info);
 #ifdef VTR_ENABLE_DEBUG_LOGGING
         if (f_router_debug) print_invalid_routing_info();
 #endif
@@ -1675,9 +1675,9 @@ static void print_route_status(int itry, double elapsed_sec, float pres_fac, int
     fflush(stdout);
 }
 
-static void print_overused_nodes_status(const OveruseInfo& overuse_info) {
+static void print_overused_nodes_status(const t_router_opts& router_opts, const OveruseInfo& overuse_info) {
     //Display upper limit
-    if (overuse_info.overused_nodes >= 1000) {
+    if (int(overuse_info.overused_nodes) > router_opts.max_reported_overused_rr_nodes) {
         return;
     }
 

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1676,8 +1676,10 @@ static void print_route_status(int itry, double elapsed_sec, float pres_fac, int
 }
 
 static void print_overused_nodes_status(const t_router_opts& router_opts, const OveruseInfo& overuse_info) {
-    //Display upper limit
-    if (int(overuse_info.overused_nodes) > router_opts.max_reported_overused_rr_nodes) {
+    //Overuse info display upper limit
+    if (overuse_info.overused_nodes > router_opts.max_logged_overused_rr_nodes) {
+        VTR_LOG("\nTotal number of overused nodes is larger than the logging limit.\n");
+        VTR_LOG("For more detailed information, use the --generate_rr_node_overuse_report option.\n\n");
         return;
     }
 
@@ -1699,7 +1701,7 @@ static void print_overused_nodes_status(const t_router_opts& router_opts, const 
     }
 
     VTR_LOG("Total number of overused nodes: %d\n", overuse_info.overused_nodes);
-    VTR_LOG("\n");
+    VTR_LOG("For more detailed information, use the --generate_rr_node_overuse_report option.\n\n");
 }
 
 static void print_overused_nodes_header() {

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -131,7 +131,7 @@ static void print_route_status(int itry,
                                std::shared_ptr<const SetupHoldTimingInfo> timing_info,
                                float est_success_iteration);
 
-static void print_overused_nodes_status(OveruseInfo& overuse_info);
+static void print_overused_nodes_status(const OveruseInfo& overuse_info);
 static void print_overused_nodes_header();
 static void print_single_overused_node_status(int overuse_index, int inode);
 
@@ -1675,15 +1675,16 @@ static void print_route_status(int itry, double elapsed_sec, float pres_fac, int
     fflush(stdout);
 }
 
-static void print_overused_nodes_status(OveruseInfo& overuse_info) {
+static void print_overused_nodes_status(const OveruseInfo& overuse_info) {
+    //Display upper limit
     if (overuse_info.overused_nodes >= 1000) {
         return;
     }
 
-    //Print header
+    //Print overuse info header
     print_overused_nodes_header();
 
-    //Print overuse info
+    //Print overuse info body
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& route_ctx = g_vpr_ctx.routing();
 
@@ -1696,9 +1697,13 @@ static void print_overused_nodes_status(OveruseInfo& overuse_info) {
             overuse_index++;
         }
     }
+
+    VTR_LOG("Total number of overused nodes: %d\n", overuse_info.overused_nodes);
+    VTR_LOG("\n");
 }
 
 static void print_overused_nodes_header() {
+    VTR_LOG("\nRouting Failure Diagnostics: Printing Overused Nodes Information\n");
     VTR_LOG("------ ------- ---------- --------- -------- ------------ ------- ------- ------- ------- ------- ------- ------------ -----------------\n");
     VTR_LOG("   No.   Inode  Occupancy  Capacity  RR Node    Direction    Side     PTC    Xlow    Ylow   Xhigh   Yhigh   Resistance       Capacitance\n");
     VTR_LOG("                                        type                          NUM                                                               \n");

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1683,16 +1683,19 @@ static void print_route_status(int itry, double elapsed_sec, float pres_fac, int
 
 static void print_overused_nodes_status(const t_router_opts& router_opts, const OveruseInfo& overuse_info) {
     //Print the index of this routing failure
-    VTR_LOG("\nRouting failure index #%d\n", num_routing_failed);
+    VTR_LOG("\nFailed routing attempt #%d\n", num_routing_failed);
 
-    //Overuse info display upper limit
-    if (overuse_info.overused_nodes > router_opts.max_logged_overused_rr_nodes) {
-        VTR_LOG("Total number of overused nodes is larger than the logging limit.\n");
-    } else {
-        log_overused_nodes_status();
-        VTR_LOG("Total number of overused nodes: %d\n", overuse_info.overused_nodes);
+    size_t num_overused = overuse_info.overused_nodes;
+    size_t max_logged_overused_rr_nodes = router_opts.max_logged_overused_rr_nodes;
+
+    //Overused nodes info logging upper limit
+    VTR_LOG("Total number of overused nodes: %d\n", num_overused);
+    if (num_overused > max_logged_overused_rr_nodes) {
+        VTR_LOG("Total number of overused nodes is larger than the logging limit (%d).\n", max_logged_overused_rr_nodes);
+        VTR_LOG("Displaying the first %d entries.\n", max_logged_overused_rr_nodes);
     }
 
+    log_overused_nodes_status(max_logged_overused_rr_nodes);
     VTR_LOG("\n");
 }
 

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -549,6 +549,36 @@ const char* t_rr_graph_view::node_type_string(RRNodeId id) const {
     return rr_node_typename[node_type(id)];
 }
 
+const char* t_rr_graph_storage::node_direction_string(RRNodeId id) const {
+    e_direction direction = node_direction(id);
+
+    if (direction == e_direction::INC_DIRECTION) {
+        return "INC_DIR";
+    } else if (direction == e_direction::DEC_DIRECTION) {
+        return "DEC_DIR";
+    } else if (direction == e_direction::BI_DIRECTION) {
+        return "BI_DIR";
+    }
+
+    VTR_ASSERT(direction == e_direction::NO_DIRECTION);
+    return "NO_DIR";
+}
+
+const char* t_rr_graph_storage::node_side_string(RRNodeId id) const {
+    return SIDE_STRING[node_side(id)];
+}
+
+float t_rr_graph_storage::node_R(RRNodeId id) const {
+    auto& device_ctx = g_vpr_ctx.device();
+    return device_ctx.rr_rc_data[node_rc_index(id)].R;
+}
+
+float t_rr_graph_storage::node_C(RRNodeId id) const {
+    auto& device_ctx = g_vpr_ctx.device();
+    VTR_ASSERT(node_rc_index(id) < (short)device_ctx.rr_rc_data.size());
+    return device_ctx.rr_rc_data[node_rc_index(id)].C;
+}
+
 void t_rr_graph_storage::set_node_ptc_num(RRNodeId id, short new_ptc_num) {
     node_ptc_[id].ptc_.pin_num = new_ptc_num; //TODO: eventually remove
 }

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -155,6 +155,8 @@ class t_rr_graph_storage {
     int16_t node_rc_index(RRNodeId id) const {
         return node_storage_[id].rc_index_;
     }
+    float node_R(RRNodeId id) const;
+    float node_C(RRNodeId id) const;
 
     short node_xlow(RRNodeId id) const {
         return node_storage_[id].xlow_;
@@ -182,6 +184,7 @@ class t_rr_graph_storage {
                 node_storage_.data(), node_storage_.size()),
             id);
     }
+    const char* node_direction_string(RRNodeId id) const;
 
     e_side node_side(RRNodeId id) const {
         return get_node_side(
@@ -189,6 +192,7 @@ class t_rr_graph_storage {
                 node_storage_.data(), node_storage_.size()),
             id);
     }
+    const char* node_side_string(RRNodeId id) const;
 
     /* PTC get methods */
     short node_ptc_num(RRNodeId id) const;


### PR DESCRIPTION
#### Description
Add the option **--max_logged_overused_rr_nodes N**, which is set to N=20 by default.
When each routing attempt fails, if the # of overused nodes is less than or equal to N, then print out the diagnostics of the overused nodes.

Add the option **--generate_rr_node_overuse_report on/off**, which generates a detailed report on overused RR nodes if the final routing attempt fails (i.e. the routing process has failed).

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1453

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
