### PR TITLE
clang-tidy fixes around const std::string references.

### DIFF
--- a/ODIN_II/SRC/Hashtable.cpp
+++ b/ODIN_II/SRC/Hashtable.cpp
@@ -29,33 +29,33 @@
 #include "vtr_memory.h"
 
 void Hashtable::destroy_free_items() {
-    for (auto kv : my_map)
+    for (const auto& kv : my_map)
         vtr::free(kv.second);
 }
 
-void Hashtable::add(std::string key, void* item) {
-    this->my_map.emplace(key, item);
+void Hashtable::add(const std::string& key, void* item) {
+    this->my_map.insert({key, item});
 }
 
-void* Hashtable::remove(std::string key) {
+void* Hashtable::remove(const std::string& key) {
     void* value = NULL;
     auto v = this->my_map.find(key);
     if (v != this->my_map.end()) {
-        value = v->second;
-        this->my_map.erase(v);
+        value = this->my_map[key];
+        this->my_map.erase(key);
     }
     return value;
 }
 
-void* Hashtable::get(std::string key) {
+void* Hashtable::get(const std::string& key) {
     void* value = NULL;
     auto v = this->my_map.find(key);
     if (v != this->my_map.end())
-        value = v->second;
+        value = this->my_map[key];
 
     return value;
 }
 
 bool Hashtable::is_empty() {
-    return my_map.empty();
+    return (my_map.size() == 0);
 }

--- a/ODIN_II/SRC/ast_util.cpp
+++ b/ODIN_II/SRC/ast_util.cpp
@@ -29,6 +29,7 @@
 #include <stdarg.h>
 #include <math.h>
 #include <algorithm>
+#include <utility>
 #include "odin_globals.h"
 #include "odin_types.h"
 
@@ -520,7 +521,7 @@ void change_to_number_node(ast_node_t* node, VNumber number) {
 
     node->type = NUMBERS;
     node->types.identifier = temp_ident;
-    node->types.vnumber = new VNumber(number);
+    node->types.vnumber = new VNumber(std::move(number));
 }
 
 /*---------------------------------------------------------------------------------------------

--- a/ODIN_II/SRC/hierarchy_util.cpp
+++ b/ODIN_II/SRC/hierarchy_util.cpp
@@ -5,7 +5,7 @@
 STRING_CACHE* copy_param_table_sc(STRING_CACHE* to_copy);
 
 ast_node_t* resolve_hierarchical_name_reference_by_path_search(sc_hierarchy* local_ref, std::string identifier);
-ast_node_t* resolve_hierarchical_name_reference_by_upward_search(sc_hierarchy* local_ref, std::string identifier);
+ast_node_t* resolve_hierarchical_name_reference_by_upward_search(sc_hierarchy* local_ref, const std::string& identifier);
 
 sc_hierarchy* init_sc_hierarchy() {
     sc_hierarchy* hierarchy = (sc_hierarchy*)vtr::calloc(1, sizeof(sc_hierarchy));
@@ -275,7 +275,7 @@ ast_node_t* resolve_hierarchical_name_reference_by_path_search(sc_hierarchy* loc
 /*---------------------------------------------------------------------------
  * (function: resolve_hierarchical_name_reference_by_upward_search)
  *-------------------------------------------------------------------------*/
-ast_node_t* resolve_hierarchical_name_reference_by_upward_search(sc_hierarchy* local_ref, std::string identifier) {
+ast_node_t* resolve_hierarchical_name_reference_by_upward_search(sc_hierarchy* local_ref, const std::string& identifier) {
     if (!identifier.empty()) {
         ast_node_t* var_declare = NULL;
 

--- a/ODIN_II/SRC/implicit_memory.cpp
+++ b/ODIN_II/SRC/implicit_memory.cpp
@@ -236,7 +236,7 @@ void free_implicit_memory_index_and_finalize_memories() {
     implicit_memory_inputs.clear();
 
     if (!implicit_memories.empty()) {
-        for (auto mem_it : implicit_memories) {
+        for (const auto& mem_it : implicit_memories) {
             finalize_implicit_memory(mem_it.second);
             vtr::free(mem_it.second->name);
             vtr::free(mem_it.second);

--- a/ODIN_II/SRC/include/Hashtable.hpp
+++ b/ODIN_II/SRC/include/Hashtable.hpp
@@ -35,11 +35,11 @@ class Hashtable {
 
   public:
     // Adds an item to the hashtable.
-    void add(std::string key, void* item);
+    void add(const std::string& key, void* item);
     // Removes an item from the hashtable. If the item is not present, a null pointer is returned.
-    void* remove(std::string key);
+    void* remove(const std::string& key);
     // Gets an item from the hashtable without removing it. If the item is not present, a null pointer is returned.
-    void* get(std::string key);
+    void* get(const std::string& key);
     // Check to see if the hashtable is empty.
     bool is_empty();
     // calls free on each item.

--- a/ODIN_II/SRC/include/netlist_visualizer.h
+++ b/ODIN_II/SRC/include/netlist_visualizer.h
@@ -4,7 +4,7 @@
 #include <string>
 #include "odin_types.h"
 
-void graphVizOutputNetlist(std::string path, const char* name, uintptr_t marker_value, netlist_t* input_netlist);
-void graphVizOutputCombinationalNet(std::string path, const char* name, uintptr_t marker_value, nnode_t* current_node);
+void graphVizOutputNetlist(const std::string& path, const char* name, uintptr_t marker_value, netlist_t* input_netlist);
+void graphVizOutputCombinationalNet(const std::string& path, const char* name, uintptr_t marker_value, nnode_t* current_node);
 
 #endif

--- a/ODIN_II/SRC/include/node_creation_library.h
+++ b/ODIN_II/SRC/include/node_creation_library.h
@@ -23,7 +23,7 @@ char* op_node_name(operation_list op, char* instance_prefix_name);
 char* hard_node_name(nnode_t* node, char* instance_name_prefix, char* hb_name, char* hb_inst);
 nnode_t* make_mult_block(nnode_t* node, short mark);
 
-edge_type_e edge_type_blif_enum(std::string edge_kind_str, loc_t loc);
+edge_type_e edge_type_blif_enum(const std::string& edge_kind_str, loc_t loc);
 const char* edge_type_blif_str(nnode_t* node);
 
 #endif

--- a/ODIN_II/SRC/include/odin_util.h
+++ b/ODIN_II/SRC/include/odin_util.h
@@ -9,9 +9,9 @@
 
 long shift_left_value_with_overflow_check(long input_value, long shift_by, loc_t loc);
 
-std::string get_file_extension(std::string input_file);
-void create_directory(std::string path);
-void assert_supported_file_extension(std::string input_file, loc_t loc);
+std::string get_file_extension(const std::string& input_file);
+void create_directory(const std::string& path);
+void assert_supported_file_extension(const std::string& input_file, loc_t loc);
 FILE* open_file(const char* file_name, const char* open_type);
 
 const char* name_based_on_op(operation_list op);
@@ -66,7 +66,7 @@ double wall_time();
 int print_progress_bar(double completion, int position, int length, double time);
 
 void trim_string(char* string, const char* chars);
-bool only_one_is_true(std::vector<bool> tested);
+bool only_one_is_true(const std::vector<bool>& tested);
 int odin_sprintf(char* s, const char* format, ...);
 char* str_collate(char* str1, char* str2);
 

--- a/ODIN_II/SRC/include/parse_making_ast.h
+++ b/ODIN_II/SRC/include/parse_making_ast.h
@@ -99,7 +99,7 @@ ast_node_t* newDefparam(ids id, ast_node_t* val, loc_t loc);
 void next_parsed_verilog_file(ast_node_t* file_items_list);
 
 /* VISUALIZATION */
-void graphVizOutputAst(std::string path, ast_node_t* top);
+void graphVizOutputAst(const std::string& path, ast_node_t* top);
 void graphVizOutputAst_traverse_node(FILE* fp, ast_node_t* node, ast_node_t* from, int from_num);
 void graphVizOutputAst_Var_Declare(FILE* fp, ast_node_t* node, int from_num);
 

--- a/ODIN_II/SRC/multipliers.cpp
+++ b/ODIN_II/SRC/multipliers.cpp
@@ -348,7 +348,7 @@ void instantiate_hard_multiplier(nnode_t* node, short mark, netlist_t* /*netlist
 
     declare_hard_multiplier(node);
 
-    std::string node_name = "";
+    std::string node_name;
     if (node->name) {
         node_name = node->name;
         vtr::free(node->name);

--- a/ODIN_II/SRC/netlist_visualizer.cpp
+++ b/ODIN_II/SRC/netlist_visualizer.cpp
@@ -43,7 +43,7 @@ void backward_traversal_net_graph_display(FILE* out, uintptr_t marker_value, nno
 /*---------------------------------------------------------------------------------------------
  * (function: graphVizOutputNetlist)
  *-------------------------------------------------------------------------------------------*/
-void graphVizOutputNetlist(std::string path, const char* name, uintptr_t marker_value, netlist_t* netlist) {
+void graphVizOutputNetlist(const std::string& path, const char* name, uintptr_t marker_value, netlist_t* netlist) {
     char path_and_file[4096];
     FILE* fp;
 
@@ -163,7 +163,7 @@ void depth_first_traverse_visualize(nnode_t* node, FILE* fp, uintptr_t traverse_
 /*---------------------------------------------------------------------------------------------
  * (function: graphVizOutputCobinationalNet)
  *-------------------------------------------------------------------------------------------*/
-void graphVizOutputCombinationalNet(std::string path, const char* name, uintptr_t marker_value, nnode_t* current_node) {
+void graphVizOutputCombinationalNet(const std::string& path, const char* name, uintptr_t marker_value, nnode_t* current_node) {
     char path_and_file[4096];
     FILE* fp;
 

--- a/ODIN_II/SRC/node_creation_library.cpp
+++ b/ODIN_II/SRC/node_creation_library.cpp
@@ -247,7 +247,7 @@ const char* edge_type_blif_str(nnode_t* node) {
     }
 }
 
-edge_type_e edge_type_blif_enum(std::string edge_kind_str, loc_t loc) {
+edge_type_e edge_type_blif_enum(const std::string& edge_kind_str) {
     if (edge_kind_str == "fe")
         return FALLING_EDGE_SENSITIVITY;
     else if (edge_kind_str == "re")

--- a/ODIN_II/SRC/odin_ii.cpp
+++ b/ODIN_II/SRC/odin_ii.cpp
@@ -341,7 +341,7 @@ int terminate_odin_ii(netlist_t* odin_netlist) {
 }
 
 struct ParseInitRegState {
-    int from_str(std::string str) {
+    int from_str(const std::string& str) {
         if (str == "0")
             return 0;
         else if (str == "1")

--- a/ODIN_II/SRC/odin_util.cpp
+++ b/ODIN_II/SRC/odin_util.cpp
@@ -56,7 +56,7 @@ long shift_left_value_with_overflow_check(long input_value, long shift_by, loc_t
     return input_value << shift_by;
 }
 
-std::string get_file_extension(std::string input_file) {
+std::string get_file_extension(const std::string& input_file) {
     auto dot_location = input_file.find_last_of('.');
     if (dot_location != std::string::npos) {
         return input_file.substr(dot_location);
@@ -65,7 +65,7 @@ std::string get_file_extension(std::string input_file) {
     }
 }
 
-void create_directory(std::string path) {
+void create_directory(const std::string& path) {
     // CREATE OUTPUT DIRECTORY
     int error_code = 0;
 #ifdef WIN32
@@ -79,7 +79,7 @@ void create_directory(std::string path) {
     }
 }
 
-void assert_supported_file_extension(std::string input_file, loc_t loc) {
+void assert_supported_file_extension(const std::string& input_file, loc_t loc) {
     bool supported = false;
     std::string extension = get_file_extension(input_file);
     for (int i = 0; i < file_extension_supported_END && !supported; i++) {
@@ -830,7 +830,16 @@ std::string find_substring(char* src, const char* sKey, int flag) {
  * Prints the time in appropriate units.
  */
 void print_time(double time) {
-    printf("%.1fms", time * 1000);
+    if (time > 24 * 3600)
+        printf("%.1fd", time / (24 * 3600.0));
+    else if (time > 3600)
+        printf("%.1fh", time / 3600.0);
+    else if (time > 60)
+        printf("%.1fm", time / 60.0);
+    else if (time > 1)
+        printf("%.1fs", time);
+    else
+        printf("%.1fms", time * 1000);
 }
 
 /*
@@ -963,7 +972,7 @@ bool output_vector_headers_equal(char* buffer1, char* buffer2) {
 /**
  * verifies only one condition evaluates to true
  */
-bool only_one_is_true(std::vector<bool> tested) {
+bool only_one_is_true(const std::vector<bool>& tested) {
     bool previous_value = false;
     for (bool next_value : tested) {
         if (!previous_value && next_value)

--- a/ODIN_II/SRC/odin_util.cpp
+++ b/ODIN_II/SRC/odin_util.cpp
@@ -87,7 +87,7 @@ void assert_supported_file_extension(const std::string& input_file, loc_t loc) {
     }
 
     if (!supported) {
-        std::string supported_extension_list = "";
+        std::string supported_extension_list;
         for (int i = 0; i < file_extension_supported_END; i++) {
             supported_extension_list += " ";
             supported_extension_list += file_extension_supported_STR[i];

--- a/ODIN_II/SRC/output_blif.cpp
+++ b/ODIN_II/SRC/output_blif.cpp
@@ -174,7 +174,7 @@ FILE* create_blif(const char* file_name) {
 
     /* open the file for output */
     if (global_args.high_level_block.provenance() == argparse::Provenance::SPECIFIED) {
-        std::string out_file = "";
+        std::string out_file;
         out_file = out_file + file_name + "_" + global_args.high_level_block.value() + ".blif";
         out = fopen(out_file.c_str(), "w+");
     } else {

--- a/ODIN_II/SRC/parse_making_ast.cpp
+++ b/ODIN_II/SRC/parse_making_ast.cpp
@@ -1812,7 +1812,7 @@ int unique_label_count;
 /*---------------------------------------------------------------------------
  * (function: graphVizOutputAst)
  *-------------------------------------------------------------------------*/
-void graphVizOutputAst(std::string path, ast_node_t* top) {
+void graphVizOutputAst(const std::string& path, ast_node_t* top) {
     char path_and_file[4096];
     FILE* fp;
     static int file_num = 0;

--- a/ODIN_II/SRC/read_blif.cpp
+++ b/ODIN_II/SRC/read_blif.cpp
@@ -290,7 +290,7 @@ void create_latch_node_and_driver(FILE* file, Hashtable* output_nets_hash) {
             names[4] = names[2];
             names[2] = vtr::strdup("re");
         } else {
-            std::string line = "";
+            std::string line;
             for (int i = 0; i < input_token_count; i++) {
                 line += names[i];
                 line += " ";

--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -1786,7 +1786,7 @@ static void instantiate_memory(nnode_t* node, long data_width, long addr_width) 
     }
 }
 
-static int parse_mif_radix(std::string radix) {
+static int parse_mif_radix(const std::string& radix) {
     return (radix == "HEX") ? 16 : (radix == "DEC") ? 10 : (radix == "OCT") ? 8 : (radix == "BIN") ? 2 : 0;
 }
 
@@ -2312,7 +2312,7 @@ static test_vector* parse_test_vector(char* buffer) {
  *
  * If you want better randomness, call srand at some point.
  */
-static bool contains_a_substr_of_name(std::vector<std::string> held, const char* name_in) {
+static bool contains_a_substr_of_name(const std::vector<std::string>& held, const char* name_in) {
     if (!name_in)
         return false;
 

--- a/abc/src/base/abci/abcTiming.c
+++ b/abc/src/base/abci/abcTiming.c
@@ -45,7 +45,7 @@ struct Abc_ManTime_t_
 
 #define TOLERANCE 0.001
 
-static inline int          Abc_FloatEqual( float x, float y )     { return fabs(x-y) < TOLERANCE; }
+static inline int          Abc_FloatEqual( float x, float y )     { return fabsf(x-y) < TOLERANCE; }
 
 // static functions
 static Abc_ManTime_t *     Abc_ManTimeStart( Abc_Ntk_t * pNtk );

--- a/abc/src/map/scl/sclSize.c
+++ b/abc/src/map/scl/sclSize.c
@@ -342,7 +342,7 @@ void Abc_SclTimeNode( SC_Man * p, Abc_Obj_t * pObj, int fDept )
         if ( fDept )
         {
             SC_Pair * pDepOut  = Abc_SclObjDept( p, pObj );
-            float EstDelta = p->EstLinear * log( Value );
+            float EstDelta = p->EstLinear * logf( Value );
             DeptRise = pDepOut->rise;
             DeptFall = pDepOut->fall;
             pDepOut->rise += EstDelta;
@@ -374,7 +374,7 @@ void Abc_SclTimeNode( SC_Man * p, Abc_Obj_t * pObj, int fDept )
         else
         {
             SC_Pair * pArrOut  = Abc_SclObjTime( p, pObj );
-            float EstDelta = p->EstLinear * log( Value );
+            float EstDelta = p->EstLinear * logf( Value );
             pArrOut->rise += EstDelta;
             pArrOut->fall += EstDelta;
         }
@@ -864,7 +864,7 @@ void Abc_SclPrintBuffersOne( SC_Man * p, Abc_Obj_t * pObj, int nOffset )
     printf( "L =%5.0f ff   ",  Abc_SclCountNonBufferLoad(p, pObj) );
     printf( "Lx =%5.0f ff  ",  100.0*Abc_SclCountNonBufferLoad(p, pObj)/p->EstLoadAve );
     printf( "Dx =%5.0f ps  ",  Abc_SclCountNonBufferDelay(p, pObj)/Abc_SclCountNonBufferFanouts(pObj) - Abc_SclObjTimeOne(p, pObj, 1) );
-    printf( "Cx =%5.0f ps",    (Abc_SclCountNonBufferDelay(p, pObj)/Abc_SclCountNonBufferFanouts(pObj) - Abc_SclObjTimeOne(p, pObj, 1))/log(Abc_SclCountNonBufferLoad(p, pObj)/p->EstLoadAve) );
+    printf( "Cx =%5.0f ps",    (Abc_SclCountNonBufferDelay(p, pObj)/Abc_SclCountNonBufferFanouts(pObj) - Abc_SclObjTimeOne(p, pObj, 1))/logf(Abc_SclCountNonBufferLoad(p, pObj)/p->EstLoadAve) );
     }
     printf( "\n" );
 }

--- a/dev/odin2_helper/Makefile
+++ b/dev/odin2_helper/Makefile
@@ -9,7 +9,7 @@ default: $(EXE)
 run: Md5Core.vv
 
 $(EXE): $(EXE).c++
-	g++ -Wall -Wextra -Werror -pedantic -std=c++11 $< -o $@ -ggdb -D_GLIBCXX_DEBUG
+	g++ -Wall -Wextra -Werror -pedantic -std=c++14 $< -o $@ -ggdb -D_GLIBCXX_DEBUG
 
 test: Md5Core.v
 	less $<

--- a/libs/EXTERNAL/capnproto/c++/src/capnp/compat/json.h
+++ b/libs/EXTERNAL/capnproto/c++/src/capnp/compat/json.h
@@ -137,7 +137,7 @@ public:
 
   template <typename T>
   void encode(T&& value, JsonValue::Builder output) const;
-  void encode(DynamicValue::Reader input, Type type, JsonValue::Builder output) const;
+  void encode(const DynamicValue::Reader& input, Type type, JsonValue::Builder output) const;
   void decode(JsonValue::Reader input, DynamicStruct::Builder output) const;
   template <typename T>
   Orphan<T> decode(JsonValue::Reader input, Orphanage orphanage) const;
@@ -238,7 +238,7 @@ private:
 
   kj::Own<Impl> impl;
 
-  void encodeField(StructSchema::Field field, DynamicValue::Reader input,
+  void encodeField(StructSchema::Field field, const DynamicValue::Reader& input,
                    JsonValue::Builder output) const;
   Orphan<DynamicList> decodeArray(List<JsonValue>::Reader input, ListSchema type, Orphanage orphanage) const;
   void decodeObject(JsonValue::Reader input, StructSchema type, Orphanage orphanage, DynamicStruct::Builder output) const;

--- a/libs/EXTERNAL/capnproto/c++/src/capnp/compiler/parser.c++
+++ b/libs/EXTERNAL/capnproto/c++/src/capnp/compiler/parser.c++
@@ -709,8 +709,8 @@ CapnpParser::CapnpParser(Orphanage orphanageParam, ErrorReporter& errorReporterP
   auto& ordinalOrColon = arena.copy(p::oneOf(
       p::transform(p::sequence(parsers.ordinal, p::optional(op("!")), p::optional(op(":"))),
           [](Orphan<LocatedInteger>&& ordinal,
-                 kj::Maybe<kj::Tuple<>> exclamation,
-                 kj::Maybe<kj::Tuple<>> colon)
+                 const kj::Maybe<kj::Tuple<>>& exclamation,
+                 const kj::Maybe<kj::Tuple<>>& colon)
                    -> kj::Tuple<kj::Maybe<Orphan<LocatedInteger>>, bool, bool> {
             return kj::tuple(kj::mv(ordinal), exclamation == nullptr, colon == nullptr);
           }),

--- a/libs/EXTERNAL/capnproto/c++/src/capnp/dynamic.c++
+++ b/libs/EXTERNAL/capnproto/c++/src/capnp/dynamic.c++
@@ -1014,7 +1014,7 @@ void DynamicStruct::Builder::set(kj::StringPtr name,
                                  std::initializer_list<DynamicValue::Reader> value) {
   auto list = init(name, value.size()).as<DynamicList>();
   uint i = 0;
-  for (auto element: value) {
+  for (const auto& element: value) {
     list.set(i++, element);
   }
 }
@@ -1416,7 +1416,7 @@ Orphan<DynamicValue> DynamicList::Builder::disown(uint index) {
 void DynamicList::Builder::copyFrom(std::initializer_list<DynamicValue::Reader> value) {
   KJ_REQUIRE(value.size() == size(), "DynamicList::copyFrom() argument had different size.");
   uint i = 0;
-  for (auto element: value) {
+  for (const auto& element: value) {
     set(i++, element);
   }
 }

--- a/libs/EXTERNAL/capnproto/c++/src/capnp/stringify.c++
+++ b/libs/EXTERNAL/capnproto/c++/src/capnp/stringify.c++
@@ -227,7 +227,7 @@ static kj::StringTree print(const DynamicValue::Reader& value,
   KJ_UNREACHABLE;
 }
 
-kj::StringTree stringify(DynamicValue::Reader value) {
+kj::StringTree stringify(const DynamicValue::Reader& value) {
   return print(value, schema::Type::STRUCT, Indent(false), BARE);
 }
 

--- a/libs/EXTERNAL/capnproto/c++/src/kj/filesystem.c++
+++ b/libs/EXTERNAL/capnproto/c++/src/kj/filesystem.c++
@@ -1499,8 +1499,8 @@ private:
       lastModified = clock.now();
     }
 
-    bool tryTransferChild(EntryImpl& entry, const FsNode::Type type, kj::Maybe<Date> lastModified,
-                          kj::Maybe<uint64_t> size, const Directory& fromDirectory,
+    bool tryTransferChild(EntryImpl& entry, const FsNode::Type type, const kj::Maybe<Date>& lastModified,
+                          const kj::Maybe<uint64_t>& size, const Directory& fromDirectory,
                           PathPtr fromPath, TransferMode mode) {
       switch (type) {
         case FsNode::Type::FILE:

--- a/libs/EXTERNAL/libargparse/src/argparse.cpp
+++ b/libs/EXTERNAL/libargparse/src/argparse.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <set>
 #include <limits>
+#include <utility>
 
 #include "argparse.hpp"
 #include "argparse_util.hpp"
@@ -17,15 +18,15 @@ namespace argparse {
      */
 
     ArgumentParser::ArgumentParser(std::string prog_name, std::string description_str, std::ostream& os)
-        : description_(description_str)
+        : description_(std::move(description_str))
         , formatter_(new DefaultFormatter())
         , os_(os)
         {
-        prog(prog_name);
+        prog(std::move(prog_name));
         argument_groups_.push_back(ArgumentGroup("arguments"));
     }
 
-    ArgumentParser& ArgumentParser::prog(std::string prog_name, bool basename_only) {
+    ArgumentParser& ArgumentParser::prog(const std::string& prog_name, bool basename_only) {
         if (basename_only) {
             prog_ = basename(prog_name);
         } else {
@@ -35,17 +36,17 @@ namespace argparse {
     }
 
     ArgumentParser& ArgumentParser::version(std::string version_str) {
-        version_ = version_str;
+        version_ = std::move(version_str);
         return *this;
     }
 
     ArgumentParser& ArgumentParser::epilog(std::string epilog_str) {
-        epilog_ = epilog_str;
+        epilog_ = std::move(epilog_str);
         return *this;
     }
 
     ArgumentGroup& ArgumentParser::add_argument_group(std::string description_str) {
-        argument_groups_.push_back(ArgumentGroup(description_str));
+        argument_groups_.push_back(ArgumentGroup(std::move(description_str)));
         return argument_groups_[argument_groups_.size() - 1];
     }
 
@@ -410,11 +411,11 @@ namespace argparse {
      * ArgumentGroup
      */
     ArgumentGroup::ArgumentGroup(std::string name_str)
-        : name_(name_str)
+        : name_(std::move(name_str))
         {}
 
     ArgumentGroup& ArgumentGroup::epilog(std::string str) {
-        epilog_ = str;
+        epilog_ = std::move(str);
         return *this;
     }
     std::string ArgumentGroup::name() const { return name_; }
@@ -425,8 +426,8 @@ namespace argparse {
      * Argument
      */
     Argument::Argument(std::string long_opt, std::string short_opt)
-        : long_opt_(long_opt)
-        , short_opt_(short_opt) {
+        : long_opt_(std::move(long_opt))
+        , short_opt_(std::move(short_opt)) {
 
         if (long_opt_.size() < 1) {
             throw ArgParseError("Argument must be at least one character long");
@@ -445,7 +446,7 @@ namespace argparse {
     }
 
     Argument& Argument::help(std::string help_str) {
-        help_ = help_str;
+        help_ = std::move(help_str);
         return *this;
     }
 
@@ -476,12 +477,12 @@ namespace argparse {
     }
 
     Argument& Argument::metavar(std::string metavar_str) {
-        metavar_ = metavar_str;
+        metavar_ = std::move(metavar_str);
         return *this;
     }
 
     Argument& Argument::choices(std::vector<std::string> choice_values) {
-        choices_ = choice_values;
+        choices_ = std::move(choice_values);
         return *this;
     }
 
@@ -536,7 +537,7 @@ namespace argparse {
     }
 
     Argument& Argument::group_name(std::string grp) {
-        group_name_ = grp;
+        group_name_ = std::move(grp);
         return *this;
     }
 

--- a/libs/EXTERNAL/libargparse/src/argparse.hpp
+++ b/libs/EXTERNAL/libargparse/src/argparse.hpp
@@ -37,7 +37,7 @@ namespace argparse {
             ArgumentParser(std::string prog_name, std::string description_str=std::string(), std::ostream& os=std::cout);
 
             //Overrides the program name
-            ArgumentParser& prog(std::string prog, bool basename_only=true);
+            ArgumentParser& prog(const std::string& prog, bool basename_only=true);
 
             //Sets the program version
             ArgumentParser& version(std::string version);
@@ -294,7 +294,7 @@ namespace argparse {
     template<typename T, typename Converter>
     class SingleValueArgument : public Argument {
         public: //Constructors
-            SingleValueArgument(ArgValue<T>& dest, std::string long_opt, std::string short_opt)
+            SingleValueArgument(ArgValue<T>& dest, const std::string& long_opt, const std::string& short_opt)
                 : Argument(long_opt, short_opt)
                 , dest_(dest)
                 {}
@@ -364,7 +364,7 @@ namespace argparse {
     template<typename Converter>
     class SingleValueArgument<bool,Converter> : public Argument {
         public: //Constructors
-            SingleValueArgument(ArgValue<bool>& dest, std::string long_opt, std::string short_opt)
+            SingleValueArgument(ArgValue<bool>& dest, const std::string& long_opt, const std::string& short_opt)
                 : Argument(long_opt, short_opt)
                 , dest_(dest)
                 {}
@@ -432,7 +432,7 @@ namespace argparse {
     template<typename T, typename Converter>
     class MultiValueArgument : public Argument {
         public: //Constructors
-            MultiValueArgument(ArgValue<T>& dest, std::string long_opt, std::string short_opt)
+            MultiValueArgument(ArgValue<T>& dest, const std::string& long_opt, const std::string& short_opt)
                 : Argument(long_opt, short_opt)
                 , dest_(dest)
                 {}
@@ -440,7 +440,7 @@ namespace argparse {
         public: //Mutators
             void set_dest_to_default() override {
                 auto& target = dest_.mutable_value(Provenance::DEFAULT);
-                for (auto default_str : default_value_) {
+                for (const auto& default_str : default_value_) {
                     auto val = Converter().from_str(default_str);
                     target.insert(std::end(target), val.value());
                 }

--- a/libs/EXTERNAL/libargparse/src/argparse_default_converter.hpp
+++ b/libs/EXTERNAL/libargparse/src/argparse_default_converter.hpp
@@ -1,6 +1,7 @@
 #ifndef ARGPARSE_DEFAULT_CONVERTER_HPP
 #define ARGPARSE_DEFAULT_CONVERTER_HPP
 #include <sstream>
+#include <utility>
 #include <vector>
 #include <typeinfo>
 #include "argparse_error.hpp"
@@ -38,7 +39,7 @@ arg_type() { return ""; } //Empty
 template<typename T>
 class DefaultConverter {
     public:
-        ConvertedValue<T> from_str(std::string str) {
+        ConvertedValue<T> from_str(const std::string& str) {
             std::stringstream ss(str);
 
             T val = T();
@@ -124,12 +125,12 @@ class DefaultConverter<std::string> {
     public:
         ConvertedValue<std::string> from_str(std::string str) { 
             ConvertedValue<std::string> converted_value;
-            converted_value.set_value(str);
+            converted_value.set_value(std::move(str));
             return converted_value;
         }
         ConvertedValue<std::string> to_str(std::string val) {
             ConvertedValue<std::string> converted_value;
-            converted_value.set_value(val);
+            converted_value.set_value(std::move(val));
             return converted_value;
         }
         std::vector<std::string> default_choices() { return {}; }
@@ -140,7 +141,7 @@ class DefaultConverter<std::string> {
 template<>
 class DefaultConverter<const char*> {
     public:
-        ConvertedValue<const char*> from_str(std::string str) { 
+        ConvertedValue<const char*> from_str(const std::string& str) { 
             ConvertedValue<const char*> val;
             val.set_value(strdup(str.c_str()));
             return val;
@@ -158,7 +159,7 @@ class DefaultConverter<const char*> {
 template<>
 class DefaultConverter<char*> {
     public:
-        ConvertedValue<char*> from_str(std::string str) { 
+        ConvertedValue<char*> from_str(const std::string& str) { 
             ConvertedValue<char*> val;
             val.set_value(strdup(str.c_str()));
             return val;

--- a/libs/EXTERNAL/libargparse/src/argparse_util.cpp
+++ b/libs/EXTERNAL/libargparse/src/argparse_util.cpp
@@ -39,7 +39,7 @@ namespace argparse {
         return false;
     }
 
-    bool is_valid_choice(std::string str, const std::vector<std::string>& choices) {
+    bool is_valid_choice(const std::string& str, const std::vector<std::string>& choices) {
         if (choices.empty()) return true;
 
         auto find_iter = std::find(choices.begin(), choices.end(), str);
@@ -74,7 +74,7 @@ namespace argparse {
         return res;
     }
 
-    std::vector<std::string> wrap_width(std::string str, size_t width, std::vector<std::string> break_strs) {
+    std::vector<std::string> wrap_width(std::string str, size_t width, const std::vector<std::string>& break_strs) {
         std::vector<std::string> wrapped_lines;
 
         size_t start = 0;
@@ -114,13 +114,13 @@ namespace argparse {
         return wrapped_lines;
     }
 
-    std::string basename(std::string filepath) {
+    std::string basename(const std::string& filepath) {
 #ifdef _WIN32
         //Windows uses back-slash as directory divider
         auto pos = filepath.rfind("\\");
 #else
         //*nix-like uses forward-slash as directory divider
-        auto pos = filepath.rfind("/");
+        auto pos = filepath.rfind('/');
 #endif
         if (pos == std::string::npos) {
             pos = 0;

--- a/libs/EXTERNAL/libargparse/src/argparse_util.hpp
+++ b/libs/EXTERNAL/libargparse/src/argparse_util.hpp
@@ -24,21 +24,21 @@ namespace argparse {
     bool is_argument(std::string str, const std::map<std::string,std::shared_ptr<Argument>>& arg_map);
 
     //Returns true if str is in choices, or choices is empty
-    bool is_valid_choice(std::string str, const std::vector<std::string>& choices);
+    bool is_valid_choice(const std::string& str, const std::vector<std::string>& choices);
 
     //Returns 'str' interpreted as type T
     // Throws an exception if conversion fails
     template<typename T> 
-    T as(std::string str);
+    T as(const std::string& str);
 
     template<typename Container>
-    std::string join(Container container, std::string join_str);
+    std::string join(Container container, const std::string& join_str);
 
     char* strdup(const char* str);
 
-    std::vector<std::string> wrap_width(std::string str, size_t width, std::vector<std::string> split_str={" ", "/"});
+    std::vector<std::string> wrap_width(std::string str, size_t width, const std::vector<std::string>& split_str={" ", "/"});
 
-    std::string basename(std::string filepath);
+    std::string basename(const std::string& filepath);
 } //namespace
 
 #include "argparse_util.tpp"

--- a/libs/EXTERNAL/libargparse/src/argparse_util.tpp
+++ b/libs/EXTERNAL/libargparse/src/argparse_util.tpp
@@ -4,7 +4,7 @@
 namespace argparse {
 
     template<typename T> 
-    T as(std::string str) {
+    T as(const std::string& str) {
         
         std::stringstream ss(str);
 
@@ -19,7 +19,7 @@ namespace argparse {
     }
 
     template<typename Container>
-    std::string join(Container container, std::string join_str) {
+    std::string join(Container container, const std::string& join_str) {
         std::stringstream ss;
 
         bool first = true;

--- a/libs/EXTERNAL/libargparse/src/argparse_value.hpp
+++ b/libs/EXTERNAL/libargparse/src/argparse_value.hpp
@@ -11,7 +11,7 @@ namespace argparse {
             typedef T value_type;
         public:
             void set_value(T val) { errored_ = false; value_ = val; }
-            void set_error(std::string msg) { errored_ = true; error_msg_ = msg; }
+            void set_error(const std::string& msg) { errored_ = true; error_msg_ = msg; }
 
             T value() const { return value_; }
             std::string error() const { return error_msg_; }
@@ -81,11 +81,11 @@ namespace argparse {
                 return value_;
             }
 
-            void set_argument_group(std::string grp) {
+            void set_argument_group(const std::string& grp) {
                 argument_group_ = grp;
             }
 
-            void set_argument_name(std::string name_str) {
+            void set_argument_name(const std::string& name_str) {
                 argument_name_ = name_str;
             }
         private:

--- a/libs/EXTERNAL/libblifparse/src/blifparse.cpp
+++ b/libs/EXTERNAL/libblifparse/src/blifparse.cpp
@@ -35,7 +35,7 @@ void Callback::param(std::string /*name*/, std::string /*value*/) {
  * the blif commands.  See blif.h for data structure
  * detials.
  */
-void blif_parse_filename(std::string filename, Callback& callback) {
+void blif_parse_filename(const std::string& filename, Callback& callback) {
     blif_parse_filename(filename.c_str(), callback);
 }
 

--- a/libs/EXTERNAL/libblifparse/src/blifparse.hpp
+++ b/libs/EXTERNAL/libblifparse/src/blifparse.hpp
@@ -95,7 +95,7 @@ class Callback {
 /*
  * External functions for loading an SDC file
  */
-void blif_parse_filename(std::string filename, Callback& callback);
+void blif_parse_filename(const std::string& filename, Callback& callback);
 void blif_parse_filename(const char* filename, Callback& callback);
 
 //Loads from 'blif'. 'filename' only used to pass a filename to callback and can be left unspecified

--- a/libs/EXTERNAL/libsdcparse/src/sdc_common.cpp
+++ b/libs/EXTERNAL/libsdcparse/src/sdc_common.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cmath>
 #include <memory>
+#include <utility>
 
 #include "sdc_common.hpp"
 #include "sdc_error.hpp"
@@ -47,7 +48,7 @@ void sdc_create_clock_add_targets(Callback& callback, const Lexer& lexer, Create
                   "If you want to define multiple targets specify them as a list (e.g. \"{target1 target2}\").\n");
     }
 
-    sdc_create_clock.targets = target_group;
+    sdc_create_clock.targets = std::move(target_group);
 }
 
 void add_sdc_create_clock(Callback& callback, const Lexer& lexer, CreateClock& sdc_create_clock) {
@@ -140,7 +141,7 @@ void sdc_set_io_delay_set_ports(Callback& callback, const Lexer& lexer, SetIoDel
         sdc_error_wrap(callback, lexer.lineno(), lexer.text(), "Currently only a single get_ports command is supported.\n"); 
     }
 
-    sdc_set_io_delay.target_ports = ports;
+    sdc_set_io_delay.target_ports = std::move(ports);
 }
 
 void add_sdc_set_io_delay(Callback& callback, const Lexer& lexer, SetIoDelay& sdc_set_io_delay) {
@@ -176,7 +177,7 @@ void sdc_set_clock_groups_set_type(Callback& callback, const Lexer& lexer, SetCl
     sdc_set_clock_groups.type = type;
 }
 
-void sdc_set_clock_groups_add_group(Callback& /*callback*/, const Lexer& /*lexer*/, SetClockGroups& sdc_set_clock_groups, StringGroup clock_group) {
+void sdc_set_clock_groups_add_group(Callback& /*callback*/, const Lexer& /*lexer*/, SetClockGroups& sdc_set_clock_groups, const StringGroup& clock_group) {
     assert(clock_group.type == StringGroupType::CLOCK || clock_group.type == StringGroupType::STRING);
 
     //Duplicate and insert the clock group
@@ -206,7 +207,7 @@ void add_sdc_set_clock_groups(Callback& callback, const Lexer& lexer, SetClockGr
  */
 void sdc_set_false_path_add_to_from_group(Callback& callback, const Lexer& lexer, 
                                                             SetFalsePath& sdc_set_false_path, 
-                                                            StringGroup group, 
+                                                            const StringGroup& group, 
                                                             FromToType to_from_dir) {
     assert(group.type == StringGroupType::CLOCK || group.type == StringGroupType::STRING);
 
@@ -255,7 +256,7 @@ void sdc_set_min_max_delay_set_value(Callback& callback, const Lexer& lexer, Set
     sdc_set_min_max_delay.value = min_max_delay;
 }
 
-void sdc_set_min_max_delay_add_to_from_group(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_min_max_delay, StringGroup group, FromToType to_from_dir) {
+void sdc_set_min_max_delay_add_to_from_group(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_min_max_delay, const StringGroup& group, FromToType to_from_dir) {
     assert(group.type == StringGroupType::CLOCK || group.type == StringGroupType::STRING);
 
     //Error checking
@@ -321,7 +322,7 @@ void sdc_set_multicycle_path_set_mcp_value(Callback& callback, const Lexer& lexe
 }
 
 void sdc_set_multicycle_path_add_to_from_group(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path, 
-                                                                     StringGroup group, 
+                                                                     const StringGroup& group, 
                                                                      FromToType to_from_dir) {
     assert(group.type == StringGroupType::CLOCK || group.type == StringGroupType::STRING || group.type == StringGroupType::PIN);
 
@@ -388,7 +389,7 @@ void sdc_set_clock_uncertainty_set_value(Callback& callback, const Lexer& lexer,
 }
 
 void sdc_set_clock_uncertainty_add_to_from_group(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty, 
-                                                                     StringGroup group, 
+                                                                     const StringGroup& group, 
                                                                      FromToType to_from_dir) {
     assert(group.type == StringGroupType::CLOCK || group.type == StringGroupType::STRING);
 
@@ -468,7 +469,7 @@ void sdc_set_clock_latency_set_value(Callback& callback, const Lexer& lexer, Set
     sdc_set_clock_latency.value = value;
 }
 
-void sdc_set_clock_latency_set_clocks(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency, StringGroup target_clocks) {
+void sdc_set_clock_latency_set_clocks(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency, const StringGroup& target_clocks) {
     if(target_clocks.type != StringGroupType::CLOCK) {
         sdc_error_wrap(callback, lexer.lineno(), lexer.text(), "Target clocks must be specified with 'get_clocks'.\n"); 
     }
@@ -503,7 +504,7 @@ void add_sdc_set_clock_latency(Callback& callback, const Lexer& lexer, SetClockL
  */
 void sdc_set_disable_timing_add_to_from_group(Callback& callback, const Lexer& lexer, 
                                                             SetDisableTiming& sdc_set_disable_timing, 
-                                                            StringGroup group, 
+                                                            const StringGroup& group, 
                                                             FromToType to_from_dir) {
 
     //Error checking
@@ -591,7 +592,7 @@ void sdc_set_timing_derate_value(Callback& callback, const Lexer& lexer, SetTimi
     sdc_set_timing_derate.value = value;
 }
 
-void sdc_set_timing_derate_targets(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate, StringGroup targets) {
+void sdc_set_timing_derate_targets(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate, const StringGroup& targets) {
     if(targets.type != StringGroupType::CELL) {
         sdc_error_wrap(callback, lexer.lineno(), lexer.text(), "Only get_cells is supported with set_timing_derate.\n"); 
     }

--- a/libs/EXTERNAL/libsdcparse/src/sdc_common.hpp
+++ b/libs/EXTERNAL/libsdcparse/src/sdc_common.hpp
@@ -32,31 +32,31 @@ void add_sdc_set_io_delay(Callback& callback, const Lexer& lexer, SetIoDelay& sd
 
 //set_clock_groups
 void sdc_set_clock_groups_set_type(Callback& callback, const Lexer& lexer, SetClockGroups& sdc_set_clock_groups, ClockGroupsType type);
-void sdc_set_clock_groups_add_group(Callback& callback, const Lexer& lexer, SetClockGroups& sdc_set_clock_groups, StringGroup clock_group);
+void sdc_set_clock_groups_add_group(Callback& callback, const Lexer& lexer, SetClockGroups& sdc_set_clock_groups, const StringGroup& clock_group);
 void add_sdc_set_clock_groups(Callback& callback, const Lexer& lexer, SetClockGroups& sdc_set_clock_groups);
 
 //set_false_path
-void sdc_set_false_path_add_to_from_group(Callback& callback, const Lexer& lexer, SetFalsePath& sdc_set_false_path, StringGroup group, FromToType to_from_dir);
+void sdc_set_false_path_add_to_from_group(Callback& callback, const Lexer& lexer, SetFalsePath& sdc_set_false_path, const StringGroup& group, FromToType to_from_dir);
 void add_sdc_set_false_path(Callback& callback, const Lexer& lexer, SetFalsePath& sdc_set_false_path);
 
 //set_max_delay
 void sdc_set_min_max_delay_set_type(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_max_delay, MinMaxType type);
 void sdc_set_min_max_delay_set_value(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_max_delay, double max_delay);
-void sdc_set_min_max_delay_add_to_from_group(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_max_delay, StringGroup group, FromToType to_from_dir);
+void sdc_set_min_max_delay_add_to_from_group(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_max_delay, const StringGroup& group, FromToType to_from_dir);
 void add_sdc_set_min_max_delay(Callback& callback, const Lexer& lexer, SetMinMaxDelay& sdc_set_max_delay);
 
 //set_multicycle_path
 void sdc_set_multicycle_path_set_setup(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path);
 void sdc_set_multicycle_path_set_hold(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path);
 void sdc_set_multicycle_path_set_mcp_value(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path, int mcp_value);
-void sdc_set_multicycle_path_add_to_from_group(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path, StringGroup group, FromToType to_from_dir);
+void sdc_set_multicycle_path_add_to_from_group(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path, const StringGroup& group, FromToType to_from_dir);
 void add_sdc_set_multicycle_path(Callback& callback, const Lexer& lexer, SetMulticyclePath& sdc_set_multicycle_path);
 
 //set_clock_uncertainty
 void sdc_set_clock_uncertainty_set_setup(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty);
 void sdc_set_clock_uncertainty_set_hold(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty);
 void sdc_set_clock_uncertainty_set_value(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty, float value);
-void sdc_set_clock_uncertainty_add_to_from_group(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty, StringGroup group, FromToType to_from_dir);
+void sdc_set_clock_uncertainty_add_to_from_group(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty, const StringGroup& group, FromToType to_from_dir);
 void add_sdc_set_clock_uncertainty(Callback& callback, const Lexer& lexer, SetClockUncertainty& sdc_set_clock_uncertainty);
 
 //set_clock_latency
@@ -64,11 +64,11 @@ void sdc_set_clock_latency_set_type(Callback& callback, const Lexer& lexer, SetC
 void sdc_set_clock_latency_early(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency);
 void sdc_set_clock_latency_late(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency);
 void sdc_set_clock_latency_set_value(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency, float value);
-void sdc_set_clock_latency_set_clocks(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency, StringGroup clock_targets);
+void sdc_set_clock_latency_set_clocks(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency, const StringGroup& clock_targets);
 void add_sdc_set_clock_latency(Callback& callback, const Lexer& lexer, SetClockLatency& sdc_set_clock_latency);
 
 //set_disable_timing
-void sdc_set_disable_timing_add_to_from_group(Callback& callback, const Lexer& lexer, SetDisableTiming& sdc_set_disable_timing, StringGroup group, FromToType to_from_dir);
+void sdc_set_disable_timing_add_to_from_group(Callback& callback, const Lexer& lexer, SetDisableTiming& sdc_set_disable_timing, const StringGroup& group, FromToType to_from_dir);
 void add_sdc_set_disable_timing(Callback& callback, const Lexer& lexer, SetDisableTiming& sdc_set_disable_timing);
 
 //set_timing_derate
@@ -76,7 +76,7 @@ void sdc_set_timing_derate_early(Callback& callback, const Lexer& lexer, SetTimi
 void sdc_set_timing_derate_late(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate);
 void sdc_set_timing_derate_target_type(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate, TimingDerateTargetType target_type);
 void sdc_set_timing_derate_value(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate, float value);
-void sdc_set_timing_derate_targets(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate, StringGroup targets);
+void sdc_set_timing_derate_targets(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_timing_derate, const StringGroup& targets);
 void add_sdc_set_timing_derate(Callback& callback, const Lexer& lexer, SetTimingDerate& sdc_set_multicycle_path);
 
 //string_group

--- a/libs/EXTERNAL/libsdcparse/src/sdcparse.cpp
+++ b/libs/EXTERNAL/libsdcparse/src/sdcparse.cpp
@@ -8,7 +8,7 @@
 
 namespace sdcparse {
 
-void sdc_parse_filename(std::string filename, Callback& callback) {
+void sdc_parse_filename(const std::string& filename, Callback& callback) {
     sdc_parse_filename(filename.c_str(), callback);
 }
 

--- a/libs/EXTERNAL/libsdcparse/src/sdcparse.hpp
+++ b/libs/EXTERNAL/libsdcparse/src/sdcparse.hpp
@@ -132,7 +132,7 @@ class Callback {
 /*
  * External functions for loading an SDC file
  */
-void sdc_parse_filename(std::string filename, Callback& callback);
+void sdc_parse_filename(const std::string& filename, Callback& callback);
 void sdc_parse_filename(const char* filename, Callback& callback);
 
 //Loads from 'sdc'. 'filename' only used to pass a filename to callback and can be left unspecified

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/TimingConstraints.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/TimingConstraints.cpp
@@ -286,7 +286,7 @@ TimingConstraints::source_latency_range TimingConstraints::source_latencies(Arri
     }
 }
 
-DomainId TimingConstraints::create_clock_domain(const std::string name) { 
+DomainId TimingConstraints::create_clock_domain(const std::string& name) { 
     DomainId id = find_clock_domain(name);
     if(!id) {
         //Create it

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/TimingConstraints.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/TimingConstraints.hpp
@@ -122,7 +122,7 @@ class TimingConstraints {
         void print_constraints() const;
     public: //Mutators
         ///\returns The DomainId of the clock with the specified name (will be created if it doesn not exist)
-        DomainId create_clock_domain(const std::string name);
+        DomainId create_clock_domain(const std::string& name);
 
         ///Sets the setup constraint between src_domain and sink_domain with value constraint
         void set_setup_constraint(const DomainId src_domain, const DomainId sink_domain, const Time constraint);

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/TimingGraph.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/TimingGraph.cpp
@@ -874,7 +874,7 @@ std::vector<std::vector<NodeId>> identify_combinational_loops(const TimingGraph&
 }
 
 std::vector<NodeId> find_transitively_connected_nodes(const TimingGraph& tg, 
-                                                      const std::vector<NodeId> through_nodes, 
+                                                      const std::vector<NodeId>& through_nodes, 
                                                       size_t max_depth) {
     std::vector<NodeId> nodes;
 
@@ -890,7 +890,7 @@ std::vector<NodeId> find_transitively_connected_nodes(const TimingGraph& tg,
 }
 
 std::vector<NodeId> find_transitive_fanin_nodes(const TimingGraph& tg, 
-                                                const std::vector<NodeId> sinks, 
+                                                const std::vector<NodeId>& sinks, 
                                                 size_t max_depth) {
     std::vector<NodeId> nodes;
 
@@ -905,7 +905,7 @@ std::vector<NodeId> find_transitive_fanin_nodes(const TimingGraph& tg,
 }
 
 std::vector<NodeId> find_transitive_fanout_nodes(const TimingGraph& tg, 
-                                                 const std::vector<NodeId> sources, 
+                                                 const std::vector<NodeId>& sources, 
                                                  size_t max_depth) {
     std::vector<NodeId> nodes;
 

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/TimingGraph.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/TimingGraph.hpp
@@ -53,6 +53,7 @@
  * support is added), it may be a good idea apply these modifications automatically as needed.
  *
  */
+#include <utility>
 #include <vector>
 #include <set>
 #include <limits>
@@ -310,17 +311,17 @@ std::vector<std::vector<NodeId>> identify_combinational_loops(const TimingGraph&
 //Returns the set of nodes transitively connected (either fanin or fanout) to nodes in through_nodes
 //up to max_depth (default infinite) hops away
 std::vector<NodeId> find_transitively_connected_nodes(const TimingGraph& tg, 
-                                                      const std::vector<NodeId> through_nodes, 
+                                                      const std::vector<NodeId>& through_nodes, 
                                                       size_t max_depth=std::numeric_limits<size_t>::max());
 
 //Returns the set of nodes in the transitive fanin of nodes in sinks up to max_depth (default infinite) hops away
 std::vector<NodeId> find_transitive_fanin_nodes(const TimingGraph& tg, 
-                                                const std::vector<NodeId> sinks, 
+                                                const std::vector<NodeId>& sinks, 
                                                 size_t max_depth=std::numeric_limits<size_t>::max());
 
 //Returns the set of nodes in the transitive fanout of nodes in sources up to max_depth (default infinite) hops away
 std::vector<NodeId> find_transitive_fanout_nodes(const TimingGraph& tg,
-                                                 const std::vector<NodeId> sources, 
+                                                 const std::vector<NodeId>& sources, 
                                                  size_t max_depth=std::numeric_limits<size_t>::max());
 
 EdgeType infer_edge_type(const TimingGraph& tg, EdgeId edge);
@@ -329,7 +330,7 @@ EdgeType infer_edge_type(const TimingGraph& tg, EdgeId edge);
 struct GraphIdMaps {
     GraphIdMaps(tatum::util::linear_map<NodeId,NodeId> node_map,
                 tatum::util::linear_map<EdgeId,EdgeId> edge_map)
-        : node_id_map(node_map), edge_id_map(edge_map) {}
+        : node_id_map(std::move(node_map)), edge_id_map(std::move(edge_map)) {}
     tatum::util::linear_map<NodeId,NodeId> node_id_map;
     tatum::util::linear_map<EdgeId,EdgeId> edge_id_map;
 };

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/TimingReporter.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/TimingReporter.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <utility>
 #include <vector>
 
 #include "tatum/util/tatum_math.hpp"
@@ -29,13 +30,13 @@ void ReportTimingPathHelper::update_print_path(std::ostream& os, std::string poi
 
     tatum::Time incr = path - prev_path_;
 
-    print_path_line(os, point, to_printable_string(incr, unit_scale_, precision_), to_printable_string(path, unit_scale_, precision_));
+    print_path_line(os, std::move(point), to_printable_string(incr, unit_scale_, precision_), to_printable_string(path, unit_scale_, precision_));
 
     prev_path_ = path;
 }
 
 void ReportTimingPathHelper::update_print_path_no_incr(std::ostream& os, std::string point, tatum::Time path) {
-    print_path_line(os, point, "", to_printable_string(path, unit_scale_, precision_));
+    print_path_line(os, std::move(point), "", to_printable_string(path, unit_scale_, precision_));
 
     prev_path_ = path;
 }
@@ -45,10 +46,10 @@ void ReportTimingPathHelper::reset_path() {
 }
 
 void ReportTimingPathHelper::print_path_line_no_incr(std::ostream& os, std::string point, tatum::Time path) const {
-    print_path_line(os, point, "", to_printable_string(path, unit_scale_, precision_));
+    print_path_line(os, std::move(point), "", to_printable_string(path, unit_scale_, precision_));
 }
 
-void ReportTimingPathHelper::print_path_line(std::ostream& os, std::string point, std::string incr, std::string path) const {
+void ReportTimingPathHelper::print_path_line(std::ostream& os, const std::string& point, const std::string& incr, const std::string& path) const {
     os << std::setw(point_width_) << std::left << point;
     os << std::setw(incr_width_) << std::right << incr;
     os << std::setw(path_width_) << std::right << path;
@@ -84,7 +85,7 @@ TimingReporter::TimingReporter(const TimingGraphNameResolver& name_resolver,
     //pass
 }
 
-void TimingReporter::report_timing_setup(std::string filename, 
+void TimingReporter::report_timing_setup(const std::string& filename, 
                                          const SetupTimingAnalyzer& setup_analyzer,
                                          size_t npaths) const {
     std::ofstream os(filename);
@@ -99,7 +100,7 @@ void TimingReporter::report_timing_setup(std::ostream& os,
     report_timing(os, paths);
 }
 
-void TimingReporter::report_timing_hold(std::string filename, 
+void TimingReporter::report_timing_hold(const std::string& filename, 
                                          const HoldTimingAnalyzer& hold_analyzer,
                                          size_t npaths) const {
     std::ofstream os(filename);
@@ -114,7 +115,7 @@ void TimingReporter::report_timing_hold(std::ostream& os,
     report_timing(os, paths);
 }
 
-void TimingReporter::report_skew_setup(std::string filename, 
+void TimingReporter::report_skew_setup(const std::string& filename, 
                                          const SetupTimingAnalyzer& setup_analyzer,
                                          size_t nworst) const {
     std::ofstream os(filename);
@@ -132,7 +133,7 @@ void TimingReporter::report_skew_setup(std::ostream& os,
     os << "#End of clock skew for setup timing startpoint/endpoint report\n";
 }
 
-void TimingReporter::report_skew_hold(std::string filename, 
+void TimingReporter::report_skew_hold(const std::string& filename, 
                                          const HoldTimingAnalyzer& hold_analyzer,
                                          size_t nworst) const {
     std::ofstream os(filename);
@@ -150,7 +151,7 @@ void TimingReporter::report_skew_hold(std::ostream& os,
     os << "#End of clock skew for hold timing startpoint/endpoint report\n";
 }
 
-void TimingReporter::report_unconstrained_setup(std::string filename, 
+void TimingReporter::report_unconstrained_setup(const std::string& filename, 
                                                           const tatum::SetupTimingAnalyzer& setup_analyzer) const {
     std::ofstream os(filename);
     report_unconstrained_setup(os, setup_analyzer);
@@ -170,7 +171,7 @@ void TimingReporter::report_unconstrained_setup(std::ostream& os,
     os << "#End of unconstrained setup startpoint/endpoint report\n";
 }
 
-void TimingReporter::report_unconstrained_hold(std::string filename, 
+void TimingReporter::report_unconstrained_hold(const std::string& filename, 
                                                          const tatum::HoldTimingAnalyzer& hold_analyzer) const {
     std::ofstream os(filename);
     report_unconstrained_hold(os, hold_analyzer);
@@ -694,7 +695,7 @@ bool TimingReporter::nearly_equal(const Time& lhs, const Time& rhs) const {
 
 size_t TimingReporter::estimate_point_print_width(const TimingPath& path) const {
     size_t width = 60; //default
-    for(auto subpath : {path.clock_launch_path(), path.data_arrival_path(), path.clock_capture_path()}) {
+    for(const auto& subpath : {path.clock_launch_path(), path.data_arrival_path(), path.clock_capture_path()}) {
         for(auto elem : subpath.elements()) {
             //Take the longest typical point name
             std::string point = name_resolver_.node_name(elem.node()) + " (" + name_resolver_.node_type_name(elem.node()) + ")";

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/TimingReporter.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/TimingReporter.hpp
@@ -33,7 +33,7 @@ namespace tatum { namespace detail {
 
             void print_path_line_no_incr(std::ostream& os, std::string point, tatum::Time path) const;
 
-            void print_path_line(std::ostream& os, std::string point, std::string incr, std::string path) const;
+            void print_path_line(std::ostream& os, const std::string& point, const std::string& incr, const std::string& path) const;
 
             void print_divider(std::ostream& os) const;
 
@@ -62,22 +62,22 @@ class TimingReporter {
                        float unit_scale=1e-9,
                        size_t precision=3);
     public:
-        void report_timing_setup(std::string filename, const tatum::SetupTimingAnalyzer& setup_analyzer, size_t npaths=REPORT_TIMING_DEFAULT_NPATHS) const;
+        void report_timing_setup(const std::string& filename, const tatum::SetupTimingAnalyzer& setup_analyzer, size_t npaths=REPORT_TIMING_DEFAULT_NPATHS) const;
         void report_timing_setup(std::ostream& os, const tatum::SetupTimingAnalyzer& setup_analyzer, size_t npaths=REPORT_TIMING_DEFAULT_NPATHS) const;
 
-        void report_timing_hold(std::string filename, const tatum::HoldTimingAnalyzer& hold_analyzer, size_t npaths=REPORT_TIMING_DEFAULT_NPATHS) const;
+        void report_timing_hold(const std::string& filename, const tatum::HoldTimingAnalyzer& hold_analyzer, size_t npaths=REPORT_TIMING_DEFAULT_NPATHS) const;
         void report_timing_hold(std::ostream& os, const tatum::HoldTimingAnalyzer& hold_analyzer, size_t npaths=REPORT_TIMING_DEFAULT_NPATHS) const;
 
-        void report_skew_setup(std::string filename, const tatum::SetupTimingAnalyzer& setup_analyzer, size_t nworst=REPORT_TIMING_DEFAULT_NPATHS) const;
+        void report_skew_setup(const std::string& filename, const tatum::SetupTimingAnalyzer& setup_analyzer, size_t nworst=REPORT_TIMING_DEFAULT_NPATHS) const;
         void report_skew_setup(std::ostream& os, const tatum::SetupTimingAnalyzer& setup_analyzer, size_t nworst=REPORT_TIMING_DEFAULT_NPATHS) const;
 
-        void report_skew_hold(std::string filename, const tatum::HoldTimingAnalyzer& hold_analyzer, size_t nworst=REPORT_TIMING_DEFAULT_NPATHS) const;
+        void report_skew_hold(const std::string& filename, const tatum::HoldTimingAnalyzer& hold_analyzer, size_t nworst=REPORT_TIMING_DEFAULT_NPATHS) const;
         void report_skew_hold(std::ostream& os, const tatum::HoldTimingAnalyzer& hold_analyzer, size_t nworst=REPORT_TIMING_DEFAULT_NPATHS) const;
 
-        void report_unconstrained_setup(std::string filename, const tatum::SetupTimingAnalyzer& setup_analyzer) const;
+        void report_unconstrained_setup(const std::string& filename, const tatum::SetupTimingAnalyzer& setup_analyzer) const;
         void report_unconstrained_setup(std::ostream& os, const tatum::SetupTimingAnalyzer& setup_analyzer) const;
 
-        void report_unconstrained_hold(std::string filename, const tatum::HoldTimingAnalyzer& hold_analyzer) const;
+        void report_unconstrained_hold(const std::string& filename, const tatum::HoldTimingAnalyzer& hold_analyzer) const;
         void report_unconstrained_hold(std::ostream& os, const tatum::HoldTimingAnalyzer& hold_analyzer) const;
 
     private:

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/analyzers/TimingAnalyzer.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/analyzers/TimingAnalyzer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <utility>
 
 #include "tatum/TimingGraphFwd.hpp"
 #include "tatum/util/tatum_range.hpp"
@@ -40,7 +41,7 @@ class TimingAnalyzer {
         ///Returns the set of nodes which were modified by the last call to update_timing()
         node_range modified_nodes() const { return modified_nodes_impl(); }
 
-        double get_profiling_data(std::string key) const { return get_profiling_data_impl(key); }
+        double get_profiling_data(std::string key) const { return get_profiling_data_impl(std::move(key)); }
 
         virtual size_t num_unconstrained_startpoints() const { return num_unconstrained_startpoints_impl(); }
         virtual size_t num_unconstrained_endpoints() const { return num_unconstrained_endpoints_impl(); }

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/base/sta_util.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/base/sta_util.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <ctime>
 #include <iostream>
 #include <iomanip>
@@ -25,7 +26,7 @@ float time_sec(struct timespec start, struct timespec end) {
 
 void print_histogram(const std::vector<float>& values, int nbuckets) {
     nbuckets = std::min(values.size(), (size_t) nbuckets);
-    int values_per_bucket = ceil((float) values.size() / nbuckets);
+    int values_per_bucket = std::ceil((float) values.size() / nbuckets);
 
     std::vector<float> buckets(nbuckets);
 
@@ -105,7 +106,7 @@ void print_node_fanout_histogram(const TimingGraph& tg, int nbuckets) {
 }
 
 
-void print_timing_graph(std::shared_ptr<const TimingGraph> tg) {
+void print_timing_graph(const std::shared_ptr<const TimingGraph>& tg) {
     for(const NodeId node_id : tg->nodes()) {
         cout << "Node: " << node_id;
         cout << " Type: " << tg->node_type(node_id);
@@ -121,7 +122,7 @@ void print_timing_graph(std::shared_ptr<const TimingGraph> tg) {
     }
 }
 
-void print_levelization(std::shared_ptr<const TimingGraph> tg) {
+void print_levelization(const std::shared_ptr<const TimingGraph>& tg) {
     cout << "Num Levels: " << tg->levels().size() << "\n";
     for(const LevelId level_id : tg->levels()) {
         const auto& level = tg->level_nodes(level_id);
@@ -302,7 +303,7 @@ void print_hold_tags(const TimingGraph& tg, const HoldTimingAnalyzer& analyzer) 
 }
 
 
-void dump_level_times(std::string fname, const TimingGraph& timing_graph, std::map<std::string,float> serial_prof_data, std::map<std::string,float> parallel_prof_data) {
+void dump_level_times(const std::string& fname, const TimingGraph& timing_graph, std::map<std::string,float> serial_prof_data, std::map<std::string,float> parallel_prof_data) {
     //Per-level speed-up
     //cout << "Level Speed-Ups by width:" << endl;
     std::map<int,std::vector<LevelId>,std::greater<int>> widths_to_levels;
@@ -313,7 +314,7 @@ void dump_level_times(std::string fname, const TimingGraph& timing_graph, std::m
 
     std::ofstream of(fname);
     of << "Width,Level,serial_fwd,serial_bck,parallel_fwd,parallel_bck"<< endl;
-    for(auto kv : widths_to_levels) {
+    for(const auto& kv : widths_to_levels) {
         int width = kv.first;
         for(const auto ilevel : kv.second) {
             std::stringstream key_fwd;

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/base/sta_util.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/base/sta_util.hpp
@@ -23,10 +23,10 @@ void print_level_histogram(const TimingGraph& tg, int nbuckets);
 void print_node_fanin_histogram(const TimingGraph& tg, int nbuckets);
 void print_node_fanout_histogram(const TimingGraph& tg, int nbuckets);
 
-void print_timing_graph(std::shared_ptr<const TimingGraph> tg);
-void print_levelization(std::shared_ptr<const TimingGraph> tg);
+void print_timing_graph(const std::shared_ptr<const TimingGraph>& tg);
+void print_levelization(const std::shared_ptr<const TimingGraph>& tg);
 
-void dump_level_times(std::string fname, const TimingGraph& timing_graph, std::map<std::string,float> serial_prof_data, std::map<std::string,float> parallel_prof_data);
+void dump_level_times(const std::string& fname, const TimingGraph& timing_graph, std::map<std::string,float> serial_prof_data, std::map<std::string,float> parallel_prof_data);
 
 
 

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/echo_writer.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/echo_writer.cpp
@@ -14,17 +14,17 @@
 
 namespace tatum {
 
-void write_tags(std::ostream& os, const std::string& type, const TimingTags::tag_range tags, const NodeId node_id);
-void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range tags, const EdgeId edge);
-void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range tags, const NodeId edge);
+void write_tags(std::ostream& os, const std::string& type, const TimingTags::tag_range& tags, const NodeId node_id);
+void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range& tags, const EdgeId edge);
+void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range& tags, const NodeId edge);
 
-void write_echo(std::string filename, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer> analyzer) {
+void write_echo(const std::string& filename, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer>& analyzer) {
     std::ofstream os(filename);
 
     write_echo(os, tg, tc, dc, analyzer);
 }
 
-void write_echo(std::ostream& os, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer> analyzer) {
+void write_echo(std::ostream& os, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer>& analyzer) {
     write_timing_graph(os, tg);
     write_timing_constraints(os, tc);
     write_delay_model(os, tg, dc);
@@ -227,7 +227,7 @@ void write_timing_constraints(std::ostream& os, const TimingConstraints& tc) {
     os << "\n";
 }
 
-void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::shared_ptr<const TimingAnalyzer> analyzer) {
+void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::shared_ptr<const TimingAnalyzer>& analyzer) {
     os << "analysis_result:\n";
 
     auto setup_analyzer = std::dynamic_pointer_cast<const SetupTimingAnalyzer>(analyzer);
@@ -291,7 +291,7 @@ void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::s
     os << "\n";
 }
 
-void write_tags(std::ostream& os, const std::string& type, const TimingTags::tag_range tags, const NodeId node_id) {
+void write_tags(std::ostream& os, const std::string& type, const TimingTags::tag_range& tags, const NodeId node_id) {
     for(const auto& tag : tags) {
         TATUM_ASSERT(tag.type() != TagType::SLACK);
 
@@ -318,7 +318,7 @@ void write_tags(std::ostream& os, const std::string& type, const TimingTags::tag
     }
 }
 
-void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range tags, const EdgeId edge) {
+void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range& tags, const EdgeId edge) {
     for(const auto& tag : tags) {
         TATUM_ASSERT(tag.type() == TagType::SLACK);
 
@@ -345,7 +345,7 @@ void write_slacks(std::ostream& os, const std::string& type, const TimingTags::t
     }
 }
 
-void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range tags, const NodeId node) {
+void write_slacks(std::ostream& os, const std::string& type, const TimingTags::tag_range& tags, const NodeId node) {
     for(const auto& tag : tags) {
         TATUM_ASSERT(tag.type() == TagType::SLACK);
 

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/echo_writer.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/echo_writer.hpp
@@ -11,10 +11,10 @@ namespace tatum {
 
 void write_timing_graph(std::ostream& os, const TimingGraph& tg);
 void write_timing_constraints(std::ostream& os, const TimingConstraints& tc);
-void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::shared_ptr<const TimingAnalyzer> analyzer);
+void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::shared_ptr<const TimingAnalyzer>& analyzer);
 void write_delay_model(std::ostream& os, const TimingGraph& tg, const DelayCalculator& dc);
 
-void write_echo(std::string filename, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer> analyzer);
-void write_echo(std::ostream& os, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer> analyzer);
+void write_echo(const std::string& filename, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer>& analyzer);
+void write_echo(std::ostream& os, const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const std::shared_ptr<const TimingAnalyzer>& analyzer);
 
 }

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
@@ -109,7 +109,7 @@ class TimingGraphWalker {
         ///Retrieve profiling information
         ///\param key The profiling key
         ///\returns The profiling value for the given key, or NaN if the key is not found
-        double get_profiling_data(std::string key) const { 
+        double get_profiling_data(const std::string& key) const { 
             auto iter = profiling_data_.find(key);
             if(iter != profiling_data_.end()) {
                 return iter->second;
@@ -118,7 +118,7 @@ class TimingGraphWalker {
             }
         }
 
-        void set_profiling_data(std::string key, double val) { 
+        void set_profiling_data(const std::string& key, double val) { 
             profiling_data_[key] = val;
         }
 

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/report/TimingPath.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/report/TimingPath.hpp
@@ -1,5 +1,7 @@
 #ifndef TATUM_TIMING_PATH_HPP
 #define TATUM_TIMING_PATH_HPP
+#include <utility>
+#include <utility>
 #include <vector>
 
 #include "tatum/report/TimingPathFwd.hpp"
@@ -88,7 +90,7 @@ class TimingSubPath {
     public:
         TimingSubPath() = default;
         TimingSubPath(std::vector<TimingPathElem> elems)
-            : elements_(elems) {}
+            : elements_(std::move(std::move(elems))) {}
 
         path_elem_range elements() const { 
             return util::make_range(elements_.begin(),
@@ -116,9 +118,9 @@ class TimingPath {
                    const TimingPathElem& data_required_elem,
                    const TimingTag& slack)
             : path_info_(info)
-            , clock_launch_path_(clock_launch)
-            , data_arrival_path_(data_arrival)
-            , clock_capture_path_(clock_capture)
+            , clock_launch_path_(std::move(std::move(clock_launch)))
+            , data_arrival_path_(std::move(std::move(data_arrival)))
+            , clock_capture_path_(std::move(std::move(clock_capture)))
             , data_required_element_(data_required_elem)
             , slack_tag_(slack) {
             //pass

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/report/graphviz_dot_writer.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/report/graphviz_dot_writer.cpp
@@ -165,7 +165,7 @@ void GraphvizDotWriter::write_dot_edge(std::ostream& os, const EdgeId edge, cons
 
         EdgeType edge_type = tg_.edge_type(edge);
 
-        std::string color = "";
+        std::string color;
         os << "\t" << node_name(src_node) << " -> " << node_name(sink_node);
         os << " [ label=\"" << edge;
         if(edge_type == EdgeType::PRIMITIVE_CLOCK_CAPTURE) {

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/report/graphviz_dot_writer.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/report/graphviz_dot_writer.cpp
@@ -23,7 +23,7 @@ GraphvizDotWriter::GraphvizDotWriter(const TimingGraph& tg, const DelayCalculato
     nodes_to_dump_ = std::set<NodeId>(nodes.begin(), nodes.end());
 }
 
-void GraphvizDotWriter::write_dot_file(std::string filename) {
+void GraphvizDotWriter::write_dot_file(const std::string& filename) {
     std::ofstream os(filename);
     write_dot_file(os);
 }
@@ -43,11 +43,11 @@ void GraphvizDotWriter::write_dot_file(std::ostream& os) {
     write_dot_format(os, node_tags, node_slacks, timing_type);
 }
 
-void GraphvizDotWriter::write_dot_file(std::string filename, const SetupTimingAnalyzer& analyzer) {
+void GraphvizDotWriter::write_dot_file(const std::string& filename, const SetupTimingAnalyzer& analyzer) {
     std::ofstream os(filename);
     write_dot_file(os, analyzer);
 }
-void GraphvizDotWriter::write_dot_file(std::string filename, const HoldTimingAnalyzer& analyzer) {
+void GraphvizDotWriter::write_dot_file(const std::string& filename, const HoldTimingAnalyzer& analyzer) {
     std::ofstream os(filename);
     write_dot_file(os, analyzer);
 }

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/report/graphviz_dot_writer.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/report/graphviz_dot_writer.hpp
@@ -38,14 +38,14 @@ class GraphvizDotWriter {
         }
 
         //Write the dot file with no timing tags
-        void write_dot_file(std::string filename);
+        void write_dot_file(const std::string& filename);
         void write_dot_file(std::ostream& os);
 
         //Write the dot file with timing tags
-        void write_dot_file(std::string filename, const SetupTimingAnalyzer& analyzer);
+        void write_dot_file(const std::string& filename, const SetupTimingAnalyzer& analyzer);
         void write_dot_file(std::ostream& os, const SetupTimingAnalyzer& analyzer);
 
-        void write_dot_file(std::string filename, const HoldTimingAnalyzer& analyzer);
+        void write_dot_file(const std::string& filename, const HoldTimingAnalyzer& analyzer);
         void write_dot_file(std::ostream& os, const HoldTimingAnalyzer& analyzer);
     private:
         void write_dot_format(std::ostream& os, 

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.cpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.cpp
@@ -7,18 +7,18 @@ namespace tatum {
  * Tag utilities
  */
 //Return the tag from the range [first,last) which has the lowest value
-TimingTags::const_iterator find_minimum_tag(TimingTags::tag_range tags) {
+TimingTags::const_iterator find_minimum_tag(const TimingTags::tag_range& tags) {
 
     return std::min_element(tags.begin(), tags.end(), TimingTagValueComp()); 
 }
 
 //Return the tag from the range [first,last) which has the highest value
-TimingTags::const_iterator find_maximum_tag(TimingTags::tag_range tags) {
+TimingTags::const_iterator find_maximum_tag(const TimingTags::tag_range& tags) {
 
     return std::max_element(tags.begin(), tags.end(), TimingTagValueComp()); 
 }
 
-TimingTags::const_iterator find_tag(TimingTags::tag_range tags, 
+TimingTags::const_iterator find_tag(const TimingTags::tag_range& tags, 
                                            DomainId launch_domain, 
                                            DomainId capture_domain) {
     for(auto iter = tags.begin(); iter != tags.end(); ++iter) {
@@ -31,7 +31,7 @@ TimingTags::const_iterator find_tag(TimingTags::tag_range tags,
 }
 
 //Returns true of the specified set of tags would constrain a node of type node_type
-bool is_constrained(NodeType node_type, TimingTags::tag_range tags) {
+bool is_constrained(NodeType node_type, const TimingTags::tag_range& tags) {
     bool has_clock_launch = false;
     bool has_clock_capture = false;
     bool has_data_required = false;

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.hpp
@@ -180,7 +180,7 @@ class TimingTags {
         std::pair<bool,iterator> find_data_required_with_valid_data_arrival(DomainId launch_domain, DomainId capture_domain);
 
 
-        iterator insert(iterator iter, const TimingTag& tag);
+        iterator insert(const iterator& iter, const TimingTag& tag);
         void grow_insert(size_t index, const TimingTag& tag);
 
         void increment_size(TagType type);
@@ -213,18 +213,18 @@ class TimingTags {
  */
 
 //Return the tag from the range [first,last) which has the lowest value
-TimingTags::const_iterator find_minimum_tag(TimingTags::tag_range tags);
+TimingTags::const_iterator find_minimum_tag(const TimingTags::tag_range& tags);
 
 //Return the tag from the range [first,last) which has the highest value
-TimingTags::const_iterator find_maximum_tag(TimingTags::tag_range tags);
+TimingTags::const_iterator find_maximum_tag(const TimingTags::tag_range& tags);
 
 //Return the tag for the specified clock domains
-TimingTags::const_iterator find_tag(TimingTags::tag_range tags,
+TimingTags::const_iterator find_tag(const TimingTags::tag_range& tags,
                                            DomainId launch_domain, 
                                            DomainId capture_domain);
 
 //Returns true of the specified set of tags would constrain a node of type node_type
-bool is_constrained(NodeType node_type, TimingTags::tag_range tags);
+bool is_constrained(NodeType node_type, const TimingTags::tag_range& tags);
 
 } //namepsace
 

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.inl
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.inl
@@ -281,7 +281,7 @@ inline std::pair<bool,TimingTags::iterator> TimingTags::find_data_required_with_
 
 inline size_t TimingTags::capacity() const { return capacity_; }
 
-inline TimingTags::iterator TimingTags::insert(iterator iter, const TimingTag& tag) {
+inline TimingTags::iterator TimingTags::insert(const iterator& iter, const TimingTag& tag) {
     size_t index = std::distance(begin(), iter);
     TATUM_ASSERT(index <= size());
 

--- a/libs/libarchfpga/src/arch_error.h
+++ b/libs/libarchfpga/src/arch_error.h
@@ -3,6 +3,7 @@
 
 #include "vtr_error.h"
 #include <cstdarg>
+#include <utility>
 
 //Note that we mark this function with the C++11 attribute 'noreturn'
 //as it will throw exceptions and not return normally. This can help
@@ -12,7 +13,7 @@
 class ArchFpgaError : public vtr::VtrError {
   public:
     ArchFpgaError(std::string msg = "", std::string new_filename = "", size_t new_linenumber = -1)
-        : vtr::VtrError(msg, new_filename, new_linenumber) {}
+        : vtr::VtrError(std::move(msg), std::move(new_filename), new_linenumber) {}
 };
 
 #endif

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <sstream>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_memory.h"
@@ -18,9 +19,7 @@ static void free_all_pb_graph_nodes(std::vector<t_logical_block_type>& type_desc
 static void free_pb_graph(t_pb_graph_node* pb_graph_node);
 static void free_pb_type(t_pb_type* pb_type);
 
-/******************** End Subroutine declarations ****************************/
-
-InstPort::InstPort(std::string str) {
+InstPort::InstPort(const std::string& str) {
     std::vector<std::string> inst_port = vtr::split(str, ".");
 
     if (inst_port.size() == 1) {
@@ -1304,7 +1303,7 @@ void primitives_annotation_clock_match(t_pin_to_pin_annotation* annotation,
     }
 }
 
-const t_segment_inf* find_segment(const t_arch* arch, std::string name) {
+const t_segment_inf* find_segment(const t_arch* arch, const std::string& name) {
     for (size_t i = 0; i < (arch->Segments).size(); ++i) {
         const t_segment_inf* seg = &arch->Segments[i];
         if (seg->name == name) {
@@ -1316,7 +1315,7 @@ const t_segment_inf* find_segment(const t_arch* arch, std::string name) {
 }
 
 bool segment_exists(const t_arch* arch, std::string name) {
-    return find_segment(arch, name) != nullptr;
+    return find_segment(arch, std::move(name)) != nullptr;
 }
 
 bool is_library_model(const char* model_name) {

--- a/libs/libarchfpga/src/arch_util.h
+++ b/libs/libarchfpga/src/arch_util.h
@@ -10,7 +10,7 @@ class InstPort {
     static constexpr int UNSPECIFIED = -1;
 
     InstPort() = default;
-    InstPort(std::string str);
+    InstPort(const std::string& str);
     std::string instance_name() const { return instance_.name; }
     std::string port_name() const { return port_.name; }
 
@@ -79,7 +79,7 @@ void primitives_annotation_clock_match(t_pin_to_pin_annotation* annotation,
                                        t_pb_type* parent_pb_type);
 
 bool segment_exists(const t_arch* arch, std::string name);
-const t_segment_inf* find_segment(const t_arch* arch, std::string name);
+const t_segment_inf* find_segment(const t_arch* arch, const std::string& name);
 bool is_library_model(const char* model_name);
 bool is_library_model(const t_model* model);
 

--- a/libs/libarchfpga/src/parse_switchblocks.cpp
+++ b/libs/libarchfpga/src/parse_switchblocks.cpp
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <string>
 #include <sstream>
+#include <utility>
 #include <vector>
 #include <stack>
 #include <utility>
@@ -256,7 +257,7 @@ static void parse_comma_separated_wire_points(const char* ch, std::vector<t_wire
 
 static void parse_num_conns(std::string num_conns, t_wireconn_inf& wireconn) {
     //num_conns is now interpretted as a formula and processed in build_switchblocks
-    wireconn.num_conns_formula = num_conns;
+    wireconn.num_conns_formula = std::move(num_conns);
 }
 
 /* Loads permutation funcs specified under Node into t_switchblock_inf. Node should be

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -28,6 +28,7 @@
 #define PHYSICAL_TYPES_H
 
 #include <functional>
+#include <utility>
 #include <vector>
 #include <unordered_map>
 #include <string>
@@ -261,10 +262,10 @@ enum e_sb_location {
  */
 struct t_grid_loc_spec {
     t_grid_loc_spec(std::string start, std::string end, std::string repeat, std::string incr)
-        : start_expr(start)
-        , end_expr(end)
-        , repeat_expr(repeat)
-        , incr_expr(incr) {}
+        : start_expr(std::move(start))
+        , end_expr(std::move(end))
+        , repeat_expr(std::move(repeat))
+        , incr_expr(std::move(incr)) {}
 
     std::string start_expr; //Starting position (inclusive)
     std::string end_expr;   //Ending position (inclusive)
@@ -343,7 +344,7 @@ struct t_grid_loc_spec {
  */
 struct t_grid_loc_def {
     t_grid_loc_def(std::string block_type_val, int priority_val)
-        : block_type(block_type_val)
+        : block_type(std::move(block_type_val))
         , priority(priority_val)
         , x("0", "W-1", "max(w+1,W)", "w") //Fill in x direction, no repeat, incr by block width
         , y("0", "H-1", "max(h+1,H)", "h") //Fill in y direction, no repeat, incr by block height

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -157,7 +157,7 @@ static void ProcessEquivalentSiteCustomConnection(pugi::xml_node Parent,
                                                   t_sub_tile* SubTile,
                                                   t_physical_tile_type* PhysicalTileType,
                                                   t_logical_block_type* LogicalBlockType,
-                                                  std::string site_name,
+                                                  const std::string& site_name,
                                                   const pugiutil::loc_data& loc_data);
 static void ProcessPinLocations(pugi::xml_node Locations,
                                 t_physical_tile_type* PhysicalTileType,
@@ -261,15 +261,15 @@ void warn_model_missing_timing(pugi::xml_node model_tag, const pugiutil::loc_dat
 bool check_model_clocks(pugi::xml_node model_tag, const pugiutil::loc_data& loc_data, const t_model* model);
 bool check_leaf_pb_model_timing_consistency(const t_pb_type* pb_type, const t_arch& arch);
 const t_pin_to_pin_annotation* find_sequential_annotation(const t_pb_type* pb_type, const t_model_ports* port, enum e_pin_to_pin_delay_annotations annot_type);
-const t_pin_to_pin_annotation* find_combinational_annotation(const t_pb_type* pb_type, std::string in_port, std::string out_port);
+const t_pin_to_pin_annotation* find_combinational_annotation(const t_pb_type* pb_type, const std::string& in_port, const std::string& out_port);
 std::string inst_port_to_port_name(std::string inst_port);
 
 static bool attribute_to_bool(const pugi::xml_node node,
                               const pugi::xml_attribute attr,
                               const pugiutil::loc_data& loc_data);
-int find_switch_by_name(const t_arch& arch, std::string switch_name);
+int find_switch_by_name(const t_arch& arch, const std::string& switch_name);
 
-e_side string_to_side(std::string side_str);
+e_side string_to_side(const std::string& side_str);
 
 static void link_physical_logical_types(std::vector<t_physical_tile_type>& PhysicalTileTypes,
                                         std::vector<t_logical_block_type>& LogicalBlockTypes);
@@ -3214,7 +3214,7 @@ static void ProcessEquivalentSiteCustomConnection(pugi::xml_node Parent,
                                                   t_sub_tile* SubTile,
                                                   t_physical_tile_type* PhysicalTileType,
                                                   t_logical_block_type* LogicalBlockType,
-                                                  std::string site_name,
+                                                  const std::string& site_name,
                                                   const pugiutil::loc_data& loc_data) {
     pugi::xml_node CurDirect;
 
@@ -4970,7 +4970,7 @@ const t_pin_to_pin_annotation* find_sequential_annotation(const t_pb_type* pb_ty
     return nullptr;
 }
 
-const t_pin_to_pin_annotation* find_combinational_annotation(const t_pb_type* pb_type, std::string in_port, std::string out_port) {
+const t_pin_to_pin_annotation* find_combinational_annotation(const t_pb_type* pb_type, const std::string& in_port, const std::string& out_port) {
     for (int iannot = 0; iannot < pb_type->num_annotations; ++iannot) {
         const t_pin_to_pin_annotation* annot = &pb_type->annotations[iannot];
         for (const auto& annot_in_str : vtr::split(annot->input_pins)) {
@@ -5013,7 +5013,7 @@ static bool attribute_to_bool(const pugi::xml_node node,
     return false;
 }
 
-int find_switch_by_name(const t_arch& arch, std::string switch_name) {
+int find_switch_by_name(const t_arch& arch, const std::string& switch_name) {
     for (int iswitch = 0; iswitch < arch.num_switches; ++iswitch) {
         const t_arch_switch_inf& arch_switch = arch.Switches[iswitch];
         if (arch_switch.name == switch_name) {
@@ -5024,7 +5024,7 @@ int find_switch_by_name(const t_arch& arch, std::string switch_name) {
     return OPEN;
 }
 
-e_side string_to_side(std::string side_str) {
+e_side string_to_side(const std::string& side_str) {
     e_side side = NUM_SIDES;
     if (side_str.empty()) {
         side = NUM_SIDES;

--- a/libs/libarchfpga/src/read_xml_util.cpp
+++ b/libs/libarchfpga/src/read_xml_util.cpp
@@ -13,7 +13,7 @@ extern ReqOpt BoolToReqOpt(bool b) {
     return ReqOpt::OPTIONAL;
 }
 
-InstPort make_inst_port(std::string str, pugi::xml_node node, const pugiutil::loc_data& loc_data) {
+InstPort make_inst_port(const std::string& str, pugi::xml_node node, const pugiutil::loc_data& loc_data) {
     InstPort inst_port;
     try {
         inst_port = InstPort(str);
@@ -43,7 +43,7 @@ InstPort make_inst_port(pugi::xml_attribute attr, pugi::xml_node node, const pug
 void bad_tag(const pugi::xml_node node,
              const pugiutil::loc_data& loc_data,
              const pugi::xml_node parent_node,
-             const std::vector<std::string> expected_tags) {
+             const std::vector<std::string>& expected_tags) {
     std::string msg = "Unexpected tag ";
     msg += "<";
     msg += node.name();
@@ -76,7 +76,7 @@ void bad_tag(const pugi::xml_node node,
 void bad_attribute(const pugi::xml_attribute attr,
                    const pugi::xml_node node,
                    const pugiutil::loc_data& loc_data,
-                   const std::vector<std::string> expected_attributes) {
+                   const std::vector<std::string>& expected_attributes) {
     std::string msg = "Unexpected attribute ";
     msg += "'";
     msg += attr.name();
@@ -109,7 +109,7 @@ void bad_attribute(const pugi::xml_attribute attr,
 void bad_attribute_value(const pugi::xml_attribute attr,
                          const pugi::xml_node node,
                          const pugiutil::loc_data& loc_data,
-                         const std::vector<std::string> expected_values) {
+                         const std::vector<std::string>& expected_values) {
     std::string msg = "Invalid value '";
     msg += attr.value();
     msg += "'";

--- a/libs/libarchfpga/src/read_xml_util.h
+++ b/libs/libarchfpga/src/read_xml_util.h
@@ -11,18 +11,18 @@ pugiutil::ReqOpt BoolToReqOpt(bool b);
 void bad_tag(const pugi::xml_node node,
              const pugiutil::loc_data& loc_data,
              const pugi::xml_node parent_node = pugi::xml_node(),
-             const std::vector<std::string> expected_tags = std::vector<std::string>());
+             const std::vector<std::string>& expected_tags = std::vector<std::string>());
 
 void bad_attribute(const pugi::xml_attribute attr,
                    const pugi::xml_node node,
                    const pugiutil::loc_data& loc_data,
-                   const std::vector<std::string> expected_attributes = std::vector<std::string>());
+                   const std::vector<std::string>& expected_attributes = std::vector<std::string>());
 void bad_attribute_value(const pugi::xml_attribute attr,
                          const pugi::xml_node node,
                          const pugiutil::loc_data& loc_data,
-                         const std::vector<std::string> expected_attributes = std::vector<std::string>());
+                         const std::vector<std::string>& expected_attributes = std::vector<std::string>());
 
-InstPort make_inst_port(std::string str, pugi::xml_node node, const pugiutil::loc_data& loc_data);
+InstPort make_inst_port(const std::string& str, pugi::xml_node node, const pugiutil::loc_data& loc_data);
 InstPort make_inst_port(pugi::xml_attribute attr, pugi::xml_node node, const pugiutil::loc_data& loc_data);
 
 #endif

--- a/libs/libpugiutil/src/pugixml_loc.hpp
+++ b/libs/libpugiutil/src/pugixml_loc.hpp
@@ -5,6 +5,7 @@
  * hanlding the retrieval of line numbers (useful for error messages)
  */
 
+#include <utility>
 #include <vector>
 #include "pugixml.hpp"
 
@@ -16,7 +17,7 @@ class loc_data {
     loc_data() = default;
 
     loc_data(std::string filename_val)
-        : filename_(filename_val) {
+        : filename_(std::move(filename_val)) {
         build_loc_data();
     }
 

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -1,13 +1,14 @@
 #include "pugixml_util.hpp"
 #include <algorithm>
+#include <utility>
 
 namespace pugiutil {
 
 //Loads the XML file specified by filename into the passed pugi::xml_document
 //
 //Returns loc_data look-up for xml node line numbers
-loc_data load_xml(pugi::xml_document& doc,      //Document object to be loaded with file contents
-                  const std::string filename) { //Filename to load from
+loc_data load_xml(pugi::xml_document& doc,       //Document object to be loaded with file contents
+                  const std::string& filename) { //Filename to load from
     auto location_data = loc_data(filename);
 
     auto load_result = doc.load_file(filename.c_str());
@@ -110,7 +111,7 @@ size_t count_children(const pugi::xml_node node,
 //  loc_data - XML file location data
 //  expected_count - The expected number of child nodes
 void expect_child_node_count(const pugi::xml_node node,
-                             std::string child_name,
+                             const std::string& child_name,
                              size_t expected_count,
                              const loc_data& loc_data) {
     size_t actual_count = count_children(node, child_name, loc_data, OPTIONAL);
@@ -188,7 +189,7 @@ void expect_only_children(const pugi::xml_node node,
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
-                            std::string explanation,
+                            const std::string& explanation,
                             const loc_data& loc_data) {
     for (auto attrib : node.attributes()) {
         std::string attrib_name = attrib.name();
@@ -233,7 +234,7 @@ void expect_only_attributes(const pugi::xml_node node,
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
                             const loc_data& loc_data) {
-    expect_only_attributes(node, attribute_names, "", loc_data);
+    expect_only_attributes(node, std::move(attribute_names), "", loc_data);
 }
 
 //Counts the number of attributes on the specified node

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -18,7 +18,7 @@ loc_data load_xml(pugi::xml_document& doc,       //Document object to be loaded 
         auto col = location_data.col(load_result.offset);
         throw XmlError("Unable to load XML file '" + filename + "', " + msg
                            + " (line: " + std::to_string(line) + " col: " + std::to_string(col) + ")",
-                       filename.c_str(), line);
+                       filename, line);
     }
 
     return location_data;

--- a/libs/libpugiutil/src/pugixml_util.hpp
+++ b/libs/libpugiutil/src/pugixml_util.hpp
@@ -13,6 +13,7 @@
  * messages if the requested item does not exists).
  */
 
+#include <utility>
 #include <vector>
 #include <stdexcept>
 #include <cstdio>
@@ -26,9 +27,9 @@ namespace pugiutil {
 //An error produced while getting an XML node/attribute
 class XmlError : public std::runtime_error {
   public:
-    XmlError(std::string msg = "", std::string new_filename = "", size_t new_linenumber = -1)
+    XmlError(const std::string& msg = "", std::string new_filename = "", size_t new_linenumber = -1)
         : std::runtime_error(msg)
-        , filename_(new_filename)
+        , filename_(std::move(new_filename))
         , linenumber_(new_linenumber) {}
 
     //Returns the filename associated with this error
@@ -48,8 +49,8 @@ class XmlError : public std::runtime_error {
 //Loads the XML file specified by filename into the passed pugi::xml_docment
 //
 //Returns loc_data look-up for xml node line numbers
-loc_data load_xml(pugi::xml_document& doc,     //Document object to be loaded with file contents
-                  const std::string filename); //Filename to load from
+loc_data load_xml(pugi::xml_document& doc,      //Document object to be loaded with file contents
+                  const std::string& filename); //Filename to load from
 
 //Defines whether something (e.g. a node/attribute) is optional or required.
 //  We use this to improve clarity at the function call site (compared to just
@@ -118,7 +119,7 @@ size_t count_children(const pugi::xml_node node,
 //  loc_data - XML file location data
 //  expected_count - The expected number of child nodes
 void expect_child_node_count(const pugi::xml_node node,
-                             std::string child_name,
+                             const std::string& child_name,
                              size_t expected_count,
                              const loc_data& loc_data);
 
@@ -159,7 +160,7 @@ void expect_only_attributes(const pugi::xml_node node,
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
-                            std::string explanation,
+                            const std::string& explanation,
                             const loc_data& loc_data);
 
 //Counts the number of attributes on the specified node

--- a/libs/librtlnumber/main.cpp
+++ b/libs/librtlnumber/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
     for (int i = 0; i < argc; i++)
         input.push_back(argv[i]);
 
-    std::string result = "";
+    std::string result;
 
     if (argc < 3) {
         ERR_MSG("Not Enough Arguments: " << std::to_string(argc - 1));

--- a/libs/librtlnumber/main.cpp
+++ b/libs/librtlnumber/main.cpp
@@ -14,7 +14,7 @@
 #include "rtl_utils.hpp"
 
 #define bad_ops(test) _bad_ops(test, __func__, __LINE__)
-inline static std::string _bad_ops(std::string test, const char* FUNCT, int LINE) {
+inline static std::string _bad_ops(const std::string& test, const char* FUNCT, int LINE) {
     std::cerr << "INVALID INPUT OPS: (" << test << ")@" << FUNCT << "::" << std::to_string(LINE) << std::endl;
     std::abort();
 }
@@ -26,7 +26,7 @@ inline static std::string _bad_ops(std::string test, const char* FUNCT, int LINE
  *                                                             
  * 	This is used for testing purposes only, unused in ODIN as the input is already preprocessed
  */
-static std::string arithmetic(std::string op, std::string a_in) {
+static std::string arithmetic(const std::string& op, const std::string& a_in) {
     VNumber a(a_in);
     VNumber result;
 
@@ -75,7 +75,7 @@ static std::string arithmetic(std::string op, std::string a_in) {
     return result.to_verilog_bitstring();
 }
 
-static std::string arithmetic(std::string a_in, std::string op, std::string b_in) {
+static std::string arithmetic(const std::string& a_in, const std::string& op, const std::string& b_in) {
     VNumber a(a_in);
     VNumber b(b_in);
     VNumber result;
@@ -141,6 +141,7 @@ static std::string arithmetic(std::string a_in, std::string op, std::string b_in
 
 int main(int argc, char** argv) {
     std::vector<std::string> input;
+    input.reserve(argc);
     for (int i = 0; i < argc; i++)
         input.push_back(argv[i]);
 
@@ -150,6 +151,38 @@ int main(int argc, char** argv) {
         ERR_MSG("Not Enough Arguments: " << std::to_string(argc - 1));
 
         return -1;
+    } else if (argc == 3 && input[1] == "is_true") {
+        VNumber input_2(input[2]);
+
+        result = (V_TRUE(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "is_false") {
+        VNumber input_2(input[2]);
+
+        result = (V_FALSE(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "is_unk") {
+        VNumber input_2(input[2]);
+
+        result = (V_UNK(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "is_x") {
+        VNumber input_2(input[2]);
+
+        result = (V_IS_X(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "is_z") {
+        VNumber input_2(input[2]);
+
+        result = (V_IS_Z(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "is_unsigned") {
+        VNumber input_2(input[2]);
+
+        result = (V_IS_UNSIGNED(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "is_signed") {
+        VNumber input_2(input[2]);
+
+        result = (V_IS_SIGNED(input_2) ? "pass" : "fail");
+    } else if (argc == 3 && input[1] == "display") {
+        VNumber input_2(input[2]);
+
+        result = V_STRING(input_2);
     } else if (argc == 3) {
         result = arithmetic(input[1], input[2]);
     } else if (argc == 4 && input[1] == "display") {

--- a/libs/librtlnumber/src/include/internal_bits.hpp
+++ b/libs/librtlnumber/src/include/internal_bits.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <string>
 #include <algorithm>
+#include <utility>
 #include <vector>
 #include <bitset>
 #include "rtl_utils.hpp"
@@ -678,7 +679,7 @@ class VNumber {
     BitSpace::VerilogBits bitstring = BitSpace::VerilogBits(1, BitSpace::_x);
 
     VNumber(BitSpace::VerilogBits other_bitstring, bool other_defined_size, bool other_sign) {
-        bitstring = BitSpace::VerilogBits(other_bitstring);
+        bitstring = BitSpace::VerilogBits(std::move(other_bitstring));
         sign = other_sign;
         defined_size = other_defined_size;
     }

--- a/libs/librtlnumber/src/include/rtl_utils.hpp
+++ b/libs/librtlnumber/src/include/rtl_utils.hpp
@@ -44,7 +44,7 @@
 std::string string_of_radix_to_bitstring(std::string orig_string, size_t radix);
 std::string convert_between_bases(std::string str, uint8_t base_from, uint8_t base_to, bool uppercase, bool big_endian);
 
-inline void _assert_Werr(bool cond, const char* FUNCT, int LINE, std::string error_string) {
+inline void _assert_Werr(bool cond, const char* FUNCT, int LINE, const std::string& error_string) {
     if (!cond) {
         std::cerr << std::endl
                   << "ERROR: " << FUNCT << "::" << std::to_string(LINE) << " Assert 'assert_Werr' Failed:\t" << error_string << "!" << std::endl

--- a/libs/librtlnumber/src/rtl_utils.cpp
+++ b/libs/librtlnumber/src/rtl_utils.cpp
@@ -192,7 +192,7 @@ static std::string _radix_digit_to_bits_str(const char digit, size_t radix, cons
             break;
         }
         case 256: {
-            std::string bitstring = "";
+            std::string bitstring;
             char temp = digit;
             // 8 bit per char
             for (int i = 0; i < 8; i++) {
@@ -222,7 +222,7 @@ static std::string _radix_digit_to_bits(const char digit, size_t radix, const ch
  * convert from different radix to bitstring
  */
 std::string string_of_radix_to_bitstring(std::string orig_string, size_t radix) {
-    std::string result = "";
+    std::string result;
 
     switch (radix) {
         case 2:
@@ -266,7 +266,7 @@ std::string string_of_radix_to_bitstring(std::string orig_string, size_t radix) 
     while (!orig_string.empty()) {
         switch (radix) {
             case 10: {
-                std::string new_number = "";
+                std::string new_number;
 
                 uint8_t rem_digit = 0;
                 for (char current_digit : orig_string) {

--- a/libs/libvtrutil/src/vtr_error.h
+++ b/libs/libvtrutil/src/vtr_error.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace vtr {
 
@@ -17,9 +18,9 @@ namespace vtr {
 class VtrError : public std::runtime_error {
   public:
     ///@brief VtrError constructor
-    VtrError(std::string msg = "", std::string new_filename = "", size_t new_linenumber = -1)
+    VtrError(const std::string& msg = "", std::string new_filename = "", size_t new_linenumber = -1)
         : std::runtime_error(msg)
-        , filename_(new_filename)
+        , filename_(std::move(new_filename))
         , linenumber_(new_linenumber) {}
 
     /**

--- a/libs/libvtrutil/src/vtr_expr_eval.cpp
+++ b/libs/libvtrutil/src/vtr_expr_eval.cpp
@@ -83,7 +83,7 @@ bool additional_assignment_op(int arg1, int arg2);
 
 /**** Function Implementations ****/
 /* returns integer result according to specified non-piece-wise formula and data */
-int FormulaParser::parse_formula(std::string formula, const t_formula_data& mydata, bool is_breakpoint) {
+int FormulaParser::parse_formula(const std::string& formula, const t_formula_data& mydata, bool is_breakpoint) {
     int result = -1;
 
     /* output in reverse-polish notation */
@@ -481,6 +481,7 @@ static void handle_operator(const Formula_Object& fobj, vector<Formula_Object>& 
     if (E_FML_OPERATOR != fobj.type) {
         throw vtr::VtrError(vtr::string_fmt("in handle_operator: passed in formula object not of type operator\n"), __FILE__, __LINE__);
     }
+
     int op_pr = get_fobj_precedence(fobj);
     bool op_assoc_is_left = op_associativity_is_left(fobj.data.op);
 
@@ -654,6 +655,7 @@ static int parse_rpn_vector(vector<Formula_Object>& rpn_vec) {
             }
         }
     }
+
     return result;
 }
 
@@ -770,7 +772,7 @@ static bool is_operator(const char ch) {
 }
 
 //returns true if string signifies a function e.g max, min
-static bool is_function(std::string name) {
+static bool is_function(const std::string& name) {
     if (name == "min"
         || name == "max"
         || name == "gcd"
@@ -801,7 +803,7 @@ t_compound_operator is_compound_op(const char* ch) {
 }
 
 //checks if the entered string is a known variable name
-static bool is_variable(std::string var_name) {
+static bool is_variable(const std::string& var_name) {
     if (same_string(var_name, "from_block") || same_string(var_name, "temp_count") || same_string(var_name, "move_num") || same_string(var_name, "route_net_id") || same_string(var_name, "in_blocks_affected") || same_string(var_name, "router_iter")) {
         return true;
     }

--- a/libs/libvtrutil/src/vtr_log.cpp
+++ b/libs/libvtrutil/src/vtr_log.cpp
@@ -19,11 +19,11 @@ void set_log_file(const char* filename) {
 
 } // namespace vtr
 
-void add_warnings_to_suppress(std::string function_name) {
+void add_warnings_to_suppress(const std::string& function_name) {
     warnings_to_suppress.insert(function_name);
 }
 
-void set_noisy_warn_log_file(std::string log_file_name) {
+void set_noisy_warn_log_file(const std::string& log_file_name) {
     std::ofstream log;
     log.open(log_file_name, std::ifstream::out | std::ifstream::trunc);
     log.close();

--- a/libs/libvtrutil/src/vtr_log.h
+++ b/libs/libvtrutil/src/vtr_log.h
@@ -40,6 +40,7 @@
  *
  * Each of the three message types also have a VTR_LOGF_* variant,
  * which will cause the message to be logged for a custom file and
+ * line location.
  *
  * For example:
  *

--- a/libs/libvtrutil/src/vtr_time.cpp
+++ b/libs/libvtrutil/src/vtr_time.cpp
@@ -1,5 +1,7 @@
 #include "vtr_time.h"
 
+#include <utility>
+
 #include "vtr_log.h"
 #include "vtr_rusage.h"
 
@@ -30,7 +32,7 @@ float Timer::delta_max_rss_mib() const {
 
 ///@brief Constructor
 ScopedActionTimer::ScopedActionTimer(std::string action_str)
-    : action_(action_str)
+    : action_(std::move(action_str))
     , depth_(f_timer_depth++) {
 }
 
@@ -69,7 +71,7 @@ int ScopedActionTimer::depth() const {
 
 ///@brief Constructor
 ScopedFinishTimer::ScopedFinishTimer(std::string action_str)
-    : ScopedActionTimer(action_str) {
+    : ScopedActionTimer(std::move(action_str)) {
 }
 
 ///@brief Destructor
@@ -83,7 +85,7 @@ ScopedFinishTimer::~ScopedFinishTimer() {
 
 ///@brief Constructor
 ScopedStartFinishTimer::ScopedStartFinishTimer(std::string action_str)
-    : ScopedActionTimer(action_str) {
+    : ScopedActionTimer(std::move(action_str)) {
     vtr::printf_info("%s%s\n", pad().c_str(), action().c_str());
 }
 

--- a/libs/libvtrutil/src/vtr_util.cpp
+++ b/libs/libvtrutil/src/vtr_util.cpp
@@ -25,7 +25,7 @@ static int cont;                 /* line continued? (used by strtok)*/
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const char* text, const std::string delims) {
+std::vector<std::string> split(const char* text, const std::string& delims) {
     if (text) {
         std::string text_str(text);
         return split(text_str, delims);
@@ -38,7 +38,7 @@ std::vector<std::string> split(const char* text, const std::string delims) {
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const std::string& text, const std::string delims) {
+std::vector<std::string> split(const std::string& text, const std::string& delims) {
     std::vector<std::string> tokens;
 
     std::string curr_tok;
@@ -101,7 +101,7 @@ std::string replace_all(const std::string& input, const std::string& search, con
 }
 
 ///@brief Retruns true if str starts with prefix
-bool starts_with(std::string str, std::string prefix) {
+bool starts_with(const std::string& str, const std::string& prefix) {
     return str.find(prefix) == 0;
 }
 

--- a/libs/libvtrutil/src/vtr_util.h
+++ b/libs/libvtrutil/src/vtr_util.h
@@ -14,8 +14,8 @@ namespace vtr {
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const char* text, const std::string delims = " \t\n");
-std::vector<std::string> split(const std::string& text, const std::string delims = " \t\n");
+std::vector<std::string> split(const char* text, const std::string& delims = " \t\n");
+std::vector<std::string> split(const std::string& text, const std::string& delims = " \t\n");
 
 ///@brief Returns 'input' with the first instance of 'search' replaced with 'replace'
 std::string replace_first(const std::string& input, const std::string& search, const std::string& replace);
@@ -24,7 +24,7 @@ std::string replace_first(const std::string& input, const std::string& search, c
 std::string replace_all(const std::string& input, const std::string& search, const std::string& replace);
 
 ///@brief Retruns true if str starts with prefix
-bool starts_with(std::string str, std::string prefix);
+bool starts_with(const std::string& str, const std::string& prefix);
 
 ///@brief Returns a std::string formatted using a printf-style format string
 std::string string_fmt(const char* fmt, ...);
@@ -39,7 +39,7 @@ std::string vstring_fmt(const char* fmt, va_list args);
  *  would return "home/user/my_files/test.blif"
  */
 template<typename Iter>
-std::string join(Iter begin, Iter end, std::string delim);
+std::string join(Iter begin, Iter end, const std::string& delim);
 
 template<typename Container>
 std::string join(Container container, std::string delim);
@@ -82,7 +82,7 @@ std::vector<std::string> ReadLineTokens(FILE* InFile, int* LineNum);
  * @brief Template join function implementation
  */
 template<typename Iter>
-std::string join(Iter begin, Iter end, std::string delim) {
+std::string join(Iter begin, Iter end, const std::string& delim) {
     std::string joined_str;
     for (auto iter = begin; iter != end; ++iter) {
         joined_str += *iter;

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -178,7 +178,7 @@ std::string FasmWriterVisitor::handle_fasm_prefix(const t_metadata_dict *meta,
 }
 
 std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const {
-  std::string clb_prefix = "";
+  std::string clb_prefix;
 
   const t_pb *pb_for_graph_node = nullptr;
 

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -419,7 +419,7 @@ static LogicVec lut_outputs(const t_pb* atom_pb, size_t num_inputs, const t_pb_r
     return lut.table();
 }
 
-const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* pb_graph_node, std::string target_type) const {
+const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* pb_graph_node, const std::string& target_type) const {
   if(pb_graph_node == nullptr) {
     return nullptr;
   }
@@ -568,7 +568,7 @@ void FasmWriterVisitor::check_for_param(const t_pb *atom) {
         VTR_ASSERT(value != nullptr);
 
         std::string fasm_params_str = value->as_string().get(strings_);
-        for(const auto param : vtr::split(fasm_params_str, "\n")) {
+        for(const auto& param : vtr::split(fasm_params_str, "\n")) {
           auto param_parts = split_fasm_entry(param, "=", "\t ");
             if(param_parts.size() == 0) {
                 continue;
@@ -588,7 +588,7 @@ void FasmWriterVisitor::check_for_param(const t_pb *atom) {
 
     auto &params = iter->second;
 
-    for(auto param : atom_ctx.nlist.block_params(atom_blk_id)) {
+    for(const auto& param : atom_ctx.nlist.block_params(atom_blk_id)) {
         auto feature = params.EmitFasmFeature(param.first, param.second);
 
         if(feature.size() > 0) {
@@ -668,7 +668,7 @@ void FasmWriterVisitor::find_clb_prefix(const t_pb_graph_node *node,
     }
 }
 
-void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux_str,
+void FasmWriterVisitor::output_fasm_mux(const std::string& fasm_mux_str,
                                         t_interconnect *interconnect,
                                         const t_pb_graph_pin *mux_input_pin) {
     auto *pb_name = mux_input_pin->parent_node->pb_type->name;
@@ -753,11 +753,11 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux_str,
         pb_name, pb_index, port_name, pin_index, fasm_mux_str.c_str());
 }
 
-void FasmWriterVisitor::output_fasm_features(const std::string features) const {
+void FasmWriterVisitor::output_fasm_features(const std::string& features) const {
   output_fasm_features(features, clb_prefix_, blk_prefix_);
 }
 
-void FasmWriterVisitor::output_fasm_features(const std::string features, const std::string clb_prefix, const std::string blk_prefix) const {
+void FasmWriterVisitor::output_fasm_features(const std::string& features, const std::string& clb_prefix, const std::string& blk_prefix) const {
   std::stringstream os(features);
 
   while(os) {

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -66,8 +66,8 @@ class FasmWriterVisitor : public NetlistVisitor {
       void finish_impl() override;
 
   private:
-      void output_fasm_features(const std::string features) const;
-      void output_fasm_features(const std::string features, const std::string clb_prefix, const std::string blk_prefix) const;
+      void output_fasm_features(const std::string& features) const;
+      void output_fasm_features(const std::string& features, const std::string& clb_prefix, const std::string& blk_prefix) const;
       void check_features(const t_metadata_dict *meta) const;
       void check_interconnect(const t_pb_routes &pb_route, int inode);
       void check_for_lut(const t_pb* atom);

--- a/utils/fasm/src/fasm_utils.cpp
+++ b/utils/fasm/src/fasm_utils.cpp
@@ -2,10 +2,11 @@
 #include "vpr_utils.h"
 
 #include <regex>
+#include <utility>
 
 namespace fasm {
 
-void parse_name_with_optional_index(const std::string in, std::string *name, int *index) {
+void parse_name_with_optional_index(const std::string& in, std::string *name, int *index) {
   auto in_parts = vtr::split(in, "[]");
 
   if(in_parts.size() == 1) {
@@ -22,14 +23,14 @@ void parse_name_with_optional_index(const std::string in, std::string *name, int
 
 std::vector<std::string> split_fasm_entry(std::string entry,
                                                  std::string delims,
-                                                 std::string ignore) {
+                                                 const std::string& ignore) {
   for (size_t ii=0; ii<entry.length(); ii++) {
     while (ignore.find(entry[ii]) != std::string::npos) {
       entry.erase(ii, 1);
     }
   }
 
-  return vtr::split(entry, delims);
+  return vtr::split(entry, std::move(delims));
 }
 
 std::vector<std::string> find_tags_in_feature (const std::string& a_String) {
@@ -61,7 +62,7 @@ std::string substitute_tags (const std::string& a_Feature, const std::map<const 
 
     // Check if those tags are defined, If not then throw an error
     bool have_errors = false;
-    for (auto tag: tags) {
+    for (const auto& tag: tags) {
         if (a_Tags.count(tag) == 0) {
             vtr::printf_error(__FILE__, __LINE__, "fasm placeholder '%s' not defined!", tag.c_str());
             have_errors = true;
@@ -77,7 +78,7 @@ std::string substitute_tags (const std::string& a_Feature, const std::map<const 
 
     // Substitute tags
     std::string feature(a_Feature);
-    for (auto tag: tags) {
+    for (const auto& tag: tags) {
         std::regex regex("\\{" + tag + "\\}");
         feature = std::regex_replace(feature, regex, a_Tags.at(tag));
     }

--- a/utils/fasm/src/fasm_utils.h
+++ b/utils/fasm/src/fasm_utils.h
@@ -13,7 +13,7 @@ namespace fasm {
 // in="A[5]" parts to *name="A", *index=5
 //
 // Throws vpr exception if parsing fails.
-void parse_name_with_optional_index(const std::string in, std::string *name, int *index);
+void parse_name_with_optional_index(const std::string& in, std::string *name, int *index);
 
 // Split FASM entry into parts.
 //
@@ -21,7 +21,7 @@ void parse_name_with_optional_index(const std::string in, std::string *name, int
 // ignore - Characters to ignore.
 std::vector<std::string> split_fasm_entry(std::string entry,
                                                  std::string delims,
-                                                 std::string ignore);
+                                                 const std::string& ignore);
 
 // Searches for tags in given string, returns their names in a vector.
 std::vector<std::string> find_tags_in_feature (const std::string& a_String);

--- a/utils/fasm/src/lut.cpp
+++ b/utils/fasm/src/lut.cpp
@@ -58,7 +58,7 @@ const LogicVec & Lut::table() {
   return table_;
 }
 
-LutOutputDefinition::LutOutputDefinition(std::string definition) {
+LutOutputDefinition::LutOutputDefinition(const std::string& definition) {
   // Parse LUT.INIT[63:0] into
   // fasm_feature = LUT.INIT
   // start_bit = 0

--- a/utils/fasm/src/lut.h
+++ b/utils/fasm/src/lut.h
@@ -35,7 +35,7 @@ class Lut {
 // Utility class that creates a FASM feature directive based on the FASM LUT definition.
 struct LutOutputDefinition {
   // Definition should be of the format <feature>[<end_bit>:<start_bit].
-  LutOutputDefinition(std::string definition);
+  LutOutputDefinition(const std::string& definition);
 
   // Return a FASM feature directive for a wire from input specified to output.
   // Also known as a route through LUT.

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -337,8 +337,8 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
             continue;
         }
 
-        if (line.find("#") != std::string::npos) {
-            auto init_pos = line.find("#");
+        if (line.find('#') != std::string::npos) {
+            auto init_pos = line.find('#');
             lut_def = line.substr(init_pos+2);
             continue;
         }

--- a/utils/route_diag/src/main.cpp
+++ b/utils/route_diag/src/main.cpp
@@ -215,7 +215,7 @@ static void profile_source(int source_rr_node,
 }
 
 
-static t_chan_width setup_chan_width(t_router_opts router_opts,
+static t_chan_width setup_chan_width(const t_router_opts& router_opts,
         t_chan_width_dist chan_width_dist) {
     /*we give plenty of tracks, this increases routability for the */
     /*lookup table generation */

--- a/vpr/src/base/CheckSetup.cpp
+++ b/vpr/src/base/CheckSetup.cpp
@@ -12,7 +12,7 @@ void CheckSetup(const t_packer_opts& PackerOpts,
                 const t_router_opts& RouterOpts,
                 const t_det_routing_arch& RoutingArch,
                 const std::vector<t_segment_inf>& Segments,
-                const t_timing_inf Timing,
+                const t_timing_inf& Timing,
                 const t_chan_width_dist Chans) {
     int i;
     int Tmp;

--- a/vpr/src/base/CheckSetup.h
+++ b/vpr/src/base/CheckSetup.h
@@ -7,7 +7,7 @@ void CheckSetup(const t_packer_opts& PackerOpts,
                 const t_router_opts& RouterOpts,
                 const t_det_routing_arch& RoutingArch,
                 const std::vector<t_segment_inf>& Segments,
-                const t_timing_inf Timing,
+                const t_timing_inf& Timing,
                 const t_chan_width_dist Chans);
 
 #endif

--- a/vpr/src/base/SetupGrid.cpp
+++ b/vpr/src/base/SetupGrid.cpp
@@ -31,8 +31,8 @@ using vtr::t_formula_data;
 
 static DeviceGrid auto_size_device_grid(const std::vector<t_grid_def>& grid_layouts, const std::map<t_logical_block_type_ptr, size_t>& minimum_instance_counts, float maximum_device_utilization);
 static std::vector<t_logical_block_type_ptr> grid_overused_resources(const DeviceGrid& grid, std::map<t_logical_block_type_ptr, size_t> instance_counts);
-static bool grid_satisfies_instance_counts(const DeviceGrid& grid, std::map<t_logical_block_type_ptr, size_t> instance_counts, float maximum_utilization);
-static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t width, size_t height, bool warn_out_of_range = true, std::vector<t_logical_block_type_ptr> limiting_resources = std::vector<t_logical_block_type_ptr>());
+static bool grid_satisfies_instance_counts(const DeviceGrid& grid, const std::map<t_logical_block_type_ptr, size_t>& instance_counts, float maximum_utilization);
+static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t width, size_t height, bool warn_out_of_range = true, const std::vector<t_logical_block_type_ptr>& limiting_resources = std::vector<t_logical_block_type_ptr>());
 
 static void CheckGrid(const DeviceGrid& grid);
 
@@ -310,7 +310,7 @@ static std::vector<t_logical_block_type_ptr> grid_overused_resources(const Devic
     return overused_resources;
 }
 
-static bool grid_satisfies_instance_counts(const DeviceGrid& grid, std::map<t_logical_block_type_ptr, size_t> instance_counts, float maximum_utilization) {
+static bool grid_satisfies_instance_counts(const DeviceGrid& grid, const std::map<t_logical_block_type_ptr, size_t>& instance_counts, float maximum_utilization) {
     //Are the resources satisified?
     auto overused_resources = grid_overused_resources(grid, instance_counts);
 
@@ -329,7 +329,7 @@ static bool grid_satisfies_instance_counts(const DeviceGrid& grid, std::map<t_lo
 }
 
 ///@brief Build the specified device grid
-static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t grid_width, size_t grid_height, bool warn_out_of_range, const std::vector<t_logical_block_type_ptr> limiting_resources) {
+static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t grid_width, size_t grid_height, bool warn_out_of_range, const std::vector<t_logical_block_type_ptr>& limiting_resources) {
     if (grid_def.grid_type == GridDefType::FIXED) {
         if (grid_def.width != int(grid_width) || grid_def.height != int(grid_height)) {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER,
@@ -710,7 +710,7 @@ static void CheckGrid(const DeviceGrid& grid) {
     }
 }
 
-float calculate_device_utilization(const DeviceGrid& grid, std::map<t_logical_block_type_ptr, size_t> instance_counts) {
+float calculate_device_utilization(const DeviceGrid& grid, const std::map<t_logical_block_type_ptr, size_t>& instance_counts) {
     //Record the resources of the grid
     std::map<t_physical_tile_type_ptr, size_t> grid_resources;
     for (size_t x = 0; x < grid.width(); ++x) {

--- a/vpr/src/base/SetupGrid.h
+++ b/vpr/src/base/SetupGrid.h
@@ -27,7 +27,7 @@ DeviceGrid create_device_grid(std::string layout_name, const std::vector<t_grid_
  * Calculate the device utilization (i.e. fraction of used grid tiles)
  * foor the specified grid and resource requirements
  */
-float calculate_device_utilization(const DeviceGrid& grid, std::map<t_logical_block_type_ptr, size_t> instance_counts);
+float calculate_device_utilization(const DeviceGrid& grid, const std::map<t_logical_block_type_ptr, size_t>& instance_counts);
 
 /**
  * @brief Returns the effective size of the device

--- a/vpr/src/base/atom_netlist.cpp
+++ b/vpr/src/base/atom_netlist.cpp
@@ -2,6 +2,7 @@
 #include <unordered_set>
 #include <queue>
 #include <numeric>
+#include <utility>
 
 #include "atom_netlist.h"
 
@@ -17,7 +18,7 @@
  *
  */
 AtomNetlist::AtomNetlist(std::string name, std::string id)
-    : Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId>(name, id)
+    : Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId>(std::move(name), std::move(id))
     , inpad_model_(nullptr)
     , outpad_model_(nullptr) {}
 
@@ -137,7 +138,7 @@ std::unordered_set<std::string> AtomNetlist::net_aliases(const std::string net_n
  * Mutators
  *
  */
-AtomBlockId AtomNetlist::create_block(const std::string name, const t_model* model, const TruthTable truth_table) {
+AtomBlockId AtomNetlist::create_block(const std::string& name, const t_model* model, const TruthTable& truth_table) {
     AtomBlockId blk_id = Netlist::create_block(name);
 
     //Initialize the data
@@ -205,7 +206,7 @@ AtomPinId AtomNetlist::create_pin(const AtomPortId port_id, BitIndex port_bit, c
     return pin_id;
 }
 
-AtomNetId AtomNetlist::create_net(const std::string name) {
+AtomNetId AtomNetlist::create_net(const std::string& name) {
     AtomNetId net_id = Netlist::create_net(name);
 
     //Check post-conditions: size
@@ -214,8 +215,8 @@ AtomNetId AtomNetlist::create_net(const std::string name) {
     return net_id;
 }
 
-AtomNetId AtomNetlist::add_net(const std::string name, AtomPinId driver, std::vector<AtomPinId> sinks) {
-    return Netlist::add_net(name, driver, sinks);
+AtomNetId AtomNetlist::add_net(const std::string& name, AtomPinId driver, std::vector<AtomPinId> sinks) {
+    return Netlist::add_net(name, driver, std::move(sinks));
 }
 
 void AtomNetlist::add_net_alias(const std::string net_name, const std::string alias_net_name) {

--- a/vpr/src/base/atom_netlist_utils.cpp
+++ b/vpr/src/base/atom_netlist_utils.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iterator>
 #include <cmath>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"
@@ -48,7 +49,7 @@ bool remove_buffer_lut(AtomNetlist& netlist, AtomBlockId blk, int verbosity);
 std::string make_unconn(size_t& unconn_count, PinType type);
 void cube_to_minterms_recurr(std::vector<vtr::LogicValue> cube, std::vector<size_t>& minterms);
 
-void print_netlist_as_blif(std::string filename, const AtomNetlist& netlist) {
+void print_netlist_as_blif(const std::string& filename, const AtomNetlist& netlist) {
     FILE* f = std::fopen(filename.c_str(), "w");
     print_netlist_as_blif(f, netlist);
     std::fclose(f);
@@ -125,7 +126,7 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist) {
         fprintf(f, "\n");
 
         //Artificial buffers
-        for (auto buf_pair : artificial_buffer_connections_required) {
+        for (const auto& buf_pair : artificial_buffer_connections_required) {
             fprintf(f, "#Artificially inserted primary-output assigment buffer\n");
             fprintf(f, ".names %s %s\n", buf_pair.first.c_str(), buf_pair.second.c_str());
             fprintf(f, "1 1\n");
@@ -346,10 +347,10 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist) {
 
         fprintf(f, "\n");
 
-        for (auto param : netlist.block_params(blk_id)) {
+        for (const auto& param : netlist.block_params(blk_id)) {
             fprintf(f, ".param %s %s\n", param.first.c_str(), param.second.c_str());
         }
-        for (auto attr : netlist.block_attrs(blk_id)) {
+        for (const auto& attr : netlist.block_attrs(blk_id)) {
             fprintf(f, ".attr %s %s\n", attr.first.c_str(), attr.second.c_str());
         }
 
@@ -650,7 +651,7 @@ std::vector<AtomPortId> find_combinationally_connected_input_ports(const AtomNet
 
     VTR_ASSERT(netlist.port_type(output_port) == PortType::OUTPUT);
 
-    std::string out_port_name = netlist.port_name(output_port);
+    const std::string& out_port_name = netlist.port_name(output_port);
 
     AtomBlockId blk = netlist.port_block(output_port);
 
@@ -672,7 +673,7 @@ std::vector<AtomPortId> find_combinationally_connected_clock_ports(const AtomNet
 
     VTR_ASSERT(netlist.port_type(output_port) == PortType::OUTPUT);
 
-    std::string out_port_name = netlist.port_name(output_port);
+    const std::string& out_port_name = netlist.port_name(output_port);
 
     AtomBlockId blk = netlist.port_block(output_port);
 
@@ -1282,7 +1283,7 @@ std::vector<vtr::LogicValue> truth_table_to_lut_mask(const AtomNetlist::TruthTab
 
 std::vector<size_t> cube_to_minterms(std::vector<vtr::LogicValue> cube) {
     std::vector<size_t> minterms;
-    cube_to_minterms_recurr(cube, minterms);
+    cube_to_minterms_recurr(std::move(cube), minterms);
     return minterms;
 }
 

--- a/vpr/src/base/atom_netlist_utils.h
+++ b/vpr/src/base/atom_netlist_utils.h
@@ -96,7 +96,7 @@ std::vector<size_t> cube_to_minterms(std::vector<vtr::LogicValue> cube);
 /*
  * Print the netlist for debugging
  */
-void print_netlist_as_blif(std::string filename, const AtomNetlist& netlist);
+void print_netlist_as_blif(const std::string& filename, const AtomNetlist& netlist);
 void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist);
 
 ///@brief Returns a user-friendly architectural identifier for the specified atom pin

--- a/vpr/src/base/clustered_netlist.cpp
+++ b/vpr/src/base/clustered_netlist.cpp
@@ -1,5 +1,7 @@
 #include "clustered_netlist.h"
 
+#include <utility>
+
 #include "vtr_assert.h"
 #include "vpr_error.h"
 
@@ -9,7 +11,7 @@
  */
 
 ClusteredNetlist::ClusteredNetlist(std::string name, std::string id)
-    : Netlist<ClusterBlockId, ClusterPortId, ClusterPinId, ClusterNetId>(name, id) {}
+    : Netlist<ClusterBlockId, ClusterPortId, ClusterPinId, ClusterNetId>(std::move(name), std::move(id)) {}
 
 /*
  *
@@ -133,7 +135,7 @@ ClusterBlockId ClusteredNetlist::create_block(const char* name, t_pb* pb, t_logi
     return blk_id;
 }
 
-ClusterPortId ClusteredNetlist::create_port(const ClusterBlockId blk_id, const std::string name, BitIndex width, PortType type) {
+ClusterPortId ClusteredNetlist::create_port(const ClusterBlockId blk_id, const std::string& name, BitIndex width, PortType type) {
     ClusterPortId port_id = find_port(blk_id, name);
     if (!port_id) {
         port_id = Netlist::create_port(blk_id, name, width, type);
@@ -164,7 +166,7 @@ ClusterPinId ClusteredNetlist::create_pin(const ClusterPortId port_id, BitIndex 
     return pin_id;
 }
 
-ClusterNetId ClusteredNetlist::create_net(const std::string name) {
+ClusterNetId ClusteredNetlist::create_net(const std::string& name) {
     //Check if the net has already been created
     StringId name_id = create_string(name);
     ClusterNetId net_id = find_net(name_id);

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -220,7 +220,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
      *
      *   @param name  The unique name of the net
      */
-    ClusterNetId create_net(const std::string name);
+    ClusterNetId create_net(const std::string& name);
 
     ///@brief Sets the flag in net_ignored_ = state
     void set_net_is_ignored(ClusterNetId net_id, bool state);

--- a/vpr/src/base/device_grid.cpp
+++ b/vpr/src/base/device_grid.cpp
@@ -1,15 +1,17 @@
 #include "device_grid.h"
+
+#include <utility>
 #include "vpr_utils.h"
 
 DeviceGrid::DeviceGrid(std::string grid_name, vtr::Matrix<t_grid_tile> grid)
-    : name_(grid_name)
-    , grid_(grid) {
+    : name_(std::move(grid_name))
+    , grid_(std::move(grid)) {
     count_instances();
 }
 
 DeviceGrid::DeviceGrid(std::string grid_name, vtr::Matrix<t_grid_tile> grid, std::vector<t_logical_block_type_ptr> limiting_res)
-    : DeviceGrid(grid_name, grid) {
-    limiting_resources_ = limiting_res;
+    : DeviceGrid(std::move(grid_name), std::move(grid)) {
+    limiting_resources_ = std::move(limiting_res);
 }
 
 size_t DeviceGrid::num_instances(t_physical_tile_type_ptr type) const {

--- a/vpr/src/base/echo_files.cpp
+++ b/vpr/src/base/echo_files.cpp
@@ -153,7 +153,7 @@ char* getOutputFileName(enum e_output_files ename) {
     return outputFileNames[(int)ename];
 }
 
-void alloc_and_load_output_file_names(const std::string default_name) {
+void alloc_and_load_output_file_names(const std::string& default_name) {
     char* name;
 
     if (outputFileNames == nullptr) {

--- a/vpr/src/base/echo_files.h
+++ b/vpr/src/base/echo_files.h
@@ -85,7 +85,7 @@ void free_echo_file_info();
 
 void setOutputFileName(enum e_output_files ename, const char* name, const char* default_name);
 char* getOutputFileName(enum e_output_files ename);
-void alloc_and_load_output_file_names(const std::string default_name);
+void alloc_and_load_output_file_names(const std::string& default_name);
 void free_output_file_names();
 
 #endif

--- a/vpr/src/base/logic_vec.h
+++ b/vpr/src/base/logic_vec.h
@@ -1,6 +1,7 @@
 #ifndef LOGIC_VEC_H
 #define LOGIC_VEC_H
 
+#include <utility>
 #include <vector>
 #include <ostream>
 
@@ -16,7 +17,7 @@ class LogicVec {
              vtr::LogicValue init_value) //Default value
         : values_(size_val, init_value) {}
     LogicVec(std::vector<vtr::LogicValue> values)
-        : values_(values) {}
+        : values_(std::move(values)) {}
 
     ///@brief Array indexing operator
     const vtr::LogicValue& operator[](size_t i) const { return values_[i]; }

--- a/vpr/src/base/netlist.h
+++ b/vpr/src/base/netlist.h
@@ -786,7 +786,7 @@ class Netlist {
      *   @param blk_id   : The block to be renamed
      *   @param new_name : The new name for the specified block
      */
-    void set_block_name(const BlockId blk_id, const std::string new_name);
+    void set_block_name(const BlockId blk_id, const std::string& new_name);
 
     /**
      * @brief Set a block attribute

--- a/vpr/src/base/netlist.tpp
+++ b/vpr/src/base/netlist.tpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <numeric>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"
@@ -37,8 +38,8 @@ NetId NetlistIdRemapper<BlockId, PortId, PinId, NetId>::new_net_id(NetId old_id)
 
 template<typename BlockId, typename PortId, typename PinId, typename NetId>
 Netlist<BlockId, PortId, PinId, NetId>::Netlist(std::string name, std::string id)
-    : netlist_name_(name)
-    , netlist_id_(id) {}
+    : netlist_name_(std::move(name))
+    , netlist_id_(std::move(id)) {}
 
 template<typename BlockId, typename PortId, typename PinId, typename NetId>
 Netlist<BlockId, PortId, PinId, NetId>::~Netlist() = default;
@@ -622,7 +623,7 @@ bool Netlist<BlockId, PortId, PinId, NetId>::verify_lookups() const {
  *
  */
 template<typename BlockId, typename PortId, typename PinId, typename NetId>
-BlockId Netlist<BlockId, PortId, PinId, NetId>::create_block(const std::string name) {
+BlockId Netlist<BlockId, PortId, PinId, NetId>::create_block(const std::string& name) {
     //Must have a non-empty name
     VTR_ASSERT_MSG(!name.empty(), "Non-Empty block name");
 
@@ -665,7 +666,7 @@ BlockId Netlist<BlockId, PortId, PinId, NetId>::create_block(const std::string n
 }
 
 template<typename BlockId, typename PortId, typename PinId, typename NetId>
-PortId Netlist<BlockId, PortId, PinId, NetId>::create_port(const BlockId blk_id, const std::string name, BitIndex width, PortType type) {
+PortId Netlist<BlockId, PortId, PinId, NetId>::create_port(const BlockId blk_id, const std::string& name, BitIndex width, PortType type) {
     //Check pre-conditions
     VTR_ASSERT_MSG(valid_block_id(blk_id), "Valid block id");
 
@@ -1966,7 +1967,7 @@ typename Netlist<BlockId, PortId, PinId, NetId>::StringId Netlist<BlockId, PortI
         string_ids_.push_back(str_id);
 
         //Store the reverse look-up
-        auto key = str;
+        const auto& key = str;
         string_to_string_id_[key] = str_id;
 
         //Initialize the data

--- a/vpr/src/base/netlist_writer.h
+++ b/vpr/src/base/netlist_writer.h
@@ -15,6 +15,6 @@
  * All written filenames end in {basename}_post_synthesis.{fmt} where {basename} is the
  * basename argument and {fmt} is the file format (e.g. v, blif, sdf)
  */
-void netlist_writer(const std::string basename, std::shared_ptr<const AnalysisDelayCalculator> delay_calc);
+void netlist_writer(const std::string& basename, std::shared_ptr<const AnalysisDelayCalculator> delay_calc);
 
 #endif

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -59,8 +59,8 @@ int binary_search_place_and_route(const t_placer_opts& placer_opts_ref,
                                   t_det_routing_arch* det_routing_arch,
                                   std::vector<t_segment_inf>& segment_inf,
                                   ClbNetPinsMatrix<float>& net_delay,
-                                  std::shared_ptr<SetupHoldTimingInfo> timing_info,
-                                  std::shared_ptr<RoutingDelayCalculator> delay_calc) {
+                                  const std::shared_ptr<SetupHoldTimingInfo>& timing_info,
+                                  const std::shared_ptr<RoutingDelayCalculator>& delay_calc) {
     vtr::vector<ClusterNetId, t_trace*> best_routing; /* Saves the best routing found so far. */
     int current, low, high, final;
     bool success, prev_success, prev2_success, Fc_clipped = false;
@@ -470,7 +470,7 @@ static float comp_width(t_chan* chan, float x, float separation) {
         case GAUSSIAN:
             val = (x - chan->xpeak) * (x - chan->xpeak)
                   / (2 * chan->width * chan->width);
-            val = chan->peak * exp(-val);
+            val = chan->peak * std::exp(-val);
             val += chan->dc;
             break;
 

--- a/vpr/src/base/place_and_route.h
+++ b/vpr/src/base/place_and_route.h
@@ -32,8 +32,8 @@ int binary_search_place_and_route(const t_placer_opts& placer_opts_ref,
                                   t_det_routing_arch* det_routing_arch,
                                   std::vector<t_segment_inf>& segment_inf,
                                   ClbNetPinsMatrix<float>& net_delay,
-                                  std::shared_ptr<SetupHoldTimingInfo> timing_info,
-                                  std::shared_ptr<RoutingDelayCalculator> delay_calc);
+                                  const std::shared_ptr<SetupHoldTimingInfo>& timing_info,
+                                  const std::shared_ptr<RoutingDelayCalculator>& delay_calc);
 
 t_chan_width init_chan(int cfactor, t_chan_width_dist chan_width_dist);
 

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -43,7 +43,7 @@ vtr::LogicValue to_vtr_logic_value(blifparse::LogicValue);
 
 struct BlifAllocCallback : public blifparse::Callback {
   public:
-    BlifAllocCallback(e_circuit_format blif_format, AtomNetlist& main_netlist, const std::string netlist_id, const t_model* user_models, const t_model* library_models)
+    BlifAllocCallback(e_circuit_format blif_format, AtomNetlist& main_netlist, const std::string& netlist_id, const t_model* user_models, const t_model* library_models)
         : main_netlist_(main_netlist)
         , netlist_id_(netlist_id)
         , user_arch_models_(user_models)
@@ -436,7 +436,7 @@ struct BlifAllocCallback : public blifparse::Callback {
     }
 
   private:
-    const t_model* find_model(std::string name) {
+    const t_model* find_model(const std::string& name) {
         const t_model* arch_model = nullptr;
         for (const t_model* arch_models : {user_arch_models_, library_arch_models_}) {
             arch_model = arch_models;
@@ -459,7 +459,7 @@ struct BlifAllocCallback : public blifparse::Callback {
         return arch_model;
     }
 
-    const t_model_ports* find_model_port(const t_model* blk_model, std::string port_name) {
+    const t_model_ports* find_model_port(const t_model* blk_model, const std::string& port_name) {
         //We need to handle both single, and multi-bit port names
         //
         //By convention multi-bit port names have the bit index stored in square brackets
@@ -575,7 +575,7 @@ struct BlifAllocCallback : public blifparse::Callback {
             } else {
                 VTR_ASSERT(blif_model.block_type(blk_id) == AtomBlockType::OUTPAD);
 
-                auto raw_output_name = blif_model.block_name(blk_id);
+                const auto& raw_output_name = blif_model.block_name(blk_id);
 
                 std::string output_name = vtr::replace_first(raw_output_name, OUTPAD_NAME_PREFIX, "");
 

--- a/vpr/src/base/read_circuit.cpp
+++ b/vpr/src/base/read_circuit.cpp
@@ -177,22 +177,22 @@ static void show_circuit_stats(const AtomNetlist& netlist) {
 
     //Determine the maximum length of a type name for nice formatting
     size_t max_block_type_len = 0;
-    for (auto kv : block_type_counts) {
+    for (const auto& kv : block_type_counts) {
         max_block_type_len = std::max(max_block_type_len, kv.first.size());
     }
     size_t max_net_type_len = 0;
-    for (auto kv : net_stats) {
+    for (const auto& kv : net_stats) {
         max_net_type_len = std::max(max_net_type_len, kv.first.size());
     }
 
     //Print the statistics
     VTR_LOG("Circuit Statistics:\n");
     VTR_LOG("  Blocks: %zu\n", netlist.blocks().size());
-    for (auto kv : block_type_counts) {
+    for (const auto& kv : block_type_counts) {
         VTR_LOG("    %-*s: %7zu\n", max_block_type_len, kv.first.c_str(), kv.second);
     }
     VTR_LOG("  Nets  : %zu\n", netlist.nets().size());
-    for (auto kv : net_stats) {
+    for (const auto& kv : net_stats) {
         VTR_LOG("    %-*s: %7.1f\n", max_net_type_len, kv.first.c_str(), kv.second);
     }
     VTR_LOG("  Netlist Clocks: %zu\n", find_netlist_logical_clock_drivers(netlist).size());

--- a/vpr/src/base/read_netlist.cpp
+++ b/vpr/src/base/read_netlist.cpp
@@ -692,7 +692,7 @@ static void processPorts(pugi::xml_node Parent, t_pb* pb, t_pb_routes& pb_route,
 
                     if (strcmp(pins[i].c_str(), "open") != 0) {
                         //For connected pins look-up the inter-block net index associated with it
-                        AtomNetId net_id = atom_ctx.nlist.find_net(pins[i].c_str());
+                        AtomNetId net_id = atom_ctx.nlist.find_net(pins[i]);
                         if (!net_id) {
                             VPR_FATAL_ERROR(VPR_ERROR_NET_F,
                                             ".blif and .net do not match, unknown net %s found in .net file.\n.",
@@ -772,7 +772,7 @@ static void processPorts(pugi::xml_node Parent, t_pb* pb, t_pb_routes& pb_route,
                     const t_pb_graph_pin* pb_gpin = &pb->pb_graph_node->output_pins[out_port][i];
                     int rr_node_index = pb_gpin->pin_count_in_cluster;
                     if (strcmp(pins[i].c_str(), "open") != 0) {
-                        AtomNetId net_id = atom_ctx.nlist.find_net(pins[i].c_str());
+                        AtomNetId net_id = atom_ctx.nlist.find_net(pins[i]);
                         if (!net_id) {
                             VPR_FATAL_ERROR(VPR_ERROR_NET_F,
                                             ".blif and .net do not match, unknown net %s found in .net file.\n",

--- a/vpr/src/base/read_netlist.cpp
+++ b/vpr/src/base/read_netlist.cpp
@@ -349,7 +349,7 @@ void processAttrsParams(pugi::xml_node Parent, const char* child_name, T& atom_n
             std::string cval = Cur.text().get();
             bool found = false;
             // Look for corresponding key-value in range from AtomNetlist
-            for (auto bitem : atom_net_range) {
+            for (const auto& bitem : atom_net_range) {
                 if (bitem.first == cname) {
                     if (bitem.second != cval) {
                         // Found in AtomNetlist range, but values don't match
@@ -369,7 +369,7 @@ void processAttrsParams(pugi::xml_node Parent, const char* child_name, T& atom_n
         }
     }
     // Check for attrs/params in AtomNetlist but not in .net file
-    for (auto bitem : atom_net_range) {
+    for (const auto& bitem : atom_net_range) {
         if (kvs.find(bitem.first) == kvs.end())
             vpr_throw(VPR_ERROR_NET_F, netlist_file_name, loc_data.line(Parent),
                       ".net file and .blif file do not match, %s %s missing in .net file.\n",

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1,4 +1,6 @@
 #include "read_options.h"
+
+#include <utility>
 #include "constant_nets.h"
 #include "clock_modeling.h"
 #include "vpr_error.h"
@@ -29,7 +31,7 @@ t_options read_options(int argc, const char** argv) {
 }
 
 struct ParseOnOff {
-    ConvertedValue<bool> from_str(std::string str) {
+    ConvertedValue<bool> from_str(const std::string& str) {
         ConvertedValue<bool> conv_value;
         if (str == "on")
             conv_value.set_value(true);
@@ -61,7 +63,7 @@ struct ParseOnOff {
 };
 
 struct ParseCircuitFormat {
-    ConvertedValue<e_circuit_format> from_str(std::string str) {
+    ConvertedValue<e_circuit_format> from_str(const std::string& str) {
         ConvertedValue<e_circuit_format> conv_value;
         if (str == "auto")
             conv_value.set_value(e_circuit_format::AUTO);
@@ -97,7 +99,7 @@ struct ParseCircuitFormat {
     }
 };
 struct ParseRoutePredictor {
-    ConvertedValue<e_routing_failure_predictor> from_str(std::string str) {
+    ConvertedValue<e_routing_failure_predictor> from_str(const std::string& str) {
         ConvertedValue<e_routing_failure_predictor> conv_value;
         if (str == "safe")
             conv_value.set_value(SAFE);
@@ -133,7 +135,7 @@ struct ParseRoutePredictor {
 };
 
 struct ParseRouterAlgorithm {
-    ConvertedValue<e_router_algorithm> from_str(std::string str) {
+    ConvertedValue<e_router_algorithm> from_str(const std::string& str) {
         ConvertedValue<e_router_algorithm> conv_value;
         if (str == "breadth_first")
             conv_value.set_value(BREADTH_FIRST);
@@ -199,7 +201,7 @@ struct ParseNodeReorderAlgorithm {
 };
 
 struct RouteBudgetsAlgorithm {
-    ConvertedValue<e_routing_budgets_algorithm> from_str(std::string str) {
+    ConvertedValue<e_routing_budgets_algorithm> from_str(const std::string& str) {
         ConvertedValue<e_routing_budgets_algorithm> conv_value;
         if (str == "minimax")
             conv_value.set_value(MINIMAX);
@@ -239,7 +241,7 @@ struct RouteBudgetsAlgorithm {
 };
 
 struct ParseRouteType {
-    ConvertedValue<e_route_type> from_str(std::string str) {
+    ConvertedValue<e_route_type> from_str(const std::string& str) {
         ConvertedValue<e_route_type> conv_value;
         if (str == "global")
             conv_value.set_value(GLOBAL);
@@ -270,7 +272,7 @@ struct ParseRouteType {
 };
 
 struct ParseBaseCost {
-    ConvertedValue<e_base_cost_type> from_str(std::string str) {
+    ConvertedValue<e_base_cost_type> from_str(const std::string& str) {
         ConvertedValue<e_base_cost_type> conv_value;
         if (str == "delay_normalized")
             conv_value.set_value(DELAY_NORMALIZED);
@@ -352,7 +354,7 @@ struct ParsePlaceDeltaDelayAlgorithm {
 };
 
 struct ParsePlaceAlgorithm {
-    ConvertedValue<e_place_algorithm> from_str(std::string str) {
+    ConvertedValue<e_place_algorithm> from_str(const std::string& str) {
         ConvertedValue<e_place_algorithm> conv_value;
         if (str == "bounding_box") {
             conv_value.set_value(BOUNDING_BOX_PLACE);
@@ -456,7 +458,7 @@ struct ParseFixPins {
 };
 
 struct ParseClusterSeed {
-    ConvertedValue<e_cluster_seed> from_str(std::string str) {
+    ConvertedValue<e_cluster_seed> from_str(const std::string& str) {
         ConvertedValue<e_cluster_seed> conv_value;
         if (str == "timing")
             conv_value.set_value(e_cluster_seed::TIMING);
@@ -503,7 +505,7 @@ struct ParseClusterSeed {
 };
 
 struct ParseConstantNetMethod {
-    ConvertedValue<e_constant_net_method> from_str(std::string str) {
+    ConvertedValue<e_constant_net_method> from_str(const std::string& str) {
         ConvertedValue<e_constant_net_method> conv_value;
         if (str == "global")
             conv_value.set_value(CONSTANT_NET_GLOBAL);
@@ -534,7 +536,7 @@ struct ParseConstantNetMethod {
 };
 
 struct ParseTimingReportDetail {
-    ConvertedValue<e_timing_report_detail> from_str(std::string str) {
+    ConvertedValue<e_timing_report_detail> from_str(const std::string& str) {
         ConvertedValue<e_timing_report_detail> conv_value;
         if (str == "netlist")
             conv_value.set_value(e_timing_report_detail::NETLIST);
@@ -574,7 +576,7 @@ struct ParseTimingReportDetail {
 };
 
 struct ParseClockModeling {
-    ConvertedValue<e_clock_modeling> from_str(std::string str) {
+    ConvertedValue<e_clock_modeling> from_str(const std::string& str) {
         ConvertedValue<e_clock_modeling> conv_value;
         if (str == "ideal")
             conv_value.set_value(IDEAL_CLOCK);
@@ -612,7 +614,7 @@ struct ParseClockModeling {
 };
 
 struct ParseUnrelatedClustering {
-    ConvertedValue<e_unrelated_clustering> from_str(std::string str) {
+    ConvertedValue<e_unrelated_clustering> from_str(const std::string& str) {
         ConvertedValue<e_unrelated_clustering> conv_value;
         if (str == "on")
             conv_value.set_value(e_unrelated_clustering::ON);
@@ -650,7 +652,7 @@ struct ParseUnrelatedClustering {
 };
 
 struct ParseBalanceBlockTypeUtil {
-    ConvertedValue<e_balance_block_type_util> from_str(std::string str) {
+    ConvertedValue<e_balance_block_type_util> from_str(const std::string& str) {
         ConvertedValue<e_balance_block_type_util> conv_value;
         if (str == "on")
             conv_value.set_value(e_balance_block_type_util::ON);
@@ -688,7 +690,7 @@ struct ParseBalanceBlockTypeUtil {
 };
 
 struct ParseConstGenInference {
-    ConvertedValue<e_const_gen_inference> from_str(std::string str) {
+    ConvertedValue<e_const_gen_inference> from_str(const std::string& str) {
         ConvertedValue<e_const_gen_inference> conv_value;
         if (str == "none")
             conv_value.set_value(e_const_gen_inference::NONE);
@@ -726,7 +728,7 @@ struct ParseConstGenInference {
 };
 
 struct ParseIncrRerouteDelayRipup {
-    ConvertedValue<e_incr_reroute_delay_ripup> from_str(std::string str) {
+    ConvertedValue<e_incr_reroute_delay_ripup> from_str(const std::string& str) {
         ConvertedValue<e_incr_reroute_delay_ripup> conv_value;
         if (str == "on")
             conv_value.set_value(e_incr_reroute_delay_ripup::ON);
@@ -764,7 +766,7 @@ struct ParseIncrRerouteDelayRipup {
 };
 
 struct ParseRouteBBUpdate {
-    ConvertedValue<e_route_bb_update> from_str(std::string str) {
+    ConvertedValue<e_route_bb_update> from_str(const std::string& str) {
         ConvertedValue<e_route_bb_update> conv_value;
         if (str == "static")
             conv_value.set_value(e_route_bb_update::STATIC);
@@ -798,7 +800,7 @@ struct ParseRouteBBUpdate {
 };
 
 struct ParseRouterLookahead {
-    ConvertedValue<e_router_lookahead> from_str(std::string str) {
+    ConvertedValue<e_router_lookahead> from_str(const std::string& str) {
         ConvertedValue<e_router_lookahead> conv_value;
         if (str == "classic")
             conv_value.set_value(e_router_lookahead::CLASSIC);
@@ -836,7 +838,7 @@ struct ParseRouterLookahead {
 };
 
 struct ParsePlaceDelayModel {
-    ConvertedValue<PlaceDelayModelType> from_str(std::string str) {
+    ConvertedValue<PlaceDelayModelType> from_str(const std::string& str) {
         ConvertedValue<PlaceDelayModelType> conv_value;
         if (str == "delta")
             conv_value.set_value(PlaceDelayModelType::DELTA);
@@ -870,7 +872,7 @@ struct ParsePlaceDelayModel {
 };
 
 struct ParseReducer {
-    ConvertedValue<e_reducer> from_str(std::string str) {
+    ConvertedValue<e_reducer> from_str(const std::string& str) {
         ConvertedValue<e_reducer> conv_value;
         if (str == "min")
             conv_value.set_value(e_reducer::MIN);
@@ -1082,7 +1084,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         "\n"
         "Attempts to find the minimum routable channel width, unless a fixed"
         " channel width is specified with --route_chan_width.";
-    auto parser = argparse::ArgumentParser(prog_name, description);
+    auto parser = argparse::ArgumentParser(std::move(prog_name), description);
 
     std::string epilog = vtr::replace_all(
         "Usage Examples\n"

--- a/vpr/src/base/read_place.cpp
+++ b/vpr/src/base/read_place.cpp
@@ -119,7 +119,7 @@ void read_place_header(std::ifstream& placement_file,
             std::string place_netlist_id = tokens[3];
             std::string place_netlist_file = tokens[1];
 
-            if (place_netlist_id != cluster_ctx.clb_nlist.netlist_id().c_str()) {
+            if (place_netlist_id != cluster_ctx.clb_nlist.netlist_id()) {
                 auto msg = vtr::string_fmt(
                     "The packed netlist file that generated placement (File: '%s' ID: '%s')"
                     " does not match current netlist (File: '%s' ID: '%s')",

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -52,7 +52,7 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
 static void process_nets(std::ifstream& fp, ClusterNetId inet, std::string name, std::vector<std::string> input_tokens, const char* filename, int& lineno);
 static void process_global_blocks(std::ifstream& fp, ClusterNetId inet, const char* filename, int& lineno);
 static void format_coordinates(int& x, int& y, std::string coord, ClusterNetId net, const char* filename, const int lineno);
-static void format_pin_info(std::string& pb_name, std::string& port_name, int& pb_pin_num, std::string input);
+static void format_pin_info(std::string& pb_name, std::string& port_name, int& pb_pin_num, const std::string& input);
 static std::string format_name(std::string name);
 static bool check_rr_graph_connectivity(RRNodeId prev_node, RRNodeId node);
 
@@ -248,7 +248,7 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
         } else if (tokens[0] == "Node:") {
             /*An actual line, go through each node and add it to the route tree*/
             inode = atoi(tokens[1].c_str());
-            auto node = device_ctx.rr_nodes[inode];
+            auto& node = device_ctx.rr_nodes[inode];
 
             /*First node needs to be source. It is isolated to correctly set heap head.*/
             if (node_count == 0 && tokens[2] != "SOURCE") {
@@ -467,7 +467,7 @@ static void format_coordinates(int& x, int& y, std::string coord, ClusterNetId n
  * @brief Parse the pin info in the form of pb_name.port_name[pb_pin_num]
  *        into its appropriate variables
  */
-static void format_pin_info(std::string& pb_name, std::string& port_name, int& pb_pin_num, std::string input) {
+static void format_pin_info(std::string& pb_name, std::string& port_name, int& pb_pin_num, const std::string& input) {
     std::stringstream pb_info(input);
     std::getline(pb_info, pb_name, '.');
     std::getline(pb_info, port_name, '[');

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -107,7 +107,7 @@ bool read_route(const char* route_file, const t_router_opts& router_opts, bool v
     ++lineno;
     header.clear();
     header = vtr::split(header_str);
-    if (header[0] == "Array" && header[1] == "size:" && (vtr::atou(header[2].c_str()) != device_ctx.grid.width() || vtr::atou(header[4].c_str()) != device_ctx.grid.height())) {
+    if (header[0] == "Array" && header[1] == "size:" && (vtr::atou(header[2]) != device_ctx.grid.width() || vtr::atou(header[4]) != device_ctx.grid.height())) {
         vpr_throw(VPR_ERROR_ROUTE, route_file, lineno,
                   "Device dimensions %sx%s specified in the routing file does not match given %dx%d ",
                   header[2].c_str(), header[4].c_str(), device_ctx.grid.width(), device_ctx.grid.height());

--- a/vpr/src/base/setup_clocks.cpp
+++ b/vpr/src/base/setup_clocks.cpp
@@ -16,9 +16,9 @@ using vtr::FormulaParser;
 using vtr::t_formula_data;
 
 static MetalLayer get_metal_layer_from_name(
-    std::string metal_layer_name,
+    const std::string& metal_layer_name,
     std::unordered_map<std::string, t_metal_layer> clock_metal_layers,
-    std::string clock_network_name);
+    const std::string& clock_network_name);
 static void setup_clock_network_wires(const t_arch& Arch, FormulaParser& p, std::vector<t_segment_inf>& segment_inf);
 static void setup_clock_connections(const t_arch& Arch, FormulaParser& p);
 
@@ -45,7 +45,7 @@ void setup_clock_network_wires(const t_arch& Arch, FormulaParser& p, std::vector
     vars.set_var_value("W", grid.width());
     vars.set_var_value("H", grid.height());
 
-    for (auto clock_network_arch : clock_networks_arch) {
+    for (const auto& clock_network_arch : clock_networks_arch) {
         switch (clock_network_arch.type) {
             case e_clock_type::SPINE: {
                 std::unique_ptr<ClockSpine> spine = std::make_unique<ClockSpine>();
@@ -130,7 +130,7 @@ void setup_clock_connections(const t_arch& Arch, FormulaParser& p) {
     vars.set_var_value("W", grid.width());
     vars.set_var_value("H", grid.height());
 
-    for (auto clock_connection_arch : clock_connections_arch) {
+    for (const auto& clock_connection_arch : clock_connections_arch) {
         if (clock_connection_arch.from == "ROUTING") {
             clock_connections_device.emplace_back(new RoutingToClockConnection);
             if (RoutingToClockConnection* routing_to_clock = dynamic_cast<RoutingToClockConnection*>(clock_connections_device.back().get())) {
@@ -182,9 +182,9 @@ void setup_clock_connections(const t_arch& Arch, FormulaParser& p) {
 }
 
 MetalLayer get_metal_layer_from_name(
-    std::string metal_layer_name,
+    const std::string& metal_layer_name,
     std::unordered_map<std::string, t_metal_layer> clock_metal_layers,
-    std::string clock_network_name) {
+    const std::string& clock_network_name) {
     auto itter = clock_metal_layers.find(metal_layer_name);
 
     if (itter == clock_metal_layers.end()) {

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cmath>
 #include <sstream>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_math.h"
@@ -248,7 +249,7 @@ void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_a
      * Initialize the functions names for which VPR_ERRORs
      * are demoted to VTR_LOG_WARNs
      */
-    for (std::string func_name : vtr::split(options->disable_errors, std::string(":"))) {
+    for (const std::string& func_name : vtr::split(options->disable_errors, std::string(":"))) {
         map_error_activation_status(func_name);
     }
 
@@ -269,7 +270,7 @@ void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_a
     }
 
     set_noisy_warn_log_file(warn_log_file);
-    for (std::string func_name : vtr::split(warn_functions, std::string(":"))) {
+    for (const std::string& func_name : vtr::split(warn_functions, std::string(":"))) {
         add_warnings_to_suppress(func_name);
     }
 
@@ -817,8 +818,8 @@ RouteStatus vpr_route_fixed_W(t_vpr_setup& vpr_setup,
                             &vpr_setup.RoutingArch,
                             vpr_setup.Segments,
                             net_delay,
-                            timing_info,
-                            delay_calc,
+                            std::move(timing_info),
+                            std::move(delay_calc),
                             arch.Chans,
                             arch.Directs, arch.num_directs,
                             ScreenUpdatePriority::MAJOR);
@@ -848,8 +849,8 @@ RouteStatus vpr_route_min_W(t_vpr_setup& vpr_setup,
                                               &vpr_setup.RoutingArch,
                                               vpr_setup.Segments,
                                               net_delay,
-                                              timing_info,
-                                              delay_calc);
+                                              std::move(timing_info),
+                                              std::move(delay_calc));
 
     bool status = (min_W > 0);
     return RouteStatus(status, min_W);
@@ -858,8 +859,8 @@ RouteStatus vpr_route_min_W(t_vpr_setup& vpr_setup,
 RouteStatus vpr_load_routing(t_vpr_setup& vpr_setup,
                              const t_arch& /*arch*/,
                              int fixed_channel_width,
-                             std::shared_ptr<SetupHoldTimingInfo> timing_info,
-                             ClbNetPinsMatrix<float>& net_delay) {
+                             const std::shared_ptr<SetupHoldTimingInfo>& timing_info,
+                             vtr::vector<ClusterNetId, float*>& net_delay) {
     vtr::ScopedStartFinishTimer timer("Load Routing");
     if (NO_FIXED_CHANNEL_WIDTH == fixed_channel_width) {
         VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Fixed channel width must be specified when loading routing (was %d)", fixed_channel_width);

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1280,7 +1280,7 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
 
         //Write the post-syntesis netlist
         if (vpr_setup.AnalysisOpts.gen_post_synthesis_netlist) {
-            netlist_writer(atom_ctx.nlist.netlist_name().c_str(), analysis_delay_calc);
+            netlist_writer(atom_ctx.nlist.netlist_name(), analysis_delay_calc);
         }
 
         //Do power analysis

--- a/vpr/src/base/vpr_types.cpp
+++ b/vpr/src/base/vpr_types.cpp
@@ -6,7 +6,7 @@ t_ext_pin_util_targets::t_ext_pin_util_targets(float default_in_util, float defa
     defaults_.output_pin_util = default_out_util;
 }
 
-t_ext_pin_util t_ext_pin_util_targets::get_pin_util(std::string block_type_name) const {
+t_ext_pin_util t_ext_pin_util_targets::get_pin_util(const std::string& block_type_name) const {
     auto itr = overrides_.find(block_type_name);
     if (itr != overrides_.end()) {
         return itr->second;
@@ -14,7 +14,7 @@ t_ext_pin_util t_ext_pin_util_targets::get_pin_util(std::string block_type_name)
     return defaults_;
 }
 
-void t_ext_pin_util_targets::set_block_pin_util(std::string block_type_name, t_ext_pin_util target) {
+void t_ext_pin_util_targets::set_block_pin_util(const std::string& block_type_name, t_ext_pin_util target) {
     overrides_[block_type_name] = target;
 }
 
@@ -29,11 +29,11 @@ void t_pack_high_fanout_thresholds::set_default(int threshold) {
     default_ = threshold;
 }
 
-void t_pack_high_fanout_thresholds::set(std::string block_type_name, int threshold) {
+void t_pack_high_fanout_thresholds::set(const std::string& block_type_name, int threshold) {
     overrides_[block_type_name] = threshold;
 }
 
-int t_pack_high_fanout_thresholds::get_threshold(std::string block_type_name) const {
+int t_pack_high_fanout_thresholds::get_threshold(const std::string& block_type_name) const {
     auto itr = overrides_.find(block_type_name);
     if (itr != overrides_.end()) {
         return itr->second;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -631,7 +631,7 @@ struct t_pl_loc {
     t_pl_loc(int xloc, int yloc, int sub_tile_loc)
         : x(xloc)
         , y(yloc)
-        , sub_tile(sub_tile_loc) {}
+        , z(zloc) {}
 
     int x = OPEN;
     int y = OPEN;

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -434,7 +434,7 @@ static void initial_setup_NO_PICTURE_to_ROUTING_with_crit_path(ezgl::application
 }
 #endif //NO_GRAPHICS
 
-void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type pic_on_screen_val, std::shared_ptr<SetupTimingInfo> setup_timing_info) {
+void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type pic_on_screen_val, const std::shared_ptr<SetupTimingInfo>& setup_timing_info) {
 #ifndef NO_GRAPHICS
 
     /* Updates the screen if the user has requested graphics.  The priority  *

--- a/vpr/src/draw/draw.h
+++ b/vpr/src/draw/draw.h
@@ -20,7 +20,7 @@ extern ezgl::application application;
 
 #endif /* NO_GRAPHICS */
 
-void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type pic_on_screen_val, std::shared_ptr<SetupTimingInfo> timing_info);
+void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type pic_on_screen_val, const std::shared_ptr<SetupTimingInfo>& timing_info);
 //Initializes the drawing locations.
 //FIXME: Currently broken if no rr-graph is loaded
 void init_draw_coords(float clb_width);

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -40,6 +40,7 @@
 #include <map>
 #include <algorithm>
 #include <fstream>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"
@@ -339,7 +340,7 @@ static std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_
                                                       const t_molecule_stats& max_molecule_stats,
                                                       const vtr::vector<AtomBlockId, float>& atom_criticality);
 
-static t_pack_molecule* get_highest_gain_seed_molecule(int* seedindex, const std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules, const std::vector<AtomBlockId> seed_atoms);
+static t_pack_molecule* get_highest_gain_seed_molecule(int* seedindex, const std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules, const std::vector<AtomBlockId>& seed_atoms);
 
 static float get_molecule_gain(t_pack_molecule* molecule, std::map<AtomBlockId, float>& blk_gain);
 static int compare_molecule_gain(const void* a, const void* b);
@@ -373,7 +374,7 @@ static t_logical_block_type_ptr identify_logic_block_type(std::map<const t_model
 
 static t_pb_type* identify_le_block_type(t_logical_block_type_ptr logic_block_type);
 
-static bool pb_used_for_blif_model(const t_pb* pb, std::string blif_model_name);
+static bool pb_used_for_blif_model(const t_pb* pb, const std::string& blif_model_name);
 
 static void print_le_count(std::vector<int>& le_count, const t_pb_type* le_pb_type);
 
@@ -573,11 +574,6 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
             ClusterBlockId clb_index(num_clb);
 
             VTR_LOGV(verbosity > 2, "Complex block %d:\n", num_clb);
-
-            /*Used to store cluster's PartitionRegion as primitives are added to it.
-             * Since some of the primitives might fail legality, this structure temporarily
-             * stores PartitionRegion information while the cluster is packed*/
-            PartitionRegion temp_cluster_pr;
 
             start_new_cluster(cluster_placement_stats, primitives_list,
                               atom_molecules, clb_index, istart,
@@ -2359,7 +2355,7 @@ static void start_new_cluster(t_cluster_placement_stats* cluster_placement_stats
     }
 
     if (num_used_type_instances[block_type] > num_instances) {
-        device_ctx.grid = create_device_grid(device_layout_name, arch->grid_layouts, num_used_type_instances, target_device_utilization);
+        device_ctx.grid = create_device_grid(std::move(device_layout_name), arch->grid_layouts, num_used_type_instances, target_device_utilization);
     }
 }
 
@@ -3044,7 +3040,7 @@ static std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_
     return seed_atoms;
 }
 
-static t_pack_molecule* get_highest_gain_seed_molecule(int* seedindex, const std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules, const std::vector<AtomBlockId> seed_atoms) {
+static t_pack_molecule* get_highest_gain_seed_molecule(int* seedindex, const std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules, const std::vector<AtomBlockId>& seed_atoms) {
     auto& atom_ctx = g_vpr_ctx.atom();
 
     while (*seedindex < static_cast<int>(seed_atoms.size())) {
@@ -3859,7 +3855,7 @@ static void update_le_count(const t_pb* pb, const t_logical_block_type_ptr logic
  * This function returns true if the given physical block has
  * a primitive matching the given blif model and is used
  */
-static bool pb_used_for_blif_model(const t_pb* pb, std::string blif_model_name) {
+static bool pb_used_for_blif_model(const t_pb* pb, const std::string& blif_model_name) {
     auto pb_graph_node = pb->pb_graph_node;
     auto pb_type = pb_graph_node->pb_type;
     auto mode = &pb_type->modes[pb->mode];

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <stdlib.h>
 #include <sstream>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"
@@ -264,7 +265,7 @@ static bool try_size_device_grid(const t_arch& arch, const std::map<t_logical_bl
     auto& device_ctx = g_vpr_ctx.mutable_device();
 
     //Build the device
-    auto grid = create_device_grid(device_layout_name, arch.grid_layouts, num_type_instances, target_device_utilization);
+    auto grid = create_device_grid(std::move(device_layout_name), arch.grid_layouts, num_type_instances, target_device_utilization);
 
     /*
      *Report on the device
@@ -351,7 +352,7 @@ static t_ext_pin_util_targets parse_target_external_pin_util(std::vector<std::st
         bool default_set = false;
         std::set<std::string> seen_block_types;
 
-        for (auto spec : specs) {
+        for (const auto& spec : specs) {
             t_ext_pin_util target_ext_pin_util(1., 1.);
 
             auto block_values = vtr::split(spec, ":");
@@ -467,7 +468,7 @@ static t_pack_high_fanout_thresholds parse_high_fanout_thresholds(std::vector<st
         bool default_set = false;
         std::set<std::string> seen_block_types;
 
-        for (auto spec : specs) {
+        for (const auto& spec : specs) {
             auto block_values = vtr::split(spec, ":");
             std::string block_type;
             std::string value;

--- a/vpr/src/pack/pack_report.cpp
+++ b/vpr/src/pack/pack_report.cpp
@@ -66,7 +66,7 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
         if (total_input_pins[type] != 0) {
             os << "\t\tHistogram:\n";
             auto input_histogram = build_histogram(inputs_used[type], 10, 0, total_input_pins[type]);
-            for (auto line : format_histogram(input_histogram)) {
+            for (const auto& line : format_histogram(input_histogram)) {
                 os << "\t\t" << line << "\n";
             }
         }
@@ -83,7 +83,7 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
             os << "\t\tHistogram:\n";
 
             auto output_histogram = build_histogram(outputs_used[type], 10, 0, total_output_pins[type]);
-            for (auto line : format_histogram(output_histogram)) {
+            for (const auto& line : format_histogram(output_histogram)) {
                 os << "\t\t" << line << "\n";
             }
         }

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -40,7 +40,7 @@ static void forward_infer_pattern(t_pb_graph_pin* pb_graph_pin);
 
 static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin);
 
-static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names);
+static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(const std::unordered_map<std::string, int>& pattern_names);
 
 static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
                                                        const t_pb_graph_node* pb_graph_node);
@@ -330,7 +330,7 @@ static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin) {
  * Allocates memory for models and loads the name of the packing pattern
  * so that it can be identified and loaded with more complete information later
  */
-static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names) {
+static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(const std::unordered_map<std::string, int>& pattern_names) {
     std::vector<t_pack_patterns> nlist(pattern_names.size());
 
     for (const auto& curr_pattern : pattern_names) {

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -172,7 +172,7 @@ static void initial_placement_pl_macros(int macros_max_num_tries, std::vector<st
     // Sorting blocks to place to have most constricted ones to be placed first
     std::vector<t_pl_macro> sorted_pl_macros(pl_macros.begin(), pl_macros.end());
 
-    auto criteria = [&cluster_ctx](const t_pl_macro lhs, t_pl_macro rhs) {
+    auto criteria = [&cluster_ctx](const t_pl_macro& lhs, t_pl_macro rhs) {
         auto lhs_logical_block = cluster_ctx.clb_nlist.block_type(lhs.members[0].blk_index);
         auto rhs_logical_block = cluster_ctx.clb_nlist.block_type(rhs.members[0].blk_index);
 

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -12,7 +12,7 @@ bool f_placer_breakpoint_reached = false;
 //Records counts of reasons for aborted moves
 static std::map<std::string, size_t> f_move_abort_reasons;
 
-void log_move_abort(std::string reason) {
+void log_move_abort(const std::string& reason) {
     ++f_move_abort_reasons[reason];
 }
 
@@ -22,7 +22,7 @@ void report_aborted_moves() {
     if (f_move_abort_reasons.empty()) {
         VTR_LOG("  No moves aborted\n");
     }
-    for (auto kv : f_move_abort_reasons) {
+    for (const auto& kv : f_move_abort_reasons) {
         VTR_LOG("  %s: %zu\n", kv.first.c_str(), kv.second);
     }
 }

--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -71,7 +71,7 @@ struct t_range_limiters {
 };
 
 //Records a reasons for an aborted move
-void log_move_abort(std::string reason);
+void log_move_abort(const std::string& reason);
 
 //Prints a breif report about aborted move reasons and counts
 void report_aborted_moves();

--- a/vpr/src/place/place_macro.cpp
+++ b/vpr/src/place/place_macro.cpp
@@ -45,7 +45,7 @@ static void find_all_the_macro(int* num_of_macro, std::vector<ClusterBlockId>& p
 
 static void alloc_and_load_imacro_from_iblk(const std::vector<t_pl_macro>& macros);
 
-static void write_place_macros(std::string filename, const std::vector<t_pl_macro>& macros);
+static void write_place_macros(const std::string& filename, const std::vector<t_pl_macro>& macros);
 
 static bool is_constant_clb_net(ClusterNetId clb_net);
 
@@ -432,7 +432,7 @@ void free_placement_macros_structs() {
     }
 }
 
-static void write_place_macros(std::string filename, const std::vector<t_pl_macro>& macros) {
+static void write_place_macros(const std::string& filename, const std::vector<t_pl_macro>& macros) {
     FILE* f = vtr::fopen(filename.c_str(), "w");
 
     auto& cluster_ctx = g_vpr_ctx.clustering();

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <time.h>
 #include <limits>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_ndmatrix.h"
@@ -51,7 +52,7 @@ constexpr float IMPOSSIBLE_DELTA = std::numeric_limits<float>::infinity(); //Ind
 struct t_profile_loc {
     t_profile_loc(int x, int y, std::vector<vtr::Point<int>> delta_values)
         : root(x, y)
-        , deltas(delta_values) {}
+        , deltas(std::move(delta_values)) {}
 
     vtr::Point<int> root;
     std::vector<vtr::Point<int>> deltas;

--- a/vpr/src/power/PowerSpicedComponent.cpp
+++ b/vpr/src/power/PowerSpicedComponent.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <algorithm>
 #include <string>
+#include <utility>
 
 #include "vtr_assert.h"
 
@@ -84,7 +85,7 @@ PowerCallibSize* PowerCallibInputs::get_entry_bound(bool lower,
 
 PowerSpicedComponent::PowerSpicedComponent(std::string component_name,
                                            float (*usage_fn)(int num_inputs, float transistor_size)) {
-    name = component_name;
+    name = std::move(component_name);
     component_usage = usage_fn;
 
     /* Always pad with a high and low entry */

--- a/vpr/src/power/power_sizing.cpp
+++ b/vpr/src/power/power_sizing.cpp
@@ -21,6 +21,7 @@
  */
 
 /************************* INCLUDES *********************************/
+#include <cmath>
 #include <cstring>
 #include <cmath>
 
@@ -144,7 +145,7 @@ static double power_count_transistors_mux(t_mux_arch* mux_arch) {
 
     for (lvl_idx = 0; lvl_idx < mux_arch->levels; lvl_idx++) {
         /* Assume there is decoder logic */
-        transistor_cnt += ceil(log(max_inputs[lvl_idx]) / log((double)2.0))
+        transistor_cnt += ceil(std::log(max_inputs[lvl_idx]) / log((double)2.0))
                           * power_count_transistor_SRAM_bit();
 
         /*
@@ -249,7 +250,7 @@ void power_sizing_init() {
     auto& power_ctx = g_vpr_ctx.power();
 
     // tech size = 2 lambda, so lambda^2/4.0 = tech^2
-    f_MTA_area = ((POWER_MTA_L * POWER_MTA_W) / 4.0) * pow(power_ctx.tech->tech_size, (float)2.0);
+    f_MTA_area = ((POWER_MTA_L * POWER_MTA_W) / 4.0) * std::pow(power_ctx.tech->tech_size, (float)2.0);
 
     // Determines physical size of different PBs
     power_size_pb();

--- a/vpr/src/power/power_util.cpp
+++ b/vpr/src/power/power_util.cpp
@@ -20,6 +20,7 @@
  */
 
 /************************* INCLUDES *********************************/
+#include <cmath>
 #include <cstring>
 #include <cmath>
 #include <map>
@@ -188,7 +189,7 @@ int power_calc_buffer_num_stages(float final_stage_size,
     } else if (final_stage_size < desired_stage_effort)
         N = 2;
     else {
-        N = (int)(log(final_stage_size) / log(desired_stage_effort) + 1);
+        N = (int)(std::log(final_stage_size) / std::log(desired_stage_effort) + 1);
 
         /* We always round down.
          * Perhaps N+1 would be closer to the desired stage effort, but the delay savings

--- a/vpr/src/route/build_switchblocks.cpp
+++ b/vpr/src/route/build_switchblocks.cpp
@@ -129,6 +129,7 @@
 #include <algorithm>
 #include <iterator>
 #include <iostream>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_memory.h"
@@ -437,7 +438,7 @@ static int get_max_lcm(vector<t_switchblock_inf>* switchblocks, const t_wire_typ
 
 /* computes a horizontal row of switchblocks of size sb_row_size (or of grid.width()-4, whichever is smaller), starting
  * at coordinate (1,1) */
-static void compute_switchblock_row(int sb_row_size, t_chan_details* chan_details_x, t_chan_details* chan_details_y, vector<t_switchblock_inf>* switchblocks, const DeviceGrid& grid, int nodes_per_chan, const t_wire_type_sizes* wire_type_sizes, e_directionality directionality, t_sb_connection_map* sb_row) {
+static void compute_switchblock_row(int sb_row_size, t_chan_details* chan_details_x, t_chan_details* chan_details_y, vector<t_switchblock_inf>* switchblocks, const DeviceGrid& grid, int nodes_per_chan, t_wire_type_sizes* wire_type_sizes, e_directionality directionality, t_sb_connection_map* sb_row) {
     int y = 1;
     for (int isb = 0; isb < (int)switchblocks->size(); isb++) {
         t_switchblock_inf* sb = &(switchblocks->at(isb));
@@ -981,7 +982,7 @@ static int evaluate_num_conns_formula(t_wireconn_scratchpad* scratchpad, std::st
     vars.set_var_value("from", from_wire_count);
     vars.set_var_value("to", to_wire_count);
 
-    return scratchpad->formula_parser.parse_formula(num_conns_formula, vars);
+    return scratchpad->formula_parser.parse_formula(std::move(num_conns_formula), vars);
 }
 
 /* Here we find the correct channel (x or y), and the coordinates to index into it based on the

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -9,6 +9,7 @@
 #include "vtr_error.h"
 
 #include <random>
+#include <utility>
 #include <math.h>
 
 /*
@@ -16,11 +17,11 @@
  */
 
 void RoutingToClockConnection::set_clock_name_to_connect_to(std::string clock_name) {
-    clock_to_connect_to = clock_name;
+    clock_to_connect_to = std::move(clock_name);
 }
 
 void RoutingToClockConnection::set_clock_switch_point_name(std::string clock_switch_point_name) {
-    switch_point_name = clock_switch_point_name;
+    switch_point_name = std::move(clock_switch_point_name);
 }
 
 void RoutingToClockConnection::set_switch_location(int x, int y) {
@@ -131,19 +132,19 @@ int RoutingToClockConnection::create_virtual_clock_network_sink_node(
  */
 
 void ClockToClockConneciton::set_from_clock_name(std::string clock_name) {
-    from_clock = clock_name;
+    from_clock = std::move(clock_name);
 }
 
 void ClockToClockConneciton::set_from_clock_switch_point_name(std::string switch_point_name) {
-    from_switch = switch_point_name;
+    from_switch = std::move(switch_point_name);
 }
 
 void ClockToClockConneciton::set_to_clock_name(std::string clock_name) {
-    to_clock = clock_name;
+    to_clock = std::move(clock_name);
 }
 
 void ClockToClockConneciton::set_to_clock_switch_point_name(std::string switch_point_name) {
-    to_switch = switch_point_name;
+    to_switch = std::move(switch_point_name);
 }
 
 void ClockToClockConneciton::set_switch(int arch_switch_index) {
@@ -217,12 +218,12 @@ void ClockToClockConneciton::create_switches(const ClockRRGraphBuilder& clock_gr
  */
 
 void ClockToPinsConnection::set_clock_name_to_connect_from(std::string clock_name) {
-    clock_to_connect_from = clock_name;
+    clock_to_connect_from = std::move(clock_name);
 }
 
 void ClockToPinsConnection::set_clock_switch_point_name(
     std::string connection_switch_point_name) {
-    switch_point_name = connection_switch_point_name;
+    switch_point_name = std::move(connection_switch_point_name);
 }
 
 void ClockToPinsConnection::set_switch(int arch_switch_index) {

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -1,5 +1,7 @@
 #include "clock_network_builders.h"
 
+#include <utility>
+
 #include "globals.h"
 
 #include "vtr_assert.h"
@@ -17,7 +19,7 @@ void populate_segment_values(int seg_index,
                              int length,
                              MetalLayer layer,
                              std::vector<t_segment_inf>& segment_inf) {
-    segment_inf[seg_index].name = name;
+    segment_inf[seg_index].name = std::move(name);
     segment_inf[seg_index].length = length;
     segment_inf[seg_index].frequency = 1;
     segment_inf[seg_index].Rmetal = layer.r_metal;
@@ -49,7 +51,7 @@ std::string ClockNetwork::get_name() const {
  */
 
 void ClockNetwork::set_clock_name(std::string clock_name) {
-    clock_name_ = clock_name;
+    clock_name_ = std::move(clock_name);
 }
 
 void ClockNetwork::set_num_instance(int num_inst) {
@@ -124,7 +126,7 @@ void ClockRib::set_drive_switch(int switch_idx) {
 }
 
 void ClockRib::set_drive_name(std::string name) {
-    drive.name = name;
+    drive.name = std::move(name);
 }
 
 void ClockRib::set_tap_locations(int offset_x, int increment_x) {
@@ -133,7 +135,7 @@ void ClockRib::set_tap_locations(int offset_x, int increment_x) {
 }
 
 void ClockRib::set_tap_name(std::string name) {
-    tap.name = name;
+    tap.name = std::move(name);
 }
 
 /*
@@ -417,7 +419,7 @@ void ClockSpine::set_drive_switch(int switch_idx) {
 }
 
 void ClockSpine::set_drive_name(std::string name) {
-    drive.name = name;
+    drive.name = std::move(name);
 }
 
 void ClockSpine::set_tap_locations(int offset_y, int increment_y) {
@@ -426,7 +428,7 @@ void ClockSpine::set_tap_locations(int offset_y, int increment_y) {
 }
 
 void ClockSpine::set_tap_name(std::string name) {
-    tap.name = name;
+    tap.name = std::move(name);
 }
 
 /*

--- a/vpr/src/route/clock_network_builders.h
+++ b/vpr/src/route/clock_network_builders.h
@@ -2,6 +2,7 @@
 #define CLOCK_NETWORK_BUILDERS_H
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "clock_fwd.h"
@@ -140,8 +141,8 @@ class ClockRib : public ClockNetwork {
     ClockRib(Wire wire1, WireRepeat repeat1, RibDrive drive1, RibTaps tap1)
         : x_chan_wire(wire1)
         , repeat(repeat1)
-        , drive(drive1)
-        , tap(tap1) {}
+        , drive(std::move(drive1))
+        , tap(std::move(tap1)) {}
     /*
      * Getters
      */

--- a/vpr/src/route/connection_based_routing.h
+++ b/vpr/src/route/connection_based_routing.h
@@ -115,7 +115,7 @@ class Connection_based_routing_resources {
     // check each connection of each net to see if any satisfy the criteria described above (for the forcible_reroute_connection_flag data structure)
     // and if so, mark them to be rerouted
     bool forcibly_reroute_connections(float max_criticality,
-                                      std::shared_ptr<const SetupTimingInfo> timing_info,
+                                      const std::shared_ptr<const SetupTimingInfo>& timing_info,
                                       const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                                       ClbNetPinsMatrix<float>& net_delay);
 };

--- a/vpr/src/route/route_budgets.cpp
+++ b/vpr/src/route/route_budgets.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include "vpr_context.h"
 #include <fstream>
+#include <utility>
 #include "vpr_error.h"
 #include "globals.h"
 #include "tatum/util/tatum_assert.hpp"
@@ -357,7 +358,7 @@ void route_budgets::set_min_max_budgets_equal() {
     }
 }
 
-float route_budgets::minimax_PERT(std::shared_ptr<SetupHoldTimingInfo> orig_timing_info, std::shared_ptr<SetupHoldTimingInfo> timing_info, ClbNetPinsMatrix<float>& temp_budgets, ClbNetPinsMatrix<float>& net_delay, const ClusteredPinAtomPinsLookup& netlist_pin_lookup, analysis_type analysis_type, bool keep_in_bounds, slack_allocated_type slack_type) {
+float route_budgets::minimax_PERT(const std::shared_ptr<SetupHoldTimingInfo>& timing_info, std::shared_ptr<SetupHoldTimingInfo> timing_info, ClbNetPinsMatrix<float>& temp_budgets, ClbNetPinsMatrix<float>& net_delay, const ClusteredPinAtomPinsLookup& netlist_pin_lookup, analysis_type analysis_type, bool keep_in_bounds, slack_allocated_type slack_type) {
     /*This function uses weights to calculate how much slack to allocate to a connection.
      * The weights are deteremined by how much delay of the whole path is present in this connection*/
 
@@ -435,7 +436,7 @@ float route_budgets::minimax_PERT(std::shared_ptr<SetupHoldTimingInfo> orig_timi
     return max_budget_change;
 }
 
-float route_budgets::calculate_clb_pin_slack(ClusterNetId net_id, int ipin, std::shared_ptr<SetupHoldTimingInfo> timing_info, const ClusteredPinAtomPinsLookup& netlist_pin_lookup, analysis_type type, AtomPinId& atom_pin) {
+float route_budgets::calculate_clb_pin_slack(ClusterNetId net_id, int ipin, const std::shared_ptr<SetupHoldTimingInfo>& timing_info, const ClusteredPinAtomPinsLookup& netlist_pin_lookup, analysis_type type, AtomPinId& atom_pin) {
     /*Calculates the slack for the specific clb pin. Takes the minimum slack. Keeps track of the pin
      * used in this calculation so it can be used again for getting the total path delay*/
     auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -456,7 +457,9 @@ float route_budgets::calculate_clb_pin_slack(ClusterNetId net_id, int ipin, std:
             continue;
         } else if (timing_info->hold_pin_slack(pin) == std::numeric_limits<float>::infinity() && type == HOLD) {
             if (clb_min_slack == delay_upper_bound[net_id][ipin]) {
-                atom_pin = pin;
+                if (clb_min_slack == delay_upper_bound[net_id][ipin]) {
+                    atom_pin = pin;
+                }
             }
             continue;
         } else {
@@ -477,7 +480,7 @@ float route_budgets::calculate_clb_pin_slack(ClusterNetId net_id, int ipin, std:
     return clb_min_slack;
 }
 
-float route_budgets::get_total_path_delay(std::shared_ptr<const tatum::SetupHoldTimingAnalyzer> timing_analyzer,
+float route_budgets::get_total_path_delay(const std::shared_ptr<const tatum::SetupHoldTimingAnalyzer>& timing_analyzer,
                                           analysis_type analysis_type,
                                           ClusterNetId net_id,
                                           int ipin,
@@ -581,7 +584,7 @@ float route_budgets::get_total_path_delay(std::shared_ptr<const tatum::SetupHold
 }
 
 void route_budgets::allocate_slack_using_delays_and_criticalities(ClbNetPinsMatrix<float>& net_delay,
-                                                                  std::shared_ptr<SetupTimingInfo> timing_info,
+                                                                  const std::shared_ptr<SetupTimingInfo>& timing_info,
                                                                   const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                                                                   const t_router_opts& router_opts) {
     /*Simplifies the budget calculation. The pin criticality describes 1-slack ratio

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -2,6 +2,7 @@
 #include <ctime>
 #include <cmath>
 #include <algorithm>
+#include <utility>
 #include <vector>
 #include <iostream>
 

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstdio>
 #include <ctime>
 #include <cmath>
@@ -295,6 +296,7 @@ bool try_timing_driven_route_tmpl(const t_router_opts& router_opts,
     }
 
     CBRR connections_inf{};
+    VTR_ASSERT_SAFE(connections_inf.sanity_check_lookup());
 
     route_budgets budgeting_inf;
 
@@ -1179,8 +1181,10 @@ static bool timing_driven_pre_route_to_clock_root(
     ClusterNetId net_id,
     int sink_node,
     const t_conn_cost_params cost_params,
+    float pres_fac,
     int high_fanout_threshold,
     t_rt_node* rt_root,
+    const RouterLookahead& router_lookahead,
     SpatialRouteTreeLookup& spatial_rt_lookup,
     RouterStats& router_stats) {
     auto& route_ctx = g_vpr_ctx.mutable_routing();
@@ -1571,7 +1575,7 @@ static bool timing_driven_check_net_delays(ClbNetPinsMatrix<float>& net_delay) {
     for (auto net_id : cluster_ctx.clb_nlist.nets()) {
         for (ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net_id).size(); ipin++) {
             if (net_delay_check[net_id][ipin] == 0.) { /* Should be only GLOBAL nets */
-                if (fabs(net_delay[net_id][ipin]) > ERROR_TOL) {
+                if (std::fabs(net_delay[net_id][ipin]) > ERROR_TOL) {
                     VPR_ERROR(VPR_ERROR_ROUTE,
                               "in timing_driven_check_net_delays: net %lu pin %d.\n"
                               "\tIncremental calc. net_delay is %g, but from scratch net delay is %g.\n",

--- a/vpr/src/route/route_timing.h
+++ b/vpr/src/route/route_timing.h
@@ -23,8 +23,8 @@ bool try_timing_driven_route(const t_router_opts& router_opts,
                              const std::vector<t_segment_inf>& segment_inf,
                              ClbNetPinsMatrix<float>& net_delay,
                              const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
-                             std::shared_ptr<SetupHoldTimingInfo> timing_info,
-                             std::shared_ptr<RoutingDelayCalculator> delay_calc,
+                             const std::shared_ptr<SetupHoldTimingInfo>& timing_info,
+                             const std::shared_ptr<RoutingDelayCalculator>& delay_calc,
                              ScreenUpdatePriority first_iteration_priority);
 
 template<typename ConnectionRouter>

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstdio>
 #include <cmath>
 #include <vector>
@@ -73,7 +74,7 @@ void collect_route_tree_connections(const t_rt_node* node, std::multiset<std::tu
 
 constexpr float epsilon = 1e-15;
 static bool equal_approx(float a, float b) {
-    return fabs(a - b) < epsilon;
+    return std::fabs(a - b) < epsilon;
 }
 
 bool alloc_route_tree_timing_structs(bool exists_ok) {

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -1,4 +1,6 @@
 #include "router_delay_profiling.h"
+
+#include <utility>
 #include "globals.h"
 #include "route_tree_type.h"
 #include "route_common.h"
@@ -217,7 +219,7 @@ void alloc_routing_structs(t_chan_width chan_width,
     create_rr_graph(graph_type,
                     device_ctx.physical_tile_types,
                     device_ctx.grid,
-                    chan_width,
+                    std::move(chan_width),
                     device_ctx.num_arch_switches,
                     det_routing_arch,
                     segment_inf,

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -1,5 +1,7 @@
 #include "router_lookahead.h"
 
+#include <utility>
+
 #include "router_lookahead_map.h"
 #include "router_lookahead_extended_map.h"
 #include "vpr_error.h"
@@ -26,8 +28,8 @@ static std::unique_ptr<RouterLookahead> make_router_lookahead_object(e_router_lo
 
 std::unique_ptr<RouterLookahead> make_router_lookahead(
     e_router_lookahead router_lookahead_type,
-    std::string write_lookahead,
-    std::string read_lookahead,
+    const std::string& write_lookahead,
+    const std::string& read_lookahead,
     const std::vector<t_segment_inf>& segment_inf) {
     std::unique_ptr<RouterLookahead> router_lookahead = make_router_lookahead_object(router_lookahead_type);
 
@@ -191,7 +193,7 @@ void invalidate_router_lookahead_cache() {
 const RouterLookahead* get_cached_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
-    std::string read_lookahead,
+    const std::string& read_lookahead,
     const std::vector<t_segment_inf>& segment_inf) {
     auto& router_ctx = g_vpr_ctx.routing();
 
@@ -209,7 +211,7 @@ const RouterLookahead* get_cached_router_lookahead(
             cache_key,
             make_router_lookahead(
                 router_lookahead_type,
-                write_lookahead,
+                std::move(write_lookahead),
                 read_lookahead,
                 segment_inf));
     }

--- a/vpr/src/route/router_lookahead.h
+++ b/vpr/src/route/router_lookahead.h
@@ -35,8 +35,8 @@ class RouterLookahead {
 // cannot be used.
 std::unique_ptr<RouterLookahead> make_router_lookahead(
     e_router_lookahead router_lookahead_type,
-    std::string write_lookahead,
-    std::string read_lookahead,
+    const std::string& write_lookahead,
+    const std::string& read_lookahead,
     const std::vector<t_segment_inf>& segment_inf);
 
 // Clear router lookahead cache (e.g. when changing or free rrgraph).
@@ -49,7 +49,7 @@ void invalidate_router_lookahead_cache();
 const RouterLookahead* get_cached_router_lookahead(
     e_router_lookahead router_lookahead_type,
     std::string write_lookahead,
-    std::string read_lookahead,
+    const std::string& read_lookahead,
     const std::vector<t_segment_inf>& segment_inf);
 
 class ClassicLookahead : public RouterLookahead {

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -801,12 +801,12 @@ Cost_Entry Expansion_Cost_Entry::get_geomean_entry() {
     float geomean_delay = 0;
     float geomean_cong = 0;
     for (auto cost_entry : this->cost_vector) {
-        geomean_delay += log(cost_entry.delay);
-        geomean_cong += log(cost_entry.congestion);
+        geomean_delay += std::log(cost_entry.delay);
+        geomean_cong += std::log(cost_entry.congestion);
     }
 
-    geomean_delay = exp(geomean_delay / (float)this->cost_vector.size());
-    geomean_cong = exp(geomean_cong / (float)this->cost_vector.size());
+    geomean_delay = std::exp(geomean_delay / (float)this->cost_vector.size());
+    geomean_cong = std::exp(geomean_cong / (float)this->cost_vector.size());
 
     return Cost_Entry(geomean_delay, geomean_cong);
 }
@@ -837,7 +837,7 @@ Cost_Entry Expansion_Cost_Entry::get_median_entry() {
     /* sort the cost entries into bins */
     std::vector<std::vector<Cost_Entry>> entry_bins(num_bins, std::vector<Cost_Entry>());
     for (auto entry : this->cost_vector) {
-        float bin_num = floor((entry.delay - min_del_entry.delay) / bin_size);
+        float bin_num = std::floor((entry.delay - min_del_entry.delay) / bin_size);
 
         VTR_ASSERT(vtr::nint(bin_num) >= 0 && vtr::nint(bin_num) <= num_bins);
         if (vtr::nint(bin_num) == num_bins) {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <cmath>
@@ -290,7 +291,7 @@ static void build_rr_graph(const t_graph_type graph_type,
                            t_chan_width nodes_per_chan,
                            const enum e_switch_block_type sb_type,
                            const int Fs,
-                           const std::vector<t_switchblock_inf> switchblocks,
+                           const std::vector<t_switchblock_inf>& switchblocks,
                            const int num_arch_switches,
                            const std::vector<t_segment_inf>& segment_inf,
                            const int global_route_switch,
@@ -310,7 +311,7 @@ static void build_rr_graph(const t_graph_type graph_type,
 void create_rr_graph(const t_graph_type graph_type,
                      const std::vector<t_physical_tile_type>& block_types,
                      const DeviceGrid& grid,
-                     const t_chan_width nodes_per_chan,
+                     const t_chan_width& nodes_per_chan,
                      const int num_arch_switches,
                      t_det_routing_arch* det_routing_arch,
                      const std::vector<t_segment_inf>& segment_inf,
@@ -410,7 +411,7 @@ static void build_rr_graph(const t_graph_type graph_type,
                            t_chan_width nodes_per_chan,
                            const enum e_switch_block_type sb_type,
                            const int Fs,
-                           const std::vector<t_switchblock_inf> switchblocks,
+                           const std::vector<t_switchblock_inf>& switchblocks,
                            const int num_arch_switches,
                            const std::vector<t_segment_inf>& segment_inf,
                            const int global_route_switch,
@@ -944,7 +945,7 @@ static std::vector<std::vector<bool>> alloc_and_load_perturb_ipins(const int L_n
                 }
 
                 if ((Fc_in[itype][0][iseg] <= tracks_in_seg_type - 2)
-                    && (fabs(Fc_ratio - vtr::nint(Fc_ratio))
+                    && (std::fabs(Fc_ratio - vtr::nint(Fc_ratio))
                         < (0.5 / (float)tracks_in_seg_type))) {
                     result[itype][iseg] = true;
                 }
@@ -2857,7 +2858,7 @@ static std::vector<bool> alloc_and_load_perturb_opins(const t_physical_tile_type
      *  case.								*/
 
     /* get an upper bound on the number of prime factors of num_wire_types	*/
-    max_primes = (int)floor(log((float)num_wire_types) / log(2.0));
+    max_primes = (int)floor(std::log((float)num_wire_types) / log(2.0));
     max_primes = std::max(max_primes, 1); //Minimum of 1 to ensure we allocate space for at least one prime_factor
 
     prime_factors = (int*)vtr::malloc(max_primes * sizeof(int));
@@ -2895,7 +2896,7 @@ static std::vector<bool> alloc_and_load_perturb_opins(const t_physical_tile_type
 
         n = step_size / prime_factors[i];
         n = n - (float)vtr::nint(n); /* fractinal part */
-        if (fabs(n) < threshold) {
+        if (std::fabs(n) < threshold) {
             perturb_opins[0] = true;
             break;
         } else {

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -29,7 +29,7 @@ enum {
 void create_rr_graph(const t_graph_type graph_type,
                      const std::vector<t_physical_tile_type>& block_types,
                      const DeviceGrid& grid,
-                     t_chan_width nodes_per_chan,
+                     const t_chan_width& nodes_per_chan,
                      const int num_arch_switches,
                      t_det_routing_arch* det_routing_arch,
                      const std::vector<t_segment_inf>& segment_inf,

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -39,7 +39,7 @@ static void load_block_rr_indices(RRGraphBuilder& rr_graph_builder,
                                   const DeviceGrid& grid,
                                   int* index);
 
-static int get_bidir_track_to_chan_seg(const std::vector<int> conn_tracks,
+static int get_bidir_track_to_chan_seg(const std::vector<int>& conn_tracks,
                                        const t_rr_node_indices& L_rr_node_indices,
                                        const int to_chan,
                                        const int to_seg,
@@ -1880,7 +1880,7 @@ int get_track_to_tracks(const int from_chan,
     return num_conn;
 }
 
-static int get_bidir_track_to_chan_seg(const std::vector<int> conn_tracks,
+static int get_bidir_track_to_chan_seg(const std::vector<int>& conn_tracks,
                                        const t_rr_node_indices& L_rr_node_indices,
                                        const int to_chan,
                                        const int to_seg,

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -598,9 +598,9 @@ float trans_per_buf(float Rbuf, float R_minW_nmos, float R_minW_pmos) {
         /* Target stage ratio = 4.  1 minimum width buffer, then num_stage bigger *
          * ones.                                                                  */
 
-        num_stage = vtr::nint(log10(R_minW_nmos / Rbuf) / log10(4.));
+        num_stage = vtr::nint(std::log10(R_minW_nmos / Rbuf) / log10(4.));
         num_stage = std::max(num_stage, 1);
-        stage_ratio = pow((float)(R_minW_nmos / Rbuf), (float)(1. / (float)num_stage));
+        stage_ratio = std::pow((float)(R_minW_nmos / Rbuf), (float)(1. / (float)num_stage));
 
         Rstage = R_minW_nmos;
         trans_count = 0.;
@@ -637,7 +637,7 @@ static float trans_per_mux(int num_inputs, float trans_sram_bit, float pass_tran
         /* This is a large multiplexer so design it using a two-level multiplexer   *
          * + 0.00001 is to make sure exact square roots two don't get rounded down  *
          * to one lower level.                                                      */
-        num_second_stage_trans = (int)floor((float)sqrt((float)num_inputs) + 0.00001);
+        num_second_stage_trans = (int)floor((float)std::sqrt((float)num_inputs) + 0.00001);
         pass_trans = (num_inputs + num_second_stage_trans) * pass_trans_area;
         sram_trans = (ceil((float)num_inputs / num_second_stage_trans - 0.00001)
                       + num_second_stage_trans)
@@ -689,11 +689,11 @@ static float trans_per_R(float Rtrans, float R_minW_trans) {
     } else if (trans_area_eq == AREA_IMPROVED_NMOS_ONLY) {
         /* New transistor area estimation equation. Here only NMOS transistors
          * are taken into account */
-        trans_area = 0.447 + 0.128 * drive_strength + 0.391 * sqrt(drive_strength);
+        trans_area = 0.447 + 0.128 * drive_strength + 0.391 * std::sqrt(drive_strength);
     } else if (trans_area_eq == AREA_IMPROVED_MIXED) {
         /* New transistor area estimation equation. Here both NMOS and PMOS
          * transistors are taken into account (extra spacing needed for N-wells) */
-        trans_area = 0.518 + 0.127 * drive_strength + 0.428 * sqrt(drive_strength);
+        trans_area = 0.518 + 0.127 * drive_strength + 0.428 * std::sqrt(drive_strength);
     } else {
         VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Unrecognized transistor area model: %d\n", (int)trans_area_eq);
     }

--- a/vpr/src/route/rr_graph_clock.h
+++ b/vpr/src/route/rr_graph_clock.h
@@ -51,14 +51,14 @@ class SwitchPoints {
     /* Example: x,y = middle of the chip, switch_point_name == name of main drive
      * of global clock spine, returns the rr_nodes of all the clock spines that
      * start the newtork there*/
-    std::vector<int> get_rr_node_indices_at_location(std::string switch_point_name,
+    std::vector<int> get_rr_node_indices_at_location(const std::string& switch_point_name,
                                                      int x,
                                                      int y) const;
 
-    std::set<std::pair<int, int>> get_switch_locations(std::string switch_point_name) const;
+    std::set<std::pair<int, int>> get_switch_locations(const std::string& switch_point_name) const;
 
     /** Setters **/
-    void insert_switch_node_idx(std::string switch_point_name, int x, int y, int node_idx);
+    void insert_switch_node_idx(const std::string& switch_point_name, int x, int y, int node_idx);
 };
 
 class ClockRRGraphBuilder {
@@ -92,20 +92,20 @@ class ClockRRGraphBuilder {
     }
 
     /* Saves a map from switch rr_node idx -> {x, y} location */
-    void add_switch_location(std::string clock_name,
+    void add_switch_location(const std::string& clock_name,
                              std::string switch_point_name,
                              int x,
                              int y,
                              int node_index);
 
     /* Returns the rr_node idx of the switch at location {x, y} */
-    std::vector<int> get_rr_node_indices_at_switch_location(std::string clock_name,
+    std::vector<int> get_rr_node_indices_at_switch_location(const std::string& clock_name,
                                                             std::string switch_point_name,
                                                             int x,
                                                             int y) const;
 
     /* Returns all the switch locations for the a certain clock network switch */
-    std::set<std::pair<int, int>> get_switch_locations(std::string clock_name,
+    std::set<std::pair<int, int>> get_switch_locations(const std::string& clock_name,
                                                        std::string switch_point_name) const;
 
     void update_chan_width(t_chan_width* chan_width) const;

--- a/vpr/src/route/rr_metadata.cpp
+++ b/vpr/src/route/rr_metadata.cpp
@@ -1,5 +1,7 @@
 #include "rr_metadata.h"
 
+#include <utility>
+
 #include "globals.h"
 
 namespace vpr {
@@ -37,7 +39,7 @@ const t_metadata_value* rr_edge_metadata(int src_node, int sink_id, short switch
         return nullptr;
     }
 
-    return iter->second.one(key);
+    return iter->second.one(std::move(key));
 }
 
 void add_rr_edge_metadata(int src_node, int sink_id, short switch_id, vtr::string_view key, vtr::string_view value) {

--- a/vpr/src/timing/PreClusterDelayCalculator.h
+++ b/vpr/src/timing/PreClusterDelayCalculator.h
@@ -1,5 +1,7 @@
 #ifndef PRE_CLUSTER_DELAY_CALCULATOR_H
 #define PRE_CLUSTER_DELAY_CALCULATOR_H
+#include <utility>
+
 #include "vtr_assert.h"
 
 #include "tatum/Time.hpp"
@@ -21,7 +23,7 @@ class PreClusterDelayCalculator : public tatum::DelayCalculator {
         : netlist_(netlist)
         , netlist_lookup_(netlist_lookup)
         , inter_cluster_net_delay_(intercluster_net_delay)
-        , block_to_pb_gnode_(expected_lowest_cost_pb_gnode) {
+        , block_to_pb_gnode_(std::move(expected_lowest_cost_pb_gnode)) {
         //nop
     }
 

--- a/vpr/src/timing/concrete_timing_info.cpp
+++ b/vpr/src/timing/concrete_timing_info.cpp
@@ -3,7 +3,7 @@
 #include "timing_info.h"
 #include "concrete_timing_info.h"
 
-void warn_unconstrained(std::shared_ptr<const tatum::TimingAnalyzer> analyzer) {
+void warn_unconstrained(const std::shared_ptr<const tatum::TimingAnalyzer>& analyzer) {
     if (analyzer->num_unconstrained_startpoints() > 0) {
         VTR_LOG_WARN("%zu timing startpoints were not constrained during timing analysis\n",
                      analyzer->num_unconstrained_startpoints());

--- a/vpr/src/timing/concrete_timing_info.h
+++ b/vpr/src/timing/concrete_timing_info.h
@@ -1,6 +1,8 @@
 #ifndef VPR_CONCRETE_TIMING_INFO_H
 #define VPR_CONCRETE_TIMING_INFO_H
 
+#include <utility>
+
 #include "vtr_log.h"
 #include "timing_util.h"
 #include "vpr_error.h"
@@ -9,7 +11,7 @@
 
 #include "tatum/report/graphviz_dot_writer.hpp"
 
-void warn_unconstrained(std::shared_ptr<const tatum::TimingAnalyzer> analyzer);
+void warn_unconstrained(const std::shared_ptr<const tatum::TimingAnalyzer>& analyzer);
 
 //NOTE: These classes should not be used directly but created with the
 //      make_*_timing_info() functions in timing_info.h, and used through
@@ -23,10 +25,10 @@ class ConcreteSetupTimingInfo : public SetupTimingInfo {
                             std::shared_ptr<const tatum::TimingConstraints> timing_constraints_v,
                             std::shared_ptr<DelayCalc> delay_calc,
                             std::shared_ptr<tatum::SetupTimingAnalyzer> analyzer_v)
-        : timing_graph_(timing_graph_v)
-        , timing_constraints_(timing_constraints_v)
+        : timing_graph_(std::move(timing_graph_v))
+        , timing_constraints_(std::move(timing_constraints_v))
         , delay_calc_(delay_calc)
-        , setup_analyzer_(analyzer_v)
+        , setup_analyzer_(std::move(analyzer_v))
         , slack_crit_(g_vpr_ctx.atom().nlist, g_vpr_ctx.atom().lookup) {
         //pass
     }
@@ -179,10 +181,10 @@ class ConcreteHoldTimingInfo : public HoldTimingInfo {
                            std::shared_ptr<const tatum::TimingConstraints> timing_constraints_v,
                            std::shared_ptr<DelayCalc> delay_calc,
                            std::shared_ptr<tatum::HoldTimingAnalyzer> analyzer_v)
-        : timing_graph_(timing_graph_v)
-        , timing_constraints_(timing_constraints_v)
+        : timing_graph_(std::move(timing_graph_v))
+        , timing_constraints_(std::move(timing_constraints_v))
         , delay_calc_(delay_calc)
-        , hold_analyzer_(analyzer_v)
+        , hold_analyzer_(std::move(analyzer_v))
         , slack_crit_(g_vpr_ctx.atom().nlist, g_vpr_ctx.atom().lookup) {
         //pass
     }
@@ -276,10 +278,10 @@ template<class DelayCalc>
 class ConcreteSetupHoldTimingInfo : public SetupHoldTimingInfo {
   public:
     //Constructors
-    ConcreteSetupHoldTimingInfo(std::shared_ptr<const tatum::TimingGraph> timing_graph_v,
-                                std::shared_ptr<const tatum::TimingConstraints> timing_constraints_v,
+    ConcreteSetupHoldTimingInfo(const std::shared_ptr<const tatum::TimingGraph>& timing_graph_v,
+                                const std::shared_ptr<const tatum::TimingConstraints>& timing_constraints_v,
                                 std::shared_ptr<DelayCalc> delay_calc,
-                                std::shared_ptr<tatum::SetupHoldTimingAnalyzer> analyzer_v)
+                                const std::shared_ptr<tatum::SetupHoldTimingAnalyzer>& analyzer_v)
         : setup_timing_(timing_graph_v, timing_constraints_v, delay_calc, analyzer_v)
         , hold_timing_(timing_graph_v, timing_constraints_v, delay_calc, analyzer_v)
         , setup_hold_analyzer_(analyzer_v) {

--- a/vpr/src/timing/read_sdc.cpp
+++ b/vpr/src/timing/read_sdc.cpp
@@ -1162,7 +1162,7 @@ void apply_single_clock_default_timing_constraints(const AtomNetlist& netlist,
                                                    const AtomPinId clock_driver,
                                                    tatum::TimingConstraints& tc) {
     AtomNetId clock_net = netlist.pin_net(clock_driver);
-    std::string clock_name = netlist.net_name(clock_net);
+    const std::string& clock_name = netlist.net_name(clock_net);
 
     VTR_LOG("Setting default timing constraints:\n");
     VTR_LOG("   * constrain all primay inputs and primary outputs on netlist clock '%s'\n", clock_name.c_str());
@@ -1210,7 +1210,7 @@ void apply_multi_clock_default_timing_constraints(const AtomNetlist& netlist,
         AtomNetId clock_net = netlist.pin_net(clock_driver);
 
         //Create the clock
-        std::string clock_name = netlist.net_name(clock_net);
+        const std::string& clock_name = netlist.net_name(clock_net);
         tatum::DomainId clock = tc.create_clock_domain(clock_name);
 
         //Mark the clock domain source

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -339,8 +339,8 @@ float find_hold_total_negative_slack(const tatum::HoldTimingAnalyzer& hold_analy
     return tns;
 }
 
-tatum::NodeId find_origin_node_for_hold_slack(const tatum::TimingTags::tag_range arrival_tags,
-                                              const tatum::TimingTags::tag_range required_tags,
+tatum::NodeId find_origin_node_for_hold_slack(const tatum::TimingTags::tag_range& arrival_tags,
+                                              const tatum::TimingTags::tag_range& required_tags,
                                               float slack) {
     /*Given the slack, arrival, and required tags of a certain timing node,
      * its origin node is found*/
@@ -614,7 +614,7 @@ float calculate_clb_net_pin_setup_slack(const SetupTimingInfo& timing_info, cons
 
 float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_req,
                                const std::map<DomainPair, float>& domains_worst_slack,
-                               const tatum::TimingTags::tag_range tags) {
+                               const tatum::TimingTags::tag_range& tags) {
     //Allowable round-off tolerance during criticality calculation
     constexpr float CRITICALITY_ROUND_OFF_TOLERANCE = 1e-4;
 
@@ -685,7 +685,7 @@ float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_re
     return max_crit;
 }
 
-void print_tatum_cpds(std::vector<tatum::TimingPathInfo> cpds) {
+void print_tatum_cpds(const std::vector<tatum::TimingPathInfo>& cpds) {
     for (auto path : cpds) {
         VTR_LOG("Tatum   %zu -> %zu: least_slack=%g cpd=%g\n", size_t(path.launch_domain()), size_t(path.capture_domain()), float(path.slack()), float(path.delay()));
     }

--- a/vpr/src/timing/timing_util.h
+++ b/vpr/src/timing/timing_util.h
@@ -66,12 +66,12 @@ float find_hold_worst_slack(const tatum::HoldTimingAnalyzer& hold_analyzer, cons
 std::vector<HistogramBucket> create_hold_slack_histogram(const tatum::HoldTimingAnalyzer& hold_analyzer, size_t num_bins = 10);
 
 //Print a useful summary of timing information
-void print_hold_timing_summary(const tatum::TimingConstraints& constraints, const tatum::HoldTimingAnalyzer& hold_analyzer, std::string prefix);
+void print_hold_timing_summary(const tatum::TimingConstraints& constraints, const tatum::HoldTimingAnalyzer& hold_analyzer);
 
 float find_total_negative_slack_within_clb_blocks(const tatum::HoldTimingAnalyzer& hold_analyzer);
 
-tatum::NodeId find_origin_node_for_hold_slack(const tatum::TimingTags::tag_range arrival_tags,
-                                              const tatum::TimingTags::tag_range required_tags,
+tatum::NodeId find_origin_node_for_hold_slack(const tatum::TimingTags::tag_range& arrival_tags,
+                                              const tatum::TimingTags::tag_range& required_tags,
                                               float slack);
 
 /*
@@ -200,12 +200,12 @@ float calculate_clb_net_pin_setup_slack(const SetupTimingInfo& timing_info, cons
 // which handles the trade-off between different timing constraints in multi-clock circuits.
 float calc_relaxed_criticality(const std::map<DomainPair, float>& domains_max_req,
                                const std::map<DomainPair, float>& domains_worst_slack,
-                               const tatum::TimingTags::tag_range tags);
+                               const tatum::TimingTags::tag_range& tags);
 
 /*
  * Debug
  */
-void print_tatum_cpds(std::vector<tatum::TimingPathInfo> cpds);
+void print_tatum_cpds(const std::vector<tatum::TimingPathInfo>& cpds);
 
 tatum::NodeId id_or_pin_name_to_tnode(std::string name_or_id);
 tatum::NodeId pin_name_to_tnode(std::string name);

--- a/vpr/src/util/histogram.cpp
+++ b/vpr/src/util/histogram.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <sstream>
 #include <cmath>
+#include <utility>
 
 #include "vtr_log.h"
 #include "vtr_assert.h"
@@ -57,9 +58,9 @@ std::vector<HistogramBucket> build_histogram(std::vector<float> values, size_t n
 void print_histogram(std::vector<HistogramBucket> histogram) {
     size_t char_width = 80;
 
-    auto lines = format_histogram(histogram, char_width);
+    auto lines = format_histogram(std::move(histogram), char_width);
 
-    for (auto line : lines) {
+    for (const auto& line : lines) {
         VTR_LOG("%s\n", line.c_str());
     }
 }

--- a/vpr/src/util/vpr_error.cpp
+++ b/vpr/src/util/vpr_error.cpp
@@ -1,5 +1,6 @@
 #include <cstdarg>
 #include <string>
+#include <utility>
 
 #include "vtr_util.h"
 #include "vtr_log.h"
@@ -17,7 +18,7 @@ static std::unordered_set<std::string> functions_to_demote;
  *			anything but throw an exception which will be caught
  *			main.c.
  */
-void map_error_activation_status(std::string function_name) {
+void map_error_activation_status(const std::string& function_name) {
     functions_to_demote.insert(function_name);
 }
 
@@ -56,7 +57,7 @@ void vpr_throw_msg(enum e_vpr_error type,
                    const char* psz_file_name,
                    unsigned int line_num,
                    std::string msg) {
-    throw VprError(type, msg, psz_file_name, line_num);
+    throw VprError(type, std::move(msg), psz_file_name, line_num);
 }
 
 void vpr_throw_opt(enum e_vpr_error type,

--- a/vpr/src/util/vpr_error.h
+++ b/vpr/src/util/vpr_error.h
@@ -4,6 +4,7 @@
 #include <cstdarg>
 #include <string>
 #include <unordered_set>
+#include <utility>
 
 #include "vtr_error.h"
 
@@ -39,7 +40,7 @@ class VprError : public vtr::VtrError {
              std::string msg = "",
              std::string file = "",
              size_t linenum = -1)
-        : VtrError(msg, file, linenum)
+        : VtrError(std::move(msg), std::move(file), linenum)
         , type_(err_type) {}
 
     t_vpr_error_type type() const { return type_; }
@@ -51,7 +52,7 @@ class VprError : public vtr::VtrError {
 // This function is used to save into the functions_to_demote set
 // all the function names which contain VPR_THROW errors that are
 // going to be demoted to be VTR_LOG_WARN
-void map_error_activation_status(std::string function_name);
+void map_error_activation_status(const std::string& function_name);
 
 //VPR error reporting routines
 //

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -2,6 +2,7 @@
 #include <unordered_set>
 #include <regex>
 #include <algorithm>
+#include <utility>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"
@@ -708,7 +709,7 @@ t_physical_tile_type_ptr find_most_common_tile_type(const DeviceGrid& grid) {
 }
 
 InstPort parse_inst_port(std::string str) {
-    InstPort inst_port(str);
+    InstPort inst_port(std::move(str));
 
     auto& device_ctx = g_vpr_ctx.device();
     auto blk_type = find_tile_type_by_name(inst_port.instance_name(), device_ctx.physical_tile_types);
@@ -1066,7 +1067,7 @@ t_pb_graph_pin* get_pb_graph_node_pin_from_block_pin(ClusterBlockId iblock, int 
 }
 
 const t_port* find_pb_graph_port(const t_pb_graph_node* pb_gnode, std::string port_name) {
-    const t_pb_graph_pin* gpin = find_pb_graph_pin(pb_gnode, port_name, 0);
+    const t_pb_graph_pin* gpin = find_pb_graph_pin(pb_gnode, std::move(port_name), 0);
 
     if (gpin != nullptr) {
         return gpin->port;
@@ -1074,7 +1075,7 @@ const t_port* find_pb_graph_port(const t_pb_graph_node* pb_gnode, std::string po
     return nullptr;
 }
 
-const t_pb_graph_pin* find_pb_graph_pin(const t_pb_graph_node* pb_gnode, std::string port_name, int index) {
+const t_pb_graph_pin* find_pb_graph_pin(const t_pb_graph_node* pb_gnode, const std::string& port_name, int index) {
     for (int iport = 0; iport < pb_gnode->num_input_ports; iport++) {
         if (pb_gnode->num_input_pins[iport] < index) continue;
 


### PR DESCRIPTION
#### Description

This is the [`clang-tidy`](https://clang.llvm.org/extra/clang-tidy/) fixes that @luk036 had in his pull request at https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1078

These changes make the code follow closer to best practices around using const std::string references.
