### PR TITLE
Print not specified for floorplan constraints file when running vpr w…

### DIFF
--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -30,7 +30,11 @@ void ShowSetup(const t_vpr_setup& vpr_setup) {
     VTR_LOG("Circuit placement file: %s\n", vpr_setup.FileNameOpts.PlaceFile.c_str());
     VTR_LOG("Circuit routing file: %s\n", vpr_setup.FileNameOpts.RouteFile.c_str());
     VTR_LOG("Circuit SDC file: %s\n", vpr_setup.Timing.SDCFile.c_str());
-    VTR_LOG("Vpr floorplanning constraints file: %s\n", vpr_setup.FileNameOpts.read_vpr_constraints_file.c_str());
+    if (vpr_setup.FileNameOpts.read_vpr_constraints_file == "") {
+        VTR_LOG("Vpr floorplanning constraints file: not specified %s\n");
+    } else {
+        VTR_LOG("Vpr floorplanning constraints file: %s\n", vpr_setup.FileNameOpts.read_vpr_constraints_file.c_str());
+    }
     VTR_LOG("\n");
 
     VTR_LOG("Packer: %s\n", (vpr_setup.PackerOpts.doPacking ? "ENABLED" : "DISABLED"));

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -30,8 +30,8 @@ void ShowSetup(const t_vpr_setup& vpr_setup) {
     VTR_LOG("Circuit placement file: %s\n", vpr_setup.FileNameOpts.PlaceFile.c_str());
     VTR_LOG("Circuit routing file: %s\n", vpr_setup.FileNameOpts.RouteFile.c_str());
     VTR_LOG("Circuit SDC file: %s\n", vpr_setup.Timing.SDCFile.c_str());
-    if (vpr_setup.FileNameOpts.read_vpr_constraints_file == "") {
-        VTR_LOG("Vpr floorplanning constraints file: not specified %s\n");
+    if (vpr_setup.FileNameOpts.read_vpr_constraints_file.empty()) {
+        VTR_LOG("Vpr floorplanning constraints file: not specified\n");
     } else {
         VTR_LOG("Vpr floorplanning constraints file: %s\n", vpr_setup.FileNameOpts.read_vpr_constraints_file.c_str());
     }

--- a/vpr/src/base/vpr_constraints.h
+++ b/vpr/src/base/vpr_constraints.h
@@ -23,14 +23,14 @@
  * The following definitions are useful to understanding this class:
  *
  * Partition: a grouping of atoms that are constrained to a portion of an FPGA
- * See vpr/base/partition.h for more detail
+ * See vpr/src/base/partition.h for more detail
  *
  * Region: the x and y bounds of a rectangular region, optionally including a subtile value,
  * that atoms in a partition are constrained to
- * See vpr/base/region.h for more detail
+ * See vpr/src/base/region.h for more detail
  *
  * PartitionRegion: the union of regions that a partition can be placed in
- * See vpr/base/partition_region.h for more detail
+ * See vpr/src/base/partition_region.h for more detail
  *
  *
  */


### PR DESCRIPTION
…ithout floorplan constraints

When a floorplan constraints file is not provided when running vpr (i.e. read_vpr_constraints option not used), the VTR log file used print:
Vpr floorplanning constraints file: 

Now, it prints the following
Vpr floorplanning constraints file: not specified

This change makes it clear to the user that no constraints file was passed in when running vpr. This fix is for issue #1752 
