### PR TITLE
revert: [Odin] Buffered clks(BUF_NODE) shouldn't get inferred as new …

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -196,32 +196,16 @@ void create_netlist(ast_t* ast) {
     }
 }
 
-/**
- *---------------------------------------------------------------------------------------------
+/*---------------------------------------------------------------------------------------------
  * (function: look_for_clocks)
- * 
- * @brief going through all FF nodes looking for the clock signals.
- * If they are not clock type, they should alter to one. Since BUF
- * nodes be removed in the partial mapping, the driver of the BUF
- * nodes should be considered as a clock node. 
- * 
- * @param netlist pointer to the current netlist file
  *-------------------------------------------------------------------------------------------*/
 void look_for_clocks(netlist_t* netlist) {
     int i;
 
     for (i = 0; i < netlist->num_ff_nodes; i++) {
-        /* at this step, clock nodes must have been driving by one driver */
         oassert(netlist->ff_nodes[i]->input_pins[1]->net->num_driver_pins == 1);
-        /* node: clock driver node */
-        nnode_t* node = netlist->ff_nodes[i]->input_pins[1]->net->driver_pins[0]->node;
-
-        /* as far as a clock driver node is a BUF node, going through its drivers till finding a non-BUF node */
-        while (node->type == BUF_NODE)
-            node = node->input_pins[0]->net->driver_pins[0]->node;
-
-        if (node->type != CLOCK_NODE) {
-            node->type = CLOCK_NODE;
+        if (netlist->ff_nodes[i]->input_pins[1]->net->driver_pins[0]->node->type != CLOCK_NODE) {
+            netlist->ff_nodes[i]->input_pins[1]->net->driver_pins[0]->node->type = CLOCK_NODE;
         }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
reverting the last commit to making sure about the cause of the Symbiflow task failure in CI
PR #1695

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
