### PR TITLE
Allow router to report successful routing even if RCV fails to resolve hold

### DIFF
--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -533,7 +533,10 @@ bool try_timing_driven_route_tmpl(const t_router_opts& router_opts,
         /*
          * Are we finished?
          */
-        if (is_iteration_complete(routing_is_feasible, router_opts, itry, timing_info, rcv_finished_count == 0)) {
+
+        bool can_router_finish = rcv_finished_count == 0 || itry >= router_opts.max_router_iterations;
+
+        if (is_iteration_complete(routing_is_feasible, router_opts, itry, timing_info, can_router_finish)) {
             auto& router_ctx = g_vpr_ctx.routing();
 
             if (is_better_quality_routing(best_routing, best_routing_metrics, wirelength_info, timing_info)) {

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -533,10 +533,7 @@ bool try_timing_driven_route_tmpl(const t_router_opts& router_opts,
         /*
          * Are we finished?
          */
-
-        bool can_router_finish = rcv_finished_count == 0 || itry >= router_opts.max_router_iterations;
-
-        if (is_iteration_complete(routing_is_feasible, router_opts, itry, timing_info, can_router_finish)) {
+        if (is_iteration_complete(routing_is_feasible, router_opts, itry, timing_info, rcv_finished_count == 0)) {
             auto& router_ctx = g_vpr_ctx.routing();
 
             if (is_better_quality_routing(best_routing, best_routing_metrics, wirelength_info, timing_info)) {
@@ -1990,9 +1987,11 @@ bool is_iteration_complete(bool routing_is_feasible, const t_router_opts& router
     //in addition to routing being legal and the correct budgeting algorithm being set.
 
     if (routing_is_feasible) {
+        bool can_router_finish = rcv_finished || itry >= router_opts.max_router_iterations;
+
         if (router_opts.routing_budgets_algorithm != YOYO) {
             return true;
-        } else if (router_opts.routing_budgets_algorithm == YOYO && (timing_info->hold_worst_negative_slack() == 0 || rcv_finished) && itry != 1) {
+        } else if (router_opts.routing_budgets_algorithm == YOYO && (timing_info->hold_worst_negative_slack() == 0 || can_router_finish) && itry != 1) {
             return true;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Makes it so that RCV will report a successful routing regardless of whether hold has been resolved. This is just a simple check that allows it to report a successful routing if routing is feasible, and the maximum iteration count is reached. This doesn't fix the underlying problem of **why** RCV fails to resolve hold for some circuits (LU8PEEng and LU32PEEng) but it's a quick patch.

I want to figure out the underlying issue and also address that in this PR so I don't want to merge quite yet. 

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1533

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Make RCV more robust and versatile on multiple circuits. 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this on LU32PEEng and LU8PEEng circuits with harsh hold constraints and RCV enabled, and verified that it reports a successful routing even though hold isn't resolved. I don't see a point in running the full qor tests as this isn't a possibly breaking change yet.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
