### PR TITLE
place: fix case in which PR region does not have constraints

### DIFF
--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -31,8 +31,13 @@ int check_placement_floorplanning() {
 /*returns true if cluster has floorplanning constraints, false if it doesn't*/
 bool is_cluster_constrained(ClusterBlockId blk_id) {
     auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
-    PartitionRegion pr;
-    pr = floorplanning_ctx.cluster_constraints[blk_id];
+
+    auto keys = floorplanning_ctx.cluster_constraints.keys();
+    auto res = std::find(keys.begin(), keys.end(), blk_id);
+
+    if (res == keys.end()) return false;
+
+    auto pr = floorplanning_ctx.cluster_constraints[blk_id];
     return (!pr.empty());
 }
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The new partition region code might not take into account that partition regions are not being set and constraints are not initialized. This PR is an attempt at fixing this.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1711

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
