### PR TITLE
Add artifact collection of files ending in .gz to nightly presubmit runs

### DIFF
--- a/.github/kokoro/presubmit/nightly.cfg
+++ b/.github/kokoro/presubmit/nightly.cfg
@@ -16,6 +16,14 @@ action {
     regex: "**/place.log"
     regex: "**/route.log"
     regex: "**/*_qor.csv"
+    regex: "**/*.out.gz"
+    regex: "**/vpr_stdout.log.gz"
+    regex: "**/parse_results.txt.gz"
+    regex: "**/qor_results.txt.gz"
+    regex: "**/pack.log.gz"
+    regex: "**/place.log.gz"
+    regex: "**/route.log.gz"
+    regex: "**/*_qor.csv.gz"
     strip_prefix: "github/vtr-verilog-to-routing/"
   }
 }


### PR DESCRIPTION
Updated nightly presubmit configuration to include artifact collection for files ending in .gz. This is needed because all output files from nightly runs are zipped to save disk space, and so to collect those files the artifact collection had to be updated. The presubmit runs are the ones launced on every pull request.
