### PR TITLE
place_constraints: fixed number of tokens when reading place file

### DIFF
--- a/vpr/src/base/read_place.cpp
+++ b/vpr/src/base/read_place.cpp
@@ -205,7 +205,7 @@ void read_place_body(std::ifstream& placement_file,
         } else if (tokens[0][0] == '#') {
             continue; //Skip commented lines
 
-        } else if (tokens.size() == 4 || (tokens.size() == 5 && tokens[4][0] == '#')) {
+        } else if (tokens.size() == 4 || (tokens.size() > 4 && tokens[4][0] == '#')) {
             //Load the block location
             //
             //We should have 4 tokens of actual data, with an optional 5th (commented) token indicating VPR's


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When reading the place constraints file (`.place`) to fix some clusters, there was a bug in the token count. More precisely, the if statement that checked the token count did not take into account that there can bee more tokens than the ones specified due to the possibility to add comments to each line that generate several tokens when parsing a line.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
