### PR TITLE
Odin: add reserved keyword support in Flex and verify standard

### DIFF
--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -2668,7 +2668,6 @@ void create_param_table_for_scope(ast_node_t* module_items, sc_hierarchy* local_
                     if (var_declare->types.variable.is_input
                         || var_declare->types.variable.is_output
                         || var_declare->types.variable.is_reg
-                        || var_declare->types.variable.is_integer
                         || var_declare->types.variable.is_genvar
                         || var_declare->types.variable.is_wire
                         || var_declare->types.variable.is_defparam)

--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -1840,15 +1840,14 @@ ast_node_t* reduce_expressions(ast_node_t* node, sc_hierarchy* local_ref, long* 
 
                         long sc_spot = sc_lookup_string(local_symbol_table_sc, id);
                         if (sc_spot > -1) {
-                            bool is_signed = ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_signed;
-                            if (!is_signed) {
-                                VNumber* temp = node->children[1]->types.vnumber;
-                                VNumber* to_unsigned = new VNumber(V_UNSIGNED(*temp));
-                                node->children[1]->types.vnumber = to_unsigned;
-                                delete temp;
+                            operation_list signedness = ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.signedness;
+                            VNumber* old_value = node->children[1]->types.vnumber;
+                            if (signedness == UNSIGNED) {
+                                node->children[1]->types.vnumber = new VNumber(V_UNSIGNED(*old_value));
                             } else {
-                                /* leave as is */
+                                node->children[1]->types.vnumber = new VNumber(V_SIGNED(*old_value));
                             }
+                            delete old_value;
                         }
                     } else {
                         /* signed keyword is not supported, meaning unresolved values will already be handled as

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -166,7 +166,6 @@ ast_node_t* create_node_w_type(ids id, loc_t loc) {
     new_node->types.variable.is_inout = false;
     new_node->types.variable.is_wire = false;
     new_node->types.variable.is_reg = false;
-    new_node->types.variable.is_integer = false;
     new_node->types.variable.is_genvar = false;
     new_node->types.variable.is_memory = false;
     new_node->types.variable.signedness = UNSIGNED;

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -169,7 +169,7 @@ ast_node_t* create_node_w_type(ids id, loc_t loc) {
     new_node->types.variable.is_integer = false;
     new_node->types.variable.is_genvar = false;
     new_node->types.variable.is_memory = false;
-    new_node->types.variable.is_signed = false;
+    new_node->types.variable.signedness = UNSIGNED;
 
     return new_node;
 }

--- a/ODIN_II/SRC/enum_str.cpp
+++ b/ODIN_II/SRC/enum_str.cpp
@@ -108,7 +108,6 @@ const char* ids_STR[] = {
     "INOUT",
     "WIRE",
     "REG",
-    "INTEGER",
     "GENVAR",
     "PARAMETER",
     "LOCALPARAM",

--- a/ODIN_II/SRC/enum_str.cpp
+++ b/ODIN_II/SRC/enum_str.cpp
@@ -1,8 +1,16 @@
 #include "odin_types.h"
 
+const char* ieee_std_STR[] = {
+    "1364-1995",
+    "1364-2001-noconfig",
+    "1364-2001",
+    "1364-2005",
+};
+
 const char* file_extension_supported_STR[] = {
     ".v",
-    ".vh"};
+    ".vh",
+};
 
 const char* edge_type_e_STR[] = {
     "UNDEFINED_SENSITIVITY",

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -386,7 +386,7 @@ struct typ {
         short is_integer;
         short is_genvar;
         short is_memory;
-        short is_signed;
+        operation_list signedness;
         VNumber* initial_value = nullptr;
     } variable;
     struct

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -146,6 +146,8 @@ struct global_args_t {
 /**
  * defined in enum_str.cpp
  */
+extern const char* ieee_std_STR[];
+
 extern const char* file_extension_supported_STR[];
 
 extern const char* ZERO_GND_ZERO;
@@ -158,6 +160,13 @@ extern const char* DUAL_PORT_RAM_string;
 extern const char* edge_type_e_STR[];
 extern const char* operation_list_STR[][2];
 extern const char* ids_STR[];
+
+enum ieee_std {
+    ieee_1995,
+    ieee_2001_noconfig,
+    ieee_2001,
+    ieee_2005
+};
 
 enum file_extension_supported {
     VERILOG,

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -266,7 +266,6 @@ enum ids {
     INOUT,
     WIRE,
     REG,
-    INTEGER,
     GENVAR,
     PARAMETER,
     LOCALPARAM,
@@ -383,7 +382,6 @@ struct typ {
         short is_inout;
         short is_wire;
         short is_reg;
-        short is_integer;
         short is_genvar;
         short is_memory;
         operation_list signedness;

--- a/ODIN_II/SRC/include/parse_making_ast.h
+++ b/ODIN_II/SRC/include/parse_making_ast.h
@@ -19,9 +19,9 @@ ast_node_t* newStringNode(char* num, loc_t loc);
 ast_node_t* newList(ids type_id, ast_node_t* expression, loc_t loc);
 ast_node_t* newList_entry(ast_node_t* concat_node, ast_node_t* expression);
 ast_node_t* newListReplicate(ast_node_t* exp, ast_node_t* child, loc_t loc);
-ast_node_t* markAndProcessPortWith(ids top_type, ids port_id, ids net_id, ast_node_t* port, bool is_signed);
-ast_node_t* markAndProcessParameterWith(ids id, ast_node_t* parameter, bool is_signed);
-ast_node_t* markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t* symbol_list, bool is_signed);
+ast_node_t* markAndProcessPortWith(ids top_type, ids port_id, ids net_id, ast_node_t* port, operation_list signedness);
+ast_node_t* markAndProcessParameterWith(ids id, ast_node_t* parameter, operation_list signedness);
+ast_node_t* markAndProcessSymbolListWith(ids top_type, ids id, ast_node_t* symbol_list, operation_list signedness);
 
 /* EXPRESSIONS */
 ast_node_t* newArrayRef(char* id, ast_node_t* expression, loc_t loc);

--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -735,7 +735,7 @@ void create_all_driver_nets_in_this_scope(char* instance_name_prefix, sc_hierarc
         oassert(local_symbol_table[i]->type == VAR_DECLARE || local_symbol_table[i]->type == BLOCKING_STATEMENT);
         if (
             /* all registers are drivers */
-            (local_symbol_table[i]->types.variable.is_reg) || (local_symbol_table[i]->types.variable.is_integer)
+            (local_symbol_table[i]->types.variable.is_reg)
             /* a wire that is an input can be a driver */
             || ((local_symbol_table[i]->types.variable.is_wire)
                 && (!local_symbol_table[i]->types.variable.is_input))
@@ -1248,7 +1248,7 @@ void create_symbol_table_for_scope(ast_node_t* module_items, sc_hierarchy* local
                         continue;
 
                     oassert(var_declare->type == VAR_DECLARE);
-                    oassert((var_declare->types.variable.is_input) || (var_declare->types.variable.is_output) || (var_declare->types.variable.is_reg) || (var_declare->types.variable.is_integer) || (var_declare->types.variable.is_genvar) || (var_declare->types.variable.is_wire));
+                    oassert((var_declare->types.variable.is_input) || (var_declare->types.variable.is_output) || (var_declare->types.variable.is_reg) || (var_declare->types.variable.is_genvar) || (var_declare->types.variable.is_wire));
 
                     if (var_declare->types.variable.is_input
                         && var_declare->types.variable.is_reg) {
@@ -1281,15 +1281,14 @@ void create_symbol_table_for_scope(ast_node_t* module_items, sc_hierarchy* local
                             /* check for an initial value and copy it over if found */
                             ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.initial_value = init_value;
                         } else if ((var_declare->types.variable.is_reg) || (var_declare->types.variable.is_wire)
-                                   || (var_declare->types.variable.is_integer) || (var_declare->types.variable.is_genvar)) {
+                                   || (var_declare->types.variable.is_genvar)) {
                             /* copy the output status over */
                             ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_wire = var_declare->types.variable.is_wire;
                             ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_reg = var_declare->types.variable.is_reg;
 
-                            ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.is_integer = var_declare->types.variable.is_integer;
                             /* check for an initial value and copy it over if found */
                             ((ast_node_t*)local_symbol_table_sc->data[sc_spot])->types.variable.initial_value = init_value;
-                        } else if (!var_declare->types.variable.is_integer) {
+                        } else {
                             abort();
                         }
                     } else {
@@ -1349,7 +1348,6 @@ void create_symbol_table_for_scope(ast_node_t* module_items, sc_hierarchy* local
                     var_declare->types.variable.is_wire = true;
                     var_declare->types.variable.is_reg = false;
 
-                    var_declare->types.variable.is_integer = false;
                     var_declare->types.variable.is_input = false;
 
                     allocate_children_to_node(var_declare, {node, NULL, NULL, NULL, NULL, NULL});

--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -1073,7 +1073,7 @@ int ieee_filter(int ieee_version, int return_type) {
 		case vSIGNED:	//fallthrough
 		case vUNSIGNED: {
 			if(ieee_version < ieee_2001_noconfig)
-				delayed_error_message(PARSER, my_location, "error in parsing: (%s) only exists in 2001-noconfig or newer\n",return_type)
+				delayed_error_message(PARSER, my_location, "error in parsing: (%s) only exists in ieee 2001-noconfig or newer\n",return_type)
 			break;
 		}
 		case vCELL:	//fallthrough
@@ -1087,12 +1087,12 @@ int ieee_filter(int ieee_version, int return_type) {
 		case vLIBRARY:	//fallthrough
 		case vUSE: {
 			if(ieee_version < ieee_2001)
-				delayed_error_message(PARSER, my_location, "error in parsing: (%s) only exists in 2001 or newer\n",return_type)
+				delayed_error_message(PARSER, my_location, "error in parsing: (%s) only exists in ieee 2001 or newer\n",return_type)
 			break;
 		}
 		case vUWIRE: {
 			if(ieee_version < ieee_2005)
-				delayed_error_message(PARSER, my_location, "error in parsing: (%s) only exists in 2005 or newer\n",return_type)
+				delayed_error_message(PARSER, my_location, "error in parsing: (%s) only exists in ieee 2005 or newer\n",return_type)
 			break;
 		}
 		/* unsorted. TODO: actually sort these */

--- a/ODIN_II/SRC/verilog_bison.y
+++ b/ODIN_II/SRC/verilog_bison.y
@@ -69,7 +69,7 @@ int yylex(void);
  * Restricted keywords 
  */
 
-/* Unlabeled yet TODO: come up with labels */
+/* Unlabeled */
 %token vAUTOMATIC
 %token vDEFAULT
 %token vDESIGN
@@ -80,7 +80,6 @@ int yylex(void);
 %token vINCLUDE
 %token vINITIAL
 %token vINSTANCE
-%token vLARGE
 %token vLIBLIST
 %token vLIBRARY
 %token vNOSHOWCANCELLED
@@ -107,7 +106,7 @@ int yylex(void);
 %token vINTEGER vREAL vSCALARED vSIGNED vVECTORED vUNSIGNED
 
 /* power level */
-%token vSMALL vMEDIUM vHIGHZ0 vHIGHZ1 vPULL0 vPULL1 vPULLDOWN vPULLUP vSTRONG0 vSTRONG1 vSUPPLY0 vSUPPLY1 vWEAK0 vWEAK1
+%token vSMALL vMEDIUM vLARGE vHIGHZ0 vHIGHZ1 vPULL0 vPULL1 vPULLDOWN vPULLUP vSTRONG0 vSTRONG1 vSUPPLY0 vSUPPLY1 vWEAK0 vWEAK1
 
 /* Transistor level logic */
 %token vCMOS vNMOS vPMOS vRCMOS vRNMOS vRPMOS vRTRAN vRTRANIF0 vRTRANIF1 vTRAN vTRANIF0 vTRANIF1
@@ -262,7 +261,7 @@ port_declaration:
 	net_direction net_types var_signedness variable			{$$ = markAndProcessPortWith(MODULE, $1, $2, $4, $3);}
 	| net_direction net_types variable					{$$ = markAndProcessPortWith(MODULE, $1, $2, $3, UNSIGNED);}
 	| net_direction variable							{$$ = markAndProcessPortWith(MODULE, $1, NO_ID, $2, UNSIGNED);}
-	| net_direction vINTEGER integer_type_variable		{$$ = markAndProcessPortWith(MODULE, $1, INTEGER, $3, SIGNED);}
+	| net_direction vINTEGER integer_type_variable		{$$ = markAndProcessPortWith(MODULE, $1, REG, $3, SIGNED);}
 	| net_direction var_signedness variable					{$$ = markAndProcessPortWith(MODULE, $1, NO_ID, $3, $2);}
 	| variable											{$$ = $1;}
 	;
@@ -456,7 +455,7 @@ net_declaration:
 	;
 
 integer_declaration:
-	vINTEGER integer_type_variable_list ';'	{$$ = markAndProcessSymbolListWith(MODULE,INTEGER, $2, SIGNED);}
+	vINTEGER integer_type_variable_list ';'	{$$ = markAndProcessSymbolListWith(MODULE,REG, $2, SIGNED);}
 	;
 
 genvar_declaration:
@@ -479,7 +478,7 @@ function_return_variable:
 	;
 
 function_integer_declaration:
-	vINTEGER integer_type_variable_list 				{$$ = markAndProcessSymbolListWith(FUNCTION, INTEGER, $2, SIGNED);}
+	vINTEGER integer_type_variable_list 				{$$ = markAndProcessSymbolListWith(FUNCTION, REG, $2, SIGNED);}
 	;
 
 function_port_list:

--- a/ODIN_II/SRC/verilog_flex.l
+++ b/ODIN_II/SRC/verilog_flex.l
@@ -38,28 +38,52 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #define RECURSIVE_LIMIT 256
 
-#define YY_USER_ACTION {my_location.col = current_yycolumn; current_yycolumn = yyleng;}
+#define YY_USER_ACTION {                                           \
+    my_location.col = current_yycolumn; current_yycolumn = yyleng; \
+    }
 
-/* the define below helps with watching the parser go token by token */
-#define UNSUPPORTED_TOKEN 	{ delayed_error_message(PARSER, my_location, "%s", "Unsuported token"); }
+#define TOP_STATE() top_flex_state("")
 
-#define _STATE_TOP(str)		{ BEGIN(_state_top(str)); }
-#define POP_STATE()			{ _pop_state(); _STATE_TOP("Popped to "); }
-#define PUSH_STATE(state)	{ _push_state(state); _STATE_TOP("Pushed to ");}
-#define CHANGE_STATE(state) { _pop_state(); _push_state(state); _STATE_TOP("Switched to "); }
+#define POP_STATE() {                    \
+    flex_state.pop_back();               \
+    BEGIN(top_flex_state("Popped to ")); \
+    }
+
+#define PUSH_STATE(state)	{            \
+    flex_state.push_back(state);         \
+    BEGIN(top_flex_state("Pushed to ")); \
+    }
+
+#define CHANGE_STATE(state) {              \
+    flex_state.pop_back();                 \
+    flex_state.push_back(state);           \
+    BEGIN(top_flex_state("Switched to ")); \
+    }
 
 struct defines_t 
 {
-	std::string name;
-	bool use_va_args;
-	std::vector<std::string> args;
-	std::string body;
+    std::string name;
+    bool use_va_args;
+    std::vector<std::string> args;
+    std::string body;
 };
 
+extern loc_t my_location;
+
+int current_yycolumn = 1;
+std::unordered_map<std::string, defines_t*> defines_map;
+defines_t *current_define = NULL;
+std::vector<int> current_include_stack;
+std::vector<std::string> current_args;
+std::string current_define_body;
+
+std::vector<int> flex_state = {};
+std::vector<int> ieee_state = {};
+
 void MP();
-int _state_top(const char *str);
-void _pop_state();	
-void _push_state(int state);
+
+int top_flex_state(const char *str);
+int top_ieee_state(const char *str);
 
 void push_include(const char *file_name);
 bool pop_include();
@@ -81,19 +105,24 @@ void define_arg_push_back(char c);
 void load_define(const char *str);
 void initialize_defaults();
 
-extern loc_t my_location;
-
-int current_yycolumn = 1;
-std::unordered_map<std::string, defines_t*> defines_map;
-defines_t *current_define = NULL;
-std::vector<int> current_include_stack;
-std::vector<int> state_stack = { 0 };
-std::vector<std::string> current_args;
-std::string current_define_body;
-
+int ieee_filter(int return_type);
 %}
 
-%x INCLUDE BRACKET_MATCH COMMENT MULTI_LINE_COMMENT DEFINE_BODY SKIP ELIFCONDITION NEG_CONDITION CONDITION DEFINE_REMOVAL VAR_PARSE PARSE_DEFINE DEFINE_ARGS
+/* %x INITIAL  == 0 ** bison create initial by default and starts with it */
+%x BRACKET_MATCH
+%x COMMENT
+%x MULTI_LINE_COMMENT
+%x DEFINE_BODY
+%x SKIP
+%x ELIFCONDITION
+%x NEG_CONDITION
+%x CONDITION
+%x DEFINE_REMOVAL
+%x VAR_PARSE
+%x PARSE_DEFINE
+%x DEFINE_ARGS
+%x INCLUDE 
+%x READ_IEEE
 
 %option noyywrap
 %option nounput
@@ -112,749 +141,792 @@ vINT [[:digit:]][[:digit:]_]*
 vWORD [[:alpha:]_][[:alnum:]_$]*
 defineWORD [[:alnum:]_$]+
 vSTR ["]([^\\\"]|\\.)*["]  
-vPUNCT 	[\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
+vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
 
 %%
 
-	/*	unsupported Keywords		*/
-<INITIAL>"casex"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"casez"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"disable"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"edge"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"scalared"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"bufif0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"bufif1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"cmos"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"deassign"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"endprimitive"				{ UNSUPPORTED_TOKEN;}
-<INITIAL>"endtable"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"event"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"force"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"forever"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"fork"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"highz0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"highz1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"join"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"large"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"medium"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"nmos"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"notif0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"notif1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"pmos"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"primitive"				{ UNSUPPORTED_TOKEN;}
-<INITIAL>"pull0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"pull1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"pulldown"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"pullup"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"rcmos"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"release"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"repeat"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"rnmos"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"rpmos"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"rtran"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"rtranif0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"rtranif1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"small"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"strong0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"strong1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"supply0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"supply1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"table"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"time"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"tran"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"tranif0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"tranif1"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"vectored"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"wait"						{ UNSUPPORTED_TOKEN;}
-<INITIAL>"weak0"					{ UNSUPPORTED_TOKEN;}
-<INITIAL>"weak1"					{ UNSUPPORTED_TOKEN;}
-
-	/* preproc helpers */
+    /*********************************
+     * Preprocessor directives
+     **/
 <VAR_PARSE>{vWORD}					{ MP(); add_args_to_define(yytext); }
 <VAR_PARSE>"..."					{ MP(); add_args_to_define(yytext); }
 <VAR_PARSE>[\,]						{  }
 <VAR_PARSE>[\)]						{ CHANGE_STATE(DEFINE_BODY); }
-<PARSE_DEFINE>{defineWORD}[\(]		{ MP(); new_define_t(yytext); CHANGE_STATE(VAR_PARSE);}
-<PARSE_DEFINE>{defineWORD}			{ MP(); new_define_t(yytext); CHANGE_STATE(DEFINE_BODY);}
+<PARSE_DEFINE>{defineWORD}[\(]		{ MP(); new_define_t(yytext); CHANGE_STATE(VAR_PARSE); }
+<PARSE_DEFINE>{defineWORD}			{ MP(); new_define_t(yytext); CHANGE_STATE(DEFINE_BODY); }
 <INITIAL>"`define"					{ MP(); PUSH_STATE(PARSE_DEFINE); }
 
-<DEFINE_REMOVAL>{vWORD}				{ MP(); free_define_t(yytext); POP_STATE();}
+<DEFINE_REMOVAL>{vWORD}				{ MP(); free_define_t(yytext); POP_STATE(); }
 <INITIAL>"`undef"					{ MP(); PUSH_STATE(DEFINE_REMOVAL); }
 
 <CONDITION>{vWORD}					{ MP(); CHANGE_STATE( ((ifdef(yytext))?  INITIAL: SKIP) ); }
 <NEG_CONDITION>{vWORD}				{ MP(); CHANGE_STATE( ((ifdef(yytext))?  SKIP: INITIAL) ); }
 
-	/* since the condition did not hold true, we evaluate these statement */
+    /* since the condition did not hold true, we evaluate these statement */
 <SKIP>"`elsif"						{ MP(); CHANGE_STATE(CONDITION); }
-<SKIP>"`else"						{ MP(); CHANGE_STATE(INITIAL);}
+<SKIP>"`else"						{ MP(); CHANGE_STATE(INITIAL); }
 
-	/* since the condition held true, we need to skip these */
+    /* since the condition held true, we need to skip these */
 <INITIAL>"`elsif"					{ MP(); CHANGE_STATE(SKIP); }
-<INITIAL>"`else"					{ MP(); CHANGE_STATE(SKIP);}
+<INITIAL>"`else"					{ MP(); CHANGE_STATE(SKIP); }
 
-	/* entry point */
-<INITIAL>"`ifdef"					{ MP(); PUSH_STATE(CONDITION);}
-<INITIAL>"`ifndef"					{ MP(); PUSH_STATE(NEG_CONDITION);}
+    /* entry point */
+<INITIAL>"`ifdef"					{ MP(); PUSH_STATE(CONDITION); }
+<INITIAL>"`ifndef"					{ MP(); PUSH_STATE(NEG_CONDITION); }
 
-	/* exit point */
-<INITIAL,SKIP>"`endif"				{ MP(); POP_STATE();}
+    /* exit point */
+<INITIAL,SKIP>"`endif"				{ MP(); POP_STATE(); }
 
-<INITIAL>"`include"             	{ MP(); PUSH_STATE(INCLUDE); }
-<INCLUDE>{vSTR}      				{ MP(); push_include(yytext); POP_STATE(); }
+<INITIAL>"`include"					{ MP(); PUSH_STATE(INCLUDE); }
+<INCLUDE>{vSTR}						{ MP(); push_include(yytext); POP_STATE(); }
 
 <INITIAL>"`default_nettype"			{ MP(); return preDEFAULT_NETTYPE;}
-<INITIAL>"`resetall"				{ MP(); initialize_defaults();}
+<INITIAL>"`resetall"				{ MP(); initialize_defaults(); }
 
-	/* unsupported commands, we skip the rest of the line */
+    /* unsupported commands, we skip the rest of the line */
 <INITIAL>"`timescale"				{ MP(); PUSH_STATE(COMMENT); }
 <INITIAL>"`pragma"					{ MP(); PUSH_STATE(COMMENT); }
 <INITIAL>"`line"					{ MP(); PUSH_STATE(COMMENT); }
 <INITIAL>"`celldefine"				{ MP(); PUSH_STATE(COMMENT); }
 <INITIAL>"`endcelldefine"			{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`begin_keywords"			{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`end_keywords"			{ MP(); PUSH_STATE(COMMENT); }
 <INITIAL>"`nounconnected_drive"		{ MP(); PUSH_STATE(COMMENT); }
 <INITIAL>"`unconnected_drive"		{ MP(); PUSH_STATE(COMMENT); }
 
 
+<INITIAL>"‘begin_keywords"			{ MP(); PUSH_STATE(READ_IEEE); }
+<READ_IEEE>"\"1364-2005\""			{ MP(); ieee_state.push_back(ieee_2005);			POP_STATE(); }
+<READ_IEEE>"\"1364-2001-noconfig\""	{ MP(); ieee_state.push_back(ieee_2001_noconfig);	POP_STATE(); }
+<READ_IEEE>"\"1364-2001\""			{ MP(); ieee_state.push_back(ieee_2001);			POP_STATE(); }
+<READ_IEEE>"\"1364-1995\""			{ MP(); ieee_state.push_back(ieee_1995);			POP_STATE(); }
+<INITIAL>"`end_keywords"			{ MP(); ieee_state.pop_back(); }
+
 <DEFINE_ARGS>[\)]					{ MP(); POP_STATE(); lex_string(get_complex_define().c_str()); }
 <DEFINE_ARGS>[\,]					{ MP(); next_define_arg(); }
 <BRACKET_MATCH>[\)]					{ MP(); POP_STATE(); define_arg_push_back(yytext[0]); }
-<DEFINE_ARGS,BRACKET_MATCH>[\(]		{ MP(); PUSH_STATE(BRACKET_MATCH); define_arg_push_back(yytext[0]);}
+<DEFINE_ARGS,BRACKET_MATCH>[\(]		{ MP(); PUSH_STATE(BRACKET_MATCH); define_arg_push_back(yytext[0]); }
 <INITIAL>[\`]{vWORD}[\(]			{ MP(); load_define(yytext); PUSH_STATE(DEFINE_ARGS); }
-<INITIAL>[\`]{vWORD}				{ MP(); lex_string(get_simple_define(yytext).c_str());}
+<INITIAL>[\`]{vWORD}				{ MP(); lex_string(get_simple_define(yytext).c_str()); }
 
+    /**********************************
+     * Verilog Keywords
+     */
 
-	/* Begin Scoped items */
-<INITIAL>"begin"					{ MP(); push_scope(); return vBEGIN;}
-<INITIAL>"function"					{ MP(); push_scope(); return vFUNCTION;}
-<INITIAL>"module"					{ MP(); push_scope(); return vMODULE;}
-<INITIAL>"macromodule"				{ MP(); push_scope(); return vMODULE;}
-<INITIAL>"task"						{ MP(); push_scope(); return vTASK;}
+    /*	unsupported Keywords		*/
+<INITIAL>"cell"						{ MP(); return ieee_filter(vCELL); }
+<INITIAL>"config"					{ MP(); return ieee_filter(vCONFIG); }
+<INITIAL>"design"					{ MP(); return ieee_filter(vDESIGN); }
+<INITIAL>"endconfig"				{ MP(); return ieee_filter(vENDCONFIG); }
+<INITIAL>"incdir"					{ MP(); return ieee_filter(vINCDIR); }
+<INITIAL>"include"					{ MP(); return ieee_filter(vINCLUDE); }
+<INITIAL>"instance"					{ MP(); return ieee_filter(vINSTANCE); }
+<INITIAL>"liblist"					{ MP(); return ieee_filter(vLIBLIST); }
+<INITIAL>"library"					{ MP(); return ieee_filter(vLIBRARY); }
+<INITIAL>"use"						{ MP(); return ieee_filter(vUSE); }
+<INITIAL>"noshowcancelled"			{ MP(); return ieee_filter(vNOSHOWCANCELLED); }
+<INITIAL>"pulsestyle_ondetect"		{ MP(); return ieee_filter(vPULSESTYLE_ONDETECT); }
+<INITIAL>"pulsestyle_onevent"		{ MP(); return ieee_filter(vPULSESTYLE_ONEVENT); }
+<INITIAL>"showcancelled"			{ MP(); return ieee_filter(vSHOWCANCELLED); }
+<INITIAL>"casex"					{ MP(); return ieee_filter(vCASEX); }
+<INITIAL>"casez"					{ MP(); return ieee_filter(vCASEZ); }
+<INITIAL>"disable"					{ MP(); return ieee_filter(vDISABLE); }
+<INITIAL>"edge"						{ MP(); return ieee_filter(vEDGE); }
+<INITIAL>"scalared"					{ MP(); return ieee_filter(vSCALARED); }
+<INITIAL>"bufif0"					{ MP(); return ieee_filter(vBUFIF0); }
+<INITIAL>"bufif1"					{ MP(); return ieee_filter(vBUFIF1); }
+<INITIAL>"cmos"						{ MP(); return ieee_filter(vCMOS); }
+<INITIAL>"deassign"					{ MP(); return ieee_filter(vDEASSIGN); }
+<INITIAL>"endprimitive"				{ MP(); return ieee_filter(vENDPRIMITIVE); }
+<INITIAL>"endtable"					{ MP(); return ieee_filter(vENDTABLE); }
+<INITIAL>"event"					{ MP(); return ieee_filter(vEVENT); }
+<INITIAL>"force"					{ MP(); return ieee_filter(vFORCE); }
+<INITIAL>"forever"					{ MP(); return ieee_filter(vFOREVER); }
+<INITIAL>"fork"						{ MP(); return ieee_filter(vFORK); }
+<INITIAL>"highz0"					{ MP(); return ieee_filter(vHIGHZ0); }
+<INITIAL>"highz1"					{ MP(); return ieee_filter(vHIGHZ1); }
+<INITIAL>"join"						{ MP(); return ieee_filter(vJOIN); }
+<INITIAL>"large"					{ MP(); return ieee_filter(vLARGE); }
+<INITIAL>"medium"					{ MP(); return ieee_filter(vMEDIUM); }
+<INITIAL>"nmos"						{ MP(); return ieee_filter(vNMOS); }
+<INITIAL>"notif0"					{ MP(); return ieee_filter(vNOTIF0); }
+<INITIAL>"notif1"					{ MP(); return ieee_filter(vNOTIF1); }
+<INITIAL>"pmos"						{ MP(); return ieee_filter(vPMOS); }
+<INITIAL>"primitive"				{ MP(); return ieee_filter(vPRIMITIVE); }
+<INITIAL>"pull0"					{ MP(); return ieee_filter(vPULL0); }
+<INITIAL>"pull1"					{ MP(); return ieee_filter(vPULL1); }
+<INITIAL>"pulldown"					{ MP(); return ieee_filter(vPULLDOWN); }
+<INITIAL>"pullup"					{ MP(); return ieee_filter(vPULLUP); }
+<INITIAL>"rcmos"					{ MP(); return ieee_filter(vRCMOS); }
+<INITIAL>"release"					{ MP(); return ieee_filter(vRELEASE); }
+<INITIAL>"repeat"					{ MP(); return ieee_filter(vREPEAT); }
+<INITIAL>"rnmos"					{ MP(); return ieee_filter(vRNMOS); }
+<INITIAL>"rpmos"					{ MP(); return ieee_filter(vRPMOS); }
+<INITIAL>"rtran"					{ MP(); return ieee_filter(vRTRAN); }
+<INITIAL>"rtranif0"					{ MP(); return ieee_filter(vRTRANIF0); }
+<INITIAL>"rtranif1"					{ MP(); return ieee_filter(vRTRANIF1); }
+<INITIAL>"small"					{ MP(); return ieee_filter(vSMALL); }
+<INITIAL>"strong0"					{ MP(); return ieee_filter(vSTRONG0); }
+<INITIAL>"strong1"					{ MP(); return ieee_filter(vSTRONG1); }
+<INITIAL>"supply0"					{ MP(); return ieee_filter(vSUPPLY0); }
+<INITIAL>"supply1"					{ MP(); return ieee_filter(vSUPPLY1); }
+<INITIAL>"table"					{ MP(); return ieee_filter(vTABLE); }
+<INITIAL>"time"						{ MP(); return ieee_filter(vTIME); }
+<INITIAL>"tran"						{ MP(); return ieee_filter(vTRAN); }
+<INITIAL>"tranif0"					{ MP(); return ieee_filter(vTRANIF0); }
+<INITIAL>"tranif1"					{ MP(); return ieee_filter(vTRANIF1); }
+<INITIAL>"vectored"					{ MP(); return ieee_filter(vVECTORED); }
+<INITIAL>"wait"						{ MP(); return ieee_filter(vWAIT); }
+<INITIAL>"weak0"					{ MP(); return ieee_filter(vWEAK0); }
+<INITIAL>"weak1"					{ MP(); return ieee_filter(vWEAK1); }
 
-	/* End Scoped items */
-<INITIAL>"end"						{ MP(); return vEND;}
-<INITIAL>"endfunction"				{ MP(); return vENDFUNCTION;}
-<INITIAL>"endmodule"				{ MP(); return vENDMODULE;}
-<INITIAL>"endtask"					{ MP(); return vENDTASK;}
+    /* Begin Scoped items */
+<INITIAL>"begin"					{ MP(); push_scope(); return ieee_filter(vBEGIN); }
+<INITIAL>"function"					{ MP(); push_scope(); return ieee_filter(vFUNCTION); }
+<INITIAL>"module"					{ MP(); push_scope(); return ieee_filter(vMODULE); }
+<INITIAL>"macromodule"				{ MP(); push_scope(); return ieee_filter(vMODULE); }
+<INITIAL>"task"						{ MP(); push_scope(); return ieee_filter(vTASK); }
 
-	/*	Keywords	*/
-<INITIAL>"always"					{ MP(); return vALWAYS;}
-<INITIAL>"and"						{ MP(); return vAND;}
-<INITIAL>"assign"					{ MP(); return vASSIGN;}
-<INITIAL>"automatic"				{ MP(); return vAUTOMATIC;}
-<INITIAL>"case"						{ MP(); return vCASE;}
-<INITIAL>"default"					{ MP(); return vDEFAULT;}
-<INITIAL>"defparam"					{ MP(); return vDEFPARAM;}
-<INITIAL>"else"						{ MP(); return vELSE;}
-<INITIAL>"endcase"					{ MP(); return vENDCASE;}
-<INITIAL>"endspecify"				{ MP(); return vENDSPECIFY;}
-<INITIAL>"endgenerate"				{ MP(); return vENDGENERATE;}
-<INITIAL>"for"						{ MP(); return vFOR;}
-<INITIAL>"if"						{ MP(); return vIF;}
-<INITIAL>"initial"					{ MP(); return vINITIAL;}
-<INITIAL>"inout"					{ MP(); return vINOUT;}
-<INITIAL>"input"					{ MP(); return vINPUT;}
-<INITIAL>"integer"					{ MP(); return vINTEGER;}
-<INITIAL>"generate"					{ MP(); return vGENERATE;}
-<INITIAL>"genvar"					{ MP(); return vGENVAR;}
-<INITIAL>"nand"						{ MP(); return vNAND;}
-<INITIAL>"negedge"					{ MP(); return vNEGEDGE;}
-<INITIAL>"nor"						{ MP(); return vNOR;}
-<INITIAL>"not"						{ MP(); return vNOT;}
-<INITIAL>"or"						{ MP(); return vOR;}
-<INITIAL>"output"					{ MP(); return vOUTPUT;}
-<INITIAL>"parameter"				{ MP(); return vPARAMETER;}
-<INITIAL>"localparam"				{ MP(); return vLOCALPARAM;}
-<INITIAL>"posedge"					{ MP(); return vPOSEDGE;}
-<INITIAL>"signed"					{ MP(); return vSIGNED;}
-<INITIAL>"specify"					{ MP(); return vSPECIFY;}
-<INITIAL>"while"					{ MP(); return vWHILE;}
-<INITIAL>"xnor"						{ MP(); return vXNOR;}
-<INITIAL>"xor"						{ MP(); return vXOR;}
-<INITIAL>"specparam"				{ MP(); return vSPECPARAM;}
-<INITIAL>"buf"				        { MP(); return vBUF;}
+    /* End Scoped items */
+<INITIAL>"end"						{ MP(); return ieee_filter(vEND); }
+<INITIAL>"endfunction"				{ MP(); return ieee_filter(vENDFUNCTION); }
+<INITIAL>"endmodule"				{ MP(); return ieee_filter(vENDMODULE); }
+<INITIAL>"endtask"					{ MP(); return ieee_filter(vENDTASK); }
 
-	/* Net types */
-<INITIAL>"wire"						{ MP(); return netWIRE;}
-<INITIAL>"tri"						{ MP(); return netTRI;}
-<INITIAL>"tri0"						{ MP(); return netTRI0;}
-<INITIAL>"tri1"						{ MP(); return netTRI1;}
-<INITIAL>"wand"						{ MP(); return netWAND;}
-<INITIAL>"wor"						{ MP(); return netWOR;}
-<INITIAL>"triand"					{ MP(); return netTRIAND;}
-<INITIAL>"trior"					{ MP(); return netTRIOR;}
-<INITIAL>"trireg"					{ MP(); return netTRIREG;}
-<INITIAL>"uwire"					{ MP(); return netUWIRE;}
-<INITIAL>"none"						{ MP(); return netNONE;}
-<INITIAL>"reg"						{ MP(); return netREG;}
+    /*	Keywords	*/
+<INITIAL>"always"					{ MP(); return ieee_filter(vALWAYS); }
+<INITIAL>"and"						{ MP(); return ieee_filter(vAND); }
+<INITIAL>"assign"					{ MP(); return ieee_filter(vASSIGN); }
+<INITIAL>"automatic"				{ MP(); return ieee_filter(vAUTOMATIC); }
+<INITIAL>"case"						{ MP(); return ieee_filter(vCASE); }
+<INITIAL>"default"					{ MP(); return ieee_filter(vDEFAULT); }
+<INITIAL>"defparam"					{ MP(); return ieee_filter(vDEFPARAM); }
+<INITIAL>"else"						{ MP(); return ieee_filter(vELSE); }
+<INITIAL>"endcase"					{ MP(); return ieee_filter(vENDCASE); }
+<INITIAL>"endspecify"				{ MP(); return ieee_filter(vENDSPECIFY); }
+<INITIAL>"endgenerate"				{ MP(); return ieee_filter(vENDGENERATE); }
+<INITIAL>"for"						{ MP(); return ieee_filter(vFOR); }
+<INITIAL>"if"						{ MP(); return ieee_filter(vIF); }
+<INITIAL>"initial"					{ MP(); return ieee_filter(vINITIAL); }
+<INITIAL>"inout"					{ MP(); return ieee_filter(vINOUT); }
+<INITIAL>"input"					{ MP(); return ieee_filter(vINPUT); }
+<INITIAL>"integer"					{ MP(); return ieee_filter(vINTEGER); }
+<INITIAL>"generate"					{ MP(); return ieee_filter(vGENERATE); }
+<INITIAL>"genvar"					{ MP(); return ieee_filter(vGENVAR); }
+<INITIAL>"nand"						{ MP(); return ieee_filter(vNAND); }
+<INITIAL>"negedge"					{ MP(); return ieee_filter(vNEGEDGE); }
+<INITIAL>"nor"						{ MP(); return ieee_filter(vNOR); }
+<INITIAL>"not"						{ MP(); return ieee_filter(vNOT); }
+<INITIAL>"or"						{ MP(); return ieee_filter(vOR); }
+<INITIAL>"output"					{ MP(); return ieee_filter(vOUTPUT); }
+<INITIAL>"parameter"				{ MP(); return ieee_filter(vPARAMETER); }
+<INITIAL>"localparam"				{ MP(); return ieee_filter(vLOCALPARAM); }
+<INITIAL>"posedge"					{ MP(); return ieee_filter(vPOSEDGE); }
+<INITIAL>"signed"					{ MP(); return ieee_filter(vSIGNED); }
+<INITIAL>"unsigned"					{ MP(); return ieee_filter(vUNSIGNED); }
+<INITIAL>"specify"					{ MP(); return ieee_filter(vSPECIFY); }
+<INITIAL>"while"					{ MP(); return ieee_filter(vWHILE); }
+<INITIAL>"xnor"						{ MP(); return ieee_filter(vXNOR); }
+<INITIAL>"xor"						{ MP(); return ieee_filter(vXOR); }
+<INITIAL>"specparam"				{ MP(); return ieee_filter(vSPECPARAM); }
+<INITIAL>"buf"				        { MP(); return ieee_filter(vBUF); }
 
-	/* Operators */	
-<INITIAL>"**"						{ MP(); return voPOWER;}
-<INITIAL>"&&"						{ MP(); return voANDAND;}
-<INITIAL>"||"						{ MP(); return voOROR;}
-<INITIAL>"<="						{ MP(); return voLTE;}
-<INITIAL>"=>"						{ MP(); return voPAL;}
-<INITIAL>">="						{ MP(); return voGTE;}
-<INITIAL>"<<"						{ MP(); return voSLEFT;}
-<INITIAL>"<<<"						{ MP(); return voASLEFT;}
-<INITIAL>">>"						{ MP(); return voSRIGHT;}
-<INITIAL>">>>"						{ MP(); return voASRIGHT;}
-<INITIAL>"=="						{ MP(); return voEQUAL;}
-<INITIAL>"!="						{ MP(); return voNOTEQUAL;}
-<INITIAL>"==="						{ MP(); return voCASEEQUAL;}
-<INITIAL>"!=="						{ MP(); return voCASENOTEQUAL;}
-<INITIAL>"^~"						{ MP(); return voXNOR;}
-<INITIAL>"~^"						{ MP(); return voXNOR;}
-<INITIAL>"~&"						{ MP(); return voNAND;}
-<INITIAL>"~|"						{ MP(); return voNOR;}
-<INITIAL>"+:"						{ MP(); return vPLUS_COLON;}
-<INITIAL>"-:"						{ MP(); return vMINUS_COLON;}
+    /* Net types */
+<INITIAL>"wire"						{ MP(); return ieee_filter(vWIRE); }
+<INITIAL>"tri"						{ MP(); return ieee_filter(vTRI); }
+<INITIAL>"tri0"						{ MP(); return ieee_filter(vTRI0); }
+<INITIAL>"tri1"						{ MP(); return ieee_filter(vTRI1); }
+<INITIAL>"wand"						{ MP(); return ieee_filter(vWAND); }
+<INITIAL>"wor"						{ MP(); return ieee_filter(vWOR); }
+<INITIAL>"triand"					{ MP(); return ieee_filter(vTRIAND); }
+<INITIAL>"trior"					{ MP(); return ieee_filter(vTRIOR); }
+<INITIAL>"trireg"					{ MP(); return ieee_filter(vTRIREG); }
+<INITIAL>"uwire"					{ MP(); return ieee_filter(vUWIRE); }
+<INITIAL>"uwire"					{ MP(); return ieee_filter(vUWIRE); }
+<INITIAL>"none"						{ MP(); return ieee_filter(vNONE); }
+<INITIAL>"reg"						{ MP(); return ieee_filter(vREG); }
 
-	/*	unsupported Operators	*/
-<INITIAL>"&&&"						{ UNSUPPORTED_TOKEN;}
+    /**********************************
+     * Verilog Operators (vo)
+     */
+<INITIAL>"&&&"						{ MP(); return ieee_filter(voANDANDAND); }
+<INITIAL>"**"						{ MP(); return ieee_filter(voPOWER); }
+<INITIAL>"&&"						{ MP(); return ieee_filter(voANDAND); }
+<INITIAL>"||"						{ MP(); return ieee_filter(voOROR); }
+<INITIAL>"<="						{ MP(); return ieee_filter(voLTE); }
+<INITIAL>"=>"						{ MP(); return ieee_filter(voEGT); }
+<INITIAL>">="						{ MP(); return ieee_filter(voGTE); }
+<INITIAL>"<<"						{ MP(); return ieee_filter(voSLEFT); }
+<INITIAL>"<<<"						{ MP(); return ieee_filter(voASLEFT); }
+<INITIAL>">>"						{ MP(); return ieee_filter(voSRIGHT); }
+<INITIAL>">>>"						{ MP(); return ieee_filter(voASRIGHT); }
+<INITIAL>"=="						{ MP(); return ieee_filter(voEQUAL); }
+<INITIAL>"!="						{ MP(); return ieee_filter(voNOTEQUAL); }
+<INITIAL>"==="						{ MP(); return ieee_filter(voCASEEQUAL); }
+<INITIAL>"!=="						{ MP(); return ieee_filter(voCASENOTEQUAL); }
+<INITIAL>"^~"						{ MP(); return ieee_filter(voXNOR); }
+<INITIAL>"~^"						{ MP(); return ieee_filter(voXNOR); }
+<INITIAL>"~&"						{ MP(); return ieee_filter(voNAND); }
+<INITIAL>"~|"						{ MP(); return ieee_filter(voNOR); }
+<INITIAL>"+:"						{ MP(); return ieee_filter(voPLUSCOLON); }
+<INITIAL>"-:"						{ MP(); return ieee_filter(voMINUSCOLON); }
 
-	/*	C functions	*/	
-<INITIAL>"$clog2"					{ MP(); return vCLOG2;}
-<INITIAL>"$unsigned"				{ MP(); return voUNSIGNED;}
-<INITIAL>"$signed"					{ MP(); return voSIGNED;}
-<INITIAL>"$finish"					{ MP(); return voFINISH;}
-<INITIAL>"$display"					{ MP(); return voDISPLAY;}
-	/* catch all C functions */
-<INITIAL>[\$]{vWORD}				{ MP(); return vCFUNC;}
+    /**********************************
+     * Verilog System (vs) Functions
+     */
+<INITIAL>"$clog2"					{ MP(); return ieee_filter(vsCLOG2); }
+<INITIAL>"$unsigned"				{ MP(); return ieee_filter(vsUNSIGNED); }
+<INITIAL>"$signed"					{ MP(); return ieee_filter(vsSIGNED); }
+<INITIAL>"$finish"					{ MP(); return ieee_filter(vsFINISH); }
+<INITIAL>"$display"					{ MP(); return ieee_filter(vsDISPLAY); }
+    /* catch all C functions */
+<INITIAL>[\$]{vWORD}				{ MP(); return ieee_filter(vsFUNCTION); }
 
-	/* Integers */
+    /* Integers */
 <INITIAL>{vINT}						{ MP(); yylval.num_value = vtr::strdup(yytext); return vINT_NUMBER; }
-	/* Strings */
+    /* Strings */
 <INITIAL>{vSTR}						{ MP(); yylval.num_value = vtr::strdup(yytext); return vSTRING; }
-	/* Numbers */
+    /* Numbers */
 <INITIAL>[[:digit:]]*'[sS]?{vBIN}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
 <INITIAL>[[:digit:]]*'[sS]?{vHEX}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
 <INITIAL>[[:digit:]]*'[sS]?{vOCT}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
 <INITIAL>[[:digit:]]*'[sS]?{vDEC}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
 
-	/*	operands	*/
+    /*	operands	*/
 <INITIAL>{vWORD}(\.{vWORD})*		{ MP(); yylval.id_name = vtr::strdup(yytext); return vSYMBOL_ID; }
 
-	/* return operators */
+    /* return operators */
 <INITIAL>{vPUNCT}					{ MP(); return yytext[0]; }
 
-	/* general stuff */
+    /************
+     * general stuff 
+     **/
 
-	/* single line comment */
+    /* single line comment */
 <*>[\/][\/]							{ 
-										int state = _state_top("");
-										if (state == DEFINE_BODY)
-										{
-											/**
-											* single line comments will automaticaly continue on if we
-											* escape the new line, to prevent issues, we stop processing the macro body
-											*/
-											finalize_define();
-											_pop_state();
-										}
-										if(state != COMMENT
-										&& state != MULTI_LINE_COMMENT)
-										{
-											PUSH_STATE(COMMENT);
-										}
-									}
-	/* multi line comment */
+                                        int state = TOP_STATE();
+                                        if (state == DEFINE_BODY)
+                                        {
+                                            /**
+                                            * single line comments will automaticaly continue on if we
+                                            * escape the new line, to prevent issues, we stop processing the macro body
+                                            */
+                                            finalize_define();
+                                            POP_STATE();
+                                        }
+                                        if(state != COMMENT
+                                        && state != MULTI_LINE_COMMENT)
+                                        {
+                                            PUSH_STATE(COMMENT);
+                                        }
+                                    }
+    /* multi line comment */
 <*>[\/][\*]							{ 
-										int state = _state_top("");
-										if(state != COMMENT
-										&& state != MULTI_LINE_COMMENT)
-										{
-											PUSH_STATE(MULTI_LINE_COMMENT);
-										}
-									}
+                                        int state = TOP_STATE();
+                                        if(state != COMMENT
+                                        && state != MULTI_LINE_COMMENT)
+                                        {
+                                            PUSH_STATE(MULTI_LINE_COMMENT);
+                                        }
+                                    }
 
-<MULTI_LINE_COMMENT>[\*][\/]			{ POP_STATE(); }
+<MULTI_LINE_COMMENT>[\*][\/]		{ POP_STATE(); }
 
-<*>[[:blank:]]+						{ 	
-										int state = _state_top("");
-										if(state == DEFINE_BODY)
-										{
-											append_to_define_body(' ');
-										}
-										else if(state == DEFINE_ARGS
-										|| 		state == BRACKET_MATCH)
-										{
-											define_arg_push_back(yytext[0]);
-										} 
-									}
+<*>[[:blank:]]+						{	
+                                        int state = TOP_STATE();
+                                        if(state == DEFINE_BODY)
+                                        {
+                                            append_to_define_body(' ');
+                                        }
+                                        else if(state == DEFINE_ARGS
+                                        ||		state == BRACKET_MATCH)
+                                        {
+                                            define_arg_push_back(yytext[0]);
+                                        } 
+                                    }
 
 <*><<EOF>>							{ if ( ! pop_include() ){ free_define_map(); yyterminate(); } }
 
-	/* skip escapped newline */
+    /* skip escapped newline */
 <*>\\\r?\n							{ my_location.line++; my_location.col = 1; }
 
-	/* deal with new lines */
+    /* deal with new lines */
 <*>\r?\n							{ 
-										bool done = false;
-										do{
-											int state = _state_top("");
+                                        bool done = false;
+                                        do{
+                                            int state = TOP_STATE();
 
-											if(state == DEFINE_BODY)
-											{
-												finalize_define();
-											} 
+                                            if(state == DEFINE_BODY)
+                                            {
+                                                finalize_define();
+                                            } 
 
-											done = ( state != DEFINE_BODY && state != COMMENT );
-											if(!done)
-											{
-												POP_STATE();
-											}
+                                            done = ( state != DEFINE_BODY && state != COMMENT );
+                                            if(!done)
+                                            {
+                                                POP_STATE();
+                                            }
 
-										}while(!done);
+                                        }while(!done);
 
-										my_location.line++;
-										my_location.col = 1;
-									}
+                                        my_location.line++;
+                                        my_location.col = 1;
+                                    }
 
-	/* catch all */
-<*>.            					{ 
-										MP(); 
-										int state = _state_top("");
-										if(state == DEFINE_BODY)
-										{
-											append_to_define_body(yytext[0]);
-										}
-										else if(state == DEFINE_ARGS
-										|| 		state == BRACKET_MATCH)
-										{
-											define_arg_push_back(yytext[0]);
-										} 
-									}				
+    /* catch all */
+<*>.								{ 
+                                        MP(); 
+                                        int state = TOP_STATE();
+                                        if(state == DEFINE_BODY)
+                                        {
+                                            append_to_define_body(yytext[0]);
+                                        }
+                                        else if(state == DEFINE_ARGS
+                                        ||		state == BRACKET_MATCH)
+                                        {
+                                            define_arg_push_back(yytext[0]);
+                                        } 
+                                        else if(state == READ_IEEE)
+                                        {
+                                            /* catch stuck parser */
+                                            POP_STATE();
+                                        }
+                                    }				
 
 %%
 
 void MP()		
 { 
-	if (configuration.print_parse_tokens) 
-	{
-		printf("%d %s\n", my_location.line, yytext);
-	} 
+    if (configuration.print_parse_tokens) 
+    {
+        printf("%d %s\n", my_location.line, yytext);
+    } 
 }
 
-int _state_top(const char *str)		
+int top_flex_state(const char *str)		
 { 
-	int state = state_stack.back(); 
-	if (configuration.print_parse_tokens && strlen(str)) 
-	{
-		printf("%s state: %s\n", str,
-			(state == INCLUDE)? 			"INCLUDE":
-			(state == COMMENT)? 			"COMMENT":
-			(state == MULTI_LINE_COMMENT)? 	"MULTI_LINE_COMMENT":
-			(state == DEFINE_BODY)? 		"DEFINE_BODY":
-			(state == SKIP)? 				"SKIP":
-			(state == ELIFCONDITION)? 		"ELIFCONDITION":
-			(state == NEG_CONDITION)? 		"NEG_CONDITION":
-			(state == CONDITION)? 			"CONDITION":
-			(state == DEFINE_REMOVAL)? 		"DEFINE_REMOVAL":
-			(state == VAR_PARSE)? 			"VAR_PARSE":
-			(state == PARSE_DEFINE)? 		"PARSE_DEFINE":
-			(state == DEFINE_ARGS)? 		"DEFINE_ARGS":
-											"INITIAL"
-		);
-	} 
-	return state;
-}
-
-void _pop_state()		
-{ 
-	state_stack.pop_back(); 
-	if(state_stack.empty())
-	{
-		state_stack.push_back(INITIAL);
-	} 
-}
-
-void _push_state(int state)	
-{ 
-	state_stack.push_back(state); 
+    if(flex_state.empty())
+    {
+        flex_state.push_back(INITIAL);
+    } 
+    int state = flex_state.back(); 
+    if (configuration.print_parse_tokens && strlen(str)) 
+    {
+        printf("%s state: %s\n", str,
+            (state == INCLUDE)?			"INCLUDE":
+            (state == COMMENT)?			"COMMENT":
+            (state == MULTI_LINE_COMMENT)?	"MULTI_LINE_COMMENT":
+            (state == DEFINE_BODY)?		"DEFINE_BODY":
+            (state == SKIP)?				"SKIP":
+            (state == ELIFCONDITION)?		"ELIFCONDITION":
+            (state == NEG_CONDITION)?		"NEG_CONDITION":
+            (state == CONDITION)?			"CONDITION":
+            (state == DEFINE_REMOVAL)?		"DEFINE_REMOVAL":
+            (state == VAR_PARSE)?			"VAR_PARSE":
+            (state == PARSE_DEFINE)?		"PARSE_DEFINE":
+            (state == DEFINE_ARGS)?		"DEFINE_ARGS":
+                                            "INITIAL"
+        );
+    } 
+    return state;
 }
 
 static bool has_current_parse_file()
 {
-	return (
-		my_location.file < include_file_names.size()
-		&& my_location.file >= 0
-	);
+    return (
+        my_location.file < include_file_names.size()
+        && my_location.file >= 0
+    );
 }
 
 void lex_string(const char * str)
 {
 
-	if (configuration.print_parse_tokens) 
-	{
-		printf("Processing define %s\n", str);
-	} 
+    if (configuration.print_parse_tokens) 
+    {
+        printf("Processing define %s\n", str);
+    } 
 
-	if(has_current_parse_file() 
-	&& current_include_stack.back() == my_location.file)
-	{
-	 	include_file_names[my_location.file].second = my_location.line;
-	}
+    if(has_current_parse_file() 
+    && current_include_stack.back() == my_location.file)
+    {
+        include_file_names[my_location.file].second = my_location.line;
+    }
 
-	/* check current depth, prevent too much macro recursion */
-	loc_t posible_error_location = {include_file_names[my_location.file].second, my_location.file, -1};
-	if(current_include_stack.size() > RECURSIVE_LIMIT)
-	{
-		error_message(PARSER, posible_error_location,
-			"Reached upper macro recursion limit of %d", 
-			RECURSIVE_LIMIT);
-	}
-	else if(current_include_stack.size() > (RECURSIVE_LIMIT/2))
-	{
-		warning_message(PARSER, posible_error_location,
-			"Reached halfway to upper macro recursion limit of %d", 
-			RECURSIVE_LIMIT);
-	}
+    /* check current depth, prevent too much macro recursion */
+    loc_t posible_error_location = {include_file_names[my_location.file].second, my_location.file, -1};
+    if(current_include_stack.size() > RECURSIVE_LIMIT)
+    {
+        error_message(PARSER, posible_error_location,
+            "Reached upper macro recursion limit of %d", 
+            RECURSIVE_LIMIT);
+    }
+    else if(current_include_stack.size() > (RECURSIVE_LIMIT/2))
+    {
+        warning_message(PARSER, posible_error_location,
+            "Reached halfway to upper macro recursion limit of %d", 
+            RECURSIVE_LIMIT);
+    }
 
 
-	current_include_stack.push_back(-1);
-	my_location.line = 0;
+    current_include_stack.push_back(-1);
+    my_location.line = 0;
 
-	YY_BUFFER_STATE cur = YY_CURRENT_BUFFER;
-	YY_BUFFER_STATE yybuff = yy_scan_string(str);
-	yy_switch_to_buffer(cur);
-	yypush_buffer_state(yybuff);
+    YY_BUFFER_STATE cur = YY_CURRENT_BUFFER;
+    YY_BUFFER_STATE yybuff = yy_scan_string(str);
+    yy_switch_to_buffer(cur);
+    yypush_buffer_state(yybuff);
 
 }
 
 void push_include(const char *file_name)
 {
 
-	printf("Adding file %s to parse list\n", file_name);
+    printf("Adding file %s to parse list\n", file_name);
 
-	std::string tmp(file_name);
+    std::string tmp(file_name);
 
-	if(tmp[0] == '"')
-	{
-		tmp.erase(0,1);
-	}
+    if(tmp[0] == '"')
+    {
+        tmp.erase(0,1);
+    }
 
-	if(tmp.back() == '"')
-	{
-		tmp.pop_back();
-	}
+    if(tmp.back() == '"')
+    {
+        tmp.pop_back();
+    }
 
-	std::string current_file = "";
-	if(has_current_parse_file())
-	{
-		current_file = include_file_names[my_location.file].first;
-		if(current_include_stack.back() == my_location.file)
-		{
-	 		include_file_names[my_location.file].second = my_location.line;
-		}
-	}
+    std::string current_file = "";
+    if(has_current_parse_file())
+    {
+        current_file = include_file_names[my_location.file].first;
+        if(current_include_stack.back() == my_location.file)
+        {
+            include_file_names[my_location.file].second = my_location.line;
+        }
+    }
 
-	/* we add the path from the current file */
-	size_t loc = current_file.find_last_of("/");
-	if(loc == std::string::npos)
-	{
-		current_file = tmp;
-	}
-	else
-	{
-		current_file = current_file.substr(0, loc + 1) + tmp;
-	}
+    /* we add the path from the current file */
+    size_t loc = current_file.find_last_of("/");
+    if(loc == std::string::npos)
+    {
+        current_file = tmp;
+    }
+    else
+    {
+        current_file = current_file.substr(0, loc + 1) + tmp;
+    }
 
-	yyin = fopen(current_file.c_str(), "r");
-	if(yyin == NULL)
-	{
-		printf("Unable to open %s, trying %s\n", current_file.c_str(), tmp.c_str());
-		current_file = tmp;
-		yyin = open_file(current_file.c_str(), "r");
-	}
-	
-	my_location.line = 0;
-	current_include_stack.push_back(include_file_names.size());
-	include_file_names.push_back({current_file,my_location.line});
+    yyin = fopen(current_file.c_str(), "r");
+    if(yyin == NULL)
+    {
+        printf("Unable to open %s, trying %s\n", current_file.c_str(), tmp.c_str());
+        current_file = tmp;
+        yyin = open_file(current_file.c_str(), "r");
+    }
+    
+    my_location.line = 0;
+    current_include_stack.push_back(include_file_names.size());
+    include_file_names.push_back({current_file,my_location.line});
 
-	my_location.file = current_include_stack.back();
-	assert_supported_file_extension(include_file_names.back().first.c_str() , my_location); 
+    my_location.file = current_include_stack.back();
+    assert_supported_file_extension(include_file_names.back().first.c_str() , my_location); 
 
-	YY_BUFFER_STATE yybuff = yy_create_buffer( yyin, YY_BUF_SIZE );
-	yypush_buffer_state(yybuff);
+    YY_BUFFER_STATE yybuff = yy_create_buffer( yyin, YY_BUF_SIZE );
+    yypush_buffer_state(yybuff);
 
 }
 
 bool pop_include()
 {
-	if(has_current_parse_file())
-	{
-		if(configuration.print_parse_tokens)
-		{
-			printf("Poping file %s from parse list\n", include_file_names[my_location.file].first.c_str());
-		}
-		
-		if(yyin)
-		{
-			fflush(yyin);
-			fclose(yyin);
-			yyin = NULL;
-		}
-	}
+    if(has_current_parse_file())
+    {
+        if(configuration.print_parse_tokens)
+        {
+            printf("Poping file %s from parse list\n", include_file_names[my_location.file].first.c_str());
+        }
+        
+        if(yyin)
+        {
+            fflush(yyin);
+            fclose(yyin);
+            yyin = NULL;
+        }
+    }
 
-	if(!current_include_stack.empty())
-	{
-		current_include_stack.pop_back();
-	}
+    if(!current_include_stack.empty())
+    {
+        current_include_stack.pop_back();
+    }
 
-	if(!current_include_stack.empty())
-	{
-		if(current_include_stack.back() != -1)
-		{
-			my_location.file = current_include_stack.back();
-		}
-	}
-	else
-	{
-		my_location.file = -1;
-	}
+    if(!current_include_stack.empty())
+    {
+        if(current_include_stack.back() != -1)
+        {
+            my_location.file = current_include_stack.back();
+        }
+    }
+    else
+    {
+        my_location.file = -1;
+    }
 
-	if(has_current_parse_file() && my_location.file >= 0)
-	{
-		my_location.line = include_file_names[my_location.file].second;
+    if(has_current_parse_file() && my_location.file >= 0)
+    {
+        my_location.line = include_file_names[my_location.file].second;
 
-		if(configuration.print_parse_tokens)
-		{
-			printf("Reading file %s from line %d\n", include_file_names[my_location.file].first.c_str(), my_location.line);
-		}
-	}
-	else
-	{
-		my_location.line = -1;
-	}
-	
-	yypop_buffer_state(); 
-	return ( YY_CURRENT_BUFFER );
+        if(configuration.print_parse_tokens)
+        {
+            printf("Reading file %s from line %d\n", include_file_names[my_location.file].first.c_str(), my_location.line);
+        }
+    }
+    else
+    {
+        my_location.line = -1;
+    }
+    
+    yypop_buffer_state(); 
+    return ( YY_CURRENT_BUFFER );
 }
 
 void initialize_defaults()
 {
-	default_net_type = WIRE;
-	current_define = NULL;
-	free_define_map();
+    default_net_type = WIRE;
+    ieee_state.clear();
+    current_define = NULL;
+    free_define_map();
 }
 
 void new_define_t(const char* id)
 {
-	std::string tmp(id);
-	if(tmp.back() == '(')
-	{
-		tmp.pop_back();
-	}
+    std::string tmp(id);
+    if(tmp.back() == '(')
+    {
+        tmp.pop_back();
+    }
 
-	defines_t *new_define = new defines_t();
-	new_define->name = tmp;
-	new_define->use_va_args = false;
-	new_define->args = std::vector<std::string>();
-	new_define->body = "";
-	
-	if(defines_map.find(tmp) != defines_map.end())
-	{
-		warning_message(PARSER, my_location, "%s is redefined, overwritting its value", id);
-		delete defines_map[tmp];	
-	}
+    defines_t *new_define = new defines_t();
+    new_define->name = tmp;
+    new_define->use_va_args = false;
+    new_define->args = std::vector<std::string>();
+    new_define->body = "";
+    
+    if(defines_map.find(tmp) != defines_map.end())
+    {
+        warning_message(PARSER, my_location, "%s is redefined, overwritting its value", id);
+        delete defines_map[tmp];	
+    }
 
-	defines_map[tmp] = new_define;
-	current_define = new_define;
+    defines_map[tmp] = new_define;
+    current_define = new_define;
 }
 
 void free_define_t(const char *id)
 {
-	std::string tmp(id);
-	if(defines_map.find(tmp) != defines_map.end())
-	{
-		delete defines_map[tmp];
-		defines_map.erase(tmp);
-	}
+    std::string tmp(id);
+    if(defines_map.find(tmp) != defines_map.end())
+    {
+        delete defines_map[tmp];
+        defines_map.erase(tmp);
+    }
 }
 
 void free_define_map()
 {
-	for(auto kv: defines_map)
-	{
-		delete kv.second;
-	}
+    for(auto kv: defines_map)
+    {
+        delete kv.second;
+    }
 }
 
 std::string get_simple_define(const char *str)
 {
-	load_define(str);
-	return get_complex_define();
+    load_define(str);
+    return get_complex_define();
 }
 
 std::string get_complex_define()
 {
-	if(current_define)
-	{
-		std::string va_args_replacement = "";
+    if(current_define)
+    {
+        std::string va_args_replacement = "";
 
-		if( current_args.size() < current_define->args.size())
-		{
-			error_message(PARSER, my_location, 
-				"define `%s is being used with too few arguments, Expected %ld, got %ld", 
-					current_define->name.c_str(), current_define->args.size(),current_args.size());
-		}
-		else if( current_args.size() > current_define->args.size())
-		{
-			if(! current_define->use_va_args) {
-				error_message(PARSER, my_location, 
-					"define `%s is being used with too many arguments, Expected %ld, got %ld", 
-						current_define->name.c_str(), current_define->args.size(),current_args.size());
-			} else {
-				while(current_define->args.size() != current_args.size())
-				{
-					if(va_args_replacement != "")
-					{
-						va_args_replacement = ", " + va_args_replacement;
-					}
-					va_args_replacement = current_args.back() + va_args_replacement;
-					current_args.pop_back();
-				}
+        if( current_args.size() < current_define->args.size())
+        {
+            error_message(PARSER, my_location, 
+                "define `%s is being used with too few arguments, Expected %ld, got %ld", 
+                    current_define->name.c_str(), current_define->args.size(),current_args.size());
+        }
+        else if( current_args.size() > current_define->args.size())
+        {
+            if(! current_define->use_va_args) {
+                error_message(PARSER, my_location, 
+                    "define `%s is being used with too many arguments, Expected %ld, got %ld", 
+                        current_define->name.c_str(), current_define->args.size(),current_args.size());
+            } else {
+                while(current_define->args.size() != current_args.size())
+                {
+                    if(va_args_replacement != "")
+                    {
+                        va_args_replacement = ", " + va_args_replacement;
+                    }
+                    va_args_replacement = current_args.back() + va_args_replacement;
+                    current_args.pop_back();
+                }
 
-			}
-		}
+            }
+        }
 
-		if (current_define->use_va_args)
-		{
-			current_define->args.push_back("__VA_ARGS__");
-			current_args.push_back(va_args_replacement);
-		}
+        if (current_define->use_va_args)
+        {
+            current_define->args.push_back("__VA_ARGS__");
+            current_args.push_back(va_args_replacement);
+        }
 
 
-		for(int i=0; i<current_define->args.size(); i++)
-		{
-			std::string original_arg = current_define->args[i];
-			std::string replacement_arg = current_args[i];
+        for(int i=0; i<current_define->args.size(); i++)
+        {
+            std::string original_arg = current_define->args[i];
+            std::string replacement_arg = current_args[i];
 
-			size_t pos = current_define_body.find( original_arg, 0 );
-			while ( pos != std::string::npos )
-			{
-				current_define_body.erase(pos, original_arg.size());
-				current_define_body.insert( pos, replacement_arg );
-				pos += replacement_arg.size();
-				pos = current_define_body.find( original_arg, pos );
-			}
-		}
+            size_t pos = current_define_body.find( original_arg, 0 );
+            while ( pos != std::string::npos )
+            {
+                current_define_body.erase(pos, original_arg.size());
+                current_define_body.insert( pos, replacement_arg );
+                pos += replacement_arg.size();
+                pos = current_define_body.find( original_arg, pos );
+            }
+        }
 
-		if(configuration.print_parse_tokens )
-		{
-			printf("DEFINE = %s\n",  current_define_body.c_str());
-		}
-	}
-	return current_define_body;
+        if(configuration.print_parse_tokens )
+        {
+            printf("DEFINE = %s\n",  current_define_body.c_str());
+        }
+    }
+    return current_define_body;
 }
 
 void next_define_arg()
 {
-	current_args.push_back("");
+    current_args.push_back("");
 }
 
 void define_arg_push_back(char c)
 {
-	if(current_args.empty())
-	{
-		next_define_arg();
-	}
+    if(current_args.empty())
+    {
+        next_define_arg();
+    }
 
-	current_args.back().push_back(c);
+    current_args.back().push_back(c);
 }
 
 void load_define(const char *str)
 {
-	std::string tmp(str);
+    std::string tmp(str);
 
-	current_define = NULL;
-	current_define_body = "";
-	current_args = std::vector<std::string>();
+    current_define = NULL;
+    current_define_body = "";
+    current_args = std::vector<std::string>();
 
-	// compiler specific macros
-	if(tmp == "`__LINE__") 
-	{
-		current_define_body = std::to_string(my_location.line + 1 /* 0 indexed */);
-	}
-	else if (tmp == "`__FILE__")
-	{
-		current_define_body = "\"" + std::string(configuration.list_of_file_names[my_location.file]) + "\"";
-	}
-	else
-	{
-		if(tmp[0] == '`')
-		{
-			tmp.erase(0,1);
-		}
+    // compiler specific macros
+    if(tmp == "`__LINE__") 
+    {
+        current_define_body = std::to_string(my_location.line + 1 /* 0 indexed */);
+    }
+    else if (tmp == "`__FILE__")
+    {
+        current_define_body = "\"" + std::string(configuration.list_of_file_names[my_location.file]) + "\"";
+    }
+    else
+    {
+        if(tmp[0] == '`')
+        {
+            tmp.erase(0,1);
+        }
 
-		if(tmp.back() == '(')
-		{
-			tmp.pop_back();
-		}
+        if(tmp.back() == '(')
+        {
+            tmp.pop_back();
+        }
 
-		auto itter = defines_map.find(tmp);
-		if(itter == defines_map.end())
-		{
-			if(tmp == "elif")
-			{
-				warning_message(PARSER, my_location, 
-					"%s", "using `elif, when you probably meant `elsif");
-			}
-			else
-			{
-				warning_message(PARSER, my_location, 
-					"%s define cannot be found, replacing with empty string and continuing synthesis", 
-					tmp.c_str());
-			}
-		}
-		else
-		{
-			current_define = itter->second;
-			current_define_body = current_define->body;
-		}
-	}
+        auto itter = defines_map.find(tmp);
+        if(itter == defines_map.end())
+        {
+            if(tmp == "elif")
+            {
+                warning_message(PARSER, my_location, 
+                    "%s", "using `elif, when you probably meant `elsif");
+            }
+            else
+            {
+                warning_message(PARSER, my_location, 
+                    "%s define cannot be found, replacing with empty string and continuing synthesis", 
+                    tmp.c_str());
+            }
+        }
+        else
+        {
+            current_define = itter->second;
+            current_define_body = current_define->body;
+        }
+    }
 }
 
 void append_to_define_body(char c)
 {
-	current_define->body.push_back(c);
+    current_define->body.push_back(c);
 }
 
 void add_args_to_define(const char* str)
 {
-	std::string tmp(str);
-	if(current_define->use_va_args)
-	{
-		error_message(PARSER, my_location, 
-				"%s","... must be used as the last argument of a `define");
-	}
-	else if(tmp == "...")
-	{
-		current_define->use_va_args = true;
-	}
-	else
-	{
-		for(int i=0; i < current_define->args.size(); i++)
-		{
-			if(tmp == current_define->args[i])
-			{
-				error_message(PARSER, my_location, 
-					"%s","define has two argument with same name");
-			}
-		}
+    std::string tmp(str);
+    if(current_define->use_va_args)
+    {
+        error_message(PARSER, my_location, 
+                "%s","... must be used as the last argument of a `define");
+    }
+    else if(tmp == "...")
+    {
+        current_define->use_va_args = true;
+    }
+    else
+    {
+        for(int i=0; i < current_define->args.size(); i++)
+        {
+            if(tmp == current_define->args[i])
+            {
+                error_message(PARSER, my_location, 
+                    "%s","define has two argument with same name");
+            }
+        }
 
-		current_define->args.push_back(std::string(str));
-	}
+        current_define->args.push_back(std::string(str));
+    }
 }
 
 void finalize_define()
 {
-	current_define = NULL;
+    current_define = NULL;
 }
 
 bool ifdef(const char* id)
 {
-	return ( defines_map.find(std::string(id)) != defines_map.end() );
+    return ( defines_map.find(std::string(id)) != defines_map.end() );
+}
+
+int ieee_filter(int return_type)
+{
+    extern int ieee_filter(int std_version, int ret);
+    
+    if(ieee_state.empty())
+    {
+        ieee_state.push_back(ieee_2005);
+    } 
+    int std_version = ieee_state.back(); 
+    if (configuration.print_parse_tokens) 
+    {
+        printf("ieee version used: %s\n", ieee_std_STR[std_version]);
+    } 
+    
+    return ieee_filter(std_version, return_type);
 }

--- a/ODIN_II/SRC/verilog_flex.l
+++ b/ODIN_II/SRC/verilog_flex.l
@@ -49,7 +49,7 @@ OTHER DEALINGS IN THE SOFTWARE.
     BEGIN(top_flex_state("Popped to ")); \
     }
 
-#define PUSH_STATE(state)	{            \
+#define PUSH_STATE(state)    {            \
     flex_state.push_back(state);         \
     BEGIN(top_flex_state("Pushed to ")); \
     }
@@ -148,260 +148,260 @@ vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
     /*********************************
      * Preprocessor directives
      **/
-<VAR_PARSE>{vWORD}					{ MP(); add_args_to_define(yytext); }
-<VAR_PARSE>"..."					{ MP(); add_args_to_define(yytext); }
-<VAR_PARSE>[\,]						{  }
-<VAR_PARSE>[\)]						{ CHANGE_STATE(DEFINE_BODY); }
-<PARSE_DEFINE>{defineWORD}[\(]		{ MP(); new_define_t(yytext); CHANGE_STATE(VAR_PARSE); }
-<PARSE_DEFINE>{defineWORD}			{ MP(); new_define_t(yytext); CHANGE_STATE(DEFINE_BODY); }
-<INITIAL>"`define"					{ MP(); PUSH_STATE(PARSE_DEFINE); }
+<VAR_PARSE>{vWORD}                  { MP(); add_args_to_define(yytext); }
+<VAR_PARSE>"..."                    { MP(); add_args_to_define(yytext); }
+<VAR_PARSE>[\,]                     {  }
+<VAR_PARSE>[\)]                     { CHANGE_STATE(DEFINE_BODY); }
+<PARSE_DEFINE>{defineWORD}[\(]      { MP(); new_define_t(yytext); CHANGE_STATE(VAR_PARSE); }
+<PARSE_DEFINE>{defineWORD}          { MP(); new_define_t(yytext); CHANGE_STATE(DEFINE_BODY); }
+<INITIAL>"`define"                  { MP(); PUSH_STATE(PARSE_DEFINE); }
 
-<DEFINE_REMOVAL>{vWORD}				{ MP(); free_define_t(yytext); POP_STATE(); }
-<INITIAL>"`undef"					{ MP(); PUSH_STATE(DEFINE_REMOVAL); }
+<DEFINE_REMOVAL>{vWORD}             { MP(); free_define_t(yytext); POP_STATE(); }
+<INITIAL>"`undef"                   { MP(); PUSH_STATE(DEFINE_REMOVAL); }
 
-<CONDITION>{vWORD}					{ MP(); CHANGE_STATE( ((ifdef(yytext))?  INITIAL: SKIP) ); }
-<NEG_CONDITION>{vWORD}				{ MP(); CHANGE_STATE( ((ifdef(yytext))?  SKIP: INITIAL) ); }
+<CONDITION>{vWORD}                  { MP(); CHANGE_STATE( ((ifdef(yytext))?  INITIAL: SKIP) ); }
+<NEG_CONDITION>{vWORD}              { MP(); CHANGE_STATE( ((ifdef(yytext))?  SKIP: INITIAL) ); }
 
     /* since the condition did not hold true, we evaluate these statement */
-<SKIP>"`elsif"						{ MP(); CHANGE_STATE(CONDITION); }
-<SKIP>"`else"						{ MP(); CHANGE_STATE(INITIAL); }
+<SKIP>"`elsif"                      { MP(); CHANGE_STATE(CONDITION); }
+<SKIP>"`else"                       { MP(); CHANGE_STATE(INITIAL); }
 
     /* since the condition held true, we need to skip these */
-<INITIAL>"`elsif"					{ MP(); CHANGE_STATE(SKIP); }
-<INITIAL>"`else"					{ MP(); CHANGE_STATE(SKIP); }
+<INITIAL>"`elsif"                   { MP(); CHANGE_STATE(SKIP); }
+<INITIAL>"`else"                    { MP(); CHANGE_STATE(SKIP); }
 
     /* entry point */
-<INITIAL>"`ifdef"					{ MP(); PUSH_STATE(CONDITION); }
-<INITIAL>"`ifndef"					{ MP(); PUSH_STATE(NEG_CONDITION); }
+<INITIAL>"`ifdef"                   { MP(); PUSH_STATE(CONDITION); }
+<INITIAL>"`ifndef"                  { MP(); PUSH_STATE(NEG_CONDITION); }
 
     /* exit point */
-<INITIAL,SKIP>"`endif"				{ MP(); POP_STATE(); }
+<INITIAL,SKIP>"`endif"              { MP(); POP_STATE(); }
 
-<INITIAL>"`include"					{ MP(); PUSH_STATE(INCLUDE); }
-<INCLUDE>{vSTR}						{ MP(); push_include(yytext); POP_STATE(); }
+<INITIAL>"`include"                 { MP(); PUSH_STATE(INCLUDE); }
+<INCLUDE>{vSTR}                     { MP(); push_include(yytext); POP_STATE(); }
 
-<INITIAL>"`default_nettype"			{ MP(); return preDEFAULT_NETTYPE;}
-<INITIAL>"`resetall"				{ MP(); initialize_defaults(); }
+<INITIAL>"`default_nettype"         { MP(); return preDEFAULT_NETTYPE;}
+<INITIAL>"`resetall"                { MP(); initialize_defaults(); }
 
     /* unsupported commands, we skip the rest of the line */
-<INITIAL>"`timescale"				{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`pragma"					{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`line"					{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`celldefine"				{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`endcelldefine"			{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`nounconnected_drive"		{ MP(); PUSH_STATE(COMMENT); }
-<INITIAL>"`unconnected_drive"		{ MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`timescale"               { MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`pragma"                  { MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`line"                    { MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`celldefine"              { MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`endcelldefine"           { MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`nounconnected_drive"     { MP(); PUSH_STATE(COMMENT); }
+<INITIAL>"`unconnected_drive"       { MP(); PUSH_STATE(COMMENT); }
 
 
-<INITIAL>"‘begin_keywords"			{ MP(); PUSH_STATE(READ_IEEE); }
-<READ_IEEE>"\"1364-2005\""			{ MP(); ieee_state.push_back(ieee_2005);			POP_STATE(); }
-<READ_IEEE>"\"1364-2001-noconfig\""	{ MP(); ieee_state.push_back(ieee_2001_noconfig);	POP_STATE(); }
-<READ_IEEE>"\"1364-2001\""			{ MP(); ieee_state.push_back(ieee_2001);			POP_STATE(); }
-<READ_IEEE>"\"1364-1995\""			{ MP(); ieee_state.push_back(ieee_1995);			POP_STATE(); }
-<INITIAL>"`end_keywords"			{ MP(); ieee_state.pop_back(); }
+<INITIAL>"‘begin_keywords"          { MP(); PUSH_STATE(READ_IEEE); }
+<READ_IEEE>"\"1364-2005\""          { MP(); ieee_state.push_back(ieee_2005);            POP_STATE(); }
+<READ_IEEE>"\"1364-2001-noconfig\"" { MP(); ieee_state.push_back(ieee_2001_noconfig);    POP_STATE(); }
+<READ_IEEE>"\"1364-2001\""          { MP(); ieee_state.push_back(ieee_2001);            POP_STATE(); }
+<READ_IEEE>"\"1364-1995\""          { MP(); ieee_state.push_back(ieee_1995);            POP_STATE(); }
+<INITIAL>"`end_keywords"            { MP(); ieee_state.pop_back(); }
 
-<DEFINE_ARGS>[\)]					{ MP(); POP_STATE(); lex_string(get_complex_define().c_str()); }
-<DEFINE_ARGS>[\,]					{ MP(); next_define_arg(); }
-<BRACKET_MATCH>[\)]					{ MP(); POP_STATE(); define_arg_push_back(yytext[0]); }
-<DEFINE_ARGS,BRACKET_MATCH>[\(]		{ MP(); PUSH_STATE(BRACKET_MATCH); define_arg_push_back(yytext[0]); }
-<INITIAL>[\`]{vWORD}[\(]			{ MP(); load_define(yytext); PUSH_STATE(DEFINE_ARGS); }
-<INITIAL>[\`]{vWORD}				{ MP(); lex_string(get_simple_define(yytext).c_str()); }
+<DEFINE_ARGS>[\)]                   { MP(); POP_STATE(); lex_string(get_complex_define().c_str()); }
+<DEFINE_ARGS>[\,]                   { MP(); next_define_arg(); }
+<BRACKET_MATCH>[\)]                 { MP(); POP_STATE(); define_arg_push_back(yytext[0]); }
+<DEFINE_ARGS,BRACKET_MATCH>[\(]     { MP(); PUSH_STATE(BRACKET_MATCH); define_arg_push_back(yytext[0]); }
+<INITIAL>[\`]{vWORD}[\(]            { MP(); load_define(yytext); PUSH_STATE(DEFINE_ARGS); }
+<INITIAL>[\`]{vWORD}                { MP(); lex_string(get_simple_define(yytext).c_str()); }
 
     /**********************************
      * Verilog Keywords
      */
 
-    /*	unsupported Keywords		*/
-<INITIAL>"cell"						{ MP(); return ieee_filter(vCELL); }
-<INITIAL>"config"					{ MP(); return ieee_filter(vCONFIG); }
-<INITIAL>"design"					{ MP(); return ieee_filter(vDESIGN); }
-<INITIAL>"endconfig"				{ MP(); return ieee_filter(vENDCONFIG); }
-<INITIAL>"incdir"					{ MP(); return ieee_filter(vINCDIR); }
-<INITIAL>"include"					{ MP(); return ieee_filter(vINCLUDE); }
-<INITIAL>"instance"					{ MP(); return ieee_filter(vINSTANCE); }
-<INITIAL>"liblist"					{ MP(); return ieee_filter(vLIBLIST); }
-<INITIAL>"library"					{ MP(); return ieee_filter(vLIBRARY); }
-<INITIAL>"use"						{ MP(); return ieee_filter(vUSE); }
-<INITIAL>"noshowcancelled"			{ MP(); return ieee_filter(vNOSHOWCANCELLED); }
-<INITIAL>"pulsestyle_ondetect"		{ MP(); return ieee_filter(vPULSESTYLE_ONDETECT); }
-<INITIAL>"pulsestyle_onevent"		{ MP(); return ieee_filter(vPULSESTYLE_ONEVENT); }
-<INITIAL>"showcancelled"			{ MP(); return ieee_filter(vSHOWCANCELLED); }
-<INITIAL>"casex"					{ MP(); return ieee_filter(vCASEX); }
-<INITIAL>"casez"					{ MP(); return ieee_filter(vCASEZ); }
-<INITIAL>"disable"					{ MP(); return ieee_filter(vDISABLE); }
-<INITIAL>"edge"						{ MP(); return ieee_filter(vEDGE); }
-<INITIAL>"scalared"					{ MP(); return ieee_filter(vSCALARED); }
-<INITIAL>"bufif0"					{ MP(); return ieee_filter(vBUFIF0); }
-<INITIAL>"bufif1"					{ MP(); return ieee_filter(vBUFIF1); }
-<INITIAL>"cmos"						{ MP(); return ieee_filter(vCMOS); }
-<INITIAL>"deassign"					{ MP(); return ieee_filter(vDEASSIGN); }
-<INITIAL>"endprimitive"				{ MP(); return ieee_filter(vENDPRIMITIVE); }
-<INITIAL>"endtable"					{ MP(); return ieee_filter(vENDTABLE); }
-<INITIAL>"event"					{ MP(); return ieee_filter(vEVENT); }
-<INITIAL>"force"					{ MP(); return ieee_filter(vFORCE); }
-<INITIAL>"forever"					{ MP(); return ieee_filter(vFOREVER); }
-<INITIAL>"fork"						{ MP(); return ieee_filter(vFORK); }
-<INITIAL>"highz0"					{ MP(); return ieee_filter(vHIGHZ0); }
-<INITIAL>"highz1"					{ MP(); return ieee_filter(vHIGHZ1); }
-<INITIAL>"join"						{ MP(); return ieee_filter(vJOIN); }
-<INITIAL>"large"					{ MP(); return ieee_filter(vLARGE); }
-<INITIAL>"medium"					{ MP(); return ieee_filter(vMEDIUM); }
-<INITIAL>"nmos"						{ MP(); return ieee_filter(vNMOS); }
-<INITIAL>"notif0"					{ MP(); return ieee_filter(vNOTIF0); }
-<INITIAL>"notif1"					{ MP(); return ieee_filter(vNOTIF1); }
-<INITIAL>"pmos"						{ MP(); return ieee_filter(vPMOS); }
-<INITIAL>"primitive"				{ MP(); return ieee_filter(vPRIMITIVE); }
-<INITIAL>"pull0"					{ MP(); return ieee_filter(vPULL0); }
-<INITIAL>"pull1"					{ MP(); return ieee_filter(vPULL1); }
-<INITIAL>"pulldown"					{ MP(); return ieee_filter(vPULLDOWN); }
-<INITIAL>"pullup"					{ MP(); return ieee_filter(vPULLUP); }
-<INITIAL>"rcmos"					{ MP(); return ieee_filter(vRCMOS); }
-<INITIAL>"release"					{ MP(); return ieee_filter(vRELEASE); }
-<INITIAL>"repeat"					{ MP(); return ieee_filter(vREPEAT); }
-<INITIAL>"rnmos"					{ MP(); return ieee_filter(vRNMOS); }
-<INITIAL>"rpmos"					{ MP(); return ieee_filter(vRPMOS); }
-<INITIAL>"rtran"					{ MP(); return ieee_filter(vRTRAN); }
-<INITIAL>"rtranif0"					{ MP(); return ieee_filter(vRTRANIF0); }
-<INITIAL>"rtranif1"					{ MP(); return ieee_filter(vRTRANIF1); }
-<INITIAL>"small"					{ MP(); return ieee_filter(vSMALL); }
-<INITIAL>"strong0"					{ MP(); return ieee_filter(vSTRONG0); }
-<INITIAL>"strong1"					{ MP(); return ieee_filter(vSTRONG1); }
-<INITIAL>"supply0"					{ MP(); return ieee_filter(vSUPPLY0); }
-<INITIAL>"supply1"					{ MP(); return ieee_filter(vSUPPLY1); }
-<INITIAL>"table"					{ MP(); return ieee_filter(vTABLE); }
-<INITIAL>"time"						{ MP(); return ieee_filter(vTIME); }
-<INITIAL>"tran"						{ MP(); return ieee_filter(vTRAN); }
-<INITIAL>"tranif0"					{ MP(); return ieee_filter(vTRANIF0); }
-<INITIAL>"tranif1"					{ MP(); return ieee_filter(vTRANIF1); }
-<INITIAL>"vectored"					{ MP(); return ieee_filter(vVECTORED); }
-<INITIAL>"wait"						{ MP(); return ieee_filter(vWAIT); }
-<INITIAL>"weak0"					{ MP(); return ieee_filter(vWEAK0); }
-<INITIAL>"weak1"					{ MP(); return ieee_filter(vWEAK1); }
+    /*    unsupported Keywords        */
+<INITIAL>"cell"                      { MP(); return ieee_filter(vCELL); }
+<INITIAL>"config"                    { MP(); return ieee_filter(vCONFIG); }
+<INITIAL>"design"                    { MP(); return ieee_filter(vDESIGN); }
+<INITIAL>"endconfig"                 { MP(); return ieee_filter(vENDCONFIG); }
+<INITIAL>"incdir"                    { MP(); return ieee_filter(vINCDIR); }
+<INITIAL>"include"                   { MP(); return ieee_filter(vINCLUDE); }
+<INITIAL>"instance"                  { MP(); return ieee_filter(vINSTANCE); }
+<INITIAL>"liblist"                   { MP(); return ieee_filter(vLIBLIST); }
+<INITIAL>"library"                   { MP(); return ieee_filter(vLIBRARY); }
+<INITIAL>"use"                       { MP(); return ieee_filter(vUSE); }
+<INITIAL>"noshowcancelled"           { MP(); return ieee_filter(vNOSHOWCANCELLED); }
+<INITIAL>"pulsestyle_ondetect"       { MP(); return ieee_filter(vPULSESTYLE_ONDETECT); }
+<INITIAL>"pulsestyle_onevent"        { MP(); return ieee_filter(vPULSESTYLE_ONEVENT); }
+<INITIAL>"showcancelled"             { MP(); return ieee_filter(vSHOWCANCELLED); }
+<INITIAL>"casex"                     { MP(); return ieee_filter(vCASEX); }
+<INITIAL>"casez"                     { MP(); return ieee_filter(vCASEZ); }
+<INITIAL>"disable"                   { MP(); return ieee_filter(vDISABLE); }
+<INITIAL>"edge"                      { MP(); return ieee_filter(vEDGE); }
+<INITIAL>"scalared"                  { MP(); return ieee_filter(vSCALARED); }
+<INITIAL>"bufif0"                    { MP(); return ieee_filter(vBUFIF0); }
+<INITIAL>"bufif1"                    { MP(); return ieee_filter(vBUFIF1); }
+<INITIAL>"cmos"                      { MP(); return ieee_filter(vCMOS); }
+<INITIAL>"deassign"                  { MP(); return ieee_filter(vDEASSIGN); }
+<INITIAL>"endprimitive"              { MP(); return ieee_filter(vENDPRIMITIVE); }
+<INITIAL>"endtable"                  { MP(); return ieee_filter(vENDTABLE); }
+<INITIAL>"event"                     { MP(); return ieee_filter(vEVENT); }
+<INITIAL>"force"                     { MP(); return ieee_filter(vFORCE); }
+<INITIAL>"forever"                   { MP(); return ieee_filter(vFOREVER); }
+<INITIAL>"fork"                      { MP(); return ieee_filter(vFORK); }
+<INITIAL>"highz0"                    { MP(); return ieee_filter(vHIGHZ0); }
+<INITIAL>"highz1"                    { MP(); return ieee_filter(vHIGHZ1); }
+<INITIAL>"join"                      { MP(); return ieee_filter(vJOIN); }
+<INITIAL>"large"                     { MP(); return ieee_filter(vLARGE); }
+<INITIAL>"medium"                    { MP(); return ieee_filter(vMEDIUM); }
+<INITIAL>"nmos"                      { MP(); return ieee_filter(vNMOS); }
+<INITIAL>"notif0"                    { MP(); return ieee_filter(vNOTIF0); }
+<INITIAL>"notif1"                    { MP(); return ieee_filter(vNOTIF1); }
+<INITIAL>"pmos"                      { MP(); return ieee_filter(vPMOS); }
+<INITIAL>"primitive"                 { MP(); return ieee_filter(vPRIMITIVE); }
+<INITIAL>"pull0"                     { MP(); return ieee_filter(vPULL0); }
+<INITIAL>"pull1"                     { MP(); return ieee_filter(vPULL1); }
+<INITIAL>"pulldown"                  { MP(); return ieee_filter(vPULLDOWN); }
+<INITIAL>"pullup"                    { MP(); return ieee_filter(vPULLUP); }
+<INITIAL>"rcmos"                     { MP(); return ieee_filter(vRCMOS); }
+<INITIAL>"release"                   { MP(); return ieee_filter(vRELEASE); }
+<INITIAL>"repeat"                    { MP(); return ieee_filter(vREPEAT); }
+<INITIAL>"rnmos"                     { MP(); return ieee_filter(vRNMOS); }
+<INITIAL>"rpmos"                     { MP(); return ieee_filter(vRPMOS); }
+<INITIAL>"rtran"                     { MP(); return ieee_filter(vRTRAN); }
+<INITIAL>"rtranif0"                  { MP(); return ieee_filter(vRTRANIF0); }
+<INITIAL>"rtranif1"                  { MP(); return ieee_filter(vRTRANIF1); }
+<INITIAL>"small"                     { MP(); return ieee_filter(vSMALL); }
+<INITIAL>"strong0"                   { MP(); return ieee_filter(vSTRONG0); }
+<INITIAL>"strong1"                   { MP(); return ieee_filter(vSTRONG1); }
+<INITIAL>"supply0"                   { MP(); return ieee_filter(vSUPPLY0); }
+<INITIAL>"supply1"                   { MP(); return ieee_filter(vSUPPLY1); }
+<INITIAL>"table"                     { MP(); return ieee_filter(vTABLE); }
+<INITIAL>"time"                      { MP(); return ieee_filter(vTIME); }
+<INITIAL>"tran"                      { MP(); return ieee_filter(vTRAN); }
+<INITIAL>"tranif0"                   { MP(); return ieee_filter(vTRANIF0); }
+<INITIAL>"tranif1"                   { MP(); return ieee_filter(vTRANIF1); }
+<INITIAL>"vectored"                  { MP(); return ieee_filter(vVECTORED); }
+<INITIAL>"wait"                      { MP(); return ieee_filter(vWAIT); }
+<INITIAL>"weak0"                     { MP(); return ieee_filter(vWEAK0); }
+<INITIAL>"weak1"                     { MP(); return ieee_filter(vWEAK1); }
 
     /* Begin Scoped items */
-<INITIAL>"begin"					{ MP(); push_scope(); return ieee_filter(vBEGIN); }
-<INITIAL>"function"					{ MP(); push_scope(); return ieee_filter(vFUNCTION); }
-<INITIAL>"module"					{ MP(); push_scope(); return ieee_filter(vMODULE); }
-<INITIAL>"macromodule"				{ MP(); push_scope(); return ieee_filter(vMODULE); }
-<INITIAL>"task"						{ MP(); push_scope(); return ieee_filter(vTASK); }
+<INITIAL>"begin"                     { MP(); push_scope(); return ieee_filter(vBEGIN); }
+<INITIAL>"function"                  { MP(); push_scope(); return ieee_filter(vFUNCTION); }
+<INITIAL>"module"                    { MP(); push_scope(); return ieee_filter(vMODULE); }
+<INITIAL>"macromodule"               { MP(); push_scope(); return ieee_filter(vMODULE); }
+<INITIAL>"task"                      { MP(); push_scope(); return ieee_filter(vTASK); }
 
     /* End Scoped items */
-<INITIAL>"end"						{ MP(); return ieee_filter(vEND); }
-<INITIAL>"endfunction"				{ MP(); return ieee_filter(vENDFUNCTION); }
-<INITIAL>"endmodule"				{ MP(); return ieee_filter(vENDMODULE); }
-<INITIAL>"endtask"					{ MP(); return ieee_filter(vENDTASK); }
+<INITIAL>"end"                       { MP(); return ieee_filter(vEND); }
+<INITIAL>"endfunction"               { MP(); return ieee_filter(vENDFUNCTION); }
+<INITIAL>"endmodule"                 { MP(); return ieee_filter(vENDMODULE); }
+<INITIAL>"endtask"                   { MP(); return ieee_filter(vENDTASK); }
 
-    /*	Keywords	*/
-<INITIAL>"always"					{ MP(); return ieee_filter(vALWAYS); }
-<INITIAL>"and"						{ MP(); return ieee_filter(vAND); }
-<INITIAL>"assign"					{ MP(); return ieee_filter(vASSIGN); }
-<INITIAL>"automatic"				{ MP(); return ieee_filter(vAUTOMATIC); }
-<INITIAL>"case"						{ MP(); return ieee_filter(vCASE); }
-<INITIAL>"default"					{ MP(); return ieee_filter(vDEFAULT); }
-<INITIAL>"defparam"					{ MP(); return ieee_filter(vDEFPARAM); }
-<INITIAL>"else"						{ MP(); return ieee_filter(vELSE); }
-<INITIAL>"endcase"					{ MP(); return ieee_filter(vENDCASE); }
-<INITIAL>"endspecify"				{ MP(); return ieee_filter(vENDSPECIFY); }
-<INITIAL>"endgenerate"				{ MP(); return ieee_filter(vENDGENERATE); }
-<INITIAL>"for"						{ MP(); return ieee_filter(vFOR); }
-<INITIAL>"if"						{ MP(); return ieee_filter(vIF); }
-<INITIAL>"initial"					{ MP(); return ieee_filter(vINITIAL); }
-<INITIAL>"inout"					{ MP(); return ieee_filter(vINOUT); }
-<INITIAL>"input"					{ MP(); return ieee_filter(vINPUT); }
-<INITIAL>"integer"					{ MP(); return ieee_filter(vINTEGER); }
-<INITIAL>"generate"					{ MP(); return ieee_filter(vGENERATE); }
-<INITIAL>"genvar"					{ MP(); return ieee_filter(vGENVAR); }
-<INITIAL>"nand"						{ MP(); return ieee_filter(vNAND); }
-<INITIAL>"negedge"					{ MP(); return ieee_filter(vNEGEDGE); }
-<INITIAL>"nor"						{ MP(); return ieee_filter(vNOR); }
-<INITIAL>"not"						{ MP(); return ieee_filter(vNOT); }
-<INITIAL>"or"						{ MP(); return ieee_filter(vOR); }
-<INITIAL>"output"					{ MP(); return ieee_filter(vOUTPUT); }
-<INITIAL>"parameter"				{ MP(); return ieee_filter(vPARAMETER); }
-<INITIAL>"localparam"				{ MP(); return ieee_filter(vLOCALPARAM); }
-<INITIAL>"posedge"					{ MP(); return ieee_filter(vPOSEDGE); }
-<INITIAL>"signed"					{ MP(); return ieee_filter(vSIGNED); }
-<INITIAL>"unsigned"					{ MP(); return ieee_filter(vUNSIGNED); }
-<INITIAL>"specify"					{ MP(); return ieee_filter(vSPECIFY); }
-<INITIAL>"while"					{ MP(); return ieee_filter(vWHILE); }
-<INITIAL>"xnor"						{ MP(); return ieee_filter(vXNOR); }
-<INITIAL>"xor"						{ MP(); return ieee_filter(vXOR); }
-<INITIAL>"specparam"				{ MP(); return ieee_filter(vSPECPARAM); }
-<INITIAL>"buf"				        { MP(); return ieee_filter(vBUF); }
+    /*    Keywords    */
+<INITIAL>"always"                    { MP(); return ieee_filter(vALWAYS); }
+<INITIAL>"and"                       { MP(); return ieee_filter(vAND); }
+<INITIAL>"assign"                    { MP(); return ieee_filter(vASSIGN); }
+<INITIAL>"automatic"                 { MP(); return ieee_filter(vAUTOMATIC); }
+<INITIAL>"case"                      { MP(); return ieee_filter(vCASE); }
+<INITIAL>"default"                   { MP(); return ieee_filter(vDEFAULT); }
+<INITIAL>"defparam"                  { MP(); return ieee_filter(vDEFPARAM); }
+<INITIAL>"else"                      { MP(); return ieee_filter(vELSE); }
+<INITIAL>"endcase"                   { MP(); return ieee_filter(vENDCASE); }
+<INITIAL>"endspecify"                { MP(); return ieee_filter(vENDSPECIFY); }
+<INITIAL>"endgenerate"               { MP(); return ieee_filter(vENDGENERATE); }
+<INITIAL>"for"                       { MP(); return ieee_filter(vFOR); }
+<INITIAL>"if"                        { MP(); return ieee_filter(vIF); }
+<INITIAL>"initial"                   { MP(); return ieee_filter(vINITIAL); }
+<INITIAL>"inout"                     { MP(); return ieee_filter(vINOUT); }
+<INITIAL>"input"                     { MP(); return ieee_filter(vINPUT); }
+<INITIAL>"integer"                   { MP(); return ieee_filter(vINTEGER); }
+<INITIAL>"generate"                  { MP(); return ieee_filter(vGENERATE); }
+<INITIAL>"genvar"                    { MP(); return ieee_filter(vGENVAR); }
+<INITIAL>"nand"                      { MP(); return ieee_filter(vNAND); }
+<INITIAL>"negedge"                   { MP(); return ieee_filter(vNEGEDGE); }
+<INITIAL>"nor"                       { MP(); return ieee_filter(vNOR); }
+<INITIAL>"not"                       { MP(); return ieee_filter(vNOT); }
+<INITIAL>"or"                        { MP(); return ieee_filter(vOR); }
+<INITIAL>"output"                    { MP(); return ieee_filter(vOUTPUT); }
+<INITIAL>"parameter"                 { MP(); return ieee_filter(vPARAMETER); }
+<INITIAL>"localparam"                { MP(); return ieee_filter(vLOCALPARAM); }
+<INITIAL>"posedge"                   { MP(); return ieee_filter(vPOSEDGE); }
+<INITIAL>"signed"                    { MP(); return ieee_filter(vSIGNED); }
+<INITIAL>"unsigned"                  { MP(); return ieee_filter(vUNSIGNED); }
+<INITIAL>"specify"                   { MP(); return ieee_filter(vSPECIFY); }
+<INITIAL>"while"                     { MP(); return ieee_filter(vWHILE); }
+<INITIAL>"xnor"                      { MP(); return ieee_filter(vXNOR); }
+<INITIAL>"xor"                       { MP(); return ieee_filter(vXOR); }
+<INITIAL>"specparam"                 { MP(); return ieee_filter(vSPECPARAM); }
+<INITIAL>"buf"                       { MP(); return ieee_filter(vBUF); }
 
     /* Net types */
-<INITIAL>"wire"						{ MP(); return ieee_filter(vWIRE); }
-<INITIAL>"tri"						{ MP(); return ieee_filter(vTRI); }
-<INITIAL>"tri0"						{ MP(); return ieee_filter(vTRI0); }
-<INITIAL>"tri1"						{ MP(); return ieee_filter(vTRI1); }
-<INITIAL>"wand"						{ MP(); return ieee_filter(vWAND); }
-<INITIAL>"wor"						{ MP(); return ieee_filter(vWOR); }
-<INITIAL>"triand"					{ MP(); return ieee_filter(vTRIAND); }
-<INITIAL>"trior"					{ MP(); return ieee_filter(vTRIOR); }
-<INITIAL>"trireg"					{ MP(); return ieee_filter(vTRIREG); }
-<INITIAL>"uwire"					{ MP(); return ieee_filter(vUWIRE); }
-<INITIAL>"uwire"					{ MP(); return ieee_filter(vUWIRE); }
-<INITIAL>"none"						{ MP(); return ieee_filter(vNONE); }
-<INITIAL>"reg"						{ MP(); return ieee_filter(vREG); }
+<INITIAL>"wire"                      { MP(); return ieee_filter(vWIRE); }
+<INITIAL>"tri"                       { MP(); return ieee_filter(vTRI); }
+<INITIAL>"tri0"                      { MP(); return ieee_filter(vTRI0); }
+<INITIAL>"tri1"                      { MP(); return ieee_filter(vTRI1); }
+<INITIAL>"wand"                      { MP(); return ieee_filter(vWAND); }
+<INITIAL>"wor"                       { MP(); return ieee_filter(vWOR); }
+<INITIAL>"triand"                    { MP(); return ieee_filter(vTRIAND); }
+<INITIAL>"trior"                     { MP(); return ieee_filter(vTRIOR); }
+<INITIAL>"trireg"                    { MP(); return ieee_filter(vTRIREG); }
+<INITIAL>"uwire"                     { MP(); return ieee_filter(vUWIRE); }
+<INITIAL>"uwire"                     { MP(); return ieee_filter(vUWIRE); }
+<INITIAL>"none"                      { MP(); return ieee_filter(vNONE); }
+<INITIAL>"reg"                       { MP(); return ieee_filter(vREG); }
 
     /**********************************
      * Verilog Operators (vo)
      */
-<INITIAL>"&&&"						{ MP(); return ieee_filter(voANDANDAND); }
-<INITIAL>"**"						{ MP(); return ieee_filter(voPOWER); }
-<INITIAL>"&&"						{ MP(); return ieee_filter(voANDAND); }
-<INITIAL>"||"						{ MP(); return ieee_filter(voOROR); }
-<INITIAL>"<="						{ MP(); return ieee_filter(voLTE); }
-<INITIAL>"=>"						{ MP(); return ieee_filter(voEGT); }
-<INITIAL>">="						{ MP(); return ieee_filter(voGTE); }
-<INITIAL>"<<"						{ MP(); return ieee_filter(voSLEFT); }
-<INITIAL>"<<<"						{ MP(); return ieee_filter(voASLEFT); }
-<INITIAL>">>"						{ MP(); return ieee_filter(voSRIGHT); }
-<INITIAL>">>>"						{ MP(); return ieee_filter(voASRIGHT); }
-<INITIAL>"=="						{ MP(); return ieee_filter(voEQUAL); }
-<INITIAL>"!="						{ MP(); return ieee_filter(voNOTEQUAL); }
-<INITIAL>"==="						{ MP(); return ieee_filter(voCASEEQUAL); }
-<INITIAL>"!=="						{ MP(); return ieee_filter(voCASENOTEQUAL); }
-<INITIAL>"^~"						{ MP(); return ieee_filter(voXNOR); }
-<INITIAL>"~^"						{ MP(); return ieee_filter(voXNOR); }
-<INITIAL>"~&"						{ MP(); return ieee_filter(voNAND); }
-<INITIAL>"~|"						{ MP(); return ieee_filter(voNOR); }
-<INITIAL>"+:"						{ MP(); return ieee_filter(voPLUSCOLON); }
-<INITIAL>"-:"						{ MP(); return ieee_filter(voMINUSCOLON); }
+<INITIAL>"&&&"                       { MP(); return ieee_filter(voANDANDAND); }
+<INITIAL>"**"                        { MP(); return ieee_filter(voPOWER); }
+<INITIAL>"&&"                        { MP(); return ieee_filter(voANDAND); }
+<INITIAL>"||"                        { MP(); return ieee_filter(voOROR); }
+<INITIAL>"<="                        { MP(); return ieee_filter(voLTE); }
+<INITIAL>"=>"                        { MP(); return ieee_filter(voEGT); }
+<INITIAL>">="                        { MP(); return ieee_filter(voGTE); }
+<INITIAL>"<<"                        { MP(); return ieee_filter(voSLEFT); }
+<INITIAL>"<<<"                       { MP(); return ieee_filter(voASLEFT); }
+<INITIAL>">>"                        { MP(); return ieee_filter(voSRIGHT); }
+<INITIAL>">>>"                       { MP(); return ieee_filter(voASRIGHT); }
+<INITIAL>"=="                        { MP(); return ieee_filter(voEQUAL); }
+<INITIAL>"!="                        { MP(); return ieee_filter(voNOTEQUAL); }
+<INITIAL>"==="                       { MP(); return ieee_filter(voCASEEQUAL); }
+<INITIAL>"!=="                       { MP(); return ieee_filter(voCASENOTEQUAL); }
+<INITIAL>"^~"                        { MP(); return ieee_filter(voXNOR); }
+<INITIAL>"~^"                        { MP(); return ieee_filter(voXNOR); }
+<INITIAL>"~&"                        { MP(); return ieee_filter(voNAND); }
+<INITIAL>"~|"                        { MP(); return ieee_filter(voNOR); }
+<INITIAL>"+:"                        { MP(); return ieee_filter(voPLUSCOLON); }
+<INITIAL>"-:"                        { MP(); return ieee_filter(voMINUSCOLON); }
 
     /**********************************
      * Verilog System (vs) Functions
      */
-<INITIAL>"$clog2"					{ MP(); return ieee_filter(vsCLOG2); }
-<INITIAL>"$unsigned"				{ MP(); return ieee_filter(vsUNSIGNED); }
-<INITIAL>"$signed"					{ MP(); return ieee_filter(vsSIGNED); }
-<INITIAL>"$finish"					{ MP(); return ieee_filter(vsFINISH); }
-<INITIAL>"$display"					{ MP(); return ieee_filter(vsDISPLAY); }
+<INITIAL>"$clog2"                    { MP(); return ieee_filter(vsCLOG2); }
+<INITIAL>"$unsigned"                 { MP(); return ieee_filter(vsUNSIGNED); }
+<INITIAL>"$signed"                   { MP(); return ieee_filter(vsSIGNED); }
+<INITIAL>"$finish"                   { MP(); return ieee_filter(vsFINISH); }
+<INITIAL>"$display"                  { MP(); return ieee_filter(vsDISPLAY); }
     /* catch all C functions */
-<INITIAL>[\$]{vWORD}				{ MP(); return ieee_filter(vsFUNCTION); }
+<INITIAL>[\$]{vWORD}                 { MP(); return ieee_filter(vsFUNCTION); }
 
     /* Integers */
-<INITIAL>{vINT}						{ MP(); yylval.num_value = vtr::strdup(yytext); return vINT_NUMBER; }
+<INITIAL>{vINT}                      { MP(); yylval.num_value = vtr::strdup(yytext); return vINT_NUMBER; }
     /* Strings */
-<INITIAL>{vSTR}						{ MP(); yylval.num_value = vtr::strdup(yytext); return vSTRING; }
+<INITIAL>{vSTR}                      { MP(); yylval.num_value = vtr::strdup(yytext); return vSTRING; }
     /* Numbers */
-<INITIAL>[[:digit:]]*'[sS]?{vBIN}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
-<INITIAL>[[:digit:]]*'[sS]?{vHEX}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
-<INITIAL>[[:digit:]]*'[sS]?{vOCT}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
-<INITIAL>[[:digit:]]*'[sS]?{vDEC}	{ MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
+<INITIAL>[[:digit:]]*'[sS]?{vBIN}    { MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
+<INITIAL>[[:digit:]]*'[sS]?{vHEX}    { MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
+<INITIAL>[[:digit:]]*'[sS]?{vOCT}    { MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
+<INITIAL>[[:digit:]]*'[sS]?{vDEC}    { MP(); yylval.num_value = vtr::strdup(yytext); return vNUMBER; }
 
-    /*	operands	*/
-<INITIAL>{vWORD}(\.{vWORD})*		{ MP(); yylval.id_name = vtr::strdup(yytext); return vSYMBOL_ID; }
+    /*    operands    */
+<INITIAL>{vWORD}(\.{vWORD})*         { MP(); yylval.id_name = vtr::strdup(yytext); return vSYMBOL_ID; }
 
     /* return operators */
-<INITIAL>{vPUNCT}					{ MP(); return yytext[0]; }
+<INITIAL>{vPUNCT}                    { MP(); return yytext[0]; }
 
     /************
      * general stuff 
      **/
 
     /* single line comment */
-<*>[\/][\/]							{ 
+<*>[\/][\/]                         { 
                                         int state = TOP_STATE();
                                         if (state == DEFINE_BODY)
                                         {
@@ -419,7 +419,7 @@ vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
                                         }
                                     }
     /* multi line comment */
-<*>[\/][\*]							{ 
+<*>[\/][\*]                         { 
                                         int state = TOP_STATE();
                                         if(state != COMMENT
                                         && state != MULTI_LINE_COMMENT)
@@ -428,28 +428,28 @@ vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
                                         }
                                     }
 
-<MULTI_LINE_COMMENT>[\*][\/]		{ POP_STATE(); }
+<MULTI_LINE_COMMENT>[\*][\/]        { POP_STATE(); }
 
-<*>[[:blank:]]+						{	
+<*>[[:blank:]]+                     {    
                                         int state = TOP_STATE();
                                         if(state == DEFINE_BODY)
                                         {
                                             append_to_define_body(' ');
                                         }
                                         else if(state == DEFINE_ARGS
-                                        ||		state == BRACKET_MATCH)
+                                        ||        state == BRACKET_MATCH)
                                         {
                                             define_arg_push_back(yytext[0]);
                                         } 
                                     }
 
-<*><<EOF>>							{ if ( ! pop_include() ){ free_define_map(); yyterminate(); } }
+<*><<EOF>>                            { if ( ! pop_include() ){ free_define_map(); yyterminate(); } }
 
     /* skip escapped newline */
-<*>\\\r?\n							{ my_location.line++; my_location.col = 1; }
+<*>\\\r?\n                            { my_location.line++; my_location.col = 1; }
 
     /* deal with new lines */
-<*>\r?\n							{ 
+<*>\r?\n                            { 
                                         bool done = false;
                                         do{
                                             int state = TOP_STATE();
@@ -472,7 +472,7 @@ vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
                                     }
 
     /* catch all */
-<*>.								{ 
+<*>.                                { 
                                         MP(); 
                                         int state = TOP_STATE();
                                         if(state == DEFINE_BODY)
@@ -480,7 +480,7 @@ vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
                                             append_to_define_body(yytext[0]);
                                         }
                                         else if(state == DEFINE_ARGS
-                                        ||		state == BRACKET_MATCH)
+                                        ||        state == BRACKET_MATCH)
                                         {
                                             define_arg_push_back(yytext[0]);
                                         } 
@@ -489,11 +489,11 @@ vPUNCT [\?\:\|\^\&\<\>\-\*\/\%\(\)\{\}\[\]\~\!\;\#\,\.\@\=\+]
                                             /* catch stuck parser */
                                             POP_STATE();
                                         }
-                                    }				
+                                    }                
 
 %%
 
-void MP()		
+void MP()        
 { 
     if (configuration.print_parse_tokens) 
     {
@@ -501,7 +501,7 @@ void MP()
     } 
 }
 
-int top_flex_state(const char *str)		
+int top_flex_state(const char *str)        
 { 
     if(flex_state.empty())
     {
@@ -511,18 +511,18 @@ int top_flex_state(const char *str)
     if (configuration.print_parse_tokens && strlen(str)) 
     {
         printf("%s state: %s\n", str,
-            (state == INCLUDE)?			"INCLUDE":
-            (state == COMMENT)?			"COMMENT":
-            (state == MULTI_LINE_COMMENT)?	"MULTI_LINE_COMMENT":
-            (state == DEFINE_BODY)?		"DEFINE_BODY":
-            (state == SKIP)?				"SKIP":
-            (state == ELIFCONDITION)?		"ELIFCONDITION":
-            (state == NEG_CONDITION)?		"NEG_CONDITION":
-            (state == CONDITION)?			"CONDITION":
-            (state == DEFINE_REMOVAL)?		"DEFINE_REMOVAL":
-            (state == VAR_PARSE)?			"VAR_PARSE":
-            (state == PARSE_DEFINE)?		"PARSE_DEFINE":
-            (state == DEFINE_ARGS)?		"DEFINE_ARGS":
+            (state == INCLUDE)?            "INCLUDE":
+            (state == COMMENT)?            "COMMENT":
+            (state == MULTI_LINE_COMMENT)?    "MULTI_LINE_COMMENT":
+            (state == DEFINE_BODY)?        "DEFINE_BODY":
+            (state == SKIP)?                "SKIP":
+            (state == ELIFCONDITION)?        "ELIFCONDITION":
+            (state == NEG_CONDITION)?        "NEG_CONDITION":
+            (state == CONDITION)?            "CONDITION":
+            (state == DEFINE_REMOVAL)?        "DEFINE_REMOVAL":
+            (state == VAR_PARSE)?            "VAR_PARSE":
+            (state == PARSE_DEFINE)?        "PARSE_DEFINE":
+            (state == DEFINE_ARGS)?        "DEFINE_ARGS":
                                             "INITIAL"
         );
     } 
@@ -712,7 +712,7 @@ void new_define_t(const char* id)
     if(defines_map.find(tmp) != defines_map.end())
     {
         warning_message(PARSER, my_location, "%s is redefined, overwritting its value", id);
-        delete defines_map[tmp];	
+        delete defines_map[tmp];    
     }
 
     defines_map[tmp] = new_define;

--- a/ODIN_II/regression_test/benchmark/task/keywords/automatic/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/automatic/synthesis_result.json
@@ -7,8 +7,8 @@
             "NETLIST recursive_function.v:8 This output (simple_op.function_instance_0.function_instance_1^factorial~0) must exist...must be an error"
         ],
         "warnings": [
-            "AST recursive_function.v:14 ODIN II does not (yet) differentiate between automatic and static tasks & functions.IGNORING",
-            "AST recursive_function.v:14 ODIN_II does not fully support input/output integers in functions"
+            "AST recursive_function.v:8 Odin does not handle signed REG (factorial)",
+            "AST recursive_function.v:14 ODIN II does not (yet) differentiate between automatic and static tasks & functions.IGNORING"
         ]
     },
     "automatic/recursive_task/no_arch": {

--- a/ODIN_II/regression_test/benchmark/task/keywords/for/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/for/synthesis_result.json
@@ -2,6 +2,9 @@
     "for/generate_for_int/no_arch": {
         "test_name": "for/generate_for_int/no_arch",
         "verilog": "generate_for_int.v",
+        "warnings": [
+            "AST generate_for.vh:6 Odin does not handle signed GENVAR (i)"
+        ],
         "max_rss(MiB)": 19.3,
         "exec_time(ms)": 14.4,
         "synthesis_time(ms)": 12.9,
@@ -12,6 +15,9 @@
     "for/generate_for_ultra_wide/no_arch": {
         "test_name": "for/generate_for_ultra_wide/no_arch",
         "verilog": "generate_for_ultra_wide.v",
+        "warnings": [
+            "AST generate_for.vh:6 Odin does not handle signed GENVAR (i)"
+        ],
         "max_rss(MiB)": 1521.5,
         "exec_time(ms)": 7026.5,
         "synthesis_time(ms)": 7025.1,
@@ -22,6 +28,9 @@
     "for/generate_for_wide/no_arch": {
         "test_name": "for/generate_for_wide/no_arch",
         "verilog": "generate_for_wide.v",
+        "warnings": [
+            "AST generate_for.vh:6 Odin does not handle signed GENVAR (i)"
+        ],
         "max_rss(MiB)": 11.9,
         "exec_time(ms)": 3.8,
         "synthesis_time(ms)": 2.2,

--- a/ODIN_II/regression_test/benchmark/task/keywords/input/simulation_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/input/simulation_result.json
@@ -1,21 +1,16 @@
 {
-    "genvar/generate_for/no_arch": {
-        "test_name": "genvar/generate_for/no_arch",
-        "verilog": "generate_for.v",
-        "warnings": [
-            "AST generate_for.v:7 Odin does not handle signed GENVAR (i)"
-        ],
-        "max_rss(MiB)": 12.3,
-        "exec_time(ms)": 2.6,
-        "synthesis_time(ms)": 1.5,
-        "Po": 3,
-        "Longest Path": 2,
-        "Average Path": 2
+    "input/multiple_declarations/no_arch": {
+        "test_name": "input/multiple_declarations/no_arch",
+        "blif": "multiple_declarations.blif",
+        "exit": 134,
+        "errors": [
+            "OUTPUT_BLIF More lines (8) than values (7)."
+        ]
     },
     "DEFAULT": {
         "test_name": "n/a",
         "architecture": "n/a",
-        "verilog": "n/a",
+        "blif": "n/a",
         "exit": 0,
         "leaks": 0,
         "errors": [],
@@ -23,7 +18,8 @@
         "expectation": [],
         "max_rss(MiB)": -1,
         "exec_time(ms)": -1,
-        "synthesis_time(ms)": -1,
+        "simulation_time(ms)": -1,
+        "test_coverage(%)": -1,
         "Latch Drivers": 0,
         "Pi": 0,
         "Po": 0,

--- a/ODIN_II/regression_test/benchmark/task/keywords/input/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/input/synthesis_result.json
@@ -10,10 +10,18 @@
     "input/multiple_declarations/no_arch": {
         "test_name": "input/multiple_declarations/no_arch",
         "verilog": "multiple_declarations.v",
-        "exit": 134,
-        "errors": [
-            "AST multiple_declarations.v:3 Odin does not handle signed nets (a)"
-        ]
+        "warnings": [
+            "AST multiple_declarations.v:3 Odin does not handle signed WIRE (a)",
+            "AST multiple_declarations.v:3 Odin does not handle signed WIRE (b)",
+            "AST multiple_declarations.v:3 Odin does not handle signed WIRE (c)",
+            "AST multiple_declarations.v:7 Odin does not handle signed WIRE (h)",
+            "AST multiple_declarations.v:7 Odin does not handle signed WIRE (i)",
+            "AST multiple_declarations.v:7 Odin does not handle signed WIRE (j)"
+        ],
+        "Pi": 11,
+        "Po": 11,
+        "Longest Path": 2,
+        "Average Path": 2
     },
     "DEFAULT": {
         "test_name": "n/a",

--- a/ODIN_II/regression_test/benchmark/task/keywords/integer/simulation_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/integer/simulation_result.json
@@ -1,0 +1,61 @@
+{
+    "integer/integer_outside/no_arch": {
+        "test_name": "integer/integer_outside/no_arch",
+        "blif": "integer_outside.blif",
+        "exit": 134,
+        "errors": [
+            "OUTPUT_BLIF Vector files differ."
+        ],
+        "warnings": [
+            "OUTPUT_BLIF Vector 0 mismatch:",
+            "OUTPUT_BLIF Vector 1 mismatch:",
+            "OUTPUT_BLIF Vector 2 mismatch:",
+            "OUTPUT_BLIF Vector 3 mismatch:",
+            "OUTPUT_BLIF Vector 4 mismatch:",
+            "OUTPUT_BLIF Vector 5 mismatch:"
+        ]
+    },
+    "integer/integer_port/no_arch": {
+        "test_name": "integer/integer_port/no_arch",
+        "blif": "integer_port.blif",
+        "exit": 134,
+        "errors": [
+            "OUTPUT_BLIF Vector files differ."
+        ],
+        "warnings": [
+            "OUTPUT_BLIF Vector 0 mismatch:",
+            "OUTPUT_BLIF Vector 1 mismatch:",
+            "OUTPUT_BLIF Vector 3 mismatch:",
+            "OUTPUT_BLIF Vector 4 mismatch:",
+            "OUTPUT_BLIF Vector 5 mismatch:"
+        ]
+    },
+    "DEFAULT": {
+        "test_name": "n/a",
+        "architecture": "n/a",
+        "blif": "n/a",
+        "exit": 0,
+        "leaks": 0,
+        "errors": [],
+        "warnings": [],
+        "expectation": [],
+        "max_rss(MiB)": -1,
+        "exec_time(ms)": -1,
+        "simulation_time(ms)": -1,
+        "test_coverage(%)": -1,
+        "Latch Drivers": 0,
+        "Pi": 0,
+        "Po": 0,
+        "logic element": 0,
+        "latch": 0,
+        "Adder": -1,
+        "Multiplier": -1,
+        "Memory": -1,
+        "Hard Ip": -1,
+        "generic logic size": -1,
+        "Longest Path": 0,
+        "Average Path": 0,
+        "Estimated LUTs": 0,
+        "Total Node": 0
+    }
+}

--- a/ODIN_II/regression_test/benchmark/task/keywords/integer/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/integer/synthesis_result.json
@@ -4,24 +4,57 @@
         "verilog": "integer_failure.v",
         "exit": 134,
         "errors": [
-            "AST integer_failure.v:3 Odin does not handle signed ports (a)"
+            "NETLIST integer_failure.v:3 Input cannot be defined as a reg"
+        ],
+        "warnings": [
+            "AST integer_failure.v:3 Odin does not handle signed REG (a)",
+            "AST integer_failure.v:3 Odin does not handle signed INPUT (a)",
+            "AST integer_failure.v:3 Odin does not handle signed ports (a)",
+            "AST integer_failure.v:4 Odin does not handle signed REG (b)",
+            "AST integer_failure.v:4 Odin does not handle signed INPUT (b)",
+            "AST integer_failure.v:4 Odin does not handle signed ports (b)",
+            "AST integer_failure.v:6 Odin does not handle signed REG (c)",
+            "AST integer_failure.v:6 Odin does not handle signed OUTPUT (c)",
+            "AST integer_failure.v:6 Odin does not handle signed ports (c)"
         ]
     },
     "integer/integer_outside/no_arch": {
         "test_name": "integer/integer_outside/no_arch",
         "verilog": "integer_outside.v",
-        "exit": 134,
-        "errors": [
-            "AST integer_outside.v:3 Odin does not handle signed ports (a)"
-        ]
+        "warnings": [
+            "AST integer_outside.v:3 Odin does not handle signed INPUT (a)",
+            "AST integer_outside.v:3 Odin does not handle signed ports (a)",
+            "AST integer_outside.v:4 Odin does not handle signed INPUT (b)",
+            "AST integer_outside.v:4 Odin does not handle signed ports (b)",
+            "AST integer_outside.v:8 Odin does not handle signed REG (c)"
+        ],
+        "Pi": 2,
+        "Po": 1,
+        "logic element": 1,
+        "Longest Path": 3,
+        "Average Path": 3,
+        "Estimated LUTs": 1,
+        "Total Node": 1
     },
     "integer/integer_port/no_arch": {
         "test_name": "integer/integer_port/no_arch",
         "verilog": "integer_port.v",
-        "exit": 134,
-        "errors": [
-            "AST integer_port.v:3 Odin does not handle signed ports (a)"
-        ]
+        "warnings": [
+            "AST integer_port.v:3 Odin does not handle signed INPUT (a)",
+            "AST integer_port.v:3 Odin does not handle signed ports (a)",
+            "AST integer_port.v:4 Odin does not handle signed INPUT (b)",
+            "AST integer_port.v:4 Odin does not handle signed ports (b)",
+            "AST integer_port.v:6 Odin does not handle signed REG (c)",
+            "AST integer_port.v:6 Odin does not handle signed OUTPUT (c)",
+            "AST integer_port.v:6 Odin does not handle signed ports (c)"
+        ],
+        "Pi": 32,
+        "Po": 32,
+        "logic element": 33,
+        "Longest Path": 19,
+        "Average Path": 3,
+        "Estimated LUTs": 33,
+        "Total Node": 33
     },
     "DEFAULT": {
         "test_name": "n/a",

--- a/ODIN_II/regression_test/benchmark/task/keywords/output/simulation_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/output/simulation_result.json
@@ -1,21 +1,16 @@
 {
-    "genvar/generate_for/no_arch": {
-        "test_name": "genvar/generate_for/no_arch",
-        "verilog": "generate_for.v",
-        "warnings": [
-            "AST generate_for.v:7 Odin does not handle signed GENVAR (i)"
-        ],
-        "max_rss(MiB)": 12.3,
-        "exec_time(ms)": 2.6,
-        "synthesis_time(ms)": 1.5,
-        "Po": 3,
-        "Longest Path": 2,
-        "Average Path": 2
+    "output/multiple_declarations/no_arch": {
+        "test_name": "output/multiple_declarations/no_arch",
+        "blif": "multiple_declarations.blif",
+        "exit": 134,
+        "errors": [
+            "OUTPUT_BLIF More lines (8) than values (7)."
+        ]
     },
     "DEFAULT": {
         "test_name": "n/a",
         "architecture": "n/a",
-        "verilog": "n/a",
+        "blif": "n/a",
         "exit": 0,
         "leaks": 0,
         "errors": [],
@@ -23,7 +18,8 @@
         "expectation": [],
         "max_rss(MiB)": -1,
         "exec_time(ms)": -1,
-        "synthesis_time(ms)": -1,
+        "simulation_time(ms)": -1,
+        "test_coverage(%)": -1,
         "Latch Drivers": 0,
         "Pi": 0,
         "Po": 0,

--- a/ODIN_II/regression_test/benchmark/task/keywords/output/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/output/synthesis_result.json
@@ -2,10 +2,18 @@
     "output/multiple_declarations/no_arch": {
         "test_name": "output/multiple_declarations/no_arch",
         "verilog": "multiple_declarations.v",
-        "exit": 134,
-        "errors": [
-            "AST multiple_declarations.v:3 Odin does not handle signed nets (a)"
-        ]
+        "warnings": [
+            "AST multiple_declarations.v:3 Odin does not handle signed WIRE (a)",
+            "AST multiple_declarations.v:3 Odin does not handle signed WIRE (b)",
+            "AST multiple_declarations.v:3 Odin does not handle signed WIRE (c)",
+            "AST multiple_declarations.v:7 Odin does not handle signed WIRE (h)",
+            "AST multiple_declarations.v:7 Odin does not handle signed WIRE (i)",
+            "AST multiple_declarations.v:7 Odin does not handle signed WIRE (j)"
+        ],
+        "Pi": 11,
+        "Po": 11,
+        "Longest Path": 2,
+        "Average Path": 2
     },
     "output/output_port_failure/no_arch": {
         "test_name": "output/output_port_failure/no_arch",

--- a/ODIN_II/regression_test/benchmark/task/keywords/parameter/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/parameter/synthesis_result.json
@@ -14,6 +14,7 @@
         "test_name": "parameter/parameter_define/no_arch",
         "verilog": "parameter_define.v",
         "warnings": [
+            "AST parameter_define.v:7 Odin does not handle signed REG (i)",
             "NETLIST parameter_define.v:6 This output is undriven (simple_op^out~4) and will be removed",
             "NETLIST parameter_define.v:6 Net simple_op^out~4 driving node simple_op^out~4 is itself undriven."
         ],

--- a/ODIN_II/regression_test/benchmark/task/keywords/signed_unsigned/simulation_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/signed_unsigned/simulation_result.json
@@ -1,0 +1,88 @@
+{
+    "signed_unsigned/signed_to_signed/no_arch": {
+        "test_name": "signed_unsigned/signed_to_signed/no_arch",
+        "blif": "signed_to_signed.blif",
+        "exit": 134,
+        "errors": [
+            "OUTPUT_BLIF Vector files differ."
+        ],
+        "warnings": [
+            "OUTPUT_BLIF Vector 0 mismatch:",
+            "OUTPUT_BLIF Vector 1 mismatch:",
+            "OUTPUT_BLIF Vector 4 mismatch:",
+            "OUTPUT_BLIF Vector 5 mismatch:"
+        ]
+    },
+    "signed_unsigned/signed_to_unsigned/no_arch": {
+        "test_name": "signed_unsigned/signed_to_unsigned/no_arch",
+        "blif": "signed_to_unsigned.blif",
+        "exit": 134,
+        "errors": [
+            "OUTPUT_BLIF Vector files differ."
+        ],
+        "warnings": [
+            "OUTPUT_BLIF Vector 0 mismatch:",
+            "OUTPUT_BLIF Vector 1 mismatch:",
+            "OUTPUT_BLIF Vector 4 mismatch:",
+            "OUTPUT_BLIF Vector 5 mismatch:"
+        ]
+    },
+    "signed_unsigned/unsigned_to_signed/no_arch": {
+        "test_name": "signed_unsigned/unsigned_to_signed/no_arch",
+        "blif": "unsigned_to_signed.blif",
+        "max_rss(MiB)": 29.8,
+        "exec_time(ms)": 3.9,
+        "simulation_time(ms)": 0.7,
+        "test_coverage(%)": 100,
+        "Pi": 4,
+        "Po": 6,
+        "logic element": 6,
+        "Longest Path": 3,
+        "Average Path": 3,
+        "Estimated LUTs": 6,
+        "Total Node": 6
+    },
+    "signed_unsigned/unsigned_to_unsigned/no_arch": {
+        "test_name": "signed_unsigned/unsigned_to_unsigned/no_arch",
+        "blif": "unsigned_to_unsigned.blif",
+        "max_rss(MiB)": 30.2,
+        "exec_time(ms)": 3.3,
+        "simulation_time(ms)": 0.5,
+        "test_coverage(%)": 100,
+        "Pi": 4,
+        "Po": 6,
+        "logic element": 6,
+        "Longest Path": 3,
+        "Average Path": 3,
+        "Estimated LUTs": 6,
+        "Total Node": 6
+    },
+    "DEFAULT": {
+        "test_name": "n/a",
+        "architecture": "n/a",
+        "blif": "n/a",
+        "exit": 0,
+        "leaks": 0,
+        "errors": [],
+        "warnings": [],
+        "expectation": [],
+        "max_rss(MiB)": -1,
+        "exec_time(ms)": -1,
+        "simulation_time(ms)": -1,
+        "test_coverage(%)": -1,
+        "Latch Drivers": 0,
+        "Pi": 0,
+        "Po": 0,
+        "logic element": 0,
+        "latch": 0,
+        "Adder": -1,
+        "Multiplier": -1,
+        "Memory": -1,
+        "Hard Ip": -1,
+        "generic logic size": -1,
+        "Longest Path": 0,
+        "Average Path": 0,
+        "Estimated LUTs": 0,
+        "Total Node": 0
+    }
+}

--- a/ODIN_II/regression_test/benchmark/task/keywords/signed_unsigned/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/signed_unsigned/synthesis_result.json
@@ -2,41 +2,48 @@
     "signed_unsigned/signed_to_signed/no_arch": {
         "test_name": "signed_unsigned/signed_to_signed/no_arch",
         "verilog": "signed_to_signed.v",
-        "exit": 134,
-        "errors": [
-            "AST signed_to_signed.v:2 Odin does not handle signed ports (a)"
-        ]
+        "warnings": [
+            "AST signed_to_signed.v:2 Odin does not handle signed INPUT (a)",
+            "AST signed_to_signed.v:2 Odin does not handle signed ports (a)",
+            "AST signed_to_signed.v:3 Odin does not handle signed OUTPUT (b)",
+            "AST signed_to_signed.v:3 Odin does not handle signed ports (b)"
+        ],
+        "Pi": 4,
+        "Po": 6,
+        "Longest Path": 2,
+        "Average Path": 2
     },
     "signed_unsigned/signed_to_unsigned/no_arch": {
         "test_name": "signed_unsigned/signed_to_unsigned/no_arch",
         "verilog": "signed_to_unsigned.v",
-        "exit": 134,
-        "errors": [
+        "warnings": [
+            "AST signed_to_unsigned.v:2 Odin does not handle signed INPUT (a)",
             "AST signed_to_unsigned.v:2 Odin does not handle signed ports (a)"
-        ]
+        ],
+        "Pi": 4,
+        "Po": 6,
+        "Longest Path": 2,
+        "Average Path": 2
     },
     "signed_unsigned/unsigned_to_signed/no_arch": {
         "test_name": "signed_unsigned/unsigned_to_signed/no_arch",
         "verilog": "unsigned_to_signed.v",
-        "exit": 134,
-        "errors": [
+        "warnings": [
+            "AST unsigned_to_signed.v:3 Odin does not handle signed OUTPUT (b)",
             "AST unsigned_to_signed.v:3 Odin does not handle signed ports (b)"
         ],
-        "warnings": [
-            "PARSE_TO_AST unsigned_to_signed.v:2 error in parsing: (syntax error, unexpected '[', expecting ';' or ',')"
-        ]
+        "Pi": 4,
+        "Po": 6,
+        "Longest Path": 2,
+        "Average Path": 2
     },
     "signed_unsigned/unsigned_to_unsigned/no_arch": {
         "test_name": "signed_unsigned/unsigned_to_unsigned/no_arch",
         "verilog": "unsigned_to_unsigned.v",
-        "exit": 134,
-        "errors": [
-            "AST unsigned_to_unsigned.v:1 No matching declaration for port a"
-        ],
-        "warnings": [
-            "PARSE_TO_AST unsigned_to_unsigned.v:2 error in parsing: (syntax error, unexpected '[', expecting ';' or ',')",
-            "PARSE_TO_AST unsigned_to_unsigned.v:3 error in parsing: (syntax error, unexpected '[', expecting ';' or ',')"
-        ]
+        "Pi": 4,
+        "Po": 6,
+        "Longest Path": 2,
+        "Average Path": 2
     },
     "DEFAULT": {
         "test_name": "n/a",

--- a/ODIN_II/regression_test/benchmark/task/keywords/specify_endspecify/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/specify_endspecify/synthesis_result.json
@@ -7,7 +7,7 @@
             "PARSE_TO_AST Parser found (4) errors in your syntax, exiting"
         ],
         "warnings": [
-            "PARSE_TO_AST specify_conditional.v:15 error in parsing: (syntax error, unexpected vIF, expecting vENDSPECIFY or vSPECPARAM or '(')",
+            "PARSE_TO_AST specify_conditional.v:15 error in parsing: (syntax error, unexpected vIF, expecting vSPECPARAM or vENDSPECIFY or '(')",
             "PARSE_TO_AST specify_conditional.v:16 error in parsing: (syntax error, unexpected '(')",
             "PARSE_TO_AST specify_conditional.v:17 error in parsing: (syntax error, unexpected '(')",
             "PARSE_TO_AST specify_conditional.v:18 error in parsing: (syntax error, unexpected '(')"

--- a/ODIN_II/regression_test/benchmark/task/keywords/while/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/keywords/while/synthesis_result.json
@@ -5,6 +5,9 @@
         "exit": 134,
         "errors": [
             "AST while_loop.v:13 While statements are NOT supported"
+        ],
+        "warnings": [
+            "AST while_loop.v:6 Odin does not handle signed REG (i)"
         ]
     },
     "DEFAULT": {

--- a/ODIN_II/regression_test/benchmark/task/micro/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/micro/synthesis_result.json
@@ -4130,6 +4130,10 @@
         "test_name": "micro/case_generate/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "case_generate.v",
+        "warnings": [
+            "AST case_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST case_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 29.4,
         "exec_time(ms)": 56.8,
         "synthesis_time(ms)": 11.4,
@@ -4145,6 +4149,10 @@
         "test_name": "micro/case_generate/k6_N10_40nm",
         "architecture": "k6_N10_40nm.xml",
         "verilog": "case_generate.v",
+        "warnings": [
+            "AST case_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST case_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 20.1,
         "exec_time(ms)": 18,
         "synthesis_time(ms)": 12.3,
@@ -4157,6 +4165,10 @@
         "test_name": "micro/case_generate/k6_N10_mem32K_40nm",
         "architecture": "k6_N10_mem32K_40nm.xml",
         "verilog": "case_generate.v",
+        "warnings": [
+            "AST case_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST case_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 28.9,
         "exec_time(ms)": 52.3,
         "synthesis_time(ms)": 11.6,
@@ -4170,6 +4182,10 @@
     "micro/case_generate/no_arch": {
         "test_name": "micro/case_generate/no_arch",
         "verilog": "case_generate.v",
+        "warnings": [
+            "AST case_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST case_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 17.7,
         "exec_time(ms)": 14.1,
         "synthesis_time(ms)": 12.7,
@@ -4256,6 +4272,10 @@
         "test_name": "micro/generate/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "generate.v",
+        "warnings": [
+            "AST generate.v:10 Odin does not handle signed GENVAR (i)",
+            "AST generate.v:11 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 29.5,
         "exec_time(ms)": 43.2,
         "synthesis_time(ms)": 8.1,
@@ -4277,6 +4297,10 @@
         "test_name": "micro/generate/k6_N10_40nm",
         "architecture": "k6_N10_40nm.xml",
         "verilog": "generate.v",
+        "warnings": [
+            "AST generate.v:10 Odin does not handle signed GENVAR (i)",
+            "AST generate.v:11 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 20,
         "exec_time(ms)": 15.8,
         "synthesis_time(ms)": 10.2,
@@ -4295,6 +4319,10 @@
         "test_name": "micro/generate/k6_N10_mem32K_40nm",
         "architecture": "k6_N10_mem32K_40nm.xml",
         "verilog": "generate.v",
+        "warnings": [
+            "AST generate.v:10 Odin does not handle signed GENVAR (i)",
+            "AST generate.v:11 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 29.2,
         "exec_time(ms)": 52,
         "synthesis_time(ms)": 11.2,
@@ -4314,6 +4342,10 @@
     "micro/generate/no_arch": {
         "test_name": "micro/generate/no_arch",
         "verilog": "generate.v",
+        "warnings": [
+            "AST generate.v:10 Odin does not handle signed GENVAR (i)",
+            "AST generate.v:11 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 17.7,
         "exec_time(ms)": 13.6,
         "synthesis_time(ms)": 12.2,
@@ -4331,6 +4363,10 @@
         "test_name": "micro/if_generate/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "if_generate.v",
+        "warnings": [
+            "AST if_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST if_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 30,
         "exec_time(ms)": 57.4,
         "synthesis_time(ms)": 12.4,
@@ -4346,6 +4382,10 @@
         "test_name": "micro/if_generate/k6_N10_40nm",
         "architecture": "k6_N10_40nm.xml",
         "verilog": "if_generate.v",
+        "warnings": [
+            "AST if_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST if_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 20.1,
         "exec_time(ms)": 18.5,
         "synthesis_time(ms)": 12.8,
@@ -4358,6 +4398,10 @@
         "test_name": "micro/if_generate/k6_N10_mem32K_40nm",
         "architecture": "k6_N10_mem32K_40nm.xml",
         "verilog": "if_generate.v",
+        "warnings": [
+            "AST if_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST if_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 29.4,
         "exec_time(ms)": 53.8,
         "synthesis_time(ms)": 12.4,
@@ -4371,6 +4415,10 @@
     "micro/if_generate/no_arch": {
         "test_name": "micro/if_generate/no_arch",
         "verilog": "if_generate.v",
+        "warnings": [
+            "AST if_generate.v:8 Odin does not handle signed GENVAR (i)",
+            "AST if_generate.v:9 Odin does not handle signed GENVAR (j)"
+        ],
         "max_rss(MiB)": 18.5,
         "exec_time(ms)": 12.7,
         "synthesis_time(ms)": 11.6,

--- a/ODIN_II/regression_test/benchmark/task/syntax/synthesis_result.json
+++ b/ODIN_II/regression_test/benchmark/task/syntax/synthesis_result.json
@@ -3,6 +3,9 @@
         "test_name": "syntax/8_bit_for_pass_through/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "8_bit_for_pass_through.v",
+        "warnings": [
+            "AST 8_bit_for_pass_through.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 26.8,
         "exec_time(ms)": 51.8,
         "synthesis_time(ms)": 5.3,
@@ -24,6 +27,9 @@
         "test_name": "syntax/8_bit_for_pass_through_module/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "8_bit_for_pass_through_module.v",
+        "warnings": [
+            "AST 8_bit_for_pass_through_module.v:5 Odin does not handle signed GENVAR (i)"
+        ],
         "max_rss(MiB)": 28.8,
         "exec_time(ms)": 44.5,
         "synthesis_time(ms)": 7.2,
@@ -44,6 +50,9 @@
     "syntax/8_bit_for_pass_through_module/no_arch": {
         "test_name": "syntax/8_bit_for_pass_through_module/no_arch",
         "verilog": "8_bit_for_pass_through_module.v",
+        "warnings": [
+            "AST 8_bit_for_pass_through_module.v:5 Odin does not handle signed GENVAR (i)"
+        ],
         "max_rss(MiB)": 16,
         "exec_time(ms)": 9.8,
         "synthesis_time(ms)": 8.4,
@@ -60,6 +69,9 @@
     "syntax/8_bit_for_pass_through/no_arch": {
         "test_name": "syntax/8_bit_for_pass_through/no_arch",
         "verilog": "8_bit_for_pass_through.v",
+        "warnings": [
+            "AST 8_bit_for_pass_through.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 13.6,
         "exec_time(ms)": 10.4,
         "synthesis_time(ms)": 8.4,
@@ -77,6 +89,9 @@
         "test_name": "syntax/8_bit_for_pass_through_off_by_1/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "8_bit_for_pass_through_off_by_1.v",
+        "warnings": [
+            "AST 8_bit_for_pass_through_off_by_1.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 27.8,
         "exec_time(ms)": 54.8,
         "synthesis_time(ms)": 6.5,
@@ -97,6 +112,9 @@
     "syntax/8_bit_for_pass_through_off_by_1/no_arch": {
         "test_name": "syntax/8_bit_for_pass_through_off_by_1/no_arch",
         "verilog": "8_bit_for_pass_through_off_by_1.v",
+        "warnings": [
+            "AST 8_bit_for_pass_through_off_by_1.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 15.2,
         "exec_time(ms)": 8.9,
         "synthesis_time(ms)": 7.5,
@@ -599,6 +617,9 @@
         "test_name": "syntax/complex_post_for_loop/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "complex_post_for_loop.v",
+        "warnings": [
+            "AST complex_post_for_loop.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 26.9,
         "exec_time(ms)": 49.6,
         "synthesis_time(ms)": 5.5,
@@ -619,6 +640,9 @@
     "syntax/complex_post_for_loop/no_arch": {
         "test_name": "syntax/complex_post_for_loop/no_arch",
         "verilog": "complex_post_for_loop.v",
+        "warnings": [
+            "AST complex_post_for_loop.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 13.8,
         "exec_time(ms)": 7.3,
         "synthesis_time(ms)": 5.9,
@@ -672,11 +696,10 @@
         "verilog": "deassign.v",
         "exit": 134,
         "errors": [
-            "PARSE_TO_AST Parser found (2) errors in your syntax, exiting"
+            "PARSE_TO_AST Parser found (1) errors in your syntax, exiting"
         ],
         "warnings": [
-            "PARSE_TO_AST deassign.v:21 Unsuported token",
-            "PARSE_TO_AST deassign.v:21 error in parsing: (syntax error, unexpected ';', expecting voLTE or '=')"
+            "PARSE_TO_AST deassign.v:21 error in parsing: (syntax error, unexpected vDEASSIGN)"
         ]
     },
     "syntax/deassign/no_arch": {
@@ -684,11 +707,10 @@
         "verilog": "deassign.v",
         "exit": 134,
         "errors": [
-            "PARSE_TO_AST Parser found (2) errors in your syntax, exiting"
+            "PARSE_TO_AST Parser found (1) errors in your syntax, exiting"
         ],
         "warnings": [
-            "PARSE_TO_AST deassign.v:21 Unsuported token",
-            "PARSE_TO_AST deassign.v:21 error in parsing: (syntax error, unexpected ';', expecting voLTE or '=')"
+            "PARSE_TO_AST deassign.v:21 error in parsing: (syntax error, unexpected vDEASSIGN)"
         ]
     },
     "syntax/delay_syntax/k6_frac_N10_frac_chain_mem32K_40nm": {
@@ -893,6 +915,9 @@
         "test_name": "syntax/for_loop_adv_post/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "for_loop_adv_post.v",
+        "warnings": [
+            "AST for_loop_adv_post.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 26.2,
         "exec_time(ms)": 48.7,
         "synthesis_time(ms)": 3.8,
@@ -913,6 +938,9 @@
     "syntax/for_loop_adv_post/no_arch": {
         "test_name": "syntax/for_loop_adv_post/no_arch",
         "verilog": "for_loop_adv_post.v",
+        "warnings": [
+            "AST for_loop_adv_post.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 13,
         "exec_time(ms)": 5.8,
         "synthesis_time(ms)": 4.4,
@@ -930,6 +958,9 @@
         "test_name": "syntax/for_loop_adv_pre/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "for_loop_adv_pre.v",
+        "warnings": [
+            "AST for_loop_adv_pre.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 26.9,
         "exec_time(ms)": 49.5,
         "synthesis_time(ms)": 5.2,
@@ -950,6 +981,9 @@
     "syntax/for_loop_adv_pre/no_arch": {
         "test_name": "syntax/for_loop_adv_pre/no_arch",
         "verilog": "for_loop_adv_pre.v",
+        "warnings": [
+            "AST for_loop_adv_pre.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 13.7,
         "exec_time(ms)": 7.2,
         "synthesis_time(ms)": 5.9,
@@ -1053,7 +1087,9 @@
         ],
         "warnings": [
             "PARSE_TO_AST function_hdr.v:14 error in parsing: (syntax error, unexpected vINT_NUMBER, expecting vSYMBOL_ID or '{')",
-            "AST function_hdr.vh:13 ODIN_II does not fully support input/output integers in functions"
+            "AST function_hdr.v:15 Odin does not handle signed REG (output_int)",
+            "AST function_hdr.vh:2 Odin does not handle signed REG (func_out)",
+            "AST function_hdr.vh:5 Odin does not handle signed REG (test_int)"
         ]
     },
     "syntax/function_hdr/no_arch": {
@@ -1065,7 +1101,9 @@
         ],
         "warnings": [
             "PARSE_TO_AST function_hdr.v:14 error in parsing: (syntax error, unexpected vINT_NUMBER, expecting vSYMBOL_ID or '{')",
-            "AST function_hdr.vh:13 ODIN_II does not fully support input/output integers in functions"
+            "AST function_hdr.v:15 Odin does not handle signed REG (output_int)",
+            "AST function_hdr.vh:2 Odin does not handle signed REG (func_out)",
+            "AST function_hdr.vh:5 Odin does not handle signed REG (test_int)"
         ]
     },
     "syntax/function_syntax/k6_frac_N10_frac_chain_mem32K_40nm": {
@@ -1105,6 +1143,9 @@
         "test_name": "syntax/h7_of_8_bit_for_pass_through/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "h7_of_8_bit_for_pass_through.v",
+        "warnings": [
+            "AST h7_of_8_bit_for_pass_through.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 26.8,
         "exec_time(ms)": 45,
         "synthesis_time(ms)": 4.3,
@@ -1125,6 +1166,9 @@
     "syntax/h7_of_8_bit_for_pass_through/no_arch": {
         "test_name": "syntax/h7_of_8_bit_for_pass_through/no_arch",
         "verilog": "h7_of_8_bit_for_pass_through.v",
+        "warnings": [
+            "AST h7_of_8_bit_for_pass_through.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 13.4,
         "exec_time(ms)": 6.5,
         "synthesis_time(ms)": 5.2,
@@ -1582,6 +1626,9 @@
         "test_name": "syntax/l2_and_h2_of_8_bit_for_pass_through/k6_frac_N10_frac_chain_mem32K_40nm",
         "architecture": "k6_frac_N10_frac_chain_mem32K_40nm.xml",
         "verilog": "l2_and_h2_of_8_bit_for_pass_through.v",
+        "warnings": [
+            "AST l2_and_h2_of_8_bit_for_pass_through.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 26.4,
         "exec_time(ms)": 47.4,
         "synthesis_time(ms)": 4,
@@ -1602,6 +1649,9 @@
     "syntax/l2_and_h2_of_8_bit_for_pass_through/no_arch": {
         "test_name": "syntax/l2_and_h2_of_8_bit_for_pass_through/no_arch",
         "verilog": "l2_and_h2_of_8_bit_for_pass_through.v",
+        "warnings": [
+            "AST l2_and_h2_of_8_bit_for_pass_through.v:11 Odin does not handle signed REG (i)"
+        ],
         "max_rss(MiB)": 13,
         "exec_time(ms)": 5.8,
         "synthesis_time(ms)": 4.4,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR:
- add the ieee_std verification before passing over tokens in flex
- completes the reserved keyword support,

TODO:
- add c functions support

#### Motivation and Context
verilog 2005 support

#### How Has This Been Tested?
no new test was added since this does not ast support.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
