### PR TITLE
Added block information for the IPIN/OPIN grid location in the overuse report

### DIFF
--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -722,7 +722,7 @@ struct t_grid_blocks {
      * occupied by a block at this grid location. The subtile id serves
      * as the z-dimensional offset in the grid indexing.
      */
-    inline bool subtile_empty(size_t isubtile) {
+    inline bool subtile_empty(size_t isubtile) const {
         return blocks[isubtile] == EMPTY_BLOCK_ID;
     }
 };

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -706,8 +706,25 @@ struct t_block_loc {
 
 ///@brief Stores the clustered blocks placed at a particular grid location
 struct t_grid_blocks {
-    int usage;                          ///<How many valid blocks are in use at this location
-    std::vector<ClusterBlockId> blocks; ///<The clustered blocks associated with this grid location
+    int usage; ///<How many valid blocks are in use at this location
+
+    /**
+     * @brief The clustered blocks associated with this grid location.
+     *
+     * Index range: [0..device_ctx.grid[x_loc][y_loc].type->capacity]
+     */
+    std::vector<ClusterBlockId> blocks;
+
+    /**
+     * @brief Test if a subtile at a grid location is occupied by a block.
+     *
+     * Returns true if the subtile corresponds to the passed-in id is not
+     * occupied by a block at this grid location. The subtile id serves
+     * as the z-dimensional offset in the grid indexing.
+     */
+    inline bool subtile_empty(size_t isubtile) {
+        return blocks[isubtile] == EMPTY_BLOCK_ID;
+    }
 };
 
 ///@brief Names of various files

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -55,6 +55,8 @@ void log_overused_nodes_status(int max_logged_overused_rr_nodes) {
  *
  * Print all the overused RR nodes' info in the report file report_overused_nodes.rpt.
  * The report generation is turned on by the VPR option: --generate_rr_node_overuse_report on.
+ * This report will be generated only if the last routing attempt fails, which
+ * causes the whole VPR flow to fail.
  */
 void report_overused_nodes() {
     const auto& device_ctx = g_vpr_ctx.device();
@@ -166,9 +168,9 @@ static void report_overused_ipin_opin(std::ostream& os, RRNodeId node_id) {
     os << "Number of blocks currently occupying this grid location = " << grid_info.usage << '\n';
 
     size_t iblock = 0;
-    for (size_t isubtile = 0; isubtile < grid_blocks.size(); ++isubtile) {
-        //Check if the block is empty
-        if (grid_info.subtile_empty[isubtile]) {
+    for (size_t isubtile = 0; isubtile < grid_info.blocks.size(); ++isubtile) {
+        //Check if there is a valid block at this subtile location
+        if (grid_info.subtile_empty(isubtile)) {
             continue;
         }
 

--- a/vpr/src/route/overuse_report.h
+++ b/vpr/src/route/overuse_report.h
@@ -3,6 +3,25 @@
 #include "rr_graph_storage.h"
 #include <map>
 
+/**
+ * @brief Global routines related to displaying RR node overuse info.
+ *
+ * This file contains all the routines that print out the information on overused RR nodes
+ * and congested nets. The main purpose of these routines is to aid the debugging process
+ * should the VPR fail to implement the circuit. Functionalities that resolve these circuit
+ * issues should NOT be included here or in overuse_report.cpp
+ *
+ * An RR node is overused when the number of nets passing through it exceed the node's
+ * routing net capacity. A successfully routed circuit is void of these overused nodes.
+ *
+ * All the nets passing through an overused RR node are flagged as congested nets.
+ */
+
+///@brief Print out RR node overuse info in the VPR logfile.
 void log_overused_nodes_status(int max_logged_overused_rr_nodes);
+
+///@brief Print out RR node overuse info in a post-VPR report file.
 void report_overused_nodes();
+
+///@brief Generate a overused RR nodes to congested nets lookup table.
 void generate_overused_nodes_to_congested_net_lookup(std::map<RRNodeId, std::set<ClusterNetId>>& nodes_to_nets_lookup);


### PR DESCRIPTION

#### Related Issue
#1467 

#### Example report
[ipin_report.txt](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/5099061/ipin_report.txt)

#### Reproduce
1. cd to the VTR root directory
2. ./vtr_flow/scripts/run_vtr_flow.pl ./vtr_flow/benchmarks/verilog/diffeq2.v ./vtr_flow/arch/timing/k6_frac_N10_frac_chain_mem32K_40nm.xml -crit_path_router_iterations 100 --max_logged_overused_rr_nodes 50 --route_chan_width 32 --generate_rr_node_overuse_report on -temp_dir report_test
3. ls report_test/report_overused_nodes.rpt

#### Note
I added block information for OPINs as well. If this is not desired, I'll discard this feature.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
