### PR TITLE
Odin: fix extraneous semi colon warning

### DIFF
--- a/ODIN_II/SRC/include/MixingOptimization.hpp
+++ b/ODIN_II/SRC/include/MixingOptimization.hpp
@@ -35,7 +35,7 @@ class MixingOpt {
      * @brief Construct a new Mixing Opt object for disabled optimization
      * usable for querying 'hardenable' condition
      */
-    MixingOpt() { _enabled = false; };
+    MixingOpt() { _enabled = false; }
 
     /**
      * @brief Construct a new Mixing Opt object
@@ -52,7 +52,7 @@ class MixingOpt {
     MixingOpt(float ratio, operation_list kind)
         : _kind(kind) {
         _ratio = ratio;
-    };
+    }
 
     /**
      * @brief Destroy the Mixing Opt object
@@ -158,7 +158,7 @@ class MultsOpt : public MixingOpt {
      * usable for querying 'hardenable' condition
      */
     MultsOpt()
-        : MixingOpt(){};
+        : MixingOpt() {}
 
     /**
      * @brief Construct a new Mults Opt object

--- a/ODIN_II/SRC/include/netlist_statistic.h
+++ b/ODIN_II/SRC/include/netlist_statistic.h
@@ -4,7 +4,7 @@
 #include "netlist_utils.h"
 
 static const unsigned int traversal_id = 0;
-static const uintptr_t mult_optimization_traverse_value = (const uintptr_t)&traversal_id;
+static const uintptr_t mult_optimization_traverse_value = (uintptr_t)&traversal_id;
 
 stat_t* get_stats(signal_list_t* input_signals, signal_list_t* output_signals, netlist_t* netlist, uintptr_t traverse_mark_number);
 stat_t* get_stats(nnode_t** node_list, long long node_count, netlist_t* netlist, uintptr_t traverse_mark_number);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
warnings are thrown on gcc 10.0.1

```
../ODIN_II/SRC/include/MixingOptimization.hpp:38:38: warning: extra ';' after in-class function definition [-Wextra-semi]
   38 |     MixingOpt() { _enabled = false; };
      |                                      ^
      |                                      -
../ODIN_II/SRC/include/MixingOptimization.hpp:55:6: warning: extra ';' after in-class function definition [-Wextra-semi]
   55 |     };
      |      ^
      |      -
../ODIN_II/SRC/include/MixingOptimization.hpp:161:24: warning: extra ';' after in-class function definition [-Wextra-semi]
  161 |         : MixingOpt(){};
      |                        ^
      |                        -
In file included from ../ODIN_II/SRC/MixingOptimization.cpp:29:
../ODIN_II/SRC/include/netlist_statistic.h:7:59: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
    7 | static const uintptr_t mult_optimization_traverse_value = (const uintptr_t)&traversal_id;
```

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
