### PR TITLE
place: fix illegal swap of fixed blocks

### DIFF
--- a/vpr/src/place/critical_uniform_move_generator.cpp
+++ b/vpr/src/place/critical_uniform_move_generator.cpp
@@ -18,6 +18,10 @@ e_create_move CriticalUniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved
         return e_create_move::ABORT; //No movable block found
     }
 
+    if (place_ctx.block_locs[b_from].is_fixed) {
+        return e_create_move::ABORT; //Block is fixed, cannot move
+    }
+
     t_pl_loc from = place_ctx.block_locs[b_from].loc;
     auto cluster_from_type = cluster_ctx.clb_nlist.block_type(b_from);
     auto grid_from_type = g_vpr_ctx.device().grid[from.x][from.y].type;

--- a/vpr/src/place/feasible_region_move_generator.cpp
+++ b/vpr/src/place/feasible_region_move_generator.cpp
@@ -20,6 +20,10 @@ e_create_move FeasibleRegionMoveGenerator::propose_move(t_pl_blocks_to_be_moved&
         return e_create_move::ABORT; //No movable block found
     }
 
+    if (place_ctx.block_locs[b_from].is_fixed) {
+        return e_create_move::ABORT; //Block is fixed, cannot move
+    }
+
     //from block data
     t_pl_loc from = place_ctx.block_locs[b_from].loc;
     auto cluster_from_type = cluster_ctx.clb_nlist.block_type(b_from);

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -116,6 +116,10 @@ e_block_move_result record_single_block_swap(t_pl_blocks_to_be_moved& blocks_aff
 
     auto& place_ctx = g_vpr_ctx.mutable_placement();
 
+    if (place_ctx.block_locs[b_from].is_fixed) {
+        return e_block_move_result::ABORT;
+    }
+
     VTR_ASSERT_SAFE(to.sub_tile < int(place_ctx.grid_blocks[to.x][to.y].blocks.size()));
 
     ClusterBlockId b_to = place_ctx.grid_blocks[to.x][to.y].blocks[to.sub_tile];

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -1,6 +1,8 @@
 #include "../src/base/partition_region.h"
 #include "catch.hpp"
 
+#include "vpr_api.h"
+#include "globals.h"
 #include "vpr_constraints.h"
 #include "partition.h"
 #include "region.h"
@@ -420,4 +422,61 @@ TEST_CASE("RegionLocked", "[vpr]") {
     is_r2_locked = r2.locked();
 
     REQUIRE(is_r2_locked == false);
+}
+
+static constexpr const char kArchFile[] = "test_read_arch_metadata.xml";
+
+// Test that place constraints are not changed during placement
+TEST_CASE("PlaceConstraintsIntegrity", "[vpr]") {
+    auto options = t_options();
+    auto arch = t_arch();
+    auto vpr_setup = t_vpr_setup();
+
+    vpr_initialize_logging();
+
+    // Command line arguments
+    const char* argv[] = {
+        "test_vpr",
+        kArchFile,
+        "wire.eblif",
+        "--fix_clusters", "wire.constraints",
+        "--place_static_move_prob", "0", "0", "0", "0", "0", "100", "0",
+        "--RL_agent_placement", "off"};
+    vpr_init(sizeof(argv) / sizeof(argv[0]), argv,
+             &options, &vpr_setup, &arch);
+
+    vpr_pack_flow(vpr_setup, arch);
+    vpr_create_device(vpr_setup, arch);
+    vpr_place_flow(vpr_setup, arch);
+
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    auto& place_ctx = g_vpr_ctx.placement();
+
+    // Check if constraints are preserved
+
+    // Input block
+    ClusterBlockId input_blk_id = cluster_ctx.clb_nlist.find_block("di");
+    int input_x = 2;
+    int input_y = 1;
+    int input_sub_tile = 5;
+
+    auto input_loc = place_ctx.block_locs[input_blk_id].loc;
+
+    REQUIRE(input_x == input_loc.x);
+    REQUIRE(input_y == input_loc.y);
+    REQUIRE(input_sub_tile == input_loc.sub_tile);
+
+    // Output block
+    ClusterBlockId output_blk_id = cluster_ctx.clb_nlist.find_block("out:do");
+    int output_x = 2;
+    int output_y = 1;
+    int output_sub_tile = 1;
+
+    auto output_loc = place_ctx.block_locs[output_blk_id].loc;
+
+    REQUIRE(output_x == output_loc.x);
+    REQUIRE(output_y == output_loc.y);
+    REQUIRE(output_sub_tile == output_loc.sub_tile);
+
+    vpr_free_all(arch, vpr_setup);
 }

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -435,6 +435,10 @@ TEST_CASE("PlaceConstraintsIntegrity", "[vpr]") {
     vpr_initialize_logging();
 
     // Command line arguments
+    //
+    // parameters description:
+    //      - place_static_move_prob: Timing Feasible Region move type is always selected.
+    //      - RL_agent_placement: disabled. This way the desired move type is selected.
     const char* argv[] = {
         "test_vpr",
         kArchFile,

--- a/vpr/test/wire.constraints
+++ b/vpr/test/wire.constraints
@@ -1,0 +1,4 @@
+#block name	x	y	subblk	block number
+#----------	--	--	------	------------
+out:do		2	1	1	#0
+di		2	1	5	#1


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This PR fixes an issue for which a fixed block could get swapped during placement

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1681


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Critical blocks and IOs cannot get swapped and must preserve the initial constraints.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
