### PR TITLE
Add missing post routing cluster pin fixup to genfasm

### DIFF
--- a/libs/EXTERNAL/libargparse/src/argparse.cpp
+++ b/libs/EXTERNAL/libargparse/src/argparse.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <string>
 #include <set>
+#include <limits>
 
 #include "argparse.hpp"
 #include "argparse_util.hpp"

--- a/utils/fasm/src/main.cpp
+++ b/utils/fasm/src/main.cpp
@@ -22,6 +22,8 @@ using namespace std;
 
 #include "fasm.h"
 
+#include "post_routing_pb_pin_fixup.h"
+
 /*
  * Exit codes to signal success/failure to scripts
  * calling vpr
@@ -78,6 +80,17 @@ int main(int argc, const char **argv) {
 
         bool flow_succeeded = false;
         flow_succeeded = vpr_flow(vpr_setup, Arch);
+
+        /* Sync netlist to the actual routing (necessary if there are block
+           ports with equivalent pins) */
+        if (flow_succeeded) {
+            sync_netlists_to_routing(g_vpr_ctx.device(),
+                                     g_vpr_ctx.mutable_atom(),
+                                     g_vpr_ctx.mutable_clustering(),
+                                     g_vpr_ctx.placement(),
+                                     g_vpr_ctx.routing(),
+                                     vpr_setup.PackerOpts.pack_verbosity > 2);
+        }
 
         /* Actually write output FASM file. */
         flow_succeeded = write_fasm();

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -7,6 +7,7 @@
 #include "fasm_utils.h"
 #include "arch_util.h"
 #include "rr_graph_writer.h"
+#include "post_routing_pb_pin_fixup.h"
 #include <sstream>
 #include <fstream>
 #include <regex>
@@ -168,6 +169,54 @@ TEST_CASE("match_lut_init", "[fasm]") {
     CHECK(match_lut_init("16'b0000000011111111", "16'b0000111100001111"));
 }
 
+std::string get_pin_feature (size_t inode) {
+    auto& device_ctx = g_vpr_ctx.device();
+
+    // Get tile physical tile and the pin number
+    int ilow = device_ctx.rr_nodes[inode].xlow();
+    int jlow = device_ctx.rr_nodes[inode].ylow();
+    auto physical_tile = device_ctx.grid[ilow][jlow].type;
+    int pin_num = device_ctx.rr_nodes[inode].ptc_num();
+
+    // Get the sub tile (type, not instance)
+    const t_sub_tile* sub_tile_type = nullptr;
+    int sub_tile_pin = -1;
+
+    for (auto& sub_tile : physical_tile->sub_tiles) {
+        auto max_inst_pins = sub_tile.num_phy_pins / sub_tile.capacity.total();
+        for (int pin = 0; pin < sub_tile.num_phy_pins; pin++) {
+            if (sub_tile.sub_tile_to_tile_pin_indices[pin] == pin_num) {
+                sub_tile_type = &sub_tile;
+                sub_tile_pin  = pin % max_inst_pins;
+                break;
+            }
+        }
+
+        if (sub_tile_type != nullptr) {
+            break;
+        }
+    }
+
+    REQUIRE(sub_tile_type != nullptr);
+    REQUIRE(sub_tile_pin  != -1);
+
+    // Find the sub tile port and pin index
+    for (const auto& port : sub_tile_type->ports) {
+        int pin_lo = port.absolute_first_pin_index;
+        int pin_hi = pin_lo + port.num_pins;
+
+        if (sub_tile_pin >= pin_lo && sub_tile_pin < pin_hi) {
+            int port_pin = sub_tile_pin - pin_lo;
+            fprintf(stderr, "    %zu %s %d\n", inode, port.name, port_pin);
+            return vtr::string_fmt("PIN_%d_%d_%s_%s_%d", ilow, jlow, sub_tile_type->name, port.name, port_pin);
+        }
+    }
+
+    // Pin not found
+    REQUIRE(false);
+    return std::string();
+}
+
 TEST_CASE("fasm_integration_test", "[fasm]") {
     {
         t_vpr_setup vpr_setup;
@@ -193,6 +242,15 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
                 auto switch_id = device_ctx.rr_nodes[inode].edge_switch(iedge);
                 auto value = vtr::string_fmt("%d_%d_%zu",
                             inode, sink_inode, switch_id);
+
+                // Add additional features to edges that go to CLB.I[11:0] pins
+                // to correlate them with features of CLB input mux later.
+                auto sink_type = device_ctx.rr_nodes[sink_inode].type();
+                if (sink_type == IPIN) {            
+                    auto pin_feature = get_pin_feature(sink_inode);
+                    value = value + "\n" + pin_feature;
+                }
+
                 vpr::add_rr_edge_metadata(inode, sink_inode, switch_id,
                         vtr::string_view("fasm_features"), vtr::string_view(value.data(), value.size()));
             }
@@ -226,6 +284,17 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
 
     bool flow_succeeded = vpr_flow(vpr_setup, arch);
     REQUIRE(flow_succeeded == true);
+
+    /* Sync netlist to the actual routing (necessary if there are block
+       ports with equivalent pins) */
+    if (flow_succeeded) {
+        sync_netlists_to_routing(g_vpr_ctx.device(),
+                                 g_vpr_ctx.mutable_atom(),
+                                 g_vpr_ctx.mutable_clustering(),
+                                 g_vpr_ctx.placement(),
+                                 g_vpr_ctx.routing(),
+                                 vpr_setup.PackerOpts.pack_verbosity > 2);
+    }
 
     std::stringstream fasm_string;
     fasm::FasmWriterVisitor visitor(&arch.strings, fasm_string);
@@ -272,6 +341,8 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     fasm_string.clear();
     fasm_string.seekg(0);
 
+    std::set<std::string> xbar_features;
+    std::set<std::tuple<int, int, std::string, std::string, int>> routed_pins; // x, y, tile, port, pin
     std::set<std::tuple<int, int, short>> routing_edges;
     std::set<std::tuple<int, int>> occupied_locs;
     bool found_lut5 = false;
@@ -313,7 +384,21 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
             }
         }
 
-        if(line.find("FLE") != std::string::npos) {
+        // A feature representing block pin used by the router
+        if(line.find("PIN_") != std::string::npos) {
+            auto parts = vtr::split(line, "_");
+            REQUIRE(parts.size() == 6);
+
+            auto x = vtr::atoi(parts[1]);
+            auto y = vtr::atoi(parts[2]);
+            auto tile = parts[3];
+            auto port = parts[4];
+            auto pin = vtr::atoi(parts[5]);
+
+            routed_pins.insert(std::make_tuple(x, y, tile, port, pin));
+        }
+
+        else if(line.find("FLE") != std::string::npos) {
 
             // Check correlation with top-level prefixes with X coordinates
             // as defined in the architecture
@@ -334,6 +419,11 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
 
             // Check presence of LOC prefix substitutions
             CHECK_THAT(line, MatchesRegex(".*X\\d+Y\\d+.*"));
+
+            // Add to xbar features
+            if (line.find("_XBAR_") != std::string::npos) {
+                xbar_features.insert(line);
+            }
 
             // Extract loc from tag
             std::smatch locMatch;
@@ -470,6 +560,28 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
 
             head = next;
         }
+    }
+
+    // Verify CLB crossbar mux features against routed pin features.
+    for (const auto& xbar_feature : xbar_features) {
+
+        // Decompose the xbar feature - extract only the necessary information
+        // such as block location and pin index.
+        std::smatch m;
+        fprintf(stderr, "%s\n", xbar_feature.c_str());
+        auto res = std::regex_match(xbar_feature, m, std::regex(
+            ".*_X([0-9]+)Y([0-9]+)\\.IN([0-9])_XBAR_I([0-9]+)$"));
+        REQUIRE(res == true);
+
+        int x = vtr::atoi(m.str(1));
+        int y = vtr::atoi(m.str(2));
+        std::string mux = m.str(3);
+        int pin = vtr::atoi(m.str(4));
+
+        // Check if there is a corresponding routed pin feature
+        auto pin_feature = std::make_tuple(x, y, std::string("clb"), std::string("I"), pin);
+        size_t count = routed_pins.count(pin_feature);
+        REQUIRE(count == 1);
     }
 
     // Verify that all LUTs defined in the BLIF file ended up in fasm

--- a/utils/fasm/test/test_fasm_arch.xml
+++ b/utils/fasm/test/test_fasm_arch.xml
@@ -431,10 +431,6 @@
           <delay_constant max="95e-12" in_port="clb.I" out_port="fle[1:1].in"/>
           <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[1:1].in"/>
         </complete>
-        <complete name="crossbar0" input="clb.I fle[1:0].out" output="fle[0:0].in[5:1]">
-          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0:0].in[5:1]"/>
-          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[0:0].in[5:1]"/>
-        </complete>
         <mux name="mux_fle0_in0" output="fle[0].in[0]"
             input="clb.I[0] clb.I[1] clb.I[2] clb.I[3] clb.I[4] clb.I[5] clb.I[6] clb.I[7] clb.I[8] clb.I[9] clb.I[10] clb.I[11] fle[0].out[0] fle[0].out[1] fle[1].out[0] fle[1].out[1]">
           <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0].in[0]"/>
@@ -457,6 +453,131 @@
                   fle[0].out[1] :   FLE0{SING}_{LOC}.IN0_XBAR_FLE0_OUT1
                   fle[1].out[0] :   FLE0{SING}_{LOC}.IN0_XBAR_FLE1_OUT0
                   fle[1].out[1] :   FLE0{SING}_{LOC}.IN0_XBAR_FLE1_OUT1
+              </meta>
+          </metadata>
+        </mux>
+        <mux name="mux_fle0_in1" output="fle[0].in[1]"
+            input="clb.I[0] clb.I[1] clb.I[2] clb.I[3] clb.I[4] clb.I[5] clb.I[6] clb.I[7] clb.I[8] clb.I[9] clb.I[10] clb.I[11] fle[0].out[0] fle[0].out[1] fle[1].out[0] fle[1].out[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0].in[1]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[0].in[1]"/>
+          <metadata>
+              <meta name="fasm_mux">
+                  clb.I[0] :        FLE0{SING}_{LOC}.IN1_XBAR_I0
+                  clb.I[1] :        FLE0{SING}_{LOC}.IN1_XBAR_I1
+                  clb.I[2] :        FLE0{SING}_{LOC}.IN1_XBAR_I2
+                  clb.I[3] :        FLE0{SING}_{LOC}.IN1_XBAR_I3
+                  clb.I[4] :        FLE0{SING}_{LOC}.IN1_XBAR_I4
+                  clb.I[5] :        FLE0{SING}_{LOC}.IN1_XBAR_I5
+                  clb.I[6] :        FLE0{SING}_{LOC}.IN1_XBAR_I6
+                  clb.I[7] :        FLE0{SING}_{LOC}.IN1_XBAR_I7
+                  clb.I[8] :        FLE0{SING}_{LOC}.IN1_XBAR_I8
+                  clb.I[9] :        FLE0{SING}_{LOC}.IN1_XBAR_I9
+                  clb.I[10] :       FLE0{SING}_{LOC}.IN1_XBAR_I10
+                  clb.I[11] :       FLE0{SING}_{LOC}.IN1_XBAR_I11
+                  fle[0].out[0] :   FLE0{SING}_{LOC}.IN1_XBAR_FLE0_OUT0
+                  fle[0].out[1] :   FLE0{SING}_{LOC}.IN1_XBAR_FLE0_OUT1
+                  fle[1].out[0] :   FLE0{SING}_{LOC}.IN1_XBAR_FLE1_OUT0
+                  fle[1].out[1] :   FLE0{SING}_{LOC}.IN1_XBAR_FLE1_OUT1
+              </meta>
+          </metadata>
+        </mux>
+        <mux name="mux_fle0_in2" output="fle[0].in[2]"
+            input="clb.I[0] clb.I[1] clb.I[2] clb.I[3] clb.I[4] clb.I[5] clb.I[6] clb.I[7] clb.I[8] clb.I[9] clb.I[10] clb.I[11] fle[0].out[0] fle[0].out[1] fle[1].out[0] fle[1].out[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0].in[2]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[0].in[2]"/>
+          <metadata>
+              <meta name="fasm_mux">
+                  clb.I[0] :        FLE0{SING}_{LOC}.IN2_XBAR_I0
+                  clb.I[1] :        FLE0{SING}_{LOC}.IN2_XBAR_I1
+                  clb.I[2] :        FLE0{SING}_{LOC}.IN2_XBAR_I2
+                  clb.I[3] :        FLE0{SING}_{LOC}.IN2_XBAR_I3
+                  clb.I[4] :        FLE0{SING}_{LOC}.IN2_XBAR_I4
+                  clb.I[5] :        FLE0{SING}_{LOC}.IN2_XBAR_I5
+                  clb.I[6] :        FLE0{SING}_{LOC}.IN2_XBAR_I6
+                  clb.I[7] :        FLE0{SING}_{LOC}.IN2_XBAR_I7
+                  clb.I[8] :        FLE0{SING}_{LOC}.IN2_XBAR_I8
+                  clb.I[9] :        FLE0{SING}_{LOC}.IN2_XBAR_I9
+                  clb.I[10] :       FLE0{SING}_{LOC}.IN2_XBAR_I10
+                  clb.I[11] :       FLE0{SING}_{LOC}.IN2_XBAR_I11
+                  fle[0].out[0] :   FLE0{SING}_{LOC}.IN2_XBAR_FLE0_OUT0
+                  fle[0].out[1] :   FLE0{SING}_{LOC}.IN2_XBAR_FLE0_OUT1
+                  fle[1].out[0] :   FLE0{SING}_{LOC}.IN2_XBAR_FLE1_OUT0
+                  fle[1].out[1] :   FLE0{SING}_{LOC}.IN2_XBAR_FLE1_OUT1
+              </meta>
+          </metadata>
+        </mux>
+        <mux name="mux_fle0_in3" output="fle[0].in[3]"
+            input="clb.I[0] clb.I[1] clb.I[2] clb.I[3] clb.I[4] clb.I[5] clb.I[6] clb.I[7] clb.I[8] clb.I[9] clb.I[10] clb.I[11] fle[0].out[0] fle[0].out[1] fle[1].out[0] fle[1].out[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0].in[3]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[0].in[3]"/>
+          <metadata>
+              <meta name="fasm_mux">
+                  clb.I[0] :        FLE0{SING}_{LOC}.IN3_XBAR_I0
+                  clb.I[1] :        FLE0{SING}_{LOC}.IN3_XBAR_I1
+                  clb.I[2] :        FLE0{SING}_{LOC}.IN3_XBAR_I2
+                  clb.I[3] :        FLE0{SING}_{LOC}.IN3_XBAR_I3
+                  clb.I[4] :        FLE0{SING}_{LOC}.IN3_XBAR_I4
+                  clb.I[5] :        FLE0{SING}_{LOC}.IN3_XBAR_I5
+                  clb.I[6] :        FLE0{SING}_{LOC}.IN3_XBAR_I6
+                  clb.I[7] :        FLE0{SING}_{LOC}.IN3_XBAR_I7
+                  clb.I[8] :        FLE0{SING}_{LOC}.IN3_XBAR_I8
+                  clb.I[9] :        FLE0{SING}_{LOC}.IN3_XBAR_I9
+                  clb.I[10] :       FLE0{SING}_{LOC}.IN3_XBAR_I10
+                  clb.I[11] :       FLE0{SING}_{LOC}.IN3_XBAR_I11
+                  fle[0].out[0] :   FLE0{SING}_{LOC}.IN3_XBAR_FLE0_OUT0
+                  fle[0].out[1] :   FLE0{SING}_{LOC}.IN3_XBAR_FLE0_OUT1
+                  fle[1].out[0] :   FLE0{SING}_{LOC}.IN3_XBAR_FLE1_OUT0
+                  fle[1].out[1] :   FLE0{SING}_{LOC}.IN3_XBAR_FLE1_OUT1
+              </meta>
+          </metadata>
+        </mux>
+        <mux name="mux_fle0_in4" output="fle[0].in[4]"
+            input="clb.I[0] clb.I[1] clb.I[2] clb.I[3] clb.I[4] clb.I[5] clb.I[6] clb.I[7] clb.I[8] clb.I[9] clb.I[10] clb.I[11] fle[0].out[0] fle[0].out[1] fle[1].out[0] fle[1].out[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0].in[4]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[0].in[4]"/>
+          <metadata>
+              <meta name="fasm_mux">
+                  clb.I[0] :        FLE0{SING}_{LOC}.IN4_XBAR_I0
+                  clb.I[1] :        FLE0{SING}_{LOC}.IN4_XBAR_I1
+                  clb.I[2] :        FLE0{SING}_{LOC}.IN4_XBAR_I2
+                  clb.I[3] :        FLE0{SING}_{LOC}.IN4_XBAR_I3
+                  clb.I[4] :        FLE0{SING}_{LOC}.IN4_XBAR_I4
+                  clb.I[5] :        FLE0{SING}_{LOC}.IN4_XBAR_I5
+                  clb.I[6] :        FLE0{SING}_{LOC}.IN4_XBAR_I6
+                  clb.I[7] :        FLE0{SING}_{LOC}.IN4_XBAR_I7
+                  clb.I[8] :        FLE0{SING}_{LOC}.IN4_XBAR_I8
+                  clb.I[9] :        FLE0{SING}_{LOC}.IN4_XBAR_I9
+                  clb.I[10] :       FLE0{SING}_{LOC}.IN4_XBAR_I10
+                  clb.I[11] :       FLE0{SING}_{LOC}.IN4_XBAR_I11
+                  fle[0].out[0] :   FLE0{SING}_{LOC}.IN4_XBAR_FLE0_OUT0
+                  fle[0].out[1] :   FLE0{SING}_{LOC}.IN4_XBAR_FLE0_OUT1
+                  fle[1].out[0] :   FLE0{SING}_{LOC}.IN4_XBAR_FLE1_OUT0
+                  fle[1].out[1] :   FLE0{SING}_{LOC}.IN4_XBAR_FLE1_OUT1
+              </meta>
+          </metadata>
+        </mux>
+        <mux name="mux_fle0_in5" output="fle[0].in[5]"
+            input="clb.I[0] clb.I[1] clb.I[2] clb.I[3] clb.I[4] clb.I[5] clb.I[6] clb.I[7] clb.I[8] clb.I[9] clb.I[10] clb.I[11] fle[0].out[0] fle[0].out[1] fle[1].out[0] fle[1].out[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0].in[5]"/>
+          <delay_constant max="75e-12" in_port="fle[1:0].out" out_port="fle[0].in[5]"/>
+          <metadata>
+              <meta name="fasm_mux">
+                  clb.I[0] :        FLE0{SING}_{LOC}.IN5_XBAR_I0
+                  clb.I[1] :        FLE0{SING}_{LOC}.IN5_XBAR_I1
+                  clb.I[2] :        FLE0{SING}_{LOC}.IN5_XBAR_I2
+                  clb.I[3] :        FLE0{SING}_{LOC}.IN5_XBAR_I3
+                  clb.I[4] :        FLE0{SING}_{LOC}.IN5_XBAR_I4
+                  clb.I[5] :        FLE0{SING}_{LOC}.IN5_XBAR_I5
+                  clb.I[6] :        FLE0{SING}_{LOC}.IN5_XBAR_I6
+                  clb.I[7] :        FLE0{SING}_{LOC}.IN5_XBAR_I7
+                  clb.I[8] :        FLE0{SING}_{LOC}.IN5_XBAR_I8
+                  clb.I[9] :        FLE0{SING}_{LOC}.IN5_XBAR_I9
+                  clb.I[10] :       FLE0{SING}_{LOC}.IN5_XBAR_I10
+                  clb.I[11] :       FLE0{SING}_{LOC}.IN5_XBAR_I11
+                  fle[0].out[0] :   FLE0{SING}_{LOC}.IN5_XBAR_FLE0_OUT0
+                  fle[0].out[1] :   FLE0{SING}_{LOC}.IN5_XBAR_FLE0_OUT1
+                  fle[1].out[0] :   FLE0{SING}_{LOC}.IN5_XBAR_FLE1_OUT0
+                  fle[1].out[1] :   FLE0{SING}_{LOC}.IN5_XBAR_FLE1_OUT1
               </meta>
           </metadata>
         </mux>


### PR DESCRIPTION
#### Description
Added execution of post routing cluster pin fixup to genfasm via the `sync_netlists_to_routing()` function.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1730

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Correct FASM generation for annotated blocks that have ports with equivalent input pins.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the testcase attached to the issue #1730. Also this PR contains update to the `genfasm` test which verifies that FASM features from clb muxes correspond to those from rr graph edges.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
