### PR TITLE
[WIP] Precalculate non-configurable node congestion base costs

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -344,6 +344,9 @@ struct RoutingContext : public Context {
      */
     vtr::dynamic_bitset<> non_configurable_bitset; /*[0...device_ctx.num_rr_nodes] */
 
+    ///@brief Congestion base cost of each non-configurably connected node
+    std::vector<float> rr_non_config_node_cong_base_costs;
+
     ///@brief Information about current routing status of each net
     t_net_routing_status net_status;
 

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -99,7 +99,6 @@ static void adjust_one_rr_occ_and_acc_cost(int inode, int add_or_sub, float acc_
 bool validate_traceback_recurr(t_trace* trace, std::set<int>& seen_rr_nodes);
 static bool validate_trace_nodes(t_trace* head, const std::unordered_set<int>& trace_nodes);
 static vtr::vector<ClusterNetId, uint8_t> load_is_clock_net();
-static void invalidate_non_configurable_cong_costs(size_t inode);
 
 /************************** Subroutine definitions ***************************/
 
@@ -383,14 +382,30 @@ void pathfinder_update_path_occupancy(t_trace* route_segment_start, int add_or_s
      * if it is 1, the net is added to the routing.
      */
 
+    auto& route_ctx = g_vpr_ctx.routing();
+    auto& device_ctx = g_vpr_ctx.device();
+
     t_trace* tptr;
+    bool inside_non_configurable_node_set = false;
 
     tptr = route_segment_start;
     if (tptr == nullptr) /* No routing yet. */
         return;
 
     for (;;) {
-        pathfinder_update_single_node_occupancy(tptr->index, add_or_sub);
+        if (!route_ctx.non_configurable_bitset.get(tptr->index)) {
+            inside_non_configurable_node_set = false;
+            pathfinder_update_single_node_occupancy(tptr->index, add_or_sub);
+        } else if (!inside_non_configurable_node_set) {
+            // If entering a non-configurable node set, update all nodes in that set,
+            // then skip updates until until out of the set.
+            inside_non_configurable_node_set = true;
+            auto itr = device_ctx.rr_node_to_non_config_node_set.find(tptr->index);
+            VTR_ASSERT(itr != device_ctx.rr_node_to_non_config_node_set.end());
+            for (int node : device_ctx.rr_non_config_node_sets[itr->second]) {
+                pathfinder_update_single_node_occupancy(node, add_or_sub);
+            }
+        }
 
         if (tptr->iswitch == OPEN) { //End of branch
             tptr = tptr->next;       /* Skip next segment. */
@@ -438,10 +453,6 @@ void pathfinder_update_acc_cost_and_overuse_info(float acc_fac, OveruseInfo& ove
             ++overused_nodes;
             total_overuse += overuse;
             worst_overuse = std::max(worst_overuse, size_t(overuse));
-
-            // If this node is part of a non-configurable set, invalidate
-            // the cached congestion cost.
-            invalidate_non_configurable_cong_costs(inode);
         }
     }
 
@@ -702,16 +713,13 @@ void reset_path_costs(const std::vector<int>& visited_rr_nodes) {
 /* Returns the congestion cost of using this rr-node plus that of any      *
  * non-configurably connected rr_nodes that must be used when it is used.  */
 float get_rr_cong_cost(int inode, float pres_fac) {
-    auto& device_ctx = g_vpr_ctx.device();
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
     float cost = 0.;
-    float non_configurable_cong_base_cost = route_context.rr_non_configurable_node_cong_base_cost[inode];
+    float non_config_cong_base_cost = route_ctx.rr_non_config_node_cong_base_costs[inode];
 
-    if (non_configurable_cong_base_cost >= 0) {
-        cost = non_configurable_cong_base_cost *
-            get_single_rr_cong_acc_cost(inode) *
-            get_single_rr_cong_pres_cost(inode, pres_fac);
+    if (non_config_cong_base_cost >= 0) {
+        cost = non_config_cong_base_cost * get_single_rr_cong_acc_cost(inode) * get_single_rr_cong_pres_cost(inode, pres_fac);
     } else {
         cost = get_single_rr_cong_cost(inode, pres_fac);
     }
@@ -937,16 +945,16 @@ void alloc_and_load_rr_node_route_structs() {
     // Calculate summed congestion base costs of non-configurable node sets.
     // An entry is invalid if less than 0.
     auto& base_costs = route_ctx.rr_non_config_node_cong_base_costs;
-    base_costs.resize(device_ctx.rr_non_config_node_sets.size());
+    base_costs.resize(device_ctx.rr_nodes.size());
     std::fill(base_costs.begin(), base_costs.end(), -1);
 
     for (auto i : device_ctx.rr_node_to_non_config_node_set) {
         route_ctx.non_configurable_bitset.set(i.first, true);
         float base_cost = 0.;
-        for (auto n : device_ctx.rr_non_config_node_sets[i]) {
+        for (int n : device_ctx.rr_non_config_node_sets[i.second]) {
             base_cost += get_single_rr_cong_base_cost(n);
         }
-        for (auto n : device_ctx.rr_non_config_node_sets[i]) {
+        for (int n : device_ctx.rr_non_config_node_sets[i.second]) {
             base_costs[n] = base_cost;
         }
     }
@@ -1470,10 +1478,6 @@ static void adjust_one_rr_occ_and_acc_cost(int inode, int add_or_sub, float acc_
     } else {
         if (add_or_sub == 1) {
             route_ctx.rr_node_route_inf[inode].acc_cost += (new_occ - capacity) * acc_fac;
-
-            // If this node is part of a non-configurable set, invalidate
-            // the cached congestion cost.
-            invalidate_non_configurable_cong_costs(inode);
         }
     }
 }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -99,6 +99,7 @@ static void adjust_one_rr_occ_and_acc_cost(int inode, int add_or_sub, float acc_
 bool validate_traceback_recurr(t_trace* trace, std::set<int>& seen_rr_nodes);
 static bool validate_trace_nodes(t_trace* head, const std::unordered_set<int>& trace_nodes);
 static vtr::vector<ClusterNetId, uint8_t> load_is_clock_net();
+static void invalidate_non_configurable_cong_costs(size_t inode);
 
 /************************** Subroutine definitions ***************************/
 
@@ -437,6 +438,10 @@ void pathfinder_update_acc_cost_and_overuse_info(float acc_fac, OveruseInfo& ove
             ++overused_nodes;
             total_overuse += overuse;
             worst_overuse = std::max(worst_overuse, size_t(overuse));
+
+            // If this node is part of a non-configurable set, invalidate
+            // the cached congestion cost.
+            invalidate_non_configurable_cong_costs(inode);
         }
     }
 
@@ -698,22 +703,17 @@ void reset_path_costs(const std::vector<int>& visited_rr_nodes) {
  * non-configurably connected rr_nodes that must be used when it is used.  */
 float get_rr_cong_cost(int inode, float pres_fac) {
     auto& device_ctx = g_vpr_ctx.device();
-    auto& route_ctx = g_vpr_ctx.routing();
+    auto& route_ctx = g_vpr_ctx.mutable_routing();
 
-    float cost = get_single_rr_cong_cost(inode, pres_fac);
+    float cost = 0.;
+    float non_configurable_cong_base_cost = route_context.rr_non_configurable_node_cong_base_cost[inode];
 
-    if (route_ctx.non_configurable_bitset.get(inode)) {
-        // Access unordered_map only when the node is part of a non-configurable set
-        auto itr = device_ctx.rr_node_to_non_config_node_set.find(inode);
-        if (itr != device_ctx.rr_node_to_non_config_node_set.end()) {
-            for (int node : device_ctx.rr_non_config_node_sets[itr->second]) {
-                if (node == inode) {
-                    continue; //Already included above
-                }
-
-                cost += get_single_rr_cong_cost(node, pres_fac);
-            }
-        }
+    if (non_configurable_cong_base_cost >= 0) {
+        cost = non_configurable_cong_base_cost *
+            get_single_rr_cong_acc_cost(inode) *
+            get_single_rr_cong_pres_cost(inode, pres_fac);
+    } else {
+        cost = get_single_rr_cong_cost(inode, pres_fac);
     }
     return (cost);
 }
@@ -934,8 +934,21 @@ void alloc_and_load_rr_node_route_structs() {
 
     reset_rr_node_route_structs();
 
+    // Calculate summed congestion base costs of non-configurable node sets.
+    // An entry is invalid if less than 0.
+    auto& base_costs = route_ctx.rr_non_config_node_cong_base_costs;
+    base_costs.resize(device_ctx.rr_non_config_node_sets.size());
+    std::fill(base_costs.begin(), base_costs.end(), -1);
+
     for (auto i : device_ctx.rr_node_to_non_config_node_set) {
         route_ctx.non_configurable_bitset.set(i.first, true);
+        float base_cost = 0.;
+        for (auto n : device_ctx.rr_non_config_node_sets[i]) {
+            base_cost += get_single_rr_cong_base_cost(n);
+        }
+        for (auto n : device_ctx.rr_non_config_node_sets[i]) {
+            base_costs[n] = base_cost;
+        }
     }
 }
 
@@ -1457,6 +1470,10 @@ static void adjust_one_rr_occ_and_acc_cost(int inode, int add_or_sub, float acc_
     } else {
         if (add_or_sub == 1) {
             route_ctx.rr_node_route_inf[inode].acc_cost += (new_occ - capacity) * acc_fac;
+
+            // If this node is part of a non-configurable set, invalidate
+            // the cached congestion cost.
+            invalidate_non_configurable_cong_costs(inode);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
VPR spends a lot of time adding costs in `get_rr_cong_cost()` when used with SymbiFlow architectures, which is called many billions of times.

This PR precomputes the sum of base costs in each node set, and uses this to compute the congestion cost more quickly.

In addition, this fixes a bug where occupation costs are not updated for all nodes in a non-configurable set.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
This is to improve VPR's performance.

#### How Has This Been Tested?
Performance measurements are still in progress.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
