### PR TITLE
Adding includes_dir and include_list_add to task config file

### DIFF
--- a/doc/src/vtr/tasks.rst
+++ b/doc/src/vtr/tasks.rst
@@ -140,6 +140,20 @@ Optional Fields
 
     For instance with ``circuit_list_add=my_circuit.v`` or ``circuit_list_add=my_circuit.blif``, the flow would look for an SDC file named ``my_circuit.sdc`` within the specified ``sdc_dir``.
 
+* **includes_dir**:  Directory path to benchmark _include_ files
+
+    Absolute path or relative to ``$VTR_ROOT/vtr_flow/``.
+
+    Note: Multiple _includes_dir_ are NOT allowed in a task config file.
+
+* **include_list_add**: A path to an _include_ file, which is relative to _includes_dir_
+    
+    Multiple _include_list_add_ can be provided.
+
+    _include_ files could act as the top module complementary, like definitions, macros or sub-modules.
+    
+    Note: _include_ files will be shared among all benchmark circuits in the task config file. 
+
 * **pass_requirements_file**: :ref:`vtr_pass_requirements` file.
 
     Absolute path or relative to ``$VTR_ROOT/vtr_flow/parse/pass_requirements/`` or ``$VTR_ROOT/vtr_flow/tasks/<task_name>/config/``

--- a/vtr_flow/benchmarks/hdl_include/ch_intrinsics_modified.v
+++ b/vtr_flow/benchmarks/hdl_include/ch_intrinsics_modified.v
@@ -1,0 +1,231 @@
+/*
+ * Modified ch_intrinsic.v relies on definitons provided in header 
+ * files and a sub module, memeory_controller located at:
+ *      vtr_flow/benchmark/hdl_include/include/generic_definitions1.vh
+ *      vtr_flow/benchmark/hdl_include/include/generic_definitions2.vh
+ *      vtr_flow/benchmark/hdl_include/include/memory_controller.v
+ *
+ * This test is modified to allow testing of run_vtr_task capability to 
+ * include additional files in a benchmark
+*/
+
+module memset
+	(
+		clk,
+		reset,
+		start,
+		finish,
+		return_val,
+		m,
+		c,
+		n,
+		memory_controller_write_enable,
+		memory_controller_address,
+		memory_controller_in,
+		memory_controller_out
+	);
+
+output[`MEMORY_CONTROLLER_ADDR_SIZE-1:0] return_val;
+reg [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] return_val;
+input clk;
+input reset;
+input start;
+
+output finish;
+reg finish;
+
+input [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] m;
+input [31:0] c;
+input [31:0] n;
+
+output [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] memory_controller_address;
+reg [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] memory_controller_address;
+
+output  memory_controller_write_enable;
+reg memory_controller_write_enable;
+
+output [`MEMORY_CONTROLLER_DATA_SIZE-1:0] memory_controller_in;
+reg [`MEMORY_CONTROLLER_DATA_SIZE-1:0] memory_controller_in;
+ 
+output [`MEMORY_CONTROLLER_DATA_SIZE-1:0] memory_controller_out;
+
+reg [3:0] cur_state;
+
+/*
+parameter Wait = 4'd0;
+parameter entry = 4'd1;
+parameter entry_1 = 4'd2;
+parameter entry_2 = 4'd3;
+parameter bb = 4'd4;
+parameter bb_1 = 4'd5;
+parameter bb1 = 4'd6;
+parameter bb1_1 = 4'd7;
+parameter bb_nph = 4'd8;
+parameter bb2 = 4'd9;
+parameter bb2_1 = 4'd10;
+parameter bb2_2 = 4'd11;
+parameter bb2_3 = 4'd12;
+parameter bb2_4 = 4'd13;
+parameter bb4 = 4'd14;
+*/
+
+memory_controller memtroll (clk,memory_controller_address, memory_controller_write_enable, memory_controller_in,  memory_controller_out);
+
+
+reg [31:0] indvar;
+reg  var1;
+reg [31:0] tmp;
+reg [31:0] tmp8;
+reg  var2;
+reg [31:0] var0;
+reg [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] scevgep;
+reg [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] s_07;
+reg [31:0] indvar_next;
+reg  exitcond;
+
+always @(posedge clk)
+if (reset)
+	cur_state <= 4'b0000;
+else
+case(cur_state)
+	4'b0000:
+	begin
+		finish <= 1'b0;
+		if (start == 1'b1)
+			cur_state <= 4'b0001;
+		else
+			cur_state <= 4'b0000;
+	end
+	4'b0001:
+	begin
+
+		
+
+		var0 <= n & 32'b00000000000000000000000000000011;
+
+		cur_state <= 4'b0010;
+	end
+	4'b0010:
+	begin
+
+		var1 <= 1'b0;
+		var0 <= 32'b00000000000000000000000000000000;
+
+		cur_state <= 4'b0011;
+	end
+	4'b0011:
+	begin
+
+		
+		if (|var1) begin
+			cur_state <= 4'b0110;
+		end
+		else 
+		begin
+		
+			cur_state <= 4'b0100;
+		end
+	end
+	4'b0100:
+	begin
+	
+		cur_state <= 4'b0101;
+	end
+	4'b0101:
+	begin
+		cur_state <= 4'b0110;
+	end
+	4'b0110:
+	begin
+
+		var2 <= | (n [31:4]);
+
+		cur_state <= 4'b0111;
+	end
+	4'b0111:
+	begin
+	
+		if (|var2) 
+		begin
+			cur_state <= 4'b1110;
+		end
+		else
+		begin
+			cur_state <= 4'b1000;
+		end
+	end
+	4'b1000:
+	begin
+                 
+		tmp <= n ;
+
+		indvar <= 32'b00000000000000000000000000000000;   
+		cur_state <= 4'b1001;
+	end
+	4'b1001:
+	begin
+
+		cur_state <= 4'b1010;
+	end
+	4'b1010:
+	begin
+	tmp8 <= indvar;
+		indvar_next <= indvar;
+		cur_state <= 4'b1011;
+	end
+	4'b1011:
+	begin
+
+		scevgep <= (m & tmp8);
+
+		exitcond <= (indvar_next == tmp);
+
+		cur_state <= 4'b1100;
+	end
+	4'b1100:
+	begin
+
+		s_07 <= scevgep;
+
+		cur_state <= 4'b1101;
+	end
+	4'b1101:
+	
+	begin
+
+
+		if (exitcond)
+		begin
+				cur_state <= 4'b1110;
+		end
+			else 
+		begin
+				indvar <= indvar_next;   
+				cur_state <= 4'b1001;
+		end
+	end
+	
+	
+	4'b1110:
+	begin
+
+		return_val <= m;
+		finish <= 1'b1;
+		cur_state <= 4'b0000;
+	end
+endcase
+
+always @(cur_state)
+begin
+
+	case(cur_state)
+	4'b1101:
+	begin
+		memory_controller_address = s_07;
+		memory_controller_write_enable = 1'b1;
+		memory_controller_in = c;
+	end
+	endcase
+end
+
+endmodule

--- a/vtr_flow/benchmarks/hdl_include/include/README.md
+++ b/vtr_flow/benchmarks/hdl_include/include/README.md
@@ -1,0 +1,44 @@
+# include files
+
+This folder contains _include_ files for running the modified version of ch_intrisinc.
+
+_include_ files can be either a Verilog file or a Verilog header file. The main point worth mentioning is that the union of include files and the circuit design includes the top module should not result in any conflict like having multiple top modules or declaring different variables with the same name.
+
+To create a task config file, the syntax for _include_ files is pretty much like the circuits or architectures. 
+In the beginning, _includes_dir_, a path to _include_ files should be specified. In the following, specifiers include_add_list adds specific _include_ files, using a relative path that will be pre-pended by the _includes_dir_ path.
+If config.txt file lists multiple benchmark circuits and multiple include files, all include files will be considered (unioned into) each circuit design. In other words, _include_ files are shared among given benchmark circuits.
+
+___________________________hdl_include task config file____________________________
+##############################################
+\# Configuration file for running experiments
+##############################################
+
+\# Path to directory of circuits to use
+circuits_dir=benchmarks/hdl_include
+
+\# Path to directory of includes circuits to use
+includes_dir=benchmarks/hdl_include/include
+
+\# Path to directory of architectures to use
+archs_dir=arch/no_timing/memory_sweep
+
+\# Add circuits to list to sweep
+circuit_list_add=ch_intrinsics_top.v
+
+\# Add circuits to includes list to sweep
+include_list_add=generic_definitions1.vh
+include_list_add=generic_definitions2.vh
+include_list_add=memory_controller.vh
+
+\# Add architectures to list to sweep
+arch_list_add=k4_N10_memSize16384_memData64.xml
+
+\# Parse info and how to parse
+parse_file=vpr_no_timing.txt
+
+\# How to parse QoR info
+qor_parse_file=qor_no_timing.txt
+
+\# Script parameters
+script_params_common=-track_memory_usage --timing_analysis off
+___________________________________________________________________________________

--- a/vtr_flow/benchmarks/hdl_include/include/generic_definitions1.vh
+++ b/vtr_flow/benchmarks/hdl_include/include/generic_definitions1.vh
@@ -1,0 +1,7 @@
+/*
+ * This header file provides definitions for ch_intrinsic_modified.v
+ * located at: 
+ *      vtr_flow/benchmarks/hdl_include/ch_intrinsic_modified.v
+*/
+`define MEMORY_CONTROLLER_ADDR_SIZE 32
+`define MEMORY_CONTROLLER_DATA_SIZE 32

--- a/vtr_flow/benchmarks/hdl_include/include/generic_definitions2.vh
+++ b/vtr_flow/benchmarks/hdl_include/include/generic_definitions2.vh
@@ -1,0 +1,8 @@
+/*
+ * This header file provides definitions for ch_intrinsic_modified.v
+ * located at: 
+ *      vtr_flow/benchmarks/hdl_include/ch_intrinsic_modified.v
+*/
+`define MEMORY_CONTROLLER_TAGS 1
+`define MEMORY_CONTROLLER_TAG_SIZE 1
+`define TAG__str 1'b0

--- a/vtr_flow/benchmarks/hdl_include/include/memory_controller.v
+++ b/vtr_flow/benchmarks/hdl_include/include/memory_controller.v
@@ -1,0 +1,64 @@
+/*
+ * This Verilog file provides the memory_controller description 
+ * for ch_intrinsic_modified.v located at: 
+ *      vtr_flow/benchmarks/hdl_include/ch_intrinsic_modified.v
+*/
+module memory_controller
+(
+	clk,
+	memory_controller_address,
+	memory_controller_write_enable,
+	memory_controller_in,
+	memory_controller_out
+);
+input clk;
+input [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] memory_controller_address;
+input memory_controller_write_enable;
+input [`MEMORY_CONTROLLER_DATA_SIZE-1:0] memory_controller_in;
+output  [`MEMORY_CONTROLLER_DATA_SIZE-1:0] memory_controller_out;
+reg [`MEMORY_CONTROLLER_DATA_SIZE-1:0] memory_controller_out;
+
+
+reg [4:0] str_address;
+reg str_write_enable;
+reg [7:0] str_in;
+wire [7:0] str_out;
+
+single_port_ram _str (
+	.clk( clk ),
+	.addr( str_address ),
+	.we( str_write_enable ),
+	.data( str_in ),
+	.out( str_out )
+);
+
+
+wire  tag;
+
+//must use all wires inside module.....
+assign tag = |memory_controller_address & |memory_controller_address & | memory_controller_in;
+reg [`MEMORY_CONTROLLER_TAG_SIZE-1:0] prevTag;
+always @(posedge clk)
+	prevTag <= tag;
+always @( tag or memory_controller_address or memory_controller_write_enable or memory_controller_in)
+begin
+
+case(tag)
+
+	1'b0:
+	begin
+		str_address = memory_controller_address[5-1+0:0];
+		str_write_enable = memory_controller_write_enable;
+		str_in[8-1:0] = memory_controller_in[8-1:0];
+	end
+endcase
+
+case(prevTag)
+
+	1'b0:
+		memory_controller_out = str_out;
+endcase
+end
+
+endmodule 
+

--- a/vtr_flow/scripts/python_libs/vtr/flow.py
+++ b/vtr_flow/scripts/python_libs/vtr/flow.py
@@ -34,6 +34,7 @@ def run(
     architecture_file,
     circuit_file,
     power_tech_file=None,
+    include_files=None,
     start_stage=VtrStage.ODIN,
     end_stage=VtrStage.VPR,
     command_runner=vtr.CommandRunner(),
@@ -134,7 +135,6 @@ def run(
     vpr_args = OrderedDict() if not vpr_args else vpr_args
     odin_args = OrderedDict() if not odin_args else odin_args
     abc_args = OrderedDict() if not abc_args else abc_args
-
     # Verify that files are Paths or convert them to Paths and check that they exist
     architecture_file = vtr.util.verify_file(architecture_file, "Architecture")
     circuit_file = vtr.util.verify_file(circuit_file, "Circuit")
@@ -167,6 +167,15 @@ def run(
     shutil.copy(str(circuit_file), str(circuit_copy))
     shutil.copy(str(architecture_file), str(architecture_copy))
 
+    # Check whether any inclulde is specified
+    if include_files:
+        # Verify include files are Paths or convert them to Path + check that they exist
+        # Copy include files to the run directory
+        for include in include_files:
+            include_file = vtr.util.verify_file(include, "Circuit")
+            include_copy = temp_dir / include_file.name
+            shutil.copy(str(include), str(include_copy))
+
     # There are multiple potential paths for the netlist to reach a tool
     # We initialize it here to the user specified circuit and let downstream
     # stages update it
@@ -179,6 +188,7 @@ def run(
         vtr.odin.run(
             architecture_copy,
             next_stage_netlist,
+            include_files,
             output_netlist=post_odin_netlist,
             command_runner=command_runner,
             temp_dir=temp_dir,

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -42,7 +42,7 @@ class VtrStageArgparseAction(argparse.Action):
 
 # pylint: enable=too-few-public-methods
 
-
+# pylint: disable=too-many-statements
 def vtr_command_argparser(prog=None):
     """
     The VTR command arg parser
@@ -322,6 +322,13 @@ def vtr_command_argparser(prog=None):
         dest="odin_config",
         help="Supplies Odin with a custom config file for optimizations.",
     )
+    odin.add_argument(
+        "-include",
+        nargs="*",
+        default=None,
+        dest="include_list_file",
+        help="List of include files to a benchmark circuit(pass to Odin as a benchmark design set)",
+    )
     #
     # VPR arguments
     #
@@ -382,6 +389,9 @@ def vtr_command_argparser(prog=None):
     return parser
 
 
+# pylint: enable=too-many-statements
+
+
 def vtr_command_main(arg_list, prog=None):
     """
     Running VTR with the specified arguemnts.
@@ -423,6 +433,7 @@ def vtr_command_main(arg_list, prog=None):
             Path(args.architecture_file),
             Path(args.circuit_file),
             power_tech_file=args.power_tech,
+            include_files=args.include_list_file,
             temp_dir=temp_dir,
             start_stage=args.start,
             end_stage=args.end,

--- a/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include/config/config.txt
@@ -1,0 +1,40 @@
+###############################################################
+# Configuration file for running experiments
+# This config file is testing the ability to specify include
+# files that should pass to Odin with the top module of the
+# benchmark (ch_intrinsic_top.v). This is done by specifying 
+# two Verilog header files that provide essential definitions, 
+# and memory_controller design that provides the design of an
+# internal component for ch_intrinsic_top. If the include files
+# are not properly included during compilation the benchmark is
+# incomplete and the flow will error out. 
+###############################################################
+
+# Path to directory of circuits to use
+circuits_dir=benchmarks/hdl_include
+
+# Path to directory of includes circuits to use
+includes_dir=benchmarks/hdl_include/include
+
+# Path to directory of architectures to use
+archs_dir=arch/no_timing/memory_sweep
+
+# Add circuits to list to sweep
+circuit_list_add=ch_intrinsics_modified.v
+
+# Add circuits to includes list to sweep
+include_list_add=generic_definitions1.vh
+include_list_add=generic_definitions2.vh
+include_list_add=memory_controller.v
+
+# Add architectures to list to sweep
+arch_list_add=k4_N10_memSize16384_memData64.xml
+
+# Parse info and how to parse
+parse_file=vpr_no_timing.txt
+
+# How to parse QoR info
+qor_parse_file=qor_no_timing.txt
+
+# Script parameters
+script_params_common=-track_memory_usage --timing_analysis off

--- a/vtr_flow/tasks/regression_tests/vtr_reg_basic/task_list.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_basic/task_list.txt
@@ -1,3 +1,4 @@
 regression_tests/vtr_reg_basic/basic_no_timing
 regression_tests/vtr_reg_basic/basic_timing
 regression_tests/vtr_reg_basic/basic_timing_no_sdc
+regression_tests/vtr_reg_basic/hdl_include


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
1. `includes_dir` and `include_list_add` have been added to task config files as optional parameters. Users can pass additional (.v) or (.vh) files including some extra feature to the VTR flow. 
2. A modified version of ch_intrinsics has been added to benchmarks without `define macros
3. New header files have added to cover the ch_intrinsics definitions
4. New test is added to vtr_reg_basic/no_timing to test the new feature

Usage:
- For **run_vtr_flow** users need to added the parameter `-include 1.v 2.vh ...`
- For **run_vtr_task**, `includes_dir` and `include_list_add` need to be specified in the task config.txt

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
PR #1753 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support a new feature to add separate files than the main circuit design to cover additional design supports like macro definitons

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`run_vtr_task`
`run_vtr_flow`
`run_reg_test`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
