### PR TITLE
Deploy new node.side() API to rr_graph builder and router

### DIFF
--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -575,10 +575,10 @@ static void check_unbuffered_edges(int from_node) {
 static bool has_adjacent_channel(const t_rr_node& node, const DeviceGrid& grid) {
     VTR_ASSERT(node.type() == IPIN || node.type() == OPIN);
 
-    if ((node.xlow() == 0 && node.side() != RIGHT)                          //left device edge connects only along block's right side
-        || (node.ylow() == int(grid.height() - 1) && node.side() != BOTTOM) //top device edge connects only along block's bottom side
-        || (node.xlow() == int(grid.width() - 1) && node.side() != LEFT)    //right deivce edge connects only along block's left side
-        || (node.ylow() == 0 && node.side() != TOP)                         //bottom deivce edge connects only along block's top side
+    if ((node.xlow() == 0 && !node.is_node_on_specific_side(RIGHT))                          //left device edge connects only along block's right side
+        || (node.ylow() == int(grid.height() - 1) && !node.is_node_on_specific_side(BOTTOM)) //top device edge connects only along block's bottom side
+        || (node.xlow() == int(grid.width() - 1) && !node.is_node_on_specific_side(LEFT))    //right deivce edge connects only along block's left side
+        || (node.ylow() == 0 && !node.is_node_on_specific_side(TOP))                         //bottom deivce edge connects only along block's top side
     ) {
         return false;
     }

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -1018,7 +1018,20 @@ static void adjust_rr_pin_position(const RRNodeId rr, int& x, int& y) {
     x = rr_graph.node_xlow(rr);
     y = rr_graph.node_ylow(rr);
 
-    e_side rr_side = rr_graph.node_side(rr);
+    /* Use the first side we can find
+     * Note that this may NOT return an accurate coordinate
+     * when a rr node appears on different sides
+     * However, current test show that the simple strategy provides
+     * a good trade-off between runtime and quality of results
+     */
+    e_side rr_side = NUM_SIDES;
+    for (const e_side& candidate_side : SIDES) {
+        if (rr_graph.is_node_on_specific_side(rr, candidate_side)) {
+            rr_side = candidate_side;
+            break;
+        }
+    }
+    VTR_ASSERT_SAFE(NUM_SIDES != rr_side);
 
     if (rr_side == LEFT) {
         x -= 1;

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -2774,7 +2774,12 @@ void add_to_rr_node_indices(t_rr_node_indices& rr_node_indices, const t_rr_graph
         for (int y = rr_node.ylow(); y <= rr_node.yhigh(); ++y) {
             auto rr_type = rr_node.type();
             if (rr_type == IPIN || rr_type == OPIN) {
-                insert_at_ptc_index(rr_node_indices[rr_node.type()][x][y][rr_node.side()], rr_node.ptc_num(), inode);
+                for (const e_side& side : SIDES) {
+                    if (!rr_node.is_node_on_specific_side(side)) {
+                        continue;
+                    }
+                    insert_at_ptc_index(rr_node_indices[rr_node.type()][x][y][side], rr_node.ptc_num(), inode);
+                }
             } else if (rr_type == CHANX) {
                 //CHANX uses odd swapped x/y indices....
                 insert_at_ptc_index(rr_node_indices[rr_node.type()][y][x][0], rr_node.ptc_num(), inode);

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -1593,13 +1593,18 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             } else if (node.type() == IPIN || node.type() == OPIN) {
                 for (int ix = node.xlow(); ix <= node.xhigh(); ix++) {
                     for (int iy = node.ylow(); iy <= node.yhigh(); iy++) {
-                        if (node.ptc_num() >= (int)indices[OPIN][ix][iy][node.side()].size()) {
-                            indices[OPIN][ix][iy][node.side()].resize(node.ptc_num() + 1, OPEN);
+                        for (const e_side& side : SIDES) {
+                            if (!node.is_node_on_specific_side(side)) {
+                                continue;
+                            }
+                            if (node.ptc_num() >= (int)indices[OPIN][ix][iy][side].size()) {
+                                indices[OPIN][ix][iy][side].resize(node.ptc_num() + 1, OPEN);
+                            }
+                            if (node.ptc_num() >= (int)indices[IPIN][ix][iy][side].size()) {
+                                indices[IPIN][ix][iy][side].resize(node.ptc_num() + 1, OPEN);
+                            }
+                            indices[node.type()][ix][iy][side][node.ptc_num()] = inode;
                         }
-                        if (node.ptc_num() >= (int)indices[IPIN][ix][iy][node.side()].size()) {
-                            indices[IPIN][ix][iy][node.side()].resize(node.ptc_num() + 1, OPEN);
-                        }
-                        indices[node.type()][ix][iy][node.side()][node.ptc_num()] = inode;
                     }
                 }
             } else if (node.type() == CHANX) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR aims to deploy the new node_side() API to rr_graph builder and router.

#### Description
<!--- Describe your changes in detail -->
This PR:
- [X] Replace all the node.side() API with node.is_node_on_specific_side() API in rr_graph builder and router.
- [ ] Patch routers' lookahead map building for multi-width and multi-height blocks. This will be patched in later pull requests, because key roadblocks have been identified: require prev_node list to be cached for each rr_node so that lookahead builder can know accurate positions for SINK nodes.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

To address issue #1580

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In Titan architecture, a ``rr_node`` may appear in multiple sides of a logic block. However, VPR's rr_graph builder and router only assumes that a ``rr_node`` locates on only 1 side. There has been patches (#1621 and #1661) to extend the side support for ``rr_node`` and deploy to GUIs. This PR is a follow-up PR as planned to deploy the new API node.is_node_on_specific_side() in place of the to-be-deprecated API node_side() in the rr_graph builder and router.
After this PR, the old API can be safely removed.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
