### PR TITLE
EBLIF cell parameter interpretation

### DIFF
--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -411,13 +411,13 @@ For example:
     .param multiplier 0.50
     .param power 001101
 
-Would set the parameters ``feedback``, ``multipleir`` and ``power``  of the above ``pll`` ``.subckt`` to ``"internal"``, ``0.50`` and ``001101`` respectively.
+Would set the parameters ``feedback``, ``multiplier`` and ``power``  of the above ``pll`` ``.subckt`` to ``"internal"``, ``0.50`` and ``001101`` respectively.
 
 Interpretation of parameter values is out of scope of the BLIF format extension.
 
 ``.param`` statements propagate to ``<parameter>`` elements in the packed netlist.
 
-Paramerer values propagate also to post-route Verilog netlist. Strings and real numbers are passed directly while binary words are prepended with the ``<N>'b`` prefix where ``N`` denotes a binary word length.
+Paramerer values propagate also to the post-route Verilog netlist, if it is generated. Strings and real numbers are passed directly while binary words are prepended with the ``<N>'b`` prefix where ``N`` denotes a binary word length.
 
 .attr
 ~~~~~

--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -391,16 +391,33 @@ The ``.param`` statement allows parameters (e.g. primitive modes) to be tagged o
 
 .. note:: ``.param`` statements apply to the previous primitive instantiation.
 
+Parameters can have one of the three available types. Type is inferred from the format in which a parameter is provided.
+
+ * **string**
+    Whenever a parameter value is quoted it is considered to be a string.
+
+ * **binary word**
+    Binary words are specified using strings of characters ``0`` and ``1``. No other characters are allowed. Number of characters denotes the word length.
+
+ * **real number**
+    Real numbers are stored as decimals where the dot ``.`` character separates the integer and fractional part. Presence of the dot character implies that the value is to be treated as a real number.
+
 For example:
 
 .. code-block:: none
 
-    .subckt dsp a=a_in b=b_in cin=c_in cout=c_out s=sum_out
-    .param mode adder
+    .subckt pll clk_in=gclk clk_out=pclk
+    .param feedback "internal"
+    .param multiplier 0.50
+    .param power 001101
 
-Would set the parameter ``mode`` of the above ``dsp`` ``.subckt`` to ``adder``.
+Would set the parameters ``feedback``, ``multipleir`` and ``power``  of the above ``pll`` ``.subckt`` to ``"internal"``, ``0.50`` and ``001101`` respectively.
+
+Interpretation of parameter values is out of scope of the BLIF format extension.
 
 ``.param`` statements propagate to ``<parameter>`` elements in the packed netlist.
+
+Paramerer values propagate also to post-route Verilog netlist. Strings and real numbers are passed directly while binary words are prepended with the ``<N>'b`` prefix where ``N`` denotes a binary word length.
 
 .attr
 ~~~~~

--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -413,6 +413,8 @@ For example:
 
 Would set the parameters ``feedback``, ``multiplier`` and ``power``  of the above ``pll`` ``.subckt`` to ``"internal"``, ``0.50`` and ``001101`` respectively.
 
+.. warning:: Integers in notation other than binary (e.g. decimal, hexadecimal) are not supported. Occurrence of params with digits other than 1 and 0 for binary words, not quoted (strings) or not separated with dot ``.`` (real numbers) are considered to be illegal.
+
 Interpretation of parameter values is out of scope of the BLIF format extension.
 
 ``.param`` statements propagate to ``<parameter>`` elements in the packed netlist.

--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -394,7 +394,7 @@ The ``.param`` statement allows parameters (e.g. primitive modes) to be tagged o
 Parameters can have one of the three available types. Type is inferred from the format in which a parameter is provided.
 
  * **string**
-    Whenever a parameter value is quoted it is considered to be a string.
+    Whenever a parameter value is quoted it is considered to be a string. BLIF parser does not allow escaped characters hence those are illegal and will cause syntax errors.
 
  * **binary word**
     Binary words are specified using strings of characters ``0`` and ``1``. No other characters are allowed. Number of characters denotes the word length.

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -20,6 +20,8 @@
 #include "vpr_error.h"
 #include "vpr_types.h"
 
+#include "read_blif.h"
+
 #include "netlist_walker.h"
 #include "netlist_writer.h"
 
@@ -625,7 +627,13 @@ class BlackBoxInst : public Instance {
 
         //Verilog parameters
         for (auto iter = params_.begin(); iter != params_.end(); ++iter) {
-            os << indent(depth + 1) << "." << iter->first << "(" << iter->second << ")";
+            /* Prepend a prefix if needed */
+            std::stringstream prefix;
+            if (is_binary_param(iter->second)) {
+                prefix << iter->second.length() << "'b";
+            }
+
+            os << indent(depth + 1) << "." << iter->first << "(" << prefix.str() << iter->second << ")";
             if (iter != --params_.end()) {
                 os << ",";
             }

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -21,6 +21,7 @@
 #include <unordered_set>
 #include <cctype> //std::isdigit
 #include <algorithm>
+#include <regex>
 
 #include "blifparse.hpp"
 #include "atom_netlist.h"
@@ -720,22 +721,14 @@ bool is_binary_param(const std::string& param) {
 }
 
 bool is_real_param(const std::string& param) {
-    const std::string real_chars = "0123456789.";
-
     /* Must be non-empty */
     if (param.empty()) {
         return false;
     }
 
-    /* The string mustn't contain any other chars that the expected ones */
-    for (size_t i = 0; i < param.length(); ++i) {
-        if (real_chars.find(param[i]) == std::string::npos) {
-            return false;
-        }
-    }
-
-    /* There must only be a single dot */
-    if (std::count(param.begin(), param.end(), '.') != 1) {
+    /* The string must match the regular expression */
+    static const std::regex real_number_expr("[+-]?([0-9]*\\.[0-9]+)|([0-9]+\\.[0-9]*)");
+    if (!std::regex_match(param, real_number_expr)) {
         return false;
     }
 

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <cctype> //std::isdigit
+#include <algorithm>
 
 #include "blifparse.hpp"
 #include "atom_netlist.h"
@@ -719,7 +720,7 @@ bool is_binary_param(const std::string& param) {
 }
 
 bool is_real_param(const std::string& param) {
-    const std::string chars = "012345678.";
+    const std::string real_chars = "0123456789.";
 
     /* Must be non-empty */
     if (param.empty()) {
@@ -728,9 +729,14 @@ bool is_real_param(const std::string& param) {
 
     /* The string mustn't contain any other chars that the expected ones */
     for (size_t i = 0; i < param.length(); ++i) {
-        if (chars.find(param[i]) == std::string::npos) {
+        if (real_chars.find(param[i]) == std::string::npos) {
             return false;
         }
+    }
+
+    /* There must only be a single dot */
+    if (std::count(param.begin(), param.end(), '.') != 1) {
+        return false;
     }
 
     /* This is a real number param */

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -392,7 +392,8 @@ struct BlifAllocCallback : public blifparse::Callback {
         bool is_valid = is_string_param(value) || is_binary_param(value) || is_real_param(value);
 
         if (!is_valid) {
-            parse_error(lineno_, ".param", "Incorrect parameter value specification");
+            std::string msg = "Incorrect parameter '" + name + "' value specification. Value '" + value + "' is not recognized as string, binary word or real number. Possible causes:\n\t* lack or inconsistency in quotes (string)\n\t* no dot '.' to separate integer and fractional part (real number)\n\t* use of characters other than '1' and '0' (binary word)";
+            parse_error(lineno_, ".param", msg);
         }
 
         curr_model().set_block_param(curr_block(), name, value);

--- a/vpr/src/base/read_blif.h
+++ b/vpr/src/base/read_blif.h
@@ -4,6 +4,10 @@
 #include "atom_netlist_fwd.h"
 #include "read_circuit.h"
 
+bool is_string_param(const std::string& param);
+bool is_binary_param(const std::string& param);
+bool is_real_param(const std::string& param);
+
 AtomNetlist read_blif(e_circuit_format circuit_format,
                       const char* blif_file,
                       const t_model* user_models,

--- a/vtr_flow/benchmarks/tests/test_eblif.eblif
+++ b/vtr_flow/benchmarks/tests/test_eblif.eblif
@@ -5,12 +5,16 @@
 .names a b a_and_b
 11 1
 .cname lut_a_and_b
-.param test_names_param "test_names_param_value"
+.param test_names_param_str "test_names_param_str_value"
+.param test_names_param_bin 00110101
+.param test_names_param_num 2.0
 .attr test_names_attrib "test_names_param_attrib"
 
 .latch a_and_b dff_q re clk 0
 .cname my_dff
-.param test_latch_param "test_latch_param_value"
+.param test_latch_param "test_latch_param_str_value"
+.param test_latch_param_bin 00110101
+.param test_latch_param_num 2.0
 .attr test_latch_attrib "test_latch_param_attrib"
 
 .conn dff_q o_dff


### PR DESCRIPTION
A proposed solution to https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1662
- Updated EBLIF cell parameter specification
- Added EBLIF parameter value validation on reading
- Added binary prefix to relevant parameters in post-routing Verilog netlist writing.

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
