### PR TITLE
rr_nodes: add fan-in list generator

### DIFF
--- a/vpr/src/route/rr_graph_util.cpp
+++ b/vpr/src/route/rr_graph_util.cpp
@@ -177,3 +177,20 @@ void reorder_rr_graph_nodes(const t_router_opts& router_opts) {
                                std::get<2>(edge));
     });
 }
+
+vtr::vector<RRNodeId, std::vector<RREdgeId>> get_fan_in_list() {
+    auto& rr_nodes = g_vpr_ctx.device().rr_nodes;
+
+    vtr::vector<RRNodeId, std::vector<RREdgeId>> node_fan_in_list;
+
+    node_fan_in_list.resize(rr_nodes.size(), std::vector<RREdgeId>(0));
+    node_fan_in_list.shrink_to_fit();
+
+    //Walk the graph and increment fanin on all dwnstream nodes
+    rr_nodes.for_each_edge(
+        [&](RREdgeId edge, __attribute__((unused)) RRNodeId src, RRNodeId sink) {
+            node_fan_in_list[sink].push_back(edge);
+        });
+
+    return node_fan_in_list;
+}

--- a/vpr/src/route/rr_graph_util.h
+++ b/vpr/src/route/rr_graph_util.h
@@ -1,10 +1,16 @@
 #ifndef RR_GRAPH_UTIL_H
 #define RR_GRAPH_UTIL_H
 
+#include "vpr_types.h"
+
 int seg_index_of_cblock(t_rr_type from_rr_type, int to_node);
 
 int seg_index_of_sblock(int from_node, int to_node);
 
 void reorder_rr_graph_nodes(const t_router_opts& router_opts);
+
+// This function generates and returns a vector indexed by RRNodeId
+// containing a list of fan-in edges for each node.
+vtr::vector<RRNodeId, std::vector<RREdgeId>> get_fan_in_list();
 
 #endif


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
It might be useful to get only the fan-in edges of a certain destination node, and currently the RR graph APIs do not provide such a possibility.

This PR adds a fan-in list constructor and its destroyer so that the extra memory is freed once the purpose of the fan-in lists has been fulfilled.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
