### PR TITLE
Chain pack pattern assertion fix

### DIFF
--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -1548,6 +1548,7 @@ static void update_chain_root_pins(t_pack_patterns* chain_pattern,
     for (const auto pin_ptr : chain_input_pins) {
         std::vector<t_pb_graph_pin*> connected_primitive_pins;
         get_all_connected_primitive_pins(pin_ptr, connected_primitive_pins);
+        VTR_ASSERT(connected_primitive_pins.size());
         primitive_input_pins.push_back(connected_primitive_pins);
     }
 
@@ -1602,8 +1603,6 @@ static void get_all_connected_primitive_pins(const t_pb_graph_pin* cluster_input
             }
         }
     }
-
-    VTR_ASSERT(connected_primitive_pins.size());
 }
 
 /**


### PR DESCRIPTION
This PR moves an assertion related to chain pack-patterns elsewhere to allow for pb_type modes that break a chain.

#### Description
Whenever there is a chain pack-pattern that passes through a pb_type with a mode in which chain-related pins are unconnected VPR raises an assertion. This happens at the pre-packing stage (the circuit doesn't matter). I've attached an example arch.xml file to allow reproduction of the issue.

In the attached example `arch.xml` there is a top-level pb_type `PB-CLB` that has two modes: `LUT4` and `LUT4_CARRY`. The former hosts the `LUT4` BLIF model (a classic LUT4) while the latter hosts a LUT that also has carry input and output pins for adder implementation `LUT4_CARRY`.

The assertion is throws specifically when the interconnect of the `LUT4` mode includes the carry-chain pin connections to the underlying pb_type where they are actually unconnected. The assertion says:

```
vpr/src/pack/prepack.cpp:1606 get_all_connected_primitive_pins: Assertion 'connected_primitive_pins.size()' failed.
```

which is kind of misleading.

By digging into the code I've realized that this assertion is placed incorrectly as it is being triggered when no connected pin is found within a specific mode which does not necessary mean that the pin is not connected in other modes.

My proposal in this PR is to move the assertion right after the recursive check done in `get_all_connected_primitive_pins` to allow for such situations. This way the assertion will get triggered only if a carry pin is completely disconnected (in all modes).

#### Related Issue
None

#### Motivation and Context

I'm using the V2X tool (https://github.com/SymbiFlow/python-symbiflow-v2x) to generate pb_type XMLs. The tool automatically generate interconnects for modes regardless whether all pins are connected inside a mode.

I found that the issue can be worked around by simply removing the unconnected pin connections from a mode interconnect. However, I'd like the architecture specification to be more flexible as having such unconnected pins is not an error as the carry chain isn't really broken. Its just requires a specific mode to be selected to complete it. This is the reason for this PR.

#### How Has This Been Tested?
I wrote a test arch.xml file that is attached below to demonstrate the issue. The upstream VPR (i.e. from master) fails with it while the one with the fix from this PR completes successfully.
[arch.xml.tar.gz](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/5510147/arch.xml.tar.gz)

The issue can be reproduced by running packing of any circuit with this architecture. The fail occurs at the prepacking stage and is not related to the circuit itself but rather to the arch.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

I'm not sure yet how to include the test with the attached arch.xml into the VTR flow but I can do that if it is requested.