### PR TITLE
Updating the documentation design tutorial 

### DIFF
--- a/doc/src/tutorials/flow/basic_flow.rst
+++ b/doc/src/tutorials/flow/basic_flow.rst
@@ -5,34 +5,40 @@ Basic Design Flow Tutorial
 
 The following steps show you to run the VTR design flow to map a sample circuit to an FPGA architecture containing embedded memories and multipliers:
 
-#.  From the :term:`$VTR_ROOT`, move to the ``vtr_flow/tasks`` directory, and run:
+#.  From the :term:`$VTR_ROOT`  , move to the ``vtr_flow/tasks/regression_tests/vtr_reg_basic`` directory, and run:
 
     .. code-block:: shell
+    
+        ../../../scripts/run_vtr_task.py basic_no_timing
+        
+    or:
+ 
+     .. code-block:: shell
 
-        ../scripts/run_vtr_task.py basic_flow
-
-    This command will run the VTR flow on a single circuit and a single architecture.
-    The files generated from the run are stored in ``basic_flow/run[#]`` where ``[#]`` is the number of runs you have done.
-    If this is your first time running the flow, the results will be stored in basic_flow/run001.
+        $VTR_ROOT/vtr_flow/scripts/run_vtr_task.py basic_no_timing 
+        
+    The subdirectory ``regression_tests/vtr_reg_basic`` contains tests that are to be run before each commit. They check for basic functionallity to make sure nothing was           extremely out of order. This command runs the VTR flow on a set of circuits and a single architecture. 
+    The files generated from the run are stored in ``basic_no_timing/run[#]`` where ``[#]`` is the number of runs you have done.
+    If this is your first time running the flow, the results will be stored in basic_no_timing/run001.
     When the script completes, enter the following command:
 
     .. code-block:: shell
 
-        ../scripts/python_libs/vtr/parse_vtr_task.py basic_flow/
+         ../../../scripts/python_libs/vtr/parse_vtr_task.py basic_no_timing/
 
     This parses out the information of the VTR run and outputs the results in a text file called ``run[#]/parse_results.txt``.
 
     More info on how to run the flow on multiple circuits and architectures along with different options later.
     Before that, we need to ensure that the run that you have done works.
 
-#.  The basic_flow comes with golden results that you can use to check for correctness.
+#.  The basic_no_timing comes with golden results that you can use to check for correctness.
     To do this check, enter the following command:
 
     .. code-block:: shell
 
-        ../scripts/python_libs/vtr/parse_vtr_task.py -check_golden basic_flow
+        ../../../scripts/python_libs/vtr/parse_vtr_task.py -check_golden basic_no_timing
 
-    It should return: ``basic_flow...[Pass]``
+    It should return: ``basic_no_timing...[Pass]``
 
     .. note::
 
@@ -41,15 +47,15 @@ The following steps show you to run the VTR design flow to map a sample circuit 
         We also included runtime estimates based on our machine.
         The actual runtimes that you get may differ dramatically from these values.
 
-#.  To see precisely which circuits, architecture, and CAD flow was employed by the run, look at ``vtr_flow/tasks/basic_flow/config/config.txt``.
+#.  To see precisely which see circuits, architecture, and CAD flow was employed by the run, look at ``vtr_flow/tasks/regression_tests/vtr_reg_basic/config.txt``.
     Inside this directory, the ``config.txt`` file contains the circuits and architecture file employed in the run.
 
     Some also contain a ``golden_results.txt`` file that is used by the scripts to check for correctness.
 
-    The ``vtr_release/vtr_flow/scripts/run_vtr_flow.py`` script describes the CAD flow employed in the test.
+    The ``$VTR_ROOT/vtr_flow/scripts/run_vtr_flow.py`` script describes the CAD flow employed in the test.
     You can modify the flow by editing this script.
 
-    At this point, feel free to run any of the tasks pre-pended with "regression".
-    These are regression tests included with the flow that test various combinations of flows, architectures, and benchmarks.
+    At this point, feel free to run any of the tasks with the prefix ``vtr_reg`` 
+    These are regression tests included with the flow that test various combinations of flows, architectures, and benchmarks.         Refer to the ``README`` for a description what each task aims to test. 
 
 #.  For more information on how the vtr_flow infrastructure works (and how to add the tests that you want to do to this infrastructure) see :ref:`vtr_tasks`.


### PR DESCRIPTION
Updating the Basic Design Flow tutorial. 
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The tests pointed to in the tutorial are outdated and golden_results don't include every parameter. Updating the tutorial to point to the basic regression tests at regression_tests/vtr_reg_basic would ensure that the design flow tutorial stays up to date.

<!--- Describe your changes in detail -->

#### Motivation and Context
Avoids the task of generating golden_results for the basic_flow tasks every time they get out-of-date. 
<!--- Why is this change required? What problem does it solve? -->


