### PR TITLE
CMake: do not install test binaries

### DIFF
--- a/libs/EXTERNAL/libblifparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libblifparse/CMakeLists.txt
@@ -69,4 +69,4 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
              COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test/test_parser.sh ${CMAKE_CURRENT_SOURCE_DIR}/test/*/*.blif ${CMAKE_CURRENT_SOURCE_DIR}/test/*/*.eblif)
 endif()
 
-install(TARGETS libblifparse blifparse_test DESTINATION bin)
+install(TARGETS libblifparse DESTINATION bin)

--- a/libs/EXTERNAL/libsdcparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libsdcparse/CMakeLists.txt
@@ -66,4 +66,4 @@ if (USES_IPO)
     endforeach()
 endif()
 
-install(TARGETS libsdcparse sdcparse_test DESTINATION bin)
+install(TARGETS libsdcparse DESTINATION bin)

--- a/libs/liblog/CMakeLists.txt
+++ b/libs/liblog/CMakeLists.txt
@@ -21,4 +21,4 @@ set_target_properties(liblog PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 add_executable(test_log ${EXEC_SOURCES})
 target_link_libraries(test_log liblog)
 
-install(TARGETS test_log liblog DESTINATION bin)
+install(TARGETS liblog DESTINATION bin)


### PR DESCRIPTION
#### Description

The test binaries used for `make test`/ctest are also installed to the destination system using `install()` directives. This makes little sense, as the tests do not need to be run outside a development environment.

#### Related Issue

N/A

#### Motivation and Context

I am packaging vtr in the [vtr-git AUR package](https://aur.archlinux.org/packages/vtr-git/). The installed package should not contain unit test binaries.

#### How Has This Been Tested?

`make install` no longer installs test binaries, `make test` still works as expected.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
