### PR TITLE
Odin: Fixes coverity error in simulation

### DIFF
--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -557,11 +557,11 @@ static int is_node_ready(nnode_t* node, int cycle) {
         for (i = 0; i < node->num_input_pins; i++) {
             npin_t* pin = node->input_pins[i];
 
-            bool has_missing_driver = false;
-            for (int j = 0; j < pin->net->num_driver_pins && !has_missing_driver; j++)
+            bool has_missing_driver = pin->net == NULL;
+            for (int j = 0; !has_missing_driver && j < pin->net->num_driver_pins; j++)
                 has_missing_driver = pin->net->driver_pins[j]->node == NULL;
 
-            if (!pin->net || has_missing_driver) {
+            if (has_missing_driver) {
                 bool already_flagged = false;
                 int j;
                 for (j = 0; j < node->num_undriven_pins; j++) {


### PR DESCRIPTION
```
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/ODIN_II/SRC/simulate_blif.cpp: 564 in is_node_ready(nnode_t *, int)()
558 npin_t* pin = node->input_pins[i];
559
560 bool has_missing_driver = false;
561 for (int j = 0; j < pin->net->num_driver_pins && !has_missing_driver; j++)
562 has_missing_driver = pin->net->driver_pins[j]->node == NULL;
563
>>> CID 214202: Null pointer dereferences (REVERSE_INULL)
>>> Null-checking "pin->net" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
564 if (!pin->net || has_missing_driver) {
565 bool already_flagged = false;
566 int j;
567 for (j = 0; j < node->num_undriven_pins; j++) {
568 if (node->undriven_pins[j] == pin)
569 already_flagged = true;
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] All new and existing tests passed
