### PR TITLE
Fixed Toggle block internal image link

### DIFF
--- a/doc/src/vpr/graphics.rst
+++ b/doc/src/vpr/graphics.rst
@@ -139,7 +139,7 @@ Toggle Block Internal
 -------------------------------
 During placement and routing you can adjust the level of block detail you visualize by using the **Toggle Block Internal**. Each block can contain a number of flip flops (ff), look up tables (lut), and other primitives. The higher the number, the deeper into the hierarchy within the cluster level block you see. 
 
-.. figure:: https://github.com/verilog-to-routing/verilog-to-routing.github.io/blob/master/img/ToggleBlockInternal.gif
+.. figure:: https://www.verilogtorouting.org/img/ToggleBlockInternal.gif
     :align: center
 
     Visualizing Block Internals


### PR DESCRIPTION
fixed the image link for toggle block internal documentation.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The link for the gif showing how block internals work was incorrect and the gif wouldn't display on the website. I corrected the link in this PR.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
