### PR TITLE
CMake: append to LINK_FLAGS instead of replacing them

### DIFF
--- a/ODIN_II/CMakeLists.txt
+++ b/ODIN_II/CMakeLists.txt
@@ -189,7 +189,7 @@ endforeach()
 #Supress IPO link warnings if IPO is enabled
 get_target_property(ODIN_USES_IPO odin_II INTERPROCEDURAL_OPTIMIZATION)
 if (ODIN_USES_IPO)
-    set_target_properties(odin_II PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET odin_II APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
 #add strict odin compiler flags, if set

--- a/blifexplorer/CMakeLists.txt
+++ b/blifexplorer/CMakeLists.txt
@@ -59,7 +59,7 @@ else()
     #Supress IPO link warnings if IPO is enabled
     get_target_property(TEST_BLIFEXPLORER_USES_IPO blifexplorer INTERPROCEDURAL_OPTIMIZATION)
     if (TEST_BLIFEXPLORER_USES_IPO)
-        set_target_properties(blifexplorer PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+        set_property(TARGET blifexplorer APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
     endif()
 
 

--- a/libs/EXTERNAL/libblifparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libblifparse/CMakeLists.txt
@@ -57,7 +57,7 @@ if (USES_IPO)
         CHECK_CXX_COMPILER_FLAG(${flag} CXX_COMPILER_SUPPORTS_${flag})
         if(CXX_COMPILER_SUPPORTS_${flag})
             #Flag supported, so enable it
-            set_target_properties(blifparse_test PROPERTIES LINK_FLAGS ${flag})
+            set_property(TARGET blifparse_test APPEND PROPERTY LINK_FLAGS ${flag})
         endif()
     endforeach()
 endif()

--- a/libs/EXTERNAL/libsdcparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libsdcparse/CMakeLists.txt
@@ -61,7 +61,7 @@ if (USES_IPO)
         CHECK_CXX_COMPILER_FLAG(${flag} CXX_COMPILER_SUPPORTS_${flag})
         if(CXX_COMPILER_SUPPORTS_${flag})
             #Flag supported, so enable it
-            set_target_properties(sdcparse_test PROPERTIES LINK_FLAGS ${flag})
+            set_property(TARGET sdcparse_test APPEND PROPERTY LINK_FLAGS ${flag})
         endif()
     endforeach()
 endif()

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(read_arch libarchfpga)
 #Supress IPO link warnings if IPO is enabled
 get_target_property(READ_ARCH_USES_IPO read_arch INTERPROCEDURAL_OPTIMIZATION)
 if (READ_ARCH_USES_IPO)
-    set_target_properties(read_arch PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET read_arch APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
 install(TARGETS libarchfpga read_arch DESTINATION bin)

--- a/utils/fasm/CMakeLists.txt
+++ b/utils/fasm/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(genfasm fasm)
 #Supress IPO link warnings if IPO is enabled
 get_target_property(GENFASM_USES_IPO genfasm INTERPROCEDURAL_OPTIMIZATION)
 if (GENFASM_USES_IPO)
-    set_target_properties(genfasm PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET genfasm APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
 #Specify link-time dependancies
@@ -52,7 +52,7 @@ target_link_libraries(test_fasm fasm libcatch)
 #Supress IPO link warnings if IPO is enabled
 get_target_property(TEST_FASM_USES_IPO test_fasm INTERPROCEDURAL_OPTIMIZATION)
 if (TEST_FASM_USES_IPO)
-    set_target_properties(test_fasm PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET test_fasm APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
 add_test(

--- a/utils/route_diag/CMakeLists.txt
+++ b/utils/route_diag/CMakeLists.txt
@@ -11,6 +11,6 @@ target_link_libraries(route_diag
 #Supress IPO link warnings if IPO is enabled
 get_target_property(TEST_ROUTE_DIAG_USES_IPO route_diag INTERPROCEDURAL_OPTIMIZATION)
 if (TEST_ROUTE_DIAG_USES_IPO)
-    set_target_properties(route_diag PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET route_diag APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -135,7 +135,7 @@ target_link_libraries(vpr libvpr)
 #Supress IPO link warnings if IPO is enabled
 get_target_property(VPR_USES_IPO vpr INTERPROCEDURAL_OPTIMIZATION)
 if (VPR_USES_IPO)
-    set_target_properties(vpr PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET vpr APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
 
@@ -263,7 +263,7 @@ target_link_libraries(test_vpr
 #Supress IPO link warnings if IPO is enabled
 get_target_property(TEST_VPR_USES_IPO vpr INTERPROCEDURAL_OPTIMIZATION)
 if (TEST_VPR_USES_IPO)
-    set_target_properties(test_vpr PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+    set_property(TARGET test_vpr APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
 add_test(NAME test_vpr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
With `INTERPROCEDURAL_OPTIMIZATION`/LTO enabled, LDFLAGS from the environment are ignored.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
CMake takes the default linker flags from the LDFLAGS environment variable and initializes the targets' `LINK_FLAGS` with it. If `set_target_property()` is used to overwrite a target's `LINK_FLAGS`, these initial linker flags from the environment are lost.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ env LDFLAGS=-Wl,-z,relro cmake -B build -S . -DVTR_IPO_BUILD=on
$ grep relro build/vpr/CMakeFiles/vpr.dir/link.txt
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
