### PR TITLE
Add .editorconfig to tell editors/IDEs basic whitespace rules.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor config file, see http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{h,c,cpp}]
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
#### Description

https://editorconfig.org/ is a common file that is understood
by virtually all editors and IDES that deal with code. With this
file, contributors to the code-base already have a good head-start
complying with the expected formatting rules.

Note, this also includes a trim_trailing_whitespace setting, that
will remove random whitespace at end of lines, which will reduce
merge conflicts on such lines. Some existing files have spurious
whitespace at the end of lines, so whenever they are edited first
under .editorconfig configuration they will be cleaned up.

#### Motivation and Context
In recent pull requests I noticed that I had to manually configure my editor to match the local customs. With a `.editorconfig` file, this wouldn've happened automatically. This is an issue all contributors face. Let's make it simple to them.