### PR TITLE
Add gitpod support

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,36 @@
+FROM gitpod/workspace-full:latest
+
+USER root
+# Install util tools.
+RUN apt-get update \
+ && apt-get install -y \
+  apt-utils \
+  sudo \
+  git \
+  less \
+  libfmt-dev \
+  libspdlog-dev \
+  lcov \
+  binutils \
+  binutils-gold \
+  build-essential \
+  flex \
+  fontconfig \
+  libcairo2-dev \
+  libgtk-3-dev \
+  libevent-dev \
+  libfontconfig1-dev \
+  liblist-moreutils-perl \
+  libncurses5-dev \
+  libx11-dev \
+  libxft-dev \
+  libxml++2.6-dev \
+  python-lxml \
+  qt5-default \
+  wget
+
+# Give back control
+USER root
+
+# Cleaning
+RUN apt-get clean

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get update \
   libxml++2.6-dev \
   python-lxml \
   qt5-default \
-  wget
+  wget \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 
 # Give back control
 USER root

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+- command: pyenv global 3.7.4 &&
+           chmod +x envconfig.sh
+
+vscode:
+  extensions:
+    - ms-vscode.cmake-tools@1.2.3:qLtqI3aUcEBX9EpuK0ZCyw==
+    - ms-vscode.cpptools@0.26.2:Pq/tmf2WN3SanVzB4xZc1g==

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Verilog to Routing (VTR)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/Loksu/vtr-verilog-to-routing)
 [![Build Status](https://github.com/verilog-to-routing/vtr-verilog-to-routing/workflows/Test/badge.svg)](https://github.com/verilog-to-routing/vtr-verilog-to-routing/actions?query=workflow%3ATest) [![Documentation Status](https://readthedocs.org/projects/vtr/badge/?version=latest)](http://docs.verilogtorouting.org/en/latest/)
 
 ## Introduction


### PR DESCRIPTION
#### Description

This is part of https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1078 which includes @luk036's changes to adds support for ["gitpod"](https://www.gitpod.io/) -- a solution which lets you create a automated development environment quickly and easily based on Docker. 