### PR TITLE
WIP/DNM kokoro: add check for final disk space usage

### DIFF
--- a/.github/kokoro/steps/vtr-test.sh
+++ b/.github/kokoro/steps/vtr-test.sh
@@ -47,3 +47,13 @@ echo "========================================"
 export VPR_NUM_WORKERS=1
 ./run_reg_test.py $VTR_TEST $VTR_TEST_OPTIONS -j$NUM_CORES
 kill $MONITOR
+
+echo "========================================"
+echo "Check final workdir size"
+echo "========================================"
+# Make sure working directory doesn't exceed disk space limit!
+echo "Working directory size: $(du -sh)"
+if [[ $(du -s | cut -d $'\t' -f 1) -gt $(expr 1024 \* 1024 \* 90) ]]; then
+    echo "Working directory too large!"
+    exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1564 reports a huge disk space usage after the completion of all the tests. This is likely a pre-existing issue that went un-noticed. This PR adds a check at the end of the VTR kokoro tests to verify what is the final amount of disk space used.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
