### PR TITLE
Don't compute congestion for non-configurable node sets up front.

### DIFF
--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -680,7 +680,6 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
     //Info for the switch connecting from_node to_node
     int iswitch = rr_nodes_.edge_switch(from_edge);
     bool switch_buffered = rr_switch_inf_[iswitch].buffered();
-    bool reached_configurably = rr_switch_inf_[iswitch].configurable();
     float switch_R = rr_switch_inf_[iswitch].R;
     float switch_Tdel = rr_switch_inf_[iswitch].Tdel;
     float switch_Cinternal = rr_switch_inf_[iswitch].Cinternal;
@@ -723,22 +722,7 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
     //Second, we adjust the Tdel to account for the delay caused by the internal capacitance.
     Tdel += Rdel_adjust * switch_Cinternal;
 
-    float cong_cost = 0.;
-    if (reached_configurably) {
-        cong_cost = get_rr_cong_cost(to_node, cost_params.pres_fac);
-    } else {
-        //Reached by a non-configurable edge.
-        //Therefore the from_node and to_node are part of the same non-configurable node set.
-#ifdef VTR_ASSERT_SAFE_ENABLED
-        VTR_ASSERT_SAFE_MSG(same_non_config_node_set(from_node, to_node),
-                            "Non-configurably connected edges should be part of the same node set");
-#endif
-
-        //The congestion cost of all nodes in the set has already been accounted for (when
-        //the current path first expanded a node in the set). Therefore do *not* re-add the congestion
-        //cost.
-        cong_cost = 0.;
-    }
+    float cong_cost = get_rr_cong_cost(to_node, cost_params.pres_fac);
 
     //Update the backward cost (upstream already included)
     to->backward_path_cost += (1. - cost_params.criticality) * cong_cost; //Congestion cost

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -694,28 +694,9 @@ void reset_path_costs(const std::vector<int>& visited_rr_nodes) {
     }
 }
 
-/* Returns the congestion cost of using this rr-node plus that of any      *
- * non-configurably connected rr_nodes that must be used when it is used.  */
+/* Returns the congestion cost of using this rr-node. */
 float get_rr_cong_cost(int inode, float pres_fac) {
-    auto& device_ctx = g_vpr_ctx.device();
-    auto& route_ctx = g_vpr_ctx.routing();
-
-    float cost = get_single_rr_cong_cost(inode, pres_fac);
-
-    if (route_ctx.non_configurable_bitset.get(inode)) {
-        // Access unordered_map only when the node is part of a non-configurable set
-        auto itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
-        if (itr != device_ctx.rr_node_to_non_config_node_set.end()) {
-            for (int node : device_ctx.rr_non_config_node_sets[itr->second]) {
-                if (node == inode) {
-                    continue; //Already included above
-                }
-
-                cost += get_single_rr_cong_cost(node, pres_fac);
-            }
-        }
-    }
-    return (cost);
+    return get_single_rr_cong_cost(inode, pres_fac);
 }
 
 /* Mark all the SINKs of this net as targets by setting their target flags  *


### PR DESCRIPTION

#### Description

This PR improves performance by not summing congestion on entry of a nonconfigurable node set.

#### Motivation and Context

Symbiflow architectures use nonconfigurable node sets to model complex channel geometry, such as L-shaped wires. When the router enters a nonconfigurable node set, it sums the congestion cost for all nodes in the set.

This simple operation is performed many billions of times, and is one of the top time consumers in the CPU profile.

#### How Has This Been Tested?
This has been tested with [fpga-tool-perf](https://github.com/SymbiFlow/fpga-tool-perf) on the Hydra cluster with SymbiFlow's modifications, and compared to the baseline, an addition to tests run on CI.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
