### PR TITLE
Add constraints propagation to update the PartitionRegions of blocks …

### DIFF
--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -82,20 +82,17 @@ static int check_macro_can_be_placed(t_pl_macro pl_macro, int itype, t_pl_loc he
     // Every macro can be placed until proven otherwise
     int macro_can_be_placed = true;
 
+    //Check whether head macro is in appropriate floorplan region
+    //return true if macro_can_be_placed = yes, false if no
     bool macro_constrained = is_macro_constrained(pl_macro);
-    PartitionRegion macro_pr;
-
-    if (macro_constrained) {
-        macro_pr = constrained_macro_locs(pl_macro);
-    }
 
     // Check whether all the members can be placed
     for (size_t imember = 0; imember < pl_macro.members.size(); imember++) {
         t_pl_loc member_pos = head_pos + pl_macro.members[imember].offset;
 
-        //if the macro is constrained, check if the member position is within the PartitionRegion for the macro
-        if (macro_constrained) {
-            bool member_loc_good = macro_pr.is_loc_in_part_reg(member_pos);
+        //if the macro is constrained, check if the head position is within the PartitionRegion for the macro
+        if (macro_constrained && imember == 0) {
+            bool member_loc_good = cluster_floorplanning_legal(pl_macro.members[imember].blk_index, member_pos);
             if (!member_loc_good) {
                 macro_can_be_placed = false;
                 break;
@@ -416,6 +413,9 @@ void initial_placement(enum e_pad_loc_type pad_loc_type, const char* constraints
     //Sort blocks
     vtr::vector<ClusterBlockId, t_block_score> block_scores = assign_block_scores();
     std::vector<ClusterBlockId> sorted_blocks = sort_blocks(block_scores);
+
+    //Perform constraints_propagation
+    constraints_propagation();
 
     // Loading legal placement locations
     zero_initialize_grid_blocks();

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -419,8 +419,8 @@ void initial_placement(enum e_pad_loc_type pad_loc_type, const char* constraints
     vtr::vector<ClusterBlockId, t_block_score> block_scores = assign_block_scores();
     std::vector<ClusterBlockId> sorted_blocks = sort_blocks(block_scores);
 
-    //Perform constraints_propagation
-    constraints_propagation();
+    //Go through blocks with floorplan constraints to ensure we have the tightest constraint on each one.
+    propagate_place_constraints();
 
     // Loading legal placement locations
     zero_initialize_grid_blocks();

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -419,7 +419,9 @@ void initial_placement(enum e_pad_loc_type pad_loc_type, const char* constraints
     vtr::vector<ClusterBlockId, t_block_score> block_scores = assign_block_scores();
     std::vector<ClusterBlockId> sorted_blocks = sort_blocks(block_scores);
 
-    //Go through blocks with floorplan constraints to ensure we have the tightest constraint on each one.
+    /* Go through cluster blocks to calculate the tightest placement
+     * floorplan constraint for each constrained block
+     */
     propagate_place_constraints();
 
     // Loading legal placement locations

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -82,15 +82,20 @@ static int check_macro_can_be_placed(t_pl_macro pl_macro, int itype, t_pl_loc he
     // Every macro can be placed until proven otherwise
     int macro_can_be_placed = true;
 
-    //Check whether head macro is in appropriate floorplan region
-    //return true if macro_can_be_placed = yes, false if no
+    //Check whether macro contains blocks with floorplan constraints
     bool macro_constrained = is_macro_constrained(pl_macro);
 
     // Check whether all the members can be placed
     for (size_t imember = 0; imember < pl_macro.members.size(); imember++) {
         t_pl_loc member_pos = head_pos + pl_macro.members[imember].offset;
 
-        //if the macro is constrained, check if the head position is within the PartitionRegion for the macro
+        /*
+         * If the macro is constrained, check that the head member is in a legal position from
+         * a floorplanning perspective. It is enough to do this check for the head member alone,
+         * because constraints propagation was performed to calculate smallest floorplan region for the head
+         * macro, based on the constraints on all of the blocks in the macro. So, if the head macro is in a
+         * legal floorplan location, all other blocks in the macro will be as well.
+         */
         if (macro_constrained && imember == 0) {
             bool member_loc_good = cluster_floorplanning_legal(pl_macro.members[imember].blk_index, member_pos);
             if (!member_loc_good) {

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -140,11 +140,13 @@ PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offs
 }
 
 void print_macro_constraint_error(const t_pl_macro& pl_macro) {
+    auto& cluster_ctx = g_vpr_ctx.clustering();
     VTR_LOG(
         "Feasible floorplanning constraints could not be calculated for the placement macro. \n"
         "The placement macro contains the following blocks: \n");
     for (unsigned int i = 0; i < pl_macro.members.size(); i++) {
-        VTR_LOG("Block #%zu ", size_t(pl_macro.members[i].blk_index));
+        std::string blk_name = cluster_ctx.clb_nlist.block_name((pl_macro.members[i].blk_index));
+        VTR_LOG("Block %s (#%zu) ", blk_name, size_t(pl_macro.members[i].blk_index));
     }
     VTR_LOG("\n");
     VPR_ERROR(VPR_ERROR_PLACE, " \n Check that the above-mentioned placement macro blocks have compatible floorplan constraints.\n");

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -146,7 +146,7 @@ void print_macro_constraint_error(const t_pl_macro& pl_macro) {
         "The placement macro contains the following blocks: \n");
     for (unsigned int i = 0; i < pl_macro.members.size(); i++) {
         std::string blk_name = cluster_ctx.clb_nlist.block_name((pl_macro.members[i].blk_index));
-        VTR_LOG("Block %s (#%zu) ", blk_name, size_t(pl_macro.members[i].blk_index));
+        VTR_LOG("Block %s (#%zu) ", blk_name.c_str(), size_t(pl_macro.members[i].blk_index));
     }
     VTR_LOG("\n");
     VPR_ERROR(VPR_ERROR_PLACE, " \n Check that the above-mentioned placement macro blocks have compatible floorplan constraints.\n");

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -113,6 +113,23 @@ PartitionRegion constrained_macro_locs(const t_pl_macro& pl_macro) {
     return macro_pr;
 }
 
+void constraints_propagation() {
+    auto& place_ctx = g_vpr_ctx.placement();
+    auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
+
+    for (auto pl_macro : place_ctx.pl_macros) {
+        if (is_macro_constrained(pl_macro)) {
+            //Update the PartitionRegions of all the clusters in the macro
+            PartitionRegion macro_pr = constrained_macro_locs(pl_macro);
+
+            for (size_t imember = 0; imember < pl_macro.members.size(); imember++) {
+                ClusterBlockId blk_id = pl_macro.members[imember].blk_index;
+                floorplanning_ctx.cluster_constraints[blk_id] = macro_pr;
+            }
+        }
+    }
+}
+
 /*returns true if location is compatible with floorplanning constraints, false if not*/
 bool cluster_floorplanning_legal(ClusterBlockId blk_id, const t_pl_loc& loc) {
     auto& floorplanning_ctx = g_vpr_ctx.floorplanning();

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -142,7 +142,7 @@ PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offs
     return macro_pr;
 }
 
-void constraints_propagation() {
+void propagate_place_constraints() {
     auto& place_ctx = g_vpr_ctx.placement();
     auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
 

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -54,8 +54,8 @@ bool is_macro_constrained(const t_pl_macro& pl_macro) {
 }
 
 /*Returns PartitionRegion of where the head of the macro could go*/
-PartitionRegion update_macro_pr(const t_pl_macro& pl_macro) {
-    PartitionRegion macro_pr;
+PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro) {
+    PartitionRegion macro_head_pr;
     bool is_member_constrained = false;
     int num_constrained_members = 0;
     auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
@@ -98,19 +98,19 @@ PartitionRegion update_macro_pr(const t_pl_macro& pl_macro) {
             }
 
             if (num_constrained_members == 1) {
-                macro_pr = modified_pr;
+                macro_head_pr = modified_pr;
             } else {
-                macro_pr = intersection(macro_pr, modified_pr);
+                macro_head_pr = intersection(macro_head_pr, modified_pr);
             }
         }
     }
 
     //if the intersection is empty, no way to place macro members together, give an error
-    if (macro_pr.empty()) {
+    if (macro_head_pr.empty()) {
         VPR_ERROR(VPR_ERROR_PLACE, " \n Feasible floorplanning constraints could not be calculated for the placement macro.\n");
     }
 
-    return macro_pr;
+    return macro_head_pr;
 }
 
 void constraints_propagation() {
@@ -123,7 +123,7 @@ void constraints_propagation() {
              * Update the PartitionRegion for the head of the macro
              * based on the constraints of all blocks contained in the macro
              */
-            PartitionRegion macro_head_pr = update_macro_pr(pl_macro);
+            PartitionRegion macro_head_pr = update_macro_head_pr(pl_macro);
 
             //Get block id of head macro member and update its PartitionRegion
             ClusterBlockId blk_id = pl_macro.members[0].blk_index;

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -37,7 +37,7 @@ bool is_macro_constrained(const t_pl_macro& pl_macro);
  * Returns PartitionRegion for the head of the macro based on the floorplan constraints
  * of all blocks in the macro.
  */
-PartitionRegion update_macro_pr(const t_pl_macro& pl_macro);
+PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro);
 
 /*
  * Updates the floorplan constraints information for all constrained macros.

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -34,10 +34,18 @@ bool cluster_floorplanning_legal(ClusterBlockId blk_id, const t_pl_loc& loc);
 bool is_macro_constrained(const t_pl_macro& pl_macro);
 
 /*
- * Returns region of valid locations for the head of the macro based on floorplan constraints
+ * Returns PartitionRegion for the head of the macro based on the floorplan constraints
+ * of all blocks in the macro.
  */
 PartitionRegion update_macro_pr(const t_pl_macro& pl_macro);
 
+/*
+ * Updates the floorplan constraints information for all constrained macros.
+ * The head member of each constrained macro is assigned a new PartitionRegion
+ * that is calculated based on the constraints of all the blocks in the macro.
+ * This is done at the start of initial placement to ease floorplan legality checking
+ * while placing macros during initial placement.
+ */
 void constraints_propagation();
 
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -37,6 +37,8 @@ bool is_macro_constrained(const t_pl_macro& pl_macro);
  */
 PartitionRegion constrained_macro_locs(const t_pl_macro& pl_macro);
 
+void constraints_propagation();
+
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;
 

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -50,7 +50,7 @@ PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro, const Partition
  * For each macro member, the updated constraint is essentially the head constraint
  * with the member's offset applied.
  */
-PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offset& offset, const PartitionRegion& grid_pr);
+PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offset& offset, const PartitionRegion& grid_pr, const t_pl_macro& pl_macro);
 
 /*
  * Updates the floorplan constraints information for all constrained macros.
@@ -60,6 +60,8 @@ PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offs
  * while placing macros during initial placement.
  */
 void propagate_place_constraints();
+
+void print_macro_constraint_error(const t_pl_macro& pl_macro);
 
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -40,6 +40,11 @@ bool is_macro_constrained(const t_pl_macro& pl_macro);
 PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro);
 
 /*
+ * Update macro member PR
+ */
+PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offset& offset);
+
+/*
  * Updates the floorplan constraints information for all constrained macros.
  * The head member of each constrained macro is assigned a new PartitionRegion
  * that is calculated based on the constraints of all the blocks in the macro.

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -40,7 +40,12 @@ bool is_macro_constrained(const t_pl_macro& pl_macro);
 PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro);
 
 /*
- * Update macro member PR
+ * Update the PartitionRegions of non-head members of a macro,
+ * based on the constraint that was calculated for the head region.
+ * The constraint that was calculated for the head region considered all
+ * constrained blocks in the macro, so to calculate the constraint for the rest
+ * of the blocks, it is just the head constraint with the offset of the member
+ * applied.
  */
 PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offset& offset);
 
@@ -51,7 +56,7 @@ PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offs
  * This is done at the start of initial placement to ease floorplan legality checking
  * while placing macros during initial placement.
  */
-void constraints_propagation();
+void propagate_place_constraints();
 
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -35,24 +35,27 @@ bool is_macro_constrained(const t_pl_macro& pl_macro);
 
 /*
  * Returns PartitionRegion for the head of the macro based on the floorplan constraints
- * of all blocks in the macro.
+ * of all blocks in the macro. For example, if there was a macro of length two and each block has
+ * a constraint, this routine will shift and intersect the two constraint regions to calculate
+ * the tightest region constraint for the head macro.
  */
-PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro);
+PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro, const PartitionRegion& grid_pr);
 
 /*
  * Update the PartitionRegions of non-head members of a macro,
- * based on the constraint that was calculated for the head region.
- * The constraint that was calculated for the head region considered all
- * constrained blocks in the macro, so to calculate the constraint for the rest
- * of the blocks, it is just the head constraint with the offset of the member
- * applied.
+ * based on the constraint that was calculated for the head region, head_pr.
+ * The constraint that was calculated for the head region must have
+ * calculated the tightest constraints for the head member
+ * by shifting and intersecting the constraints on all macro members.
+ * For each macro member, the updated constraint is essentially the head constraint
+ * with the member's offset applied.
  */
-PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offset& offset);
+PartitionRegion update_macro_member_pr(PartitionRegion& head_pr, const t_pl_offset& offset, const PartitionRegion& grid_pr);
 
 /*
  * Updates the floorplan constraints information for all constrained macros.
- * The head member of each constrained macro is assigned a new PartitionRegion
- * that is calculated based on the constraints of all the blocks in the macro.
+ * Updates the constraints to be the tightest constraints possible while adhering
+ * to the floorplan constraints of each macro member.
  * This is done at the start of initial placement to ease floorplan legality checking
  * while placing macros during initial placement.
  */

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -44,9 +44,8 @@ PartitionRegion update_macro_head_pr(const t_pl_macro& pl_macro, const Partition
 /*
  * Update the PartitionRegions of non-head members of a macro,
  * based on the constraint that was calculated for the head region, head_pr.
- * The constraint that was calculated for the head region must have
- * calculated the tightest constraints for the head member
- * by shifting and intersecting the constraints on all macro members.
+ * The constraint on the head region must be the tightest possible (i.e. implied by the
+ * entire macro) before this routine is called.
  * For each macro member, the updated constraint is essentially the head constraint
  * with the member's offset applied.
  */

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -36,7 +36,7 @@ bool is_macro_constrained(const t_pl_macro& pl_macro);
 /*
  * Returns region of valid locations for the head of the macro based on floorplan constraints
  */
-PartitionRegion constrained_macro_locs(const t_pl_macro& pl_macro);
+PartitionRegion update_macro_pr(const t_pl_macro& pl_macro);
 
 void constraints_propagation();
 

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -6,6 +6,7 @@
 #include "vpr_constraints.h"
 #include "partition.h"
 #include "region.h"
+#include "place_constraints.h"
 
 /**
  * This file contains unit tests that check the functionality of all classes related to vpr constraints. These classes include
@@ -423,6 +424,28 @@ TEST_CASE("RegionLocked", "[vpr]") {
     is_r2_locked = r2.locked();
 
     REQUIRE(is_r2_locked == false);
+}
+
+//Test calculation of macro constraints
+TEST_CASE("MacroConstraints", "[vpr]") {
+    PartitionRegion head_pr;
+    t_pl_offset offset(2, 1, 0);
+
+    Region reg;
+    reg.set_region_rect(5, 2, 9, 6);
+
+    head_pr.add_to_part_region(reg);
+
+    PartitionRegion macro_pr = update_macro_member_pr(head_pr, offset);
+
+    std::vector<Region> mac_regions = macro_pr.get_partition_region();
+
+    vtr::Rect<int> mac_rect = mac_regions[0].get_region_rect();
+
+    REQUIRE(mac_rect.xmin() == 7);
+    REQUIRE(mac_rect.ymin() == 3);
+    REQUIRE(mac_rect.xmax() == 11);
+    REQUIRE(mac_rect.ymax() == 7);
 }
 
 static constexpr const char kArchFile[] = "test_read_arch_metadata.xml";

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -427,6 +427,9 @@ TEST_CASE("RegionLocked", "[vpr]") {
 }
 
 //Test calculation of macro constraints
+/* Checks that the PartitionRegion of a macro member is updated properly according
+ * to the head member's PartitionRegion that is passed in.
+ */
 TEST_CASE("MacroConstraints", "[vpr]") {
     t_pl_macro pl_macro;
     PartitionRegion head_pr;

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -436,7 +436,12 @@ TEST_CASE("MacroConstraints", "[vpr]") {
 
     head_pr.add_to_part_region(reg);
 
-    PartitionRegion macro_pr = update_macro_member_pr(head_pr, offset);
+    Region grid_reg;
+    grid_reg.set_region_rect(0, 0, 20, 20);
+    PartitionRegion grid_pr;
+    grid_pr.add_to_part_region(grid_reg);
+
+    PartitionRegion macro_pr = update_macro_member_pr(head_pr, offset, grid_pr);
 
     std::vector<Region> mac_regions = macro_pr.get_partition_region();
 

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -428,6 +428,7 @@ TEST_CASE("RegionLocked", "[vpr]") {
 
 //Test calculation of macro constraints
 TEST_CASE("MacroConstraints", "[vpr]") {
+    t_pl_macro pl_macro;
     PartitionRegion head_pr;
     t_pl_offset offset(2, 1, 0);
 
@@ -441,7 +442,7 @@ TEST_CASE("MacroConstraints", "[vpr]") {
     PartitionRegion grid_pr;
     grid_pr.add_to_part_region(grid_reg);
 
-    PartitionRegion macro_pr = update_macro_member_pr(head_pr, offset, grid_pr);
+    PartitionRegion macro_pr = update_macro_member_pr(head_pr, offset, grid_pr, pl_macro);
 
     std::vector<Region> mac_regions = macro_pr.get_partition_region();
 


### PR DESCRIPTION
…in macros at the start of initial placement

<!--- Provide a general summary of your changes in the Title above -->
This code does constraint propagation at the start of initial placement. It goes through all the macros, and checks for floorplanning constraints on each one. For the macros that have floorplan constraints, it calculates the smallest possible floorplan region for the entire macro, based on the floorplan constraints of each block within the macro. This is all done before initial placement starts so that during initial placement, when macros are being placed, the floorplan legality can easily be checked by seeing whether the head member of the macro is in the floorplan region that was calculated earlier.

#### Related Issue
This pull request is related to adding floorplanning placement constraints to VPR, as described in this issue #932 

#### Motivation and Context
This change makes it easier to check floorplan legality for macros during initial placement.




