### PR TITLE
Fix for syntax error in vtr_flow/primitives.v

### DIFF
--- a/vtr_flow/primitives.v
+++ b/vtr_flow/primitives.v
@@ -125,7 +125,7 @@
 //K-input Look-Up Table
 module LUT_K #(
     //The Look-up Table size (number of inputs)
-    parameter K, 
+    parameter K = 1, 
 
     //The lut mask.  
     //Left-most (MSB) bit corresponds to all inputs logic one. 


### PR DESCRIPTION
#### Description
Fixed a syntax error in Verilog LUT cell model in `vtr_flow/primitives.v`. The parameter `K` of the `LUT_K` cell was missing a default value.

#### Related Issue
None

#### Motivation and Context
To be able to do post-pnr simulation of a design.

#### How Has This Been Tested?
With Yosys that can now successfully parse the file.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
