### PR TITLE
Add extended lookahead map followup

### DIFF
--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -621,7 +621,7 @@ float ConnectionRouter<Heap>::compute_node_cost_using_rcv(const t_conn_cost_para
 
     const t_conn_delay_budget* delay_budget = cost_params.delay_budget;
 
-    std::tie(expected_delay, expected_cong) = router_lookahead_.get_expected_delay_and_cong(to_node, target_node, cost_params, R_upstream);
+    std::tie(expected_delay, expected_cong) = router_lookahead_.get_expected_delay_and_cong(RRNodeId(to_node), RRNodeId(target_node), cost_params, R_upstream);
 
     float expected_total_delay_cost;
     float expected_total_cong_cost;
@@ -761,7 +761,7 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
         total_cost = compute_node_cost_using_rcv(cost_params, to_node, target_node, to->path_data->backward_delay, to->path_data->backward_cong, to->R_upstream);
     } else {
         //Update total cost
-        float expected_cost = router_lookahead_.get_expected_cost(to_node, target_node, cost_params, to->R_upstream);
+        float expected_cost = router_lookahead_.get_expected_cost(RRNodeId(to_node), RRNodeId(target_node), cost_params, to->R_upstream);
         VTR_LOGV_DEBUG(router_debug_ && !std::isfinite(expected_cost),
                        "        Lookahead from %s (%s) to %s (%s) is non-finite, expected_cost = %f, to->R_upstream = %f\n",
                        rr_node_arch_name(to_node).c_str(), describe_rr_node(to_node).c_str(),
@@ -848,7 +848,7 @@ void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
         // tot_cost = backward_path_cost + cost_params.astar_fac * expected_cost;
         float tot_cost = backward_path_cost
                          + cost_params.astar_fac
-                               * router_lookahead_.get_expected_cost(inode, target_node, cost_params, R_upstream);
+                               * router_lookahead_.get_expected_cost(RRNodeId(inode), RRNodeId(target_node), cost_params, R_upstream);
         VTR_LOGV_DEBUG(router_debug_, "  Adding node %8d to heap from init route tree with cost %g (%s)\n", inode, tot_cost, describe_rr_node(inode).c_str());
 
         push_back_node(&heap_, rr_node_route_inf_,

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -69,9 +69,14 @@ struct RoutingMetrics {
  * File-scope variables
  */
 
-//Run-time flag to control when router debug information is printed
-//Note only enables debug output if compiled with VTR_ENABLE_DEBUG_LOGGING defined
-//f_router_debug is used to stop the router when a breakpoint is reached. When a breakpoint is reached, this flag is set to true.
+/**
+ * @brief Run-time flag to control when router debug information is printed
+ * Note only enables debug output if compiled with VTR_ENABLE_DEBUG_LOGGING defined
+ * f_router_debug is used to stop the router when a breakpoint is reached. When a breakpoint is reached, this flag is set to true.
+ *
+ * In addition f_router_debug is used to print additional debug information during routing, for instance lookahead expected costs
+ * information.
+ */
 bool f_router_debug = false;
 
 //Count the number of times the router has failed

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -2144,7 +2144,7 @@ static void init_net_delay_from_lookahead(const RouterLookahead& router_lookahea
         for (size_t ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net_id).size(); ++ipin) {
             int sink_rr = route_ctx.net_rr_terminals[net_id][ipin];
 
-            float est_delay = router_lookahead.get_expected_cost(source_rr, sink_rr, cost_params, /*R_upstream=*/0.);
+            float est_delay = router_lookahead.get_expected_cost(RRNodeId(source_rr), RRNodeId(sink_rr), cost_params, /*R_upstream=*/0.);
             VTR_ASSERT(std::isfinite(est_delay) && est_delay < std::numeric_limits<float>::max());
 
             net_delay[net_id][ipin] = est_delay;

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -12,8 +12,8 @@ class RouterLookahead {
     //
     // Either compute or read methods must be invoked before invoking
     // get_expected_cost.
-    virtual float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
-    virtual std::pair<float, float> get_expected_delay_and_cong(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
+    virtual float get_expected_cost(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
+    virtual std::pair<float, float> get_expected_delay_and_cong(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const = 0;
 
     // Compute router lookahead (if needed).
     virtual void compute(const std::vector<t_segment_inf>& segment_inf) = 0;
@@ -54,8 +54,8 @@ const RouterLookahead* get_cached_router_lookahead(
 
 class ClassicLookahead : public RouterLookahead {
   public:
-    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    std::pair<float, float> get_expected_delay_and_cong(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    float get_expected_cost(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    std::pair<float, float> get_expected_delay_and_cong(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
 
     void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
     }
@@ -68,13 +68,13 @@ class ClassicLookahead : public RouterLookahead {
     }
 
   private:
-    float classic_wire_lookahead_cost(int node, int target_node, float criticality, float R_upstream) const;
+    float classic_wire_lookahead_cost(RRNodeId node, RRNodeId target_node, float criticality, float R_upstream) const;
 };
 
 class NoOpLookahead : public RouterLookahead {
   protected:
-    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    std::pair<float, float> get_expected_delay_and_cong(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    float get_expected_cost(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    std::pair<float, float> get_expected_delay_and_cong(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
 
     void compute(const std::vector<t_segment_inf>& /*segment_inf*/) override {
     }

--- a/vpr/src/route/router_lookahead_cost_map.h
+++ b/vpr/src/route/router_lookahead_cost_map.h
@@ -100,7 +100,7 @@ class CostMap {
                                  ///<delta locations that fall outside of a segment's bounding box.
                                  ///<The penalty map is addressed as follows penalty_[0][segment_index]
 
-    size_t seg_count_; ///<Total segment count in the architecture
+    size_t seg_count_ = 0; ///<Total segment count in the architecture
 
     /**
      * @brief Get penalty delay for a segment type

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -144,7 +144,7 @@ float ExtendedMapLookahead::get_chan_ipin_delays(RRNodeId to_node) const {
     auto& rr_graph = device_ctx.rr_nodes;
 
     e_rr_type to_type = rr_graph.node_type(to_node);
-    VTR_ASSERT(to_type == SINK);
+    VTR_ASSERT(to_type == SINK || to_type == IPIN);
 
     auto to_tile_type = device_ctx.grid[rr_graph.node_xlow(to_node)][rr_graph.node_ylow(to_node)].type;
     auto to_tile_index = to_tile_type->index;

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -169,13 +169,10 @@ float ExtendedMapLookahead::get_chan_ipin_delays(RRNodeId to_node) const {
 //
 //  The from_node can be of one of the following types: CHANX, CHANY, SOURCE, OPIN
 //  The to_node is always a SINK
-std::pair<float, float> ExtendedMapLookahead::get_expected_delay_and_cong(int inode, int target_node, const t_conn_cost_params& params, float /*R_upstream*/) const {
-    if (inode == target_node) {
+std::pair<float, float> ExtendedMapLookahead::get_expected_delay_and_cong(RRNodeId from_node, RRNodeId to_node, const t_conn_cost_params& params, float /*R_upstream*/) const {
+    if (from_node == to_node) {
         return std::make_pair(0., 0.);
     }
-
-    RRNodeId from_node(inode);
-    RRNodeId to_node(target_node);
 
     auto& device_ctx = g_vpr_ctx.device();
     auto& rr_graph = device_ctx.rr_nodes;
@@ -570,13 +567,13 @@ void ExtendedMapLookahead::compute(const std::vector<t_segment_inf>& segment_inf
 
 // get an expected minimum cost for routing from the current node to the target node
 float ExtendedMapLookahead::get_expected_cost(
-    int current_node,
-    int target_node,
+    RRNodeId current_node,
+    RRNodeId target_node,
     const t_conn_cost_params& params,
     float R_upstream) const {
     auto& device_ctx = g_vpr_ctx.device();
 
-    t_rr_type rr_type = device_ctx.rr_nodes[current_node].type();
+    t_rr_type rr_type = device_ctx.rr_nodes.node_type(current_node);
 
     if (rr_type == CHANX || rr_type == CHANY || rr_type == SOURCE || rr_type == OPIN) {
         float delay_cost, cong_cost;

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -230,7 +230,7 @@ std::pair<float, float> ExtendedMapLookahead::get_expected_delay_and_cong(RRNode
 
     VTR_LOGV_DEBUG(f_router_debug, "Requested lookahead from node %d to %d\n", size_t(from_node), size_t(to_node));
     const std::string& segment_name = device_ctx.rr_segments[from_seg_index].name;
-    VTR_LOGV_DEBUG(f_router_debug, "Lookahead returned %s (%d) with distance (%zd, %zd)\n",
+    VTR_LOGV_DEBUG(f_router_debug, "Lookahead returned %s (%d) with distance (%d, %d)\n",
                    segment_name.c_str(), from_seg_index,
                    dx, dy);
     VTR_LOGV_DEBUG(f_router_debug, "Lookahead delay: %g\n", expected_delay_cost);

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -143,6 +143,9 @@ float ExtendedMapLookahead::get_chan_ipin_delays(RRNodeId to_node) const {
     auto& device_ctx = g_vpr_ctx.device();
     auto& rr_graph = device_ctx.rr_nodes;
 
+    e_rr_type to_type = rr_graph.node_type(to_node);
+    VTR_ASSERT(to_type == SINK);
+
     auto to_tile_type = device_ctx.grid[rr_graph.node_xlow(to_node)][rr_graph.node_ylow(to_node)].type;
     auto to_tile_index = to_tile_type->index;
 

--- a/vpr/src/route/router_lookahead_extended_map.h
+++ b/vpr/src/route/router_lookahead_extended_map.h
@@ -59,12 +59,12 @@ class ExtendedMapLookahead : public RouterLookahead {
     /**
      * @brief Returns the expected cost to get to a destination node
      */
-    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    float get_expected_cost(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
 
     /**
      * @brief Returns a pair of expected delay and congestion
      */
-    std::pair<float, float> get_expected_delay_and_cong(int inode, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    std::pair<float, float> get_expected_delay_and_cong(RRNodeId inode, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
 
     /**
      * @brief Computes the extended lookahead map

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -230,11 +230,11 @@ static void print_wire_cost_map(const std::vector<t_segment_inf>& segment_inf);
 static void print_router_cost_map(const t_routing_cost_map& router_cost_map);
 
 /******** Interface class member function definitions ********/
-float MapLookahead::get_expected_cost(int current_node, int target_node, const t_conn_cost_params& params, float R_upstream) const {
+float MapLookahead::get_expected_cost(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const {
     auto& device_ctx = g_vpr_ctx.device();
     auto& rr_graph = device_ctx.rr_nodes;
 
-    t_rr_type rr_type = rr_graph.node_type(RRNodeId(current_node));
+    t_rr_type rr_type = rr_graph.node_type(current_node);
 
     if (rr_type == CHANX || rr_type == CHANY || rr_type == SOURCE || rr_type == OPIN) {
         float delay_cost, cong_cost;
@@ -252,12 +252,9 @@ float MapLookahead::get_expected_cost(int current_node, int target_node, const t
 /******** Function Definitions ********/
 /* queries the lookahead_map (should have been computed prior to routing) to get the expected cost
  * from the specified source to the specified target */
-std::pair<float, float> MapLookahead::get_expected_delay_and_cong(int inode, int target_node, const t_conn_cost_params& params, float /*R_upstream*/) const {
+std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_node, RRNodeId to_node, const t_conn_cost_params& params, float /*R_upstream*/) const {
     auto& device_ctx = g_vpr_ctx.device();
     auto& rr_graph = device_ctx.rr_nodes;
-
-    RRNodeId from_node(inode);
-    RRNodeId to_node(target_node);
 
     int delta_x, delta_y;
     get_xy_deltas(from_node, to_node, &delta_x, &delta_y);
@@ -329,8 +326,8 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(int inode, int
 
         VTR_ASSERT_SAFE_MSG(std::isfinite(expected_delay_cost),
                             vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
-                                            rr_node_arch_name(size_t(inode)).c_str(),
-                                            describe_rr_node(size_t(inode)).c_str())
+                                            rr_node_arch_name(size_t(from_node)).c_str(),
+                                            describe_rr_node(size_t(from_node)).c_str())
                                 .c_str());
 
     } else if (from_type == CHANX || from_type == CHANY) {
@@ -353,8 +350,8 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(int inode, int
 
         VTR_ASSERT_SAFE_MSG(std::isfinite(expected_delay_cost),
                             vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
-                                            rr_node_arch_name(size_t(inode)).c_str(),
-                                            describe_rr_node(size_t(inode)).c_str())
+                                            rr_node_arch_name(size_t(from_node)).c_str(),
+                                            describe_rr_node(size_t(from_node)).c_str())
                                 .c_str());
     } else if (from_type == IPIN) { /* Change if you're allowing route-throughs */
         return std::make_pair(0., device_ctx.rr_indexed_data[SINK_COST_INDEX].base_cost);

--- a/vpr/src/route/router_lookahead_map.h
+++ b/vpr/src/route/router_lookahead_map.h
@@ -12,8 +12,8 @@ class MapLookahead : public RouterLookahead {
     util::t_src_opin_delays src_opin_delays;
 
   protected:
-    float get_expected_cost(int node, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
-    std::pair<float, float> get_expected_delay_and_cong(int inode, int target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    float get_expected_cost(RRNodeId node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    std::pair<float, float> get_expected_delay_and_cong(RRNodeId from_node, RRNodeId to_node, const t_conn_cost_params& params, float R_upstream) const override;
 
     void compute(const std::vector<t_segment_inf>& segment_inf) override;
     void read(const std::string& file) override;

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -198,6 +198,10 @@ util::Cost_Entry util::Expansion_Cost_Entry::get_median_entry() const {
     /* find median by binning the delays of all entries and then chosing the bin
      * with the largest number of entries */
 
+    // This is code that needs to be revisited. For the time being, if the median entry
+    // method calculation is used an assertion is thrown.
+    VTR_ASSERT_MSG(false, "Get median entry calculation method is not implemented!");
+
     int num_bins = 10;
 
     /* find entries with smallest and largest delays */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Followup of https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1449.

This PR is a followup to solve some outstanding comments on the lookahead extended map that require some more work.
To not have to wait a full CI build once again, these changes are applied to this followup PR

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
