### PR TITLE
Apply reordering to node and edge metadata

### DIFF
--- a/vpr/src/base/metadata_storage.h
+++ b/vpr/src/base/metadata_storage.h
@@ -28,6 +28,26 @@ class MetadataStorage {
         data_.push_back(std::make_tuple(lookup_key, meta_key, meta_value));
     }
 
+    // Use the given mapping function to change the keys
+    void remap_keys(std::function<LookupKey(LookupKey)> key_map) {
+        if (map_.empty()) {
+            for (auto& entry : data_) {
+                std::get<0>(entry) = key_map(std::get<0>(entry));
+            }
+        } else {
+            VTR_ASSERT(data_.empty());
+            for (auto& dict : map_) {
+                for (auto& entry : dict.second) {
+                    for (auto& value : entry.second) {
+                        data_.push_back(std::make_tuple(key_map(dict.first), entry.first, value.as_string()));
+                    }
+                }
+            }
+            map_.clear();
+            build_map();
+        }
+    }
+
     typename vtr::flat_map<LookupKey, t_metadata_dict>::const_iterator find(const LookupKey& lookup_key) const {
         check_for_map();
 

--- a/vpr/src/route/rr_graph_util.cpp
+++ b/vpr/src/route/rr_graph_util.cpp
@@ -169,4 +169,11 @@ void reorder_rr_graph_nodes(const t_router_opts& router_opts) {
             }
         }
     }
+
+    device_ctx.rr_node_metadata.remap_keys([&](int node) { return size_t(dest_order[RRNodeId(node)]); });
+    device_ctx.rr_edge_metadata.remap_keys([&](std::tuple<int, int, short> edge) {
+        return std::make_tuple(size_t(dest_order[RRNodeId(std::get<0>(edge))]),
+                               size_t(dest_order[RRNodeId(std::get<1>(edge))]),
+                               std::get<2>(edge));
+    });
 }


### PR DESCRIPTION
Update RR graph node IDs in node and edge metadata when using RR graph node reordering.

#### Description
Bitstreams produced with node reordering (a `--reorder_rr_graph_nodes_algorithm` other than `none`) were not building with `fasm2bels` due to scrambled metadata.

#### Related Issue
#1270 

#### Motivation and Context
This fixes metadata when using RR node reordering.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`fasm2bels` tests now pass on [`fpga-tool-perf`](https://hydra.vtr.tools/jobset/dusty/fpga-tool-perf#tabs-jobs).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
