### PR TITLE
ODIN_II: Changes to fix coverity scan errors

### DIFF
--- a/ODIN_II/SRC/MixingOptimization.cpp
+++ b/ODIN_II/SRC/MixingOptimization.cpp
@@ -34,8 +34,7 @@
 
 void MixingOpt::scale_counts() {
     if (this->_blocks_count < 0 || this->_blocks_count == INT_MAX || this->_ratio < 0.0 || this->_ratio > 1.0) {
-        error_message(NETLIST, unknown_location, "%s",
-                      "The parameters for optimization kind:%i are configured incorrectly : count %i, ratio %f\n", this->_kind, this->_blocks_count, this->_ratio);
+        error_message(NETLIST, unknown_location, "The parameters for optimization kind:%i are configured incorrectly : count %i, ratio %f\n", this->_kind, this->_blocks_count, this->_ratio);
         exit(0);
     }
     this->_blocks_count = this->_blocks_count * this->_ratio;
@@ -43,14 +42,12 @@ void MixingOpt::scale_counts() {
 
 void MixingOpt::assign_weights(netlist_t* /*netlist*/, std::vector<nnode_t*> /*nodes*/) {
     // compute weights for all noted nodes
-    error_message(NETLIST, unknown_location, "%s",
-                  "Assign_weights mixing optimization was called for optimization without specification provided, for kind  %i\n", this->_kind);
+    error_message(NETLIST, unknown_location, "Assign_weights mixing optimization was called for optimization without specification provided, for kind  %i\n", this->_kind);
     exit(0);
 }
 
 void MixingOpt::perform(netlist_t*, std::vector<nnode_t*>&) {
-    error_message(NETLIST, unknown_location, "%s",
-                  "Performing mixing optimization was called for optimization without method provided, for kind  %i\n", this->_kind);
+    error_message(NETLIST, unknown_location, "Performing mixing optimization was called for optimization without method provided, for kind  %i\n", this->_kind);
     exit(0);
 }
 
@@ -63,8 +60,7 @@ MultsOpt::MultsOpt(int _exact)
 MultsOpt::MultsOpt(float ratio)
     : MixingOpt(ratio, MULTIPLY) {
     if (ratio < 0.0 || ratio > 1.0) {
-        error_message(NETLIST, unknown_location, "%s",
-                      "Miltipliers mixing optimization is started with wrong ratio %f\n", ratio);
+        error_message(NETLIST, unknown_location, "Miltipliers mixing optimization is started with wrong ratio %f\n", ratio);
         exit(0);
     }
 
@@ -144,14 +140,12 @@ void MultsOpt::set_blocks_needed(int new_count) {
     this->scale_counts();
 }
 void MixingOpt::instantiate_soft_logic(netlist_t* /*netlist*/, std::vector<nnode_t*> /* nodes*/) {
-    error_message(NETLIST, unknown_location, "%s",
-                  "Performing instantiate_soft_logic was called for optimization without method provided, for kind  %i\n", this->_kind);
+    error_message(NETLIST, unknown_location, "Performing instantiate_soft_logic was called for optimization without method provided, for kind  %i\n", this->_kind);
     exit(0);
 }
 
 void MixingOpt::partial_map_node(nnode_t* /*node*/, short /*traverse_value*/, netlist_t*, /*netlist*/ HardSoftLogicMixer* /*mixer*/) {
-    error_message(NETLIST, unknown_location, "%s",
-                  "Performing partial_map_node was called for optimization without method provided, for kind  %i\n", this->_kind);
+    error_message(NETLIST, unknown_location, "Performing partial_map_node was called for optimization without method provided, for kind  %i\n", this->_kind);
     exit(0);
 }
 

--- a/ODIN_II/SRC/include/MixingOptimization.hpp
+++ b/ODIN_II/SRC/include/MixingOptimization.hpp
@@ -138,7 +138,7 @@ class MixingOpt {
      * @brief this variable allows to cache traverse value
      * 
      */
-    short cached_traverse_value;
+    short cached_traverse_value = 0;
 
     // an integer representing the number of required hard blocks
     // that should be estimated and updated through set blocks needed

--- a/ODIN_II/SRC/netlist_statistic.cpp
+++ b/ODIN_II/SRC/netlist_statistic.cpp
@@ -82,8 +82,7 @@ void mixing_optimization_stats(nnode_t* node, netlist_t* netlist) {
             break;
         }
         default:
-            error_message(NETLIST, unknown_location, "%s",
-                          "Counting weights for mixing optimization for %i: Hard block type is unimplemented", node->type);
+            error_message(NETLIST, unknown_location, "Counting weights for mixing optimization for %i: Hard block type is unimplemented", node->type);
             break;
     }
 }


### PR DESCRIPTION
The commit addresses several errors
CID 212805:  API usage errors  (PRINTF_ARGS)
Related to #1496

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The printf function used as part of the odin_error, was not even treated with a warning, while was caught as coverity scan.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes the code cleaner

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed make test in ODIN_II directory

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
