### PR TITLE
read_place: do not throw error if block name is invalid

### DIFF
--- a/vpr/src/base/read_place.cpp
+++ b/vpr/src/base/read_place.cpp
@@ -226,7 +226,8 @@ void read_place_body(std::ifstream& placement_file,
                 AtomBlockId atom_blk_id = atom_ctx.nlist.find_block(block_name);
 
                 if (atom_blk_id == AtomBlockId::INVALID()) {
-                    VPR_THROW(VPR_ERROR_PLACE, "Block %s has an invalid name.\n", c_block_name);
+                    VTR_LOG_WARN("Block %s has an invalid name and it is going to be skipped.\n", c_block_name);
+                    continue;
                 } else {
                     blk_id = atom_ctx.lookup.atom_clb(atom_blk_id); //getting the ClusterBlockId of the cluster that the atom is in
                 }


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This fixes an issue when reading placement files.
Placement files can be read for two different reasons:

1. Prior to the routing stage if the flow is divided in three diffrent calls to VPR P&R stages
2. To read placement constraints files. 

In SymbiFlow, there are a set of tests which are automated and the verilog design alongside with the PCF constraints is automatically generated. The PCF constraints will translate into a placement constraints file.

The issue is that, during the various test design generation, some parameters may allow for some IO signals to be unconnected after synthesis, conflicting with the fact that VPR throws an error if a block specified in the placement constraints file is not present in the packed netlist.

Instead of throwing an error, this PR downgrades the error to a warning.

Another possible solution would be to encapsulate the check in a sub-routine that can be disabled at run-time with a flag (https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/25efd6670f14c1f23d976ef820ead8ef9b7c5e37/vpr/src/base/read_options.cpp#L1309-L1314).
This would require a sub-routine as the errors would otherwise be disabled in all the original routine, and those are errors which should not be disabled.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
SymbiFlow tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
