### PR TITLE
Neglecting concatenation case for signedness

### DIFF
--- a/ODIN_II/SRC/ast_elaborate.cpp
+++ b/ODIN_II/SRC/ast_elaborate.cpp
@@ -1813,8 +1813,11 @@ ast_node_t* reduce_expressions(ast_node_t* node, sc_hierarchy* local_ref, long* 
 
                     vtr::free(max_size);
 
-                    /* cast to unsigned if necessary */
-                    if (node_is_constant(node->children[1])) {
+                    /* 
+                     * cast to unsigned if necessary
+                     * Concatenate results are unsigned, regardless of the operands. IEEE.1364-2005 pp.65
+                     */
+                    if (node->children[0]->type != CONCATENATE && node_is_constant(node->children[1])) {
                         char* id = NULL;
                         if (node->children[0]->type == IDENTIFIERS) {
                             id = node->children[0]->types.identifier;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
According to Verilog Standard 2005, concatenate results are unsigned, regardless of the operands. 
IEEE.1364-2005 pp.65

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1634 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
    1. make test (ODIN-II)
    2. Basic Regression Tests
    3. Strong Regression Test
    4. Basic Valgrind Memory Tests (also, Valgrind memory tests for all other regression suits)
    5. Sanitized Basic Regression Tests
    6. Odin-II Micro Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
