### PR TITLE
Fix initial placement for heterogeneous tiles

### DIFF
--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -330,8 +330,9 @@ static t_physical_tile_type_ptr pick_placement_type(t_logical_block_type_ptr log
                                                     std::vector<std::vector<int>>& free_locations) {
     // Loop through the ordered map to get tiles in a decreasing priority order
     for (auto& tile : logical_block->equivalent_tiles) {
-        for (auto sub_tile : tile->sub_tiles) {
-            if (free_locations[tile->index][sub_tile.index] >= num_needed_types) {
+        auto possible_sub_tiles = get_possible_sub_tile_indices(tile, logical_block);
+        for (auto sub_tile_index : possible_sub_tiles) {
+            if (free_locations[tile->index][sub_tile_index] >= num_needed_types) {
                 return tile;
             }
         }


### PR DESCRIPTION
Signed-off-by: Andrew Butt <butta@seas.upenn.edu>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
In the case where a design contains more SLICEMs than there are CLBLM_Ls in the architecture, the initial placement would still accept the CLBLM_L as a valid placement tile, resulting in a lack of sub_tiles to make the placement. This happens because there was no distinction of valid sub_tiles for a SLICEM, so the CLBLM_L still has free SLICELs allowing CLBLM_L to be chosen as a placement tile for a SLICEM while not having any free SLICEM sub_tiles. This fix only checks the free locations of valid sub_tiles, causing CLBLM_L to be rejected for placement of a SLICEM and allowing the CLBLM_R to be used instead.

I made this fix when using the symbiflow-arch-defs defined architectures, but the issue is relevant for all architectures with heterogeneous tiles.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1298 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix allows designs that use a large percentage of available heterogeneous sub tiles to be placed without error.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The fix has been tested locally, but it might be useful to add a test with some small test architecture.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
