### PR TITLE
Avoiding Odin's xml config file to be considered as arch file

### DIFF
--- a/dev/upgrade_vtr_archs.sh
+++ b/dev/upgrade_vtr_archs.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-find vpr libs/libarchfpga ODIN_II vtr_flow/arch utils/fasm/test -name '*.xml' | xargs -n 1 python3 ./vtr_flow/scripts/upgrade_arch.py
+find vpr libs/libarchfpga vtr_flow/arch utils/fasm/test -name '*.xml' | xargs -n 1 python3 ./vtr_flow/scripts/upgrade_arch.py


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
the following warnings are showing while `dev/upgrade_vtr_archs.sh` is called. Odin's XMLs are to read the configuration of each run. There is no need to go through the Odin directory looking for XML files.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
removing warning generated by `upgrade_vtr_arch.sh`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
