### PR TITLE
Add in-class initializers for t_placer_costs to fix coverity scan defect

### DIFF
--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -278,6 +278,7 @@ void t_annealing_state::update_move_lim(float success_target, float success_rate
     move_lim = std::max(move_lim, 1);
 }
 
+///@brief Clear all data fields.
 void t_placer_statistics::reset() {
     av_cost = 0.;
     av_bb_cost = 0.;
@@ -288,6 +289,7 @@ void t_placer_statistics::reset() {
     std_dev = 0.;
 }
 
+///@brief Calculate placer success rate and cost std_dev for this iteration.
 void t_placer_statistics::single_swap_update(const t_placer_costs& costs) {
     success_sum++;
     av_cost += costs.cost;
@@ -296,6 +298,7 @@ void t_placer_statistics::single_swap_update(const t_placer_costs& costs) {
     sum_of_squares += (costs.cost) * (costs.cost);
 }
 
+///@brief Update stats when a single swap move has been accepted.
 void t_placer_statistics::calc_iteration_stats(const t_placer_costs& costs, int move_lim) {
     if (success_sum == 0) {
         av_cost = costs.cost;

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -40,11 +40,11 @@
  */
 class t_placer_costs {
   public: //members
-    double cost;
-    double bb_cost;
-    double timing_cost;
-    double bb_cost_norm;
-    double timing_cost_norm;
+    double cost = 0.;
+    double bb_cost = 0.;
+    double timing_cost = 0.;
+    double bb_cost_norm = 0.;
+    double timing_cost_norm = 0.;
 
   public: //Constructor
     t_placer_costs(t_place_algorithm algo)


### PR DESCRIPTION

#### Description
Fix Coverity Scan for t_placer_costs in place_util.h.

**Original report:**
Please find the latest report on new defect(s) introduced to Verilog to Routing found with Coverity Scan.

1 new defect(s) introduced to Verilog to Routing found with Coverity Scan.
1 defect(s), reported by Coverity Scan earlier, were marked fixed in the recent build analyzed by Coverity Scan.

New defect(s) Reported-by: Coverity Scan
Showing 1 of 1 defect(s)


** CID 214341:  Uninitialized members  (UNINIT_CTOR)
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/vpr/src/place/place_util.h: 51 in t_placer_costs::t_placer_costs(t_place_algorithm)()


________________________________________________________________________________________________________
*** CID 214341:  Uninitialized members  (UNINIT_CTOR)
/home/travis/build/verilog-to-routing/vtr-verilog-to-routing/vpr/src/place/place_util.h: 51 in t_placer_costs::t_placer_costs(t_place_algorithm)()
45         double timing_cost;
46         double bb_cost_norm;
47         double timing_cost_norm;
48     
49       public: //Constructor
50         t_placer_costs(t_place_algorithm algo)
>>>     CID 214341:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "timing_cost_norm" is not initialized in this constructor nor in any functions that it calls.
51             : place_algorithm(algo) {}
52     
53       public: //Mutator
54         void update_norm_factors();
55     
56       private:

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
