### PR TITLE
CI: Drop GCC 5&6 support

### DIFF
--- a/.github/gha/install_dependencies.sh
+++ b/.github/gha/install_dependencies.sh
@@ -35,10 +35,6 @@ sudo apt install -y \
   zip \
   qt5-default \
   clang-format-7 \
-  g++-5 \
-  gcc-5 \
-  g++-6 \
-  gcc-6 \
   g++-7 \
   gcc-7 \
   g++-8 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,8 +224,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { name: 'GCC 5 (Ubuntu Xenial - 16.04)',    eval: 'CC=gcc-5 && CXX=g++-5',           build: 'release_strict' }
-        - { name: 'GCC 6 (Debian Stretch)',           eval: 'CC=gcc-6 && CXX=g++-6',           build: 'release_strict' }
         - { name: 'GCC 7 (Ubuntu Bionic - 18.04)',    eval: 'CC=gcc-7 && CXX=g++-7',           build: ''               }
         - { name: 'GCC 8 (Debian Buster)',            eval: 'CC=gcc-8 && CXX=g++-8',           build: ''               }
         - { name: 'GCC 9 (Ubuntu Focal - 20.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           build: ''               }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ on:
   - cron: '0 0 * * 0' # weekly
 
 env:
-  MATRIX_EVAL: "CC=gcc-6 && CXX=g++-6"
+  # default compiler for all non-compatibility tests
+  MATRIX_EVAL: "CC=gcc-11 && CXX=g++-11"
 
 jobs:
 
@@ -27,7 +28,6 @@ jobs:
 
     - name: Test
       env:
-        MATRIX_EVAL: "CC=gcc-6 && CXX=g++-6"
         BUILD_TYPE: release
       run: |
         source .github/travis/common.sh
@@ -78,7 +78,6 @@ jobs:
     - name: Test
       env:
         CMAKE_PARAMS: "-DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on"
-        MATRIX_EVAL: "CC=gcc-5 && CXX=g++-5"
       run: |
         source .github/travis/common.sh
         ./.github/travis/setup.sh
@@ -104,7 +103,6 @@ jobs:
         #In order to get compilation warnings produced per source file, we must do a non-IPO build
         #We also turn warnings into errors for this target by doing a strict compile
         CMAKE_PARAMS: "-DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DVTR_ENABLE_STRICT_COMPILE=on -DVTR_IPO_BUILD=off"
-        MATRIX_EVAL: "CC=gcc-5 && CXX=g++-5"
       run: |
         source .github/travis/common.sh
         ./.github/travis/setup.sh
@@ -157,7 +155,6 @@ jobs:
     - name: Test
       env:
         CMAKE_PARAMS: ${{ matrix.params }}
-        MATRIX_EVAL: "CC=gcc-5 && CXX=g++-5"
       run: |
         source .github/travis/common.sh
         ./.github/travis/setup.sh
@@ -187,7 +184,6 @@ jobs:
     - name: Test
       env:
         CMAKE_PARAMS: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on'
-        MATRIX_EVAL: "CC=gcc-5 && CXX=g++-5"
         BUILD_TYPE: debug
         LSAN_OPTIONS: 'exitcode=42' #Use a non-standard exit code to ensure LSAN errors are detected
       run: |
@@ -213,7 +209,6 @@ jobs:
     - name: Test
       env:
         CMAKE_PARAMS: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on'
-        MATRIX_EVAL: 'CC=gcc-5 && CXX=g++-5'
         BUILD_TYPE: debug
       run: |
         source .github/travis/common.sh
@@ -285,7 +280,6 @@ jobs:
     - name: Test
       env:
         CMAKE_PARAMS: '-DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on'
-        MATRIX_EVAL: 'CC=gcc-6 && CXX=g++-6'
         _COVERITY_URL: 'https://scan.coverity.com/download/linux64'
         _COVERITY_MD5: 'd0d7d7df9d6609e578f85096a755fb8f'
       run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ CMake provides a portable cross-platform build systems with many useful features
 VTR requires a C++-14 compliant compiler.
 The following compilers are tested with VTR:
 
-* GCC/G++: 5, 6, 7, 8, 9, 10, 11
+* GCC/G++: 7, 8, 9, 10, 11
 * Clang/Clang++: 6, 7, 10
 
 Other compilers may work but are untested (your milage may vary).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ CMake provides a portable cross-platform build systems with many useful features
 
 ## Tested Compilers ##
 VTR requires a C++-14 compliant compiler.
-The following compilers are tested with VTR:
+It is tested against the default compilers of all Debian and Ubuntu releases within their standard support lifetime. Currently, those are the following:
 
 * GCC/G++: 7, 8, 9, 10, 11
 * Clang/Clang++: 6, 7, 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,6 @@ RUN apt-get install -y \
     zip \
     qt5-default \
     clang-format-7 \
-    g++-5 \
-    gcc-5 \
-    g++-6 \
-    gcc-6 \
     g++-7 \
     gcc-7 \
     g++-8 \

--- a/ODIN_II/SRC/include/odin_error.h
+++ b/ODIN_II/SRC/include/odin_error.h
@@ -36,9 +36,10 @@ extern int delayed_errors;
 extern const loc_t unknown_location;
 
 // causes an interrupt in GDB
-void _verbose_assert(bool condition, const char* condition_str, const char* odin_file_name, int odin_line_number, const char* odin_function_name);
+[[noreturn]] void _verbose_abort(const char* condition_str, const char* odin_file_name, int odin_line_number, const char* odin_function_name);
 
-#define oassert(condition) _verbose_assert(condition, #condition, __FILE__, __LINE__, __func__)
+#define oassert(condition) \
+    if (!bool(condition)) _verbose_abort(#condition, __FILE__, __LINE__, __func__)
 
 void _log_message(odin_error error_type, loc_t loc, bool soft_error, const char* function_file_name, int function_line, const char* function_name, const char* message, ...);
 

--- a/ODIN_II/SRC/odin_error.cpp
+++ b/ODIN_II/SRC/odin_error.cpp
@@ -122,23 +122,23 @@ void _log_message(odin_error error_type, loc_t loc, bool fatal_error, const char
     }
 
     fflush(stderr);
-    _verbose_assert(!fatal_error, NULL, function_file_name, function_line, function_name);
+    if (fatal_error) {
+        _verbose_abort(NULL, function_file_name, function_line, function_name);
+    }
 }
 
-void _verbose_assert(bool condition, const char* condition_str, const char* odin_file_name, int odin_line_number, const char* odin_function_name) {
+void _verbose_abort(const char* condition_str, const char* odin_file_name, int odin_line_number, const char* odin_function_name) {
     fflush(stdout);
-    if (!condition) {
-        fprintf(stderr, "\n%s:%d: %s: ", odin_file_name, odin_line_number, odin_function_name);
-        if (condition_str) {
-            // We are an assertion, print the condition that failed and which line it occurred on
-            fprintf(stderr, "Assertion %s failed\n", condition_str);
-            // odin_line_number-1 since __LINE__ starts from 1
-            print_culprit_line_with_context(-1, odin_line_number - 1, odin_file_name, 2);
-        } else {
-            // We are a parsing error, dont print the culprit line
-            fprintf(stderr, "Fatal error\n");
-        }
-        fflush(stderr);
-        std::abort();
+    fprintf(stderr, "\n%s:%d: %s: ", odin_file_name, odin_line_number, odin_function_name);
+    if (condition_str) {
+        // We are an assertion, print the condition that failed and which line it occurred on
+        fprintf(stderr, "Assertion %s failed\n", condition_str);
+        // odin_line_number-1 since __LINE__ starts from 1
+        print_culprit_line_with_context(-1, odin_line_number - 1, odin_file_name, 2);
+    } else {
+        // We are a parsing error, dont print the culprit line
+        fprintf(stderr, "Fatal error\n");
     }
+    fflush(stderr);
+    std::abort();
 }

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -190,6 +190,8 @@ if (VTR_ENABLE_STRICT_COMPILE)
     set(VPR_STRICT_COMPILE_FLAGS_TO_CHECK
         #GCC-like
         "-Werror"
+        # due to the pointer hackery in timing_driven_route_structs and BinaryHeap.heap_
+        "-Wno-error=free-nonheap-object"
         )
 
     foreach(flag ${VPR_STRICT_COMPILE_FLAGS_TO_CHECK})

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -889,6 +889,7 @@ class t_place_algorithm {
   public:
     //Constructors
     t_place_algorithm() = default;
+    t_place_algorithm(const t_place_algorithm&) = default;
     t_place_algorithm(e_place_algorithm _algo)
         : algo(_algo) {}
     ~t_place_algorithm() = default;


### PR DESCRIPTION
#### Description
See #1754 for the motivation.

GCC 5 and 6 were still used for many CI runs, so the default was updated to GCC 11. This created a few new warnings that didn't exist in the older compilers, causing the `-Werror` job to fail - I've included the fixes in this pull request.

#### Related Issue
Resolves #1754

#### How Has This Been Tested?
All CI jobs work (again).

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed