### PR TITLE
remove unnecessary placement parsing info

### DIFF
--- a/vtr_flow/parse/parse_config/vpr_standard.txt
+++ b/vtr_flow/parse/parse_config/vpr_standard.txt
@@ -13,5 +13,3 @@
 %include "timing/vpr.place.txt"
 %include "timing/vpr.route_min_chan_width.txt"
 %include "timing/vpr.route_relaxed_chan_width.txt"
-
-%include "timing/vpr.place_checks.txt"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Remove unnecessary parsed info that was used for placement debugging