### PR TITLE
Fix cleanup if `run_vtr_test.py` generates an error.

### DIFF
--- a/.github/kokoro/steps/vtr-test.sh
+++ b/.github/kokoro/steps/vtr-test.sh
@@ -45,7 +45,11 @@ echo "========================================"
 echo "Running Tests"
 echo "========================================"
 export VPR_NUM_WORKERS=1
+
+set +e
 ./run_reg_test.py $VTR_TEST $VTR_TEST_OPTIONS -j$NUM_CORES
+TEST_RESULT=$?
+set -e
 kill $MONITOR
 
 echo "========================================"
@@ -70,3 +74,5 @@ if [[ $(du -s | cut -d $'\t' -f 1) -gt $(expr 1024 \* 1024 \* 90) ]]; then
     echo "Working directory too large!"
     exit 1
 fi
+
+exit $TEST_RESULT


### PR DESCRIPTION
#### Description

There is logic to cleanup the VTR working space after `run_reg_test.py`, but if the `e` flag (terminate on error) is set, then the cleanup logic never runs.  This change un-sets the `e` flag around `run_reg_test.py` and forwards the result.

#### Related Issue

Might help with #1666 