### PR TITLE
CI: Test compatibility with recent compilers

### DIFF
--- a/.github/gha/install_dependencies.sh
+++ b/.github/gha/install_dependencies.sh
@@ -45,6 +45,10 @@ sudo apt install -y \
   gcc-8 \
   g++-9 \
   gcc-9 \
+  g++-10 \
+  gcc-10 \
+  g++-11 \
+  gcc-11 \
   clang-6.0 \
   clang-8
 #  libtbb-dev

--- a/.github/gha/install_dependencies.sh
+++ b/.github/gha/install_dependencies.sh
@@ -50,5 +50,6 @@ sudo apt install -y \
   g++-11 \
   gcc-11 \
   clang-6.0 \
-  clang-8
+  clang-7 \
+  clang-10
 #  libtbb-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,8 +236,9 @@ jobs:
         - { name: 'GCC 9 (Ubuntu Focal - 20.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           build: ''               }
         - { name: 'GCC 10 (Ubuntu Hirsute - 21.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         build: ''               }
         - { name: 'GCC 11 (Latest)',                  eval: 'CC=gcc-11 && CXX=g++-11',         build: ''               }
-        - { name: 'Clang 6 (Debian + Ubuntu common)', eval: 'CC=clang-6.0 && CXX=clang++-6.0', build: ''               }
-        - { name: 'Clang 8 (Latest Release)',         eval: 'CC=clang-8 && CXX=clang++-8',     build: ''               }
+        - { name: 'Clang 6 (Ubuntu Bionic - 18.04)',  eval: 'CC=clang-6.0 && CXX=clang++-6.0', build: ''               }
+        - { name: 'Clang 7 (Debian Buster)',          eval: 'CC=clang-7 && CXX=clang++-7',     build: ''               }
+        - { name: 'Clang 10 (Ubuntu Focal - 20.04)',  eval: 'CC=clang-10 && CXX=clang++-10',   build: ''               }
     name: 'B: ${{ matrix.name }}'
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,8 +232,10 @@ jobs:
         - { name: 'GCC 5 (Ubuntu Xenial - 16.04)',    eval: 'CC=gcc-5 && CXX=g++-5',           build: 'release_strict' }
         - { name: 'GCC 6 (Debian Stretch)',           eval: 'CC=gcc-6 && CXX=g++-6',           build: 'release_strict' }
         - { name: 'GCC 7 (Ubuntu Bionic - 18.04)',    eval: 'CC=gcc-7 && CXX=g++-7',           build: ''               }
-        - { name: 'GCC 9 (Latest Release)',           eval: 'CC=gcc-9 && CXX=g++-9',           build: ''               }
-        - { name: 'GCC 8 (Ubuntu Latest)',            eval: 'CC=gcc-8 && CXX=g++-8',           build: ''               }
+        - { name: 'GCC 8 (Debian Buster)',            eval: 'CC=gcc-8 && CXX=g++-8',           build: ''               }
+        - { name: 'GCC 9 (Ubuntu Focal - 20.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           build: ''               }
+        - { name: 'GCC 10 (Ubuntu Hirsute - 21.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         build: ''               }
+        - { name: 'GCC 11 (Latest)',                  eval: 'CC=gcc-11 && CXX=g++-11',         build: ''               }
         - { name: 'Clang 6 (Debian + Ubuntu common)', eval: 'CC=clang-6.0 && CXX=clang++-6.0', build: ''               }
         - { name: 'Clang 8 (Latest Release)',         eval: 'CC=clang-8 && CXX=clang++-8',     build: ''               }
     name: 'B: ${{ matrix.name }}'

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ CMake provides a portable cross-platform build systems with many useful features
 VTR requires a C++-14 compliant compiler.
 The following compilers are tested with VTR:
 
-* GCC/G++: 5, 6, 7, 8, 9
+* GCC/G++: 5, 6, 7, 8, 9, 10, 11
 * Clang/Clang++: 3.8, 6
 
 Other compilers may work but are untested (your milage may vary).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,7 +12,7 @@ VTR requires a C++-14 compliant compiler.
 The following compilers are tested with VTR:
 
 * GCC/G++: 5, 6, 7, 8, 9, 10, 11
-* Clang/Clang++: 3.8, 6
+* Clang/Clang++: 6, 7, 10
 
 Other compilers may work but are untested (your milage may vary).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,10 @@ RUN apt-get install -y \
     gcc-8 \
     g++-9 \
     gcc-9 \
+    g++-10 \
+    gcc-10 \
+    g++-11 \
+    gcc-11 \
     clang-6.0 \
     clang-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN apt-get install -y \
     g++-11 \
     gcc-11 \
     clang-6.0 \
-    clang-8
+    clang-7 \
+    clang-10
 
 # install CMake
 WORKDIR /tmp


### PR DESCRIPTION
#### Description

The CI compatibility tests currently only go up to GCC 9 and clang 8, which are both quite old. While clang 11 and 12 aren't in Ubuntu 18.04, clang 10 and GCC 11 are possible.

#### Related Issue
This will only work once #1749 is merged.

#### Motivation and Context
To test vtr with modern compilers.

#### How Has This Been Tested?
Since this only adds new tests, there's not much to test.

#### Types of changes
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed