### PR TITLE
pb cleaning during clustering

### DIFF
--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -1992,15 +1992,15 @@ static void start_new_cluster(t_cluster_placement_stats* cluster_placement_stats
         auto type = candidate_types[i];
 
         t_pb* pb = new t_pb;
-        pb->pb_graph_node = type->pb_graph_head;
-        alloc_and_load_pb_stats(pb, feasible_block_array_size);
-        pb->parent_pb = nullptr;
 
         *router_data = alloc_and_load_router_data(&lb_type_rr_graphs[type->index], type);
 
         //Try packing into each mode
         e_block_pack_status pack_result = BLK_STATUS_UNDEFINED;
         for (int j = 0; j < type->pb_graph_head->pb_type->num_modes && !success; j++) {
+            pb->pb_graph_node = type->pb_graph_head;
+            alloc_and_load_pb_stats(pb, feasible_block_array_size);
+            pb->parent_pb = nullptr;
             pb->mode = j;
 
             reset_cluster_placement_stats(&cluster_placement_stats[type->index]);
@@ -2022,6 +2022,9 @@ static void start_new_cluster(t_cluster_placement_stats* cluster_placement_stats
                                             FULL_EXTERNAL_PIN_UTIL);
 
             success = (pack_result == BLK_PASSED);
+            if (!success) {
+                free_pb(pb);
+            }
         }
 
         if (success) {


### PR DESCRIPTION
Recently I've encountered the assertion failure during clustering: `vpr/src/pack/cluster.cpp:1437 try_place_atom_block_rec: Assertion 'parent_pb->mode == pb_graph_node->pb_type->parent_mode->index' failed.` This PR is an attempt to fix it.

#### Description
While debugging I discovered that the issue seems to be caused by the packer changing mode of a parent pb without re-allocating appropriate children for that mode which results in a conflict. In other words: when trying mode B after mode A there are already children for mode A allocated while they shouldn't be.

With this PR I added cleaning of the pb being used to form a cluster using the `free_pb` function. The cleanup is done each time when `try_pack_molecule` fails to pack for a given mode instead of after all available modes are exhausted.

The proposed fix seems to be working. However, I'm not that familiar with the packer code to tell whether it is the appropriate way of fixing the issue. I'd welcome any suggestions if a better solution is more feasible.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I've been working for supporting a VPR architecture that is used in the OpenFPGA project in SymbiFlow (https://github.com/lnis-uofu/SOFA/blob/master/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For now only locally using a few designs that triggered the assertion.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
