### PR TITLE
libvtrcapnproto: install capnp files to DATADIR

### DIFF
--- a/libs/libvtrcapnproto/CMakeLists.txt
+++ b/libs/libvtrcapnproto/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 if(NOT MSCV)
     # These flags generate noisy but non-bug warnings when using lib kj,
     # supress them.
@@ -28,7 +30,7 @@ capnp_generate_cpp(CAPNP_SRCS CAPNP_HDRS
     ${CAPNP_DEFS}
     )
 
-install(FILES ${CAPNP_DEFS} DESTINATION capnp)
+install(FILES ${CAPNP_DEFS} DESTINATION ${CMAKE_INSTALL_DATADIR}/vtr)
 
 add_library(libvtrcapnproto STATIC
             ${CAPNP_SRCS}


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Use CMAKE_INSTALL_DATADIR in order to install capnp files to a File Hierarchy Standard compliant directory.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On Linux, with `CMAKE_INSTALL_PREFIX=/usr`, the current configuration places the capnp files in `/usr/capnp/`, which is a nonstandard directory. Using `CMAKE_INSTALL_DATADIR` results in `/usr/share/vtr/` instead, which makes more sense.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make install` places the capnp files under `CMAKE_INSTALL_PREFIX/CMAKE_INSTALL_DATADIR/vtr/`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed