### PR TITLE
Fix inconsistent buffering

### DIFF
--- a/vpr/src/place/analytic_placer.cpp
+++ b/vpr/src/place/analytic_placer.cpp
@@ -14,6 +14,7 @@
 #    include "vtr_log.h"
 #    include "cut_spreader.h"
 #    include "vpr_utils.h"
+#    include "place_util.h"
 
 // Templated struct for constructing and solving matrix equations in analytic placer
 template<typename T>

--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -394,10 +394,6 @@ static void load_rr_indexed_data_T_values(int index_start,
                 // This means that at least one edge of this node has a buffered switch,
                 // which prevails over unbuffered ones.
                 switches_buffered[cost_index] = 1;
-
-                VTR_LOG_WARN("Inconsistency in the buffering state of all wire-to-wire switches of wire segments "
-                             "with cost index (%d) to have same 'buffered' value (%d), "
-                             "but found segment switch with different 'buffered' value (%d)\n", cost_index, switches_buffered[cost_index], buffered);
             }
         }
     }
@@ -513,10 +509,6 @@ static void calculate_average_switch(int inode, double& avg_switch_R, double& av
                 // This means that at least one edge of this node has a buffered switch,
                 // which prevails over unbuffered ones.
                 buffered = 1;
-
-                VTR_LOG_WARN("Inconsitent buffering of children of rr node %s (%s)\n",
-                             rr_node_arch_name(inode).c_str(),
-                             describe_rr_node(inode).c_str());
             }
 
             num_switches++;

--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -387,8 +387,17 @@ static void load_rr_indexed_data_T_values(int index_start,
             switches_buffered[cost_index] = buffered;
         } else {
             if (switches_buffered[cost_index] != buffered) {
-                VPR_FATAL_ERROR(VPR_ERROR_ARCH,
-                                "Expecting all wire-to-wire switches of wire segments with cost index (%d) to have same 'buffered' value (%d), but found segment switch with different 'buffered' value (%d)\n", cost_index, switches_buffered[cost_index], buffered);
+                // If a previous buffering state is inconsistent with the current one,
+                // the node should be treated as buffered, as there are only two possible
+                // values for the buffering state (except for the UNDEFINED case).
+                //
+                // This means that at least one edge of this node has a buffered switch,
+                // which prevails over unbuffered ones.
+                switches_buffered[cost_index] = 1;
+
+                VTR_LOG_WARN("Inconsistency in the buffering state of all wire-to-wire switches of wire segments "
+                             "with cost index (%d) to have same 'buffered' value (%d), "
+                             "but found segment switch with different 'buffered' value (%d)\n", cost_index, switches_buffered[cost_index], buffered);
             }
         }
     }
@@ -497,6 +506,14 @@ static void calculate_average_switch(int inode, double& avg_switch_R, double& av
                     buffered = 0;
                 }
             } else if (buffered != device_ctx.rr_switch_inf[switch_index].buffered()) {
+                // If a previous buffering state is inconsistent with the current one,
+                // the node should be treated as buffered, as there are only two possible
+                // values for the buffering state (except for the UNDEFINED case).
+                //
+                // This means that at least one edge of this node has a buffered switch,
+                // which prevails over unbuffered ones.
+                buffered = 1;
+
                 VTR_LOG_WARN("Inconsitent buffering of children of rr node %s (%s)\n",
                              rr_node_arch_name(inode).c_str(),
                              describe_rr_node(inode).c_str());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes an issue related to buffered nodes.
During the rr_graph_indexed_data calculation, the state of the switches of different segment type nodes are being checked and, currently, if two different computation of the buffering state of two nodes belonging to the same cost_index (e.g. same segment type), VTR throws an error.

The changes in this PR prevent VTR to throw the error, but instead, as the buffered switches "win" against the non-buffered ones, if a conflict is found when checking the buffering state of the switches of two nodes of the same segment type.
In case of conflict then, the buffered state of a node is set to one as there is no other possibility (e.g. the conflict can only be between zero and one).

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1564#issuecomment-704348704

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Complex RR graph structure fail due to this too restrict check on the buffering state of some segments.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Strong reg tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
