### PR TITLE
Avoid strcpy inside of atom netlist.

### DIFF
--- a/vpr/src/base/atom_netlist.cpp
+++ b/vpr/src/base/atom_netlist.cpp
@@ -17,20 +17,33 @@
  *
  */
 AtomNetlist::AtomNetlist(std::string name, std::string id)
-    : Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId>(name, id) {}
+    : Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId>(name, id)
+    , inpad_model_(nullptr)
+    , outpad_model_(nullptr) {}
 
 /*
  *
  * Blocks
  *
  */
+void AtomNetlist::set_block_types(const t_model* inpad, const t_model* outpad) {
+    VTR_ASSERT(inpad != nullptr);
+    VTR_ASSERT(outpad != nullptr);
+
+    inpad_model_ = inpad;
+    outpad_model_ = outpad;
+}
+
 AtomBlockType AtomNetlist::block_type(const AtomBlockId id) const {
+    VTR_ASSERT(inpad_model_ != nullptr);
+    VTR_ASSERT(outpad_model_ != nullptr);
+
     const t_model* blk_model = block_model(id);
 
     AtomBlockType type = AtomBlockType::BLOCK;
-    if (blk_model->name == std::string(MODEL_INPUT)) {
+    if (blk_model == inpad_model_) {
         type = AtomBlockType::INPAD;
-    } else if (blk_model->name == std::string(MODEL_OUTPUT)) {
+    } else if (blk_model == outpad_model_) {
         type = AtomBlockType::OUTPAD;
     } else {
         type = AtomBlockType::BLOCK;

--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -87,6 +87,9 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
      */
     AtomNetlist(std::string name = "", std::string id = "");
 
+    AtomNetlist(const AtomNetlist& rhs) = default;
+    AtomNetlist& operator=(const AtomNetlist& rhs) = default;
+
   public: //Public types
     typedef std::vector<std::vector<vtr::LogicValue>> TruthTable;
 
@@ -94,6 +97,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     /*
      * Blocks
      */
+    void set_block_types(const t_model* inpad, const t_model* outpad);
 
     ///@brief Returns the type of the specified block
     AtomBlockType block_type(const AtomBlockId id) const;
@@ -256,6 +260,14 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     //Block data
     vtr::vector_map<AtomBlockId, const t_model*> block_models_;   //Architecture model of each block
     vtr::vector_map<AtomBlockId, TruthTable> block_truth_tables_; //Truth tables of each block
+
+    // Input IOs and output IOs always exist and have their own architecture
+    // models. While their models are already included in block_models_, we
+    // also store direct pointers to them to make checks of whether a block is
+    // an INPAD or OUTPAD fast, as such checks are common in some netlist
+    // operations (e.g. clean-up of an input netlist).
+    const t_model* inpad_model_;
+    const t_model* outpad_model_;
 
     //Port data
     vtr::vector_map<AtomPortId, const t_model_ports*> port_models_; //Architecture port models of each port

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -51,6 +51,10 @@ struct BlifAllocCallback : public blifparse::Callback {
         , blif_format_(blif_format) {
         VTR_ASSERT(blif_format_ == e_circuit_format::BLIF
                    || blif_format_ == e_circuit_format::EBLIF);
+        inpad_model_ = find_model(MODEL_INPUT);
+        outpad_model_ = find_model(MODEL_OUTPUT);
+
+        main_netlist_.set_block_types(inpad_model_, outpad_model_);
     }
 
     static constexpr const char* OUTPAD_NAME_PREFIX = "out:";
@@ -70,6 +74,7 @@ struct BlifAllocCallback : public blifparse::Callback {
         //Create a new model, and set it's name
 
         blif_models_.emplace_back(model_name, netlist_id_);
+        blif_models_.back().set_block_types(inpad_model_, outpad_model_);
         blif_models_black_box_.emplace_back(false);
         ended_ = false;
         set_curr_block(AtomBlockId::INVALID()); //This statement doesn't define a block, so mark invalid
@@ -629,6 +634,8 @@ struct BlifAllocCallback : public blifparse::Callback {
     const std::string netlist_id_; ///<Unique identifier based on the contents of the blif file
     const t_model* user_arch_models_ = nullptr;
     const t_model* library_arch_models_ = nullptr;
+    const t_model* inpad_model_;
+    const t_model* outpad_model_;
 
     size_t unique_subckt_name_counter_ = 0;
 


### PR DESCRIPTION
#### Description

Saves around 20 out of 30 seconds in circuit cleaning on baselitex 7-series flow per VPR invocation.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context

We've noticed that the circuit cleaning time was large relative to the overall runtime (30 seconds into 120 second total run).  A profile run showed about 20 seconds being spent in a simple string copy to determine if a model is either inpad/outpad.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
