### PR TITLE
Remove index >= 0 check from vtr_vector_map.h

### DIFF
--- a/libs/libvtrutil/src/vtr_vector_map.h
+++ b/libs/libvtrutil/src/vtr_vector_map.h
@@ -62,6 +62,11 @@ class vector_map {
     //Indexing
     const_reference operator[](const K n) const {
         size_t index = size_t(n);
+
+        // Shouldn't check for index >= 0, since size_t is unsigned thus won't be negative
+        // A negative input to n would result in an absurdly large number close the maximum size of size_t, and be caught by index < vec_.size()
+        // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf chapter 4.7 para 2
+
         VTR_ASSERT_SAFE_MSG(index < vec_.size(), "Out-of-range index");
         return vec_[index];
     }

--- a/libs/libvtrutil/src/vtr_vector_map.h
+++ b/libs/libvtrutil/src/vtr_vector_map.h
@@ -62,7 +62,7 @@ class vector_map {
     //Indexing
     const_reference operator[](const K n) const {
         size_t index = size_t(n);
-        VTR_ASSERT_SAFE_MSG(index >= 0 && index < vec_.size(), "Out-of-range index");
+        VTR_ASSERT_SAFE_MSG(index < vec_.size(), "Out-of-range index");
         return vec_[index];
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This check seems to be causing an issue on the latest version of g++, where it's complaining about checking the sign on an unsigned type. See the issue linked for more information.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1539

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Cleans up the build output, otherwise you get a warning everytime vector_map is referenced.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I built it successfully, and tested it on a super small circuit, everything seems in order.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
