### PR TITLE
Vtr flow max router iteration fix

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -515,7 +515,7 @@ def process_unknown_args(unknown_args):
 
         # Determine if there is a value associated with this argument
         if len(unknown_args) == 0 or (
-            unknown_args[0].startswith("-") and arg != "target_ext_pin_util"
+                unknown_args[0].startswith("-") and arg != "target_ext_pin_util"
         ):
             # Single value argument, we place these with value 'True'
             # in vpr_args

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -10,14 +10,16 @@ import textwrap
 import socket
 from datetime import datetime
 from collections import OrderedDict
-#pylint: disable=wrong-import-position, import-error
+
+# pylint: disable=wrong-import-position, import-error
 sys.path.insert(0, str(Path(__file__).resolve().parent / "python_libs"))
 import vtr
-#pylint: enable=wrong-import-position, import-error
+
+# pylint: enable=wrong-import-position, import-error
 
 BASIC_VERBOSITY = 1
 
-#pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods
 class VtrStageArgparseAction(argparse.Action):
     """
         Class to parse the VTR stages to begin and end at.
@@ -34,7 +36,10 @@ class VtrStageArgparseAction(argparse.Action):
             setattr(namespace, self.dest, vtr.VtrStage.lec)
         else:
             raise argparse.ArgumentError(self, "Invalid VTR stage '" + value + "'")
-#pylint: enable=too-few-public-methods
+
+
+# pylint: enable=too-few-public-methods
+
 
 def vtr_command_argparser(prog=None):
     """
@@ -415,9 +420,12 @@ def vtr_command_main(arg_list, prog=None):
         if args.sdc_file:
             vpr_args["sdc_file"] = get_sdc_file(args.sdc_file, prog)
 
-        print(args.name if args.name else Path(args.architecture_file).stem
-              + "/"
-              + Path(args.circuit_file).stem, end="\t\t")
+        print(
+            args.name
+            if args.name
+            else Path(args.architecture_file).stem + "/" + Path(args.circuit_file).stem,
+            end="\t\t",
+        )
         # Run the flow
         vtr.run(
             Path(args.architecture_file),
@@ -442,9 +450,7 @@ def vtr_command_main(arg_list, prog=None):
         error_status = "OK"
     except vtr.VtrError as error:
         error_status, return_status, exit_status = except_vtr_error(
-            error,
-            args.expect_fail,
-            args.verbose
+            error, args.expect_fail, args.verbose
         )
 
     except KeyboardInterrupt as error:
@@ -509,7 +515,7 @@ def process_unknown_args(unknown_args):
 
         # Determine if there is a value associated with this argument
         if len(unknown_args) == 0 or (
-                unknown_args[0].startswith("-") and arg != "target_ext_pin_util"
+            unknown_args[0].startswith("-") and arg != "target_ext_pin_util"
         ):
             # Single value argument, we place these with value 'True'
             # in vpr_args
@@ -590,6 +596,7 @@ def process_vpr_args(args, prog, temp_dir, vpr_args):
 
     return vpr_args
 
+
 def get_sdc_file(sdc_file, prog):
     """
         takes in the sdc_file and returns a path to that file if it exists.
@@ -601,6 +608,7 @@ def get_sdc_file(sdc_file, prog):
             sdc_file = Path(prog).parent.parent / sdc_file
 
     return str(vtr.verify_file(sdc_file, "sdc file"))
+
 
 def except_vtr_error(error, expect_fail, verbose):
     """

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -411,7 +411,7 @@ def vtr_command_main(arg_list, prog=None):
     return_status = 0
     try:
         vpr_args = process_unknown_args(unknown_args)
-        vpr_args.update(process_vpr_args(args, prog, temp_dir))
+        vpr_args = process_vpr_args(args, prog, temp_dir, vpr_args)
         if args.sdc_file:
             vpr_args["sdc_file"] = get_sdc_file(args.sdc_file, prog)
 
@@ -569,13 +569,13 @@ def process_odin_args(args):
     return odin_args
 
 
-def process_vpr_args(args, prog, temp_dir):
+def process_vpr_args(args, prog, temp_dir, vpr_args):
     """
         Finds arguments needed in the VPR stage of the flow
     """
-    vpr_args = OrderedDict()
     if args.crit_path_router_iterations:
-        vpr_args["max_router_iterations"] = args.crit_path_router_iterations
+        if "max_router_iterations" not in vpr_args:
+            vpr_args["max_router_iterations"] = args.crit_path_router_iterations
     if args.fix_pins:
         new_file = str(temp_dir / Path(args.fix_pins).name)
         shutil.copyfile(str((Path(prog).parent.parent / args.fix_pins)), new_file)


### PR DESCRIPTION
The max_router_iteration value being passed into run_vtr_flow was not passed onto vpr.

#### Description
The default value for the parameter crit_path_router_iterations was overriding the inserted value of max_router_iteration, if max_router_iteration  was directly input. This has been fixed

#### Related Issue
[This issue is fixed here.](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1458)

#### Motivation and Context
It is important to be able to pass parameters directly to vpr as well as pass them through the vtr flow. 

#### How Has This Been Tested?
Ran the titan tests as described in the issue, and ensured that the max_router_iteration value passed in was the one VPR was given

#### Types of changes
- [x ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed
