### PR TITLE
Direct connection lookup fix

### DIFF
--- a/vpr/src/place/place_macro.cpp
+++ b/vpr/src/place/place_macro.cpp
@@ -499,7 +499,7 @@ static bool net_is_driven_by_direct(ClusterNetId clb_net) {
 
     auto logical_block = cluster_ctx.clb_nlist.block_type(block_id);
     auto physical_tile = pick_best_physical_type(logical_block);
-    auto physical_pin  = get_physical_pin(physical_tile, logical_block, pin_index);
+    auto physical_pin = get_physical_pin(physical_tile, logical_block, pin_index);
 
     auto direct = f_idirect_from_blk_pin[physical_tile->index][physical_pin];
 

--- a/vpr/src/place/place_macro.cpp
+++ b/vpr/src/place/place_macro.cpp
@@ -497,7 +497,11 @@ static bool net_is_driven_by_direct(ClusterNetId clb_net) {
     ClusterBlockId block_id = cluster_ctx.clb_nlist.net_driver_block(clb_net);
     int pin_index = cluster_ctx.clb_nlist.net_pin_logical_index(clb_net, 0);
 
-    auto direct = f_idirect_from_blk_pin[cluster_ctx.clb_nlist.block_type(block_id)->index][pin_index];
+    auto logical_block = cluster_ctx.clb_nlist.block_type(block_id);
+    auto physical_tile = pick_best_physical_type(logical_block);
+    auto physical_pin  = get_physical_pin(physical_tile, logical_block, pin_index);
+
+    auto direct = f_idirect_from_blk_pin[physical_tile->index][physical_pin];
 
     return direct != OPEN;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a bug with direct connection lookup during identification of placement macro heads.

#### Description
<!--- Describe your changes in detail -->
The function `net_is_driven_by_direct` looks up the `f_idirect_from_blk_pin` array using logical block index and its pin index. However, the array stores information for physical blocks and their pin indices.

In this PR I've added translation from logical to physical indices and used them for lookup.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While defining architecture for a QuickLogic FPGA that utilizes carry chains I've encountered a VPR segfault during placement. During debugging I've noticed that the lookup index used in the function in question is greater than the array size which shouldn't be happening. Looking of how the `f_idirect_from_blk_pin` array is allocated and what it stores allowed me to identify the issue.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For now only locally.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
