### PR TITLE
Fixing the debugger documentation images

### DIFF
--- a/doc/src/vpr/debug_aids.rst
+++ b/doc/src/vpr/debug_aids.rst
@@ -31,7 +31,8 @@ If you want to read a text file describing the entire routing resource graph, ca
 Placer and Router Debugger
 ==========================
 
-.. image:: https://github.com/verilog-to-routing/verilog-to-routing.github.io/blob/master/img/debuggerWindow.png
+.. image:: https://www.verilogtorouting.org/img/debuggerWindow.png
+
     :align: center
 
 Overview
@@ -62,7 +63,7 @@ Upon reaching a breakpoint, the program will stop, notify the user which breakpo
 Available Variables
 ~~~~~~~~~~~~~~~~~~~
 
-.. image:: https://github.com/verilog-to-routing/verilog-to-routing.github.io/blob/master/img/advancedWindow.png
+.. image:: https://www.verilogtorouting.org/img/advancedWindow.png
     :align: center
 
 You can also find the variables’ list in the Advanced Settings Window, on the left.


### PR DESCRIPTION
Attempt to fix the broken images

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail --> The links for the images in the placer and router debugger documentation weren't working properly. The links have been changed and should work now.


#### Related Issue
<!--- Pull requests should be related to open issues --> Broken images on https://docs.verilogtorouting.org/en/latest/vpr/debug_aids/
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1717

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
