### PR TITLE
Vtr flow failure fix

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -110,23 +110,22 @@ class CommandRunner:
 
         # Enable memory tracking?
         memory_tracking = ["/usr/bin/env", "time", "-v"]
-        if self._track_memory and check_cmd(memory_tracking[0]):
-            cmd = (
-                memory_tracking
-                + [
-                    "valgrind",
-                    "--leak-check=full",
-                    "--suppressions={}".format(find_vtr_file("valgrind.supp")),
-                    "--error-exitcode=1",
-                    "--errors-for-leak-kinds=none",
-                    "--track-origins=yes",
-                    "--log-file=valgrind.log",
-                    "--error-limit=no",
-                ]
-                + cmd
-                if self._valgrind
-                else memory_tracking + cmd
-            )
+        cmd = (
+            memory_tracking
+            + [
+                "valgrind",
+                "--leak-check=full",
+                "--suppressions={}".format(find_vtr_file("valgrind.supp")),
+                "--error-exitcode=1",
+                "--errors-for-leak-kinds=none",
+                "--track-origins=yes",
+                "--log-file=valgrind.log",
+                "--error-limit=no",
+            ]
+            + cmd
+            if self._valgrind
+            else memory_tracking + cmd
+            ) if self._track_memory and check_cmd(memory_tracking[0]) else cmd
 
         # Flush before calling subprocess to ensure output is ordered
         # correctly if stdout is buffered
@@ -195,12 +194,12 @@ class CommandRunner:
         # Send to stdout
         if self._show_failures and self._verbose:
             for line in cmd_output:
-                print(indent_depth * self._indent + line,end="")
+                print(indent_depth * self._indent + line, end="")
 
         if self._show_failures and cmd_errored:
-            print("\nFailed log file follows ({}):".format(str((Path(temp_dir) / log_filename).resolve())))
+            print("\nFailed log file follows({}):".format(str((temp_dir / log_filename).resolve())))
             for line in cmd_output:
-                print(indent_depth * self._indent + "<" + line,end="")
+                print(indent_depth * self._indent + "<" + line, end="")
             raise CommandError(
                 "Executable {exec_name} failed".format(
                     exec_name=PurePath(orig_cmd[0]).name

--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -153,7 +153,7 @@ class CommandRunner:
                 stdout=subprocess.PIPE,  # We grab stdout
                 stderr=stderr,  # stderr redirected to stderr
                 universal_newlines=True,  # Lines always end in \n
-                cwd=str(temp_dir),  # Where to run the command
+                cwd=str(temp_dir)  # Where to run the command
             )
 
             # Read the output line-by-line and log it

--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -87,7 +87,7 @@ class CommandRunner:
             temp_dir: The directory to run the command in. Default: None (uses object default).
             expected_return_code: The expected return code from the command.
             If the actula return code does not match, will generate an exception. Default: 0
-            indent_depth: How deep to indent the tool output in verbose mode. Default 0
+            indent_depth: How deep to indent the tool output in verbose mode. Default: 0
         """
         # Save the original command
         orig_cmd = cmd

--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -111,21 +111,25 @@ class CommandRunner:
         # Enable memory tracking?
         memory_tracking = ["/usr/bin/env", "time", "-v"]
         cmd = (
-            memory_tracking
-            + [
-                "valgrind",
-                "--leak-check=full",
-                "--suppressions={}".format(find_vtr_file("valgrind.supp")),
-                "--error-exitcode=1",
-                "--errors-for-leak-kinds=none",
-                "--track-origins=yes",
-                "--log-file=valgrind.log",
-                "--error-limit=no",
-            ]
-            + cmd
-            if self._valgrind
-            else memory_tracking + cmd
-            ) if self._track_memory and check_cmd(memory_tracking[0]) else cmd
+            (
+                memory_tracking
+                + [
+                    "valgrind",
+                    "--leak-check=full",
+                    "--suppressions={}".format(find_vtr_file("valgrind.supp")),
+                    "--error-exitcode=1",
+                    "--errors-for-leak-kinds=none",
+                    "--track-origins=yes",
+                    "--log-file=valgrind.log",
+                    "--error-limit=no",
+                ]
+                + cmd
+                if self._valgrind
+                else memory_tracking + cmd
+            )
+            if self._track_memory and check_cmd(memory_tracking[0])
+            else cmd
+        )
 
         # Flush before calling subprocess to ensure output is ordered
         # correctly if stdout is buffered
@@ -197,7 +201,11 @@ class CommandRunner:
                 print(indent_depth * self._indent + line, end="")
 
         if self._show_failures and cmd_errored:
-            print("\nFailed log file follows({}):".format(str((temp_dir / log_filename).resolve())))
+            print(
+                "\nFailed log file follows({}):".format(
+                    str((temp_dir / log_filename).resolve())
+                )
+            )
             for line in cmd_output:
                 print(indent_depth * self._indent + "<" + line, end="")
             raise CommandError(
@@ -213,7 +221,7 @@ class CommandRunner:
                 "{}".format(PurePath(orig_cmd[0]).name),
                 cmd=cmd,
                 log=str(temp_dir / log_filename),
-                returncode=cmd_returncode
+                returncode=cmd_returncode,
             )
         return cmd_output, cmd_returncode
 

--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -121,7 +121,7 @@ class CommandRunner:
                     "--errors-for-leak-kinds=none",
                     "--track-origins=yes",
                     "--log-file=valgrind.log",
-                    "--error-limit=no",
+                    "--error-limit=no"
                 ]
                 + cmd
                 if self._valgrind


### PR DESCRIPTION
Expected failures now work when show failure is off.

#### Description
From the below issue, expected failure tests were failing if the show failures tag was not included. This has been fixed. In addition a regressed issue with error reporting has been fixed in conjunction with the show failures tag. 

#### Related Issue
[This is the issue ](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1459)that has been fixed

#### Motivation and Context
The vtr_flow should be able to expect failure when show failure is off. 

#### How Has This Been Tested?
Regression tests run with show_failure and without.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
