### PR TITLE
librtl: add bufifs and fix strings

### DIFF
--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -597,7 +597,7 @@ ast_node_t* build_hierarchy(ast_node_t* node, ast_node_t* parent, int index, sc_
                     if (!(node_is_constant(node->children[0]))) {
                         error_message(AST, node->loc,
                                       "%s", "Replication constant must be a constant expression");
-                    } else if (node->children[0]->types.vnumber->is_dont_care_string()) {
+                    } else if (node->children[0]->types.vnumber->has_unknown()) {
                         error_message(AST, node->loc,
                                       "%s", "Replication constant cannot contain x or z");
                     }
@@ -1326,7 +1326,7 @@ ast_node_t* finalize_ast(ast_node_t* node, ast_node_t* parent, sc_hierarchy* loc
                 if (!(node_is_constant(node->children[0]))) {
                     error_message(AST, node->loc,
                                   "%s", "Replication constant must be a constant expression");
-                } else if (node->children[0]->types.vnumber->is_dont_care_string()) {
+                } else if (node->children[0]->types.vnumber->has_unknown()) {
                     error_message(AST, node->loc,
                                   "%s", "Replication constant cannot contain x or z");
                 }
@@ -1700,12 +1700,12 @@ ast_node_t* finalize_ast(ast_node_t* node, ast_node_t* parent, sc_hierarchy* loc
             case RANGE_REF: {
                 bool is_constant_ref = node_is_constant(node->children[0]);
                 if (is_constant_ref) {
-                    is_constant_ref = is_constant_ref && !(node->children[0]->types.vnumber->is_dont_care_string());
+                    is_constant_ref = is_constant_ref && !(node->children[0]->types.vnumber->has_unknown());
                 }
 
                 is_constant_ref = is_constant_ref && node_is_constant(node->children[1]);
                 if (is_constant_ref) {
-                    is_constant_ref = is_constant_ref && !(node->children[1]->types.vnumber->is_dont_care_string());
+                    is_constant_ref = is_constant_ref && !(node->children[1]->types.vnumber->has_unknown());
                 }
 
                 if (!is_constant_ref) {
@@ -1721,13 +1721,13 @@ ast_node_t* finalize_ast(ast_node_t* node, ast_node_t* parent, sc_hierarchy* loc
             case ARRAY_REF: {
                 bool is_constant_ref = node_is_constant(node->children[0]);
                 if (is_constant_ref) {
-                    is_constant_ref = is_constant_ref && !(node->children[0]->types.vnumber->is_dont_care_string());
+                    is_constant_ref = is_constant_ref && !(node->children[0]->types.vnumber->has_unknown());
                 }
 
                 if (node->num_children == 2) {
                     is_constant_ref = is_constant_ref && node_is_constant(node->children[1]);
                     if (is_constant_ref) {
-                        is_constant_ref = is_constant_ref && !(node->children[1]->types.vnumber->is_dont_care_string());
+                        is_constant_ref = is_constant_ref && !(node->children[1]->types.vnumber->has_unknown());
                     }
                 }
 

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -1389,7 +1389,7 @@ void c_display(ast_node_t* node) {
      * but we will just assume, the programmer should know to use a string
      * and internally both are just numbers
      */
-    std::string format_str = node->children[0]->types.vnumber->to_printable();
+    std::string format_str = node->children[0]->types.vnumber->to_vstring('s');
     ast_node_t* argv_nodes = node->children[1];
     long argc_node = 0;
     while (!format_str.empty()) {

--- a/libs/librtlnumber/main.cpp
+++ b/libs/librtlnumber/main.cpp
@@ -26,12 +26,25 @@ inline static std::string _bad_ops(std::string test, const char* FUNCT, int LINE
  *                                                             
  * 	This is used for testing purposes only, unused in ODIN as the input is already preprocessed
  */
-
 static std::string arithmetic(std::string op, std::string a_in) {
     VNumber a(a_in);
     VNumber result;
 
-    if (op == "to_unsigned") {
+    if (op == "is_true") {
+        result = VNumber(V_TRUE(a));
+    } else if (op == "is_false") {
+        result = VNumber(V_FALSE(a));
+    } else if (op == "is_unk") {
+        result = VNumber(V_UNK(a));
+    } else if (op == "is_x") {
+        result = VNumber(V_IS_X(a));
+    } else if (op == "is_z") {
+        result = VNumber(V_IS_Z(a));
+    } else if (op == "is_unsigned") {
+        result = VNumber(V_IS_UNSIGNED(a));
+    } else if (op == "is_signed") {
+        result = VNumber(V_IS_SIGNED(a));
+    } else if (op == "to_unsigned") {
         result = V_UNSIGNED(a);
     } else if (op == "to_signed") {
         result = V_SIGNED(a);
@@ -59,7 +72,7 @@ static std::string arithmetic(std::string op, std::string a_in) {
         bad_ops(op);
     }
 
-    return result.to_full_string();
+    return result.to_verilog_bitstring();
 }
 
 static std::string arithmetic(std::string a_in, std::string op, std::string b_in) {
@@ -123,7 +136,7 @@ static std::string arithmetic(std::string a_in, std::string op, std::string b_in
         bad_ops(op);
     }
 
-    return result.to_full_string();
+    return result.to_verilog_bitstring();
 }
 
 int main(int argc, char** argv) {
@@ -137,88 +150,45 @@ int main(int argc, char** argv) {
         ERR_MSG("Not Enough Arguments: " << std::to_string(argc - 1));
 
         return -1;
-    } else if (argc == 3 && input[1] == "is_true") {
-        VNumber input_2(input[2]);
-
-        if (V_TRUE(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "is_false") {
-        VNumber input_2(input[2]);
-
-        if (V_FALSE(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "is_unk") {
-        VNumber input_2(input[2]);
-
-        if (V_UNK(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "is_x") {
-        VNumber input_2(input[2]);
-
-        if (V_IS_X(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "is_z") {
-        VNumber input_2(input[2]);
-
-        if (V_IS_Z(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "is_unsigned") {
-        VNumber input_2(input[2]);
-
-        if (V_IS_UNSIGNED(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "is_signed") {
-        VNumber input_2(input[2]);
-
-        if (V_IS_SIGNED(input_2)) {
-            result = "pass";
-        } else {
-            result = "fail";
-        }
-    } else if (argc == 3 && input[1] == "display") {
-        VNumber input_2(input[2]);
-
-        result = V_STRING(input_2);
     } else if (argc == 3) {
         result = arithmetic(input[1], input[2]);
+    } else if (argc == 4 && input[1] == "display") {
+        VNumber a(input[3]);
+        result = V_STRING(a, input[2][0]);
+    } else if (argc == 4 && input[1] == "bufif0") {
+        VNumber bus(input[2]);
+        VNumber trigger(input[3]);
+        result = V_BITWISE_BUFIF0(bus, trigger).to_verilog_bitstring();
+    } else if (argc == 4 && input[1] == "bufif1") {
+        VNumber bus(input[2]);
+        VNumber trigger(input[3]);
+        result = V_BITWISE_BUFIF1(bus, trigger).to_verilog_bitstring();
+    } else if (argc == 4 && input[1] == "notif0") {
+        VNumber bus(input[2]);
+        VNumber trigger(input[3]);
+        result = V_BITWISE_NOTIF0(bus, trigger).to_verilog_bitstring();
+    } else if (argc == 4 && input[1] == "notif1") {
+        VNumber bus(input[2]);
+        VNumber trigger(input[3]);
+        result = V_BITWISE_NOTIF1(bus, trigger).to_verilog_bitstring();
     } else if (argc == 4) {
         result = arithmetic(input[1], input[2], input[3]);
-
     } else if (argc == 6 && (input[2] == "?" && input[4] == ":")) {
         VNumber a(input[1]);
         VNumber b(input[3]);
         VNumber c(input[5]);
 
-        result = V_TERNARY(a, b, c).to_full_string();
-    } else if (argc == 6 && (input[1] == "{" && input[3] == "," && input[5] == "}")) // the pipe symbol is a hack since our test handle uses csv.
-    {
+        result = V_TERNARY(a, b, c).to_verilog_bitstring();
+    } else if (argc == 6 && (input[1] == "{" && input[3] == "," && input[5] == "}")) {
         VNumber a(input[2]);
         VNumber b(input[4]);
 
-        result = V_CONCAT({a, b}).to_full_string();
+        result = V_CONCAT({a, b}).to_verilog_bitstring();
     } else if (argc == 7 && (input[1] == "{" && input[3] == "{" && input[5] == "}" && input[6] == "}")) {
         VNumber n_times(input[2]);
         VNumber replicant(input[4]);
 
-        result = V_REPLICATE(replicant, n_times).to_full_string();
+        result = V_REPLICATE(replicant, n_times).to_verilog_bitstring();
     } else {
         ERR_MSG("invalid Arguments: " << std::to_string(argc - 1));
         return -1;

--- a/libs/librtlnumber/regression_tests/basic_regression_tests.csv
+++ b/libs/librtlnumber/regression_tests/basic_regression_tests.csv
@@ -8,34 +8,34 @@
 #####################
 
 # truth test
-simple_true,        is_true, 1'b1, pass
-simple_fail,        is_true, 1'b0, fail
-decimal_true,       is_true, 1, pass
-decimal_fail,       is_true, 0, fail
-complex_true,       is_true, 3'b1xz, pass
-complex_fail,       is_true, 3'b0xz, fail
-unknown_x,          is_true, 1'bx, fail
-unknown_z,          is_true, 1'bz, fail
-large_number_pass,  is_true, 128'h8000_0000_0000_0000, pass
+simple_true,        is_true, 1'b1, 1'b1
+simple_fail,        is_true, 1'b0, 1'b0
+decimal_true,       is_true, 1, 1'b1
+decimal_fail,       is_true, 0, 1'b0
+complex_true,       is_true, 3'b1xz, 1'b1
+complex_fail,       is_true, 3'b0xz, 1'b0
+unknown_x,          is_true, 1'bx, 1'b0
+unknown_z,          is_true, 1'bz, 1'b0
+large_number_pass,  is_true, 128'h8000_0000_0000_0000, 1'b1
 
 # type test
-simple_x_pass,      is_x,   1'bx,    pass
-simple_x_fail,      is_x,   1'b1,    fail
-complex_x_pass,     is_x,   4'bxxxx, pass
-complex_x_fail,     is_x,   4'bzxxx, fail
-simple_z_pass,      is_z,   1'bz,    pass
-simple_z_fail,      is_z,   1'b1,    fail
-complex_z_pass,     is_z,   4'bzzzz, pass
-complex_z_fail,     is_z,   4'bxzzz, fail
-simple_unk_x_pass,  is_unk, 2'bx1,   pass
-simple_unk_z_pass,  is_unk, 2'bz1,   pass
-simple_unk_fail,    is_unk, 2'b10,   fail
+simple_x_pass,      is_x,   1'bx,    1'b1
+simple_x_fail,      is_x,   1'b1,    1'b0
+complex_x_pass,     is_x,   4'bxxxx, 1'b1
+complex_x_fail,     is_x,   4'bzxxx, 1'b0
+simple_z_pass,      is_z,   1'bz,    1'b1
+simple_z_fail,      is_z,   1'b1,    1'b0
+complex_z_pass,     is_z,   4'bzzzz, 1'b1
+complex_z_fail,     is_z,   4'bxzzz, 1'b0
+simple_unk_x_pass,  is_unk, 2'bx1,   1'b1
+simple_unk_z_pass,  is_unk, 2'bz1,   1'b1
+simple_unk_fail,    is_unk, 2'b10,   1'b0
 
 # sign test
-simple_is_unsigned_pass,     is_unsigned,    2'b11,  pass
-simple_is_unsigned_fail,     is_unsigned,    2'sb11, fail
-simple_is_signed_pass,       is_signed,      2'b11,  fail
-simple_is_signed_fail,       is_signed,      2'sb11, pass
+simple_is_unsigned_pass,     is_unsigned,    2'b11,  1'b1
+simple_is_unsigned_fail,     is_unsigned,    2'sb11, 1'b0
+simple_is_signed_pass,       is_signed,      2'b11,  1'b0
+simple_is_signed_fail,       is_signed,      2'sb11, 1'b1
 
 # type conversion test
 simple_is_unsigned_1,        to_unsigned,    2'b11,  2'b11
@@ -43,8 +43,26 @@ simple_is_unsigned_2,        to_unsigned,    2'sb11, 2'b11
 simple_is_signed_1,          to_signed,      2'b11,  2'sb11
 simple_is_signed_2,          to_signed,      2'sb11, 2'sb11
 
+# string display
+simple_string_b,          display, b, 64'd18446744073709551615, 1111111111111111111111111111111111111111111111111111111111111111
+simple_string_B,          display, B, 65'd18446744073709551616, 10000000000000000000000000000000000000000000000000000000000000000
+simple_string_u,          display, u, 1'bz, 1'b0        # todo, figure out the real result for this
+simple_string_U,          display, U, 1'bx, 1'b0        # todo, figure out the real result for this
+simple_string_z,          display, z, 1'bz, z
+simple_string_Z,          display, Z, 1'bx, X
+simple_string_s,          display, s, "hello world", hello world
+simple_string_S,          display, S, "hello world", hello world
+simple_string_o,          display, o, 64'd18446744073709551615, 1777777777777777777777
+simple_string_O,          display, O, 65'd18446744073709551616, 2000000000000000000000
+simple_string_h,          display, h, 64'd18446744073709551615, ffffffffffffffff
+simple_string_H,          display, H, 64'd18446744073709551614, FFFFFFFFFFFFFFFE
+simple_string_d,          display, d, 265663, 265663
+simple_string_D,          display, D, 265663, 265663
+simple_string_c,          display, c, "hello world", h
+simple_string_C,          display, C, "world", w
+
 # string test
-simple_string,          display,        "hello world",   hello world
+simple_string,          display,        s,   "hello world", hello world
 string_compare_pass,    "hello world",  ==,  "hello world", 1'b1
 string_compare_fail,    "hello world",  ==,  "hello", 1'b0
 string_ne_pass,         "hello world",  !=,  "hello", 1'b1
@@ -76,6 +94,55 @@ simple_decimal_minus,			    6, -, 1, 5
 simple_decimal_plus,			    6, +, 1, 7
 simple_decimal_shift_right,			6,  >>>, 1, 3
 simple_decimal_shift_left,			6,  <<<, 1, 12
+
+#################
+# tristate
+
+# single bit trigger
+# ======
+
+# bufif0
+bufif0_on,                 bufif0, 4'b10xz, 1'b0, 4'b10xx
+bufif0_off,                bufif0, 4'b10xz, 1'b1, 4'bzzzz
+bufif0_dc,                 bufif0, 4'b10xz, 1'bx, 4'bxxxx
+bufif0_hihz,               bufif0, 4'b10xz, 1'bz, 4'bxxxx
+
+# bufif1
+bufif1_on,                 bufif1, 4'b10xz, 1'b1, 4'b10xx
+bufif1_off,                bufif1, 4'b10xz, 1'b0, 4'bzzzz
+bufif1_dc,                 bufif1, 4'b10xz, 1'bx, 4'bxxxx
+bufif1_hihz,               bufif1, 4'b10xz, 1'bz, 4'bxxxx
+
+# notif0
+notif0_on,                 notif0, 4'b10xz, 1'b0, 4'b01xx
+notif0_off,                notif0, 4'b10xz, 1'b1, 4'bzzzz
+notif0_dc,                 notif0, 4'b10xz, 1'bx, 4'bxxxx
+notif0_hihz,               notif0, 4'b10xz, 1'bz, 4'bxxxx
+
+# notif1
+notif1_on,                 notif1, 4'b10xz, 1'b1, 4'b01xx
+notif1_off,                notif1, 4'b10xz, 1'b0, 4'bzzzz
+notif1_dc,                 notif1, 4'b10xz, 1'bx, 4'bxxxx
+notif1_hihz,               notif1, 4'b10xz, 1'bz, 4'bxxxx
+
+# wide trigger
+# ======
+
+# bufif0
+bufif0_upper,              bufif0, 4'b10xz, 4'b1100, 4'bzzxx
+bufif0_lower,              bufif0, 4'b10xz, 4'b0011, 4'b10zz
+
+# bufif1
+bufif1_upper,              bufif1, 4'b10xz, 4'b1100, 4'b10zz
+bufif1_lower,              bufif1, 4'b10xz, 4'b0011, 4'bzzxx
+
+# notif0
+notif0_upper,              notif0, 4'b10xz, 4'b1100, 4'bzzxx
+notif0_lower,              notif0, 4'b10xz, 4'b0011, 4'b01zz
+
+# notif1
+notif1_upper,              notif1, 4'b10xz, 4'b1100, 4'b01zz
+notif1_lower,              notif1, 4'b10xz, 4'b0011, 4'bzzxx
 
 
 # Reduction

--- a/libs/librtlnumber/src/include/rtl_int.hpp
+++ b/libs/librtlnumber/src/include/rtl_int.hpp
@@ -24,7 +24,7 @@ bool V_IS_Z(VNumber& a);
 bool V_IS_SIGNED(VNumber& a);
 bool V_IS_UNSIGNED(VNumber& a);
 
-std::string V_STRING(VNumber& a);
+std::string V_STRING(VNumber& a, const char base);
 
 VNumber V_UNSIGNED(VNumber& a);
 VNumber V_SIGNED(VNumber& a);
@@ -32,7 +32,9 @@ VNumber V_ADD(VNumber& a);
 VNumber V_MINUS(VNumber& a);
 VNumber V_MINUS(VNumber& a, BitSpace::bit_value_t carry);
 
+VNumber V_BITWISE_BUF(VNumber& a);
 VNumber V_BITWISE_NOT(VNumber& a);
+
 VNumber V_BITWISE_AND(VNumber& a);
 VNumber V_BITWISE_OR(VNumber& a);
 VNumber V_BITWISE_XOR(VNumber& a);
@@ -46,6 +48,11 @@ VNumber V_LOGICAL_NOT(VNumber& a);
  */
 VNumber V_REPLICATE(VNumber& a, VNumber& n_times);
 VNumber V_CONCAT(std::vector<VNumber> concat_list);
+
+VNumber V_BITWISE_BUFIF0(VNumber& input, VNumber& trigger);
+VNumber V_BITWISE_BUFIF1(VNumber& input, VNumber& trigger);
+VNumber V_BITWISE_NOTIF0(VNumber& input, VNumber& trigger);
+VNumber V_BITWISE_NOTIF1(VNumber& input, VNumber& trigger);
 
 VNumber V_BITWISE_AND(VNumber& a, VNumber& b);
 VNumber V_BITWISE_OR(VNumber& a, VNumber& b);

--- a/libs/librtlnumber/src/include/rtl_utils.hpp
+++ b/libs/librtlnumber/src/include/rtl_utils.hpp
@@ -42,6 +42,7 @@
 #endif
 
 std::string string_of_radix_to_bitstring(std::string orig_string, size_t radix);
+std::string convert_between_bases(std::string str, uint8_t base_from, uint8_t base_to, bool uppercase, bool big_endian);
 
 inline void _assert_Werr(bool cond, const char* FUNCT, int LINE, std::string error_string) {
     if (!cond) {

--- a/libs/librtlnumber/src/rtl_int.cpp
+++ b/libs/librtlnumber/src/rtl_int.cpp
@@ -47,7 +47,7 @@ static compare_bit eval_op(VNumber& a_in, VNumber& b_in) {
                 "empty 2nd bit string");
 
 #ifndef RTL_ALLOW_UNKNOWN_COMPARE
-    if (a_in.is_dont_care_string() || b_in.is_dont_care_string())
+    if (a_in.has_unknown() || b_in.has_unknown())
         return UNK_EVAL;
 #endif
 
@@ -195,7 +195,7 @@ bool V_FALSE(VNumber& a) {
 }
 
 bool V_UNK(VNumber& a) {
-    return a.is_dont_care_string();
+    return a.has_unknown();
 }
 
 bool V_IS_X(VNumber& a) {
@@ -214,8 +214,8 @@ bool V_IS_UNSIGNED(VNumber& a) {
     return !a.is_signed();
 }
 
-std::string V_STRING(VNumber& a) {
-    return a.to_printable();
+std::string V_STRING(VNumber& a, const char base) {
+    return a.to_vstring(base);
 }
 
 /***
@@ -226,15 +226,15 @@ std::string V_STRING(VNumber& a) {
  */
 
 VNumber V_BITWISE_NOT(VNumber& a) {
-    return a.invert();
+    return a.bitwise(l_not);
 }
 
 VNumber V_LOGICAL_NOT(VNumber& a) {
-    if (a.is_dont_care_string())
+    if (a.has_unknown())
         return AMBIGUOUS_VALUE;
 
     VNumber ored = a.bitwise_reduce(l_or);
-    VNumber noted = ored.invert();
+    VNumber noted = ored.bitwise(l_not);
     return noted;
 }
 
@@ -275,17 +275,17 @@ VNumber V_BITWISE_XOR(VNumber& a) {
 }
 
 VNumber V_BITWISE_NAND(VNumber& a) {
-    VNumber to_return = a.bitwise_reduce(l_and).invert();
+    VNumber to_return = a.bitwise_reduce(l_and).bitwise(l_not);
     return to_return;
 }
 
 VNumber V_BITWISE_NOR(VNumber& a) {
-    VNumber to_return = a.bitwise_reduce(l_or).invert();
+    VNumber to_return = a.bitwise_reduce(l_or).bitwise(l_not);
     return to_return;
 }
 
 VNumber V_BITWISE_XNOR(VNumber& a) {
-    VNumber to_return = a.bitwise_reduce(l_xor).invert();
+    VNumber to_return = a.bitwise_reduce(l_xor).bitwise(l_not);
     return to_return;
 }
 
@@ -297,7 +297,7 @@ VNumber V_BITWISE_XNOR(VNumber& a) {
  */
 
 VNumber V_REPLICATE(VNumber& a, VNumber& n_times) {
-    assert_Werr(!n_times.is_dont_care_string(),
+    assert_Werr(!n_times.has_unknown(),
                 "Cannot use undefined number for the replication count");
 
     return a.replicate(n_times.get_value());
@@ -312,6 +312,46 @@ VNumber V_CONCAT(std::vector<VNumber> concat_list) {
         init = init.insert_at_lsb(concat_list[i]);
     }
     return init;
+}
+
+VNumber V_BITWISE_BUF(VNumber& a) {
+    return a.bitwise(l_buf);
+}
+
+VNumber V_BITWISE_BUFIF0(VNumber& input, VNumber& trigger) {
+    if (trigger.size() == 1 && input.size() > 1) {
+        trigger = trigger.replicate(input.size());
+    }
+    assert_Werr(input.size() == trigger.size(),
+                "tristate must either have a single trigger or contains as many as the input width");
+    return input.bitwise(trigger, l_bufif0);
+}
+
+VNumber V_BITWISE_BUFIF1(VNumber& input, VNumber& trigger) {
+    if (trigger.size() == 1 && input.size() > 1) {
+        trigger = trigger.replicate(input.size());
+    }
+    assert_Werr(input.size() == trigger.size(),
+                "tristate must either have a single trigger or contains as many as the input width");
+    return input.bitwise(trigger, l_bufif1);
+}
+
+VNumber V_BITWISE_NOTIF0(VNumber& input, VNumber& trigger) {
+    if (trigger.size() == 1 && input.size() > 1) {
+        trigger = trigger.replicate(input.size());
+    }
+    assert_Werr(input.size() == trigger.size(),
+                "tristate must either have a single trigger or contains as many as the input width");
+    return input.bitwise(trigger, l_notif0);
+}
+
+VNumber V_BITWISE_NOTIF1(VNumber& input, VNumber& trigger) {
+    if (trigger.size() == 1 && input.size() > 1) {
+        trigger = trigger.replicate(input.size());
+    }
+    assert_Werr(input.size() == trigger.size(),
+                "tristate must either have a single trigger or contains as many as the input width");
+    return input.bitwise(trigger, l_notif1);
 }
 
 VNumber V_BITWISE_AND(VNumber& a, VNumber& b) {
@@ -355,7 +395,7 @@ VNumber V_CASE_NOT_EQUAL(VNumber& a, VNumber& b) {
 }
 
 VNumber V_LOGICAL_AND(VNumber& a, VNumber& b) {
-    if (a.is_dont_care_string() || b.is_dont_care_string())
+    if (a.has_unknown() || b.has_unknown())
         return AMBIGUOUS_VALUE;
     VNumber reduxA = a.bitwise_reduce(l_or);
     VNumber reduxB = b.bitwise_reduce(l_or);
@@ -366,7 +406,7 @@ VNumber V_LOGICAL_AND(VNumber& a, VNumber& b) {
 }
 
 VNumber V_LOGICAL_OR(VNumber& a, VNumber& b) {
-    if (a.is_dont_care_string() || b.is_dont_care_string())
+    if (a.has_unknown() || b.has_unknown())
         return AMBIGUOUS_VALUE;
     VNumber reduxA = a.bitwise_reduce(l_or);
     VNumber reduxB = b.bitwise_reduce(l_or);
@@ -419,28 +459,28 @@ VNumber V_NOT_EQUAL(VNumber& a, VNumber& b) {
 }
 
 VNumber V_SIGNED_SHIFT_LEFT(VNumber& a, VNumber& b) {
-    if (b.is_dont_care_string())
+    if (b.has_unknown())
         return AMBIGUOUS_VALUE;
 
     return shift_op(a, b.get_value(), a.is_signed());
 }
 
 VNumber V_SHIFT_LEFT(VNumber& a, VNumber& b) {
-    if (b.is_dont_care_string())
+    if (b.has_unknown())
         return AMBIGUOUS_VALUE;
 
     return shift_op(a, b.get_value(), false);
 }
 
 VNumber V_SIGNED_SHIFT_RIGHT(VNumber& a, VNumber& b) {
-    if (b.is_dont_care_string())
+    if (b.has_unknown())
         return AMBIGUOUS_VALUE;
 
     return shift_op(a, -1 * b.get_value(), a.is_signed());
 }
 
 VNumber V_SHIFT_RIGHT(VNumber& a, VNumber& b) {
-    if (b.is_dont_care_string())
+    if (b.has_unknown())
         return AMBIGUOUS_VALUE;
 
     return shift_op(a, -1 * b.get_value(), false);
@@ -474,7 +514,7 @@ VNumber V_MINUS(VNumber& a, VNumber& b) {
 }
 
 VNumber V_MULTIPLY(VNumber& a_in, VNumber& b_in) {
-    if (a_in.is_dont_care_string() || b_in.is_dont_care_string()) {
+    if (a_in.has_unknown() || b_in.has_unknown()) {
         return AMBIGUOUS_VALUE;
     }
 
@@ -558,7 +598,7 @@ VNumber V_MULTIPLY(VNumber& a_in, VNumber& b_in) {
  * |-----------------------------------------------------------------------------|
  */
 VNumber V_POWER(VNumber& a, VNumber& b) {
-    if (a.is_dont_care_string() || b.is_dont_care_string()) {
+    if (a.has_unknown() || b.has_unknown()) {
         return AMBIGUOUS_VALUE;
     }
 
@@ -609,7 +649,7 @@ VNumber V_POWER(VNumber& a, VNumber& b) {
 
 /////////////////////////////
 VNumber V_DIV(VNumber& a_in, VNumber& b_in) {
-    if (a_in.is_dont_care_string() || b_in.is_dont_care_string() || eval_op(b_in, 0).is_eq())
+    if (a_in.has_unknown() || b_in.has_unknown() || eval_op(b_in, 0).is_eq())
         return AMBIGUOUS_VALUE;
 
     VNumber result("0");
@@ -655,7 +695,7 @@ VNumber V_DIV(VNumber& a_in, VNumber& b_in) {
 }
 
 VNumber V_MOD(VNumber& a_in, VNumber& b_in) {
-    if (a_in.is_dont_care_string() || b_in.is_dont_care_string() || eval_op(b_in, 0).is_eq())
+    if (a_in.has_unknown() || b_in.has_unknown() || eval_op(b_in, 0).is_eq())
         return AMBIGUOUS_VALUE;
 
     bool neg_a = a_in.is_negative();

--- a/libs/librtlnumber/src/rtl_utils.cpp
+++ b/libs/librtlnumber/src/rtl_utils.cpp
@@ -12,6 +12,60 @@
 
 static const char* base_10_digits = "0123456789";
 
+static int to_nb(char val, short base) {
+    if (base == 256) {
+        return (int)val;
+    } else if (val >= '0' && val <= '9') {
+        return val - '0';
+    } else {
+        return tolower(val) - 'a' + 10;
+    }
+}
+
+static char to_chr(int val, short base, bool uppercase) {
+    if (base == 256) {
+        return (char)val;
+    } else if (val >= 0 and val <= 9) {
+        return val + '0';
+    } else if (!uppercase) {
+        return (val - 10) + 'a';
+    } else {
+        return (val - 10) + 'A';
+    }
+}
+
+std::string convert_between_bases(std::string str, uint8_t base_from, uint8_t base_to, bool uppercase, bool big_endian) {
+    std::string digits = "";
+    while (str != "0") {
+        int carry = 0;
+
+        size_t start = (big_endian) ? str.size() - 1 : 0;
+        size_t end = (big_endian) ? 0 : str.size() - 1;
+        size_t increment = (big_endian) ? -1 : 1;
+
+        for (size_t i = start; (big_endian) ? (i >= end && i <= start) : (i >= start && i <= end); i += increment) {
+            int temp = to_nb(str[i], base_from);
+            temp += base_from * carry;
+            carry = temp % base_to;
+            temp = temp / base_to;
+            str[i] = to_chr(temp, base_from, uppercase);
+        }
+
+        if (big_endian) {
+            digits.push_back(to_chr(carry, base_to, uppercase));
+            while (str.size() > 1 && str.back() == '0') {
+                str.pop_back();
+            }
+        } else {
+            digits.insert(0, 1, to_chr(carry, base_to, uppercase));
+            while (str.size() > 1 && str[0] == '0') {
+                str.erase(0, 1);
+            }
+        }
+    }
+    return digits;
+}
+
 static uint8_t _to_decimal(char digit, const char* FUNCT, int LINE) {
     switch (std::tolower(digit)) {
         case '0':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR adds support for tristate gates to the rtl arithmetic library
Also fixes string display to convert unbounded binaries to decimal strings without converting to integers.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
