### PR TITLE
Initializing defined_size in VNumber Copy constructor

### DIFF
--- a/libs/librtlnumber/src/include/internal_bits.hpp
+++ b/libs/librtlnumber/src/include/internal_bits.hpp
@@ -728,7 +728,7 @@ class VNumber {
     VNumber(VNumber other, size_t length) {
         this->sign = other.sign;
         this->bitstring = other.bitstring.resize(other.get_padding_bit(), length);
-        // TODO this->defined_size = true?????;
+        this->defined_size = other.defined_size;
     }
 
     VNumber(const std::string& verilog_string) {


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
In VNumber copy constructor with new length, the defined_size variable was not initialized. As a result, Odin_II would throw an error in case of facing new VNumbers without defined_size equal to true while they have already a size specified.  

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1738

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix!

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
