### PR TITLE
aligned_allocator: add operator==

### DIFF
--- a/libs/libvtrutil/src/vtr_memory.h
+++ b/libs/libvtrutil/src/vtr_memory.h
@@ -136,6 +136,16 @@ struct aligned_allocator {
     }
 };
 
+/**
+ * @brief compare two aligned_allocators.
+ *
+ * Since the allocator doesn't have any internal state, all allocators for a given type are the same.
+ */
+template<typename T>
+bool operator==(const aligned_allocator<T>&, const aligned_allocator<T>&) {
+    return true;
+}
+
 } // namespace vtr
 
 #endif


### PR DESCRIPTION
#### Description
Fixes #1745, see the commit message or the issue for details.

#### How Has This Been Tested?
The test suite still passes, and compilation is now successful with GCC 11.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
