### PR TITLE
Iterate bucket heap

### DIFF
--- a/vpr/src/route/bucket.cpp
+++ b/vpr/src/route/bucket.cpp
@@ -4,10 +4,26 @@
 #include "vtr_log.h"
 #include "vpr_error.h"
 
+// Initial bucket scaling.  A larger division scaling results in smaller cost
+// range per bucket.
 static constexpr float kInitialDivisionScaling = 50000.f;
+// Initial maximum number of buckets before bucket rescaling.
 static constexpr ssize_t kInitialMaxBuckets = 1000000;
-static constexpr ssize_t kMaxMaxBuckets = 16000000;
+// If the division scaling results in more than kIncreaseFocusLimit elements
+// in the first bucket, than division scaling is increased by 2x to try to
+// lower the size of the first bucket.
+//
+// This is an attempt to dynamically scale the bucket widths to prevent the
+// bucket heap from being too cost insenstive / imprecise.
+//
+// When the division scaling is increased by 2x, the maximum number of buckets
+// also is increased by 2x to prevent excessive rescaling during runtime.
 static constexpr size_t kIncreaseFocusLimit = 2048;
+// To prevent unbounded division scaling, the 2x when the first bucket is too
+// large is limited by kMaxMaxBuckets.  If increasing the division scaling
+// will result in max_buckets_ exceeding kMaxMaxBuckets, then division scaling
+// will not be increased again.
+static constexpr ssize_t kMaxMaxBuckets = 16000000;
 
 BucketItems::BucketItems() noexcept
     : alloced_items_(0)

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -239,6 +239,7 @@ class Bucket : public HeapInterface {
     }
 
     void check_scaling();
+    void rescale();
     float rescale_func() const;
     void check_conv_factor() const;
     bool check_front_list() const;
@@ -263,6 +264,8 @@ class Bucket : public HeapInterface {
     size_t heap_head_;  /* First non-empty bucket */
     size_t heap_tail_;  /* Last non-empty bucket */
     float conv_factor_; /* Cost bucket scaling factor */
+    float division_scaling_;
+    ssize_t max_buckets_;
 
     float min_cost_; /* Smallest cost seen */
     float max_cost_; /* Large cost seen */

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -259,23 +259,42 @@ class Bucket : public HeapInterface {
 
     size_t seed_; /* Seed for fast_rand, should be non-zero */
 
-    BucketItem** heap_; /* Buckets for linked lists*/
-    size_t heap_size_;  /* Number of buckets */
-    size_t heap_head_;  /* First non-empty bucket */
-    size_t heap_tail_;  /* Last non-empty bucket */
-    float conv_factor_; /* Cost bucket scaling factor */
-    float division_scaling_;
-    ssize_t max_buckets_;
+    BucketItem** heap_;      /* Buckets for linked lists*/
+    size_t heap_size_;       /* Number of buckets */
+    size_t heap_head_;       /* First non-empty bucket */
+    size_t heap_tail_;       /* Last non-empty bucket */
+    float conv_factor_;      /* Cost bucket scaling factor */
+    float division_scaling_; /* Scaling factor used during rescaling.
+                              * Larger division scaling results in larger
+                              * conversion factor.
+                              */
+    ssize_t max_buckets_;    /* Maximum number of buckets to control when to
+                              * rescale.
+                              */
 
     float min_cost_; /* Smallest cost seen */
     float max_cost_; /* Large cost seen */
 
-    size_t num_items_;
-    size_t max_index_;
-    size_t prune_limit_;
-    size_t prune_count_;
-    std::vector<float> min_push_cost_;
+    size_t num_items_;                 /* Number of items in the bucket heap. */
+    size_t max_index_;                 /* Maximum value for index. */
+    size_t prune_limit_;               /* Maximum number of elements this bucket heap should
+                                        * have before the heap self compacts.
+                                        */
+    size_t prune_count_;               /* The number of times the bucket heap has self
+                                        * compacted.
+                                        */
+    std::vector<float> min_push_cost_; /* Lowest push cost for each index.
+                                        * Only used if the bucket has
+                                        * self-pruned.
+                                        */
 
+    /* In order to quickly randomly pop an element from the front bucket,
+     * a list of items is made.
+     *
+     * front_head_ points to the heap_ index this array was constructed from.
+     * If front_head_ is size_t::max or doesn't equal heap_head_, front_list_
+     * needs to be re-computed.
+     * */
     size_t front_head_;
     std::vector<BucketItem*> front_list_;
 };

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -273,6 +273,8 @@ class Bucket : public HeapInterface {
     size_t num_items_;
     size_t max_index_;
     size_t prune_limit_;
+    size_t prune_count_;
+    std::vector<float> min_push_cost_;
 
     size_t front_head_;
     std::vector<BucketItem*> front_list_;

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -241,6 +241,7 @@ class Bucket : public HeapInterface {
     void check_scaling();
     float rescale_func() const;
     void check_conv_factor() const;
+    bool check_front_list() const;
 
     // Expand the number of buckets.
     //
@@ -269,6 +270,9 @@ class Bucket : public HeapInterface {
     size_t num_items_;
     size_t max_index_;
     size_t prune_limit_;
+
+    size_t front_head_;
+    std::vector<BucketItem*> front_list_;
 };
 
 #endif /* _BUCKET_H */

--- a/vpr/src/route/bucket.h
+++ b/vpr/src/route/bucket.h
@@ -263,7 +263,14 @@ class Bucket : public HeapInterface {
     size_t heap_size_;       /* Number of buckets */
     size_t heap_head_;       /* First non-empty bucket */
     size_t heap_tail_;       /* Last non-empty bucket */
-    float conv_factor_;      /* Cost bucket scaling factor */
+    float conv_factor_;      /* Cost bucket scaling factor.
+                              *
+                              * Larger conv_factor_ means each bucket is
+                              * smaller.
+                              *
+                              * bucket index = cost * conv_factor_
+                              *
+                              */
     float division_scaling_; /* Scaling factor used during rescaling.
                               * Larger division scaling results in larger
                               * conversion factor.
@@ -273,7 +280,7 @@ class Bucket : public HeapInterface {
                               */
 
     float min_cost_; /* Smallest cost seen */
-    float max_cost_; /* Large cost seen */
+    float max_cost_; /* Largest cost seen */
 
     size_t num_items_;                 /* Number of items in the bucket heap. */
     size_t max_index_;                 /* Maximum value for index. */


### PR DESCRIPTION
#### Description

Make some improvements to the bucket heap.  This PR adds some dynamic rescaling to the bucket heap and adds fully randomized popping.

The fully randomized popping from the front bucket was always the intention, but it was initially believed that the cost of implementing that would be prohibitive.  It isn't that expensive to do, and improves the worst case handling a bit.

The other bit change is dynamic bucket rescaling, which was an issue identified originally, but didn't manifest in the initial test cases.  However, with some placement seeds, the non-rescaling version of the bucket heap can become cost insensitive, and as a result have poor convergence qualities.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

In some cases of tougher congestion resolution, the semi-randomized pop and lack of bucket scaling resulted in the bucket heap degrading to a semi-random walk.  By adding some dynamic bucket scaling, this behavior is limited.   This new bucket heap balances the initial behavior early in the router flow where costs are well behaved (mostly cost == time), and then transitions well into the case where costs are poorly scaled (cost == congestion).

#### How Has This Been Tested?

A failing 7-series circuit + bad seed was iterated on, and then tested with the board 7-series circuit list.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
