### PR TITLE
WIP -- travis: Install the compiler later in the setup

### DIFF
--- a/.github/travis/setup-compiler.sh
+++ b/.github/travis/setup-compiler.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+eval "${MATRIX_EVAL}"
+
+if [[ -z "$CC" ]]; then
+	echo "No \$CC value set! Can not install the compiler!"
+	exit 1
+else
+	echo "Using $CC compiler"
+fi
+if [[ -z "$CXX" ]]; then
+	echo "No \$CXX value set! Can not install the compiler!"
+	exit 1
+else
+	echo "Using $CXX compiler"
+fi
+
+UBUNTU_DISTRO=$(lsb_release -c -s)
+
+case $CC in
+	clang*)
+		echo "$CC is provided by https://apt.llvm.org"
+		wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+		cat >> /etc/apt/sources.list <<EOF
+deb http://apt.llvm.org/${UBUNTU_DISTRO} llvm-toolchain-${UBUNTU_DISTRO}-$(echo $CC | sed -e's/clang-//') main
+EOF
+		;;
+	*)
+		echo "$CC is provided by default repositories."
+		;;
+esac
+
+mkdir -p /etc/apt/apt.conf.d
+sudo tee /etc/apt/apt.conf.d/99allow_unauth <<EOF
+APT {
+	Ignore {
+		"gpg-pubkey";
+	}
+	Get {
+		AllowUnauthenticated "1";
+		Assume-Yes "1";
+		Install-Recommends "0";
+		Install-Suggests "0";
+	}
+};
+EOF
+apt-config dump
+
+sudo -E apt-get --quiet --force-yes update
+sudo -E apt-get --quiet --force-yes install $CC $CXX

--- a/.github/travis/setup-python.sh
+++ b/.github/travis/setup-python.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+# Switch to python 3.6.3
+pyenv install -f 3.6.3
+pyenv global 3.6.3
+
+# Install python modules
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+rm get-pip.py
+python3 -m pip install \
+  pylint \
+  black

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,16 +225,7 @@ jobs:
         - ./.github/travis/cron_build.sh
 
 before_script:
-  # Switch to python 3.6.3
-  - pyenv install -f 3.6.3
-  - pyenv global 3.6.3
-  # Install python modules
-  - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  - python3 get-pip.py
-  - rm get-pip.py
-  - python3 -m pip install \
-      pylint \
-      black
+  - ./.github/travis/setup-python.sh
   - source .github/travis/common.sh
   - ./.github/travis/setup.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,19 +40,6 @@ addons:
     - zip
     - qt5-default
     - clang-format-7
-    # All the compilers!
-    - g++-5
-    - gcc-5
-    - g++-6
-    - gcc-6
-    - g++-7
-    - gcc-7
-    - g++-8
-    - gcc-8
-    - g++-9
-    - gcc-9
-    - clang-6.0
-    - clang-8
 
 env:
   - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
@@ -223,6 +210,9 @@ jobs:
         - _COVERITY_MD5="d0d7d7df9d6609e578f85096a755fb8f"
       script:
         - ./.github/travis/cron_build.sh
+
+install:
+  - ./.github/travis/setup-compiler.sh
 
 before_script:
   - ./.github/travis/setup-python.sh


### PR DESCRIPTION
Currently the LLVM apt repo is a little bit unreliable, hence we need to move the compiler install to a later stage were we can do things like retries. This also means that any LLVM failures will only affect the steps that actually need the clang compiler.

TODO before merging;
 - [ ] Set up a local caching apt-proxy.
 - [ ] Figure out if we should move more from the `packages` section to be manually installed.