### PR TITLE
Adding suppression file to the new vtr-flow.py

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
+++ b/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
@@ -140,7 +140,7 @@ def run(
         temp_dir=Path("."),
         log_filename="vpr.out",
         vpr_exec=None,
-        vpr_args=None,
+        vpr_args=None
 ):
     """
     Runs VPR with the specified configuration

--- a/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
+++ b/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
@@ -3,6 +3,7 @@
 """
 from collections import OrderedDict
 from pathlib import Path
+from os import environ
 from vtr import (
     find_vtr_file,
     CommandRunner,
@@ -214,6 +215,14 @@ def run(
                     cmd += [str(item)]
             else:
                 cmd += ["--" + arg, str(value)]
+
+    #Extra options to fine-tune LeakSanitizer (LSAN) behaviour.
+    #Note that if VPR was compiled without LSAN these have no effect
+    # 'suppressions=...' Add the LeakSanitizer (LSAN) suppression file
+    # 'exitcode=12' Use a consistent exitcode (on some systems LSAN don't use the default exit code of 23)
+    # 'fast_unwind_on_malloc=0' Provide more accurate leak stack traces
+
+    environ["LSAN_OPTIONS"] = "suppressions={} exitcode=23 fast_unwind_on_malloc=0".format(find_vtr_file("lsan.supp"))\
 
     command_runner.run_system_command(
         cmd, temp_dir=temp_dir, log_filename=log_filename, indent_depth=1

--- a/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
+++ b/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
@@ -219,10 +219,13 @@ def run(
     #Extra options to fine-tune LeakSanitizer (LSAN) behaviour.
     #Note that if VPR was compiled without LSAN these have no effect
     # 'suppressions=...' Add the LeakSanitizer (LSAN) suppression file
-    # 'exitcode=12' Use a consistent exitcode (on some systems LSAN don't use the default exit code of 23)
+    # 'exitcode=12' Use a consistent exitcode
+    # (on some systems LSAN don't use the default exit code of 23)
     # 'fast_unwind_on_malloc=0' Provide more accurate leak stack traces
 
-    environ["LSAN_OPTIONS"] = "suppressions={} exitcode=23 fast_unwind_on_malloc=0".format(find_vtr_file("lsan.supp"))\
+    environ["LSAN_OPTIONS"] = (
+        "suppressions={} exitcode=23 fast_unwind_on_malloc=0".format(find_vtr_file("lsan.supp"))
+        )
 
     command_runner.run_system_command(
         cmd, temp_dir=temp_dir, log_filename=log_filename, indent_depth=1


### PR DESCRIPTION
The suppression file has now been added to the new run_vtr_flow.py 
#### Description
The old perl script included a suppression file to suppress various memory leak errors when sanitizing was enabled.  This functionality was missed in the initial conversion of run_vtr_flow to python but it is being implemented here. 

#### Related Issue
Should fix [this issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1470)
This could possibly fix [this issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1478)

#### Motivation and Context
Memory leaks in the vtr_reg_strong tests come up when sanitizing is enabled. This occurs mainly on the tests mentioned in the above issues. This causes some CI tests to fail on master.

#### How Has This Been Tested?
I unfortunately have been unable to reproduce the errors locally and am unable to test this fully. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
