### PR TITLE
Improve region intersect function

### DIFF
--- a/vpr/src/base/region.cpp
+++ b/vpr/src/base/region.cpp
@@ -103,24 +103,17 @@ Region intersection(const Region& r1, const Region& r2) {
         intersect_rect = intersection(r1_rect, r2_rect);
         intersect.set_region_rect(intersect_rect.xmin(), intersect_rect.ymin(), intersect_rect.xmax(), intersect_rect.ymax());
 
-        return intersect;
-
     } else if (r1.get_sub_tile() == NO_SUBTILE && r2.get_sub_tile() != NO_SUBTILE) {
         intersect.set_sub_tile(r2.get_sub_tile());
         intersect_rect = intersection(r1_rect, r2_rect);
         intersect.set_region_rect(intersect_rect.xmin(), intersect_rect.ymin(), intersect_rect.xmax(), intersect_rect.ymax());
 
-        return intersect;
-
     } else if (r1.get_sub_tile() != NO_SUBTILE && r2.get_sub_tile() == NO_SUBTILE) {
         intersect.set_sub_tile(r1.get_sub_tile());
         intersect_rect = intersection(r1_rect, r2_rect);
         intersect.set_region_rect(intersect_rect.xmin(), intersect_rect.ymin(), intersect_rect.xmax(), intersect_rect.ymax());
-
-        return intersect;
     }
 
-    //If none of the above cases are true, an empty intersect region is returned
     return intersect;
 }
 

--- a/vpr/src/base/region.cpp
+++ b/vpr/src/base/region.cpp
@@ -81,23 +81,46 @@ bool do_regions_intersect(Region r1, Region r2) {
 
 Region intersection(const Region& r1, const Region& r2) {
     Region intersect;
+    vtr::Rect<int> r1_rect = r1.get_region_rect();
+    vtr::Rect<int> r2_rect = r2.get_region_rect();
+    vtr::Rect<int> intersect_rect;
 
-    /**
-     * If the subtiles of the two regions don't match, there is no intersection.
-     * If they do match, the intersection function if used to get the overlap of the two regions' rectangles.
-     * If there is no overlap, an empty rectangle will be returned.
+    /*
+     * If the subtiles of two regions match (i.e. they both have no subtile specified, or the same subtile specified),
+     * the regions are intersected. The resulting intersection region will have a rectangle that reflects their overlap,
+     * (it will be empty if there is no overlap), and a subtile that is the same as that of both regions.
+     *
+     * If one of the two regions has a subtile specified, and the other does not, the regions are intersected.
+     * The resulting intersection region will have a rectangle that reflects their overlap (it will be empty if there is
+     * no overlap), and a subtile that is the same as the subtile of the region with the specific subtile assigned.
+     *
+     * If none of the above cases are true (i.e. the regions both have subtiles specified, but the subtiles do not
+     * match each other) then the intersection is not performed and a region with an empty rectangle is returned.
+     * This is because there can be no overlap in this case since the regions are constrained to two separate subtiles.
      */
     if (r1.get_sub_tile() == r2.get_sub_tile()) {
         intersect.set_sub_tile(r1.get_sub_tile());
-        vtr::Rect<int> r1_rect = r1.get_region_rect();
-        vtr::Rect<int> r2_rect = r2.get_region_rect();
-        vtr::Rect<int> intersect_rect;
-
         intersect_rect = intersection(r1_rect, r2_rect);
-
         intersect.set_region_rect(intersect_rect.xmin(), intersect_rect.ymin(), intersect_rect.xmax(), intersect_rect.ymax());
+
+        return intersect;
+
+    } else if (r1.get_sub_tile() == NO_SUBTILE && r2.get_sub_tile() != NO_SUBTILE) {
+        intersect.set_sub_tile(r2.get_sub_tile());
+        intersect_rect = intersection(r1_rect, r2_rect);
+        intersect.set_region_rect(intersect_rect.xmin(), intersect_rect.ymin(), intersect_rect.xmax(), intersect_rect.ymax());
+
+        return intersect;
+
+    } else if (r1.get_sub_tile() != NO_SUBTILE && r2.get_sub_tile() == NO_SUBTILE) {
+        intersect.set_sub_tile(r1.get_sub_tile());
+        intersect_rect = intersection(r1_rect, r2_rect);
+        intersect.set_region_rect(intersect_rect.xmin(), intersect_rect.ymin(), intersect_rect.xmax(), intersect_rect.ymax());
+
+        return intersect;
     }
 
+    //If none of the above cases are true, an empty intersect region is returned
     return intersect;
 }
 

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -47,9 +47,9 @@ static t_physical_tile_type_ptr pick_placement_type(t_logical_block_type_ptr log
 vtr::vector<ClusterBlockId, t_block_score> assign_block_scores();
 
 //Sort the blocks according to how difficult they are to place, prior to initial placement
-std::vector<ClusterBlockId> sort_blocks(vtr::vector<ClusterBlockId, t_block_score> block_scores);
+std::vector<ClusterBlockId> sort_blocks(const vtr::vector<ClusterBlockId, t_block_score>& block_scores);
 
-void print_sorted_blocks(std::vector<ClusterBlockId> sorted_blocks, vtr::vector<ClusterBlockId, t_block_score> block_scores);
+void print_sorted_blocks(const std::vector<ClusterBlockId> sorted_blocks, vtr::vector<ClusterBlockId, t_block_score>& block_scores);
 
 static int get_free_sub_tile(std::vector<std::vector<int>>& free_locations, int itype, std::vector<int> possible_sub_tiles) {
     for (int sub_tile : possible_sub_tiles) {
@@ -359,6 +359,12 @@ vtr::vector<ClusterBlockId, t_block_score> assign_block_scores() {
 
     block_scores.resize(blocks.size());
 
+    /*
+     * For the blocks with no floorplan constraints, and the blocks that are not part of macros,
+     * the block scores will remain at their default values assigned by the constructor
+     * (macro_size = 0; floorplan_constraints = 0; num_equivalent_tiles =1;
+     */
+
     //go through all blocks and store floorplan constraints and num equivalent tiles
     for (auto blk_id : blocks) {
         if (is_cluster_constrained(blk_id)) {
@@ -380,7 +386,7 @@ vtr::vector<ClusterBlockId, t_block_score> assign_block_scores() {
     return block_scores;
 }
 
-std::vector<ClusterBlockId> sort_blocks(vtr::vector<ClusterBlockId, t_block_score> block_scores) {
+std::vector<ClusterBlockId> sort_blocks(const vtr::vector<ClusterBlockId, t_block_score>& block_scores) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
     auto blocks = cluster_ctx.clb_nlist.blocks();
@@ -400,7 +406,7 @@ std::vector<ClusterBlockId> sort_blocks(vtr::vector<ClusterBlockId, t_block_scor
     return sorted_blocks;
 }
 
-void print_sorted_blocks(std::vector<ClusterBlockId> sorted_blocks, vtr::vector<ClusterBlockId, t_block_score> block_scores) {
+void print_sorted_blocks(const std::vector<ClusterBlockId> sorted_blocks, vtr::vector<ClusterBlockId, t_block_score>& block_scores) {
     VTR_LOG("\nPrinting sorted blocks: \n");
     for (unsigned int i = 0; i < sorted_blocks.size(); i++) {
         VTR_LOG("Block_Id: %zu, Macro size: %d, Num floorplan constraints: %d, Num equivalent tiles %d \n", sorted_blocks[i], block_scores[sorted_blocks[i]].macro_size, block_scores[sorted_blocks[i]].floorplan_constraints, block_scores[sorted_blocks[i]].num_equivalent_tiles);

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -49,7 +49,7 @@ vtr::vector<ClusterBlockId, t_block_score> assign_block_scores();
 //Sort the blocks according to how difficult they are to place, prior to initial placement
 std::vector<ClusterBlockId> sort_blocks(const vtr::vector<ClusterBlockId, t_block_score>& block_scores);
 
-void print_sorted_blocks(const std::vector<ClusterBlockId> sorted_blocks, vtr::vector<ClusterBlockId, t_block_score>& block_scores);
+void print_sorted_blocks(const std::vector<ClusterBlockId>& sorted_blocks, const vtr::vector<ClusterBlockId, t_block_score>& block_scores);
 
 static int get_free_sub_tile(std::vector<std::vector<int>>& free_locations, int itype, std::vector<int> possible_sub_tiles) {
     for (int sub_tile : possible_sub_tiles) {
@@ -406,7 +406,7 @@ std::vector<ClusterBlockId> sort_blocks(const vtr::vector<ClusterBlockId, t_bloc
     return sorted_blocks;
 }
 
-void print_sorted_blocks(const std::vector<ClusterBlockId> sorted_blocks, vtr::vector<ClusterBlockId, t_block_score>& block_scores) {
+void print_sorted_blocks(const std::vector<ClusterBlockId>& sorted_blocks, const vtr::vector<ClusterBlockId, t_block_score>& block_scores) {
     VTR_LOG("\nPrinting sorted blocks: \n");
     for (unsigned int i = 0; i < sorted_blocks.size(); i++) {
         VTR_LOG("Block_Id: %zu, Macro size: %d, Num floorplan constraints: %d, Num equivalent tiles %d \n", sorted_blocks[i], block_scores[sorted_blocks[i]].macro_size, block_scores[sorted_blocks[i]].floorplan_constraints, block_scores[sorted_blocks[i]].num_equivalent_tiles);


### PR DESCRIPTION
The intersection function belonging to the Region class was modified to also consider cases where one region has no subtile specified and the other region has a subtile specified.

#### Description
Previously, the region intersection function would only calculate the intersection when the two regions passed in both had no subtiles specified, or both had the same subtiles specified. However, this meant that the routine would miss out on some cases. 

For example, if region r1 was constrained from region (0,0) to (10,10) with subtile 0 specified, and region r2 was constrained from region (0,0) to (10,10) with no subtile specified, the previous intersection function would say that there is no intersection between these two regions. The new intersection function would return (0,0) to (10,10) with subtile 0 as the intersection between r1 and r2. 

#### Related Issue
This pull request is related to adding floorplanning placement constraints to VPR, as described in this issue #932

#### Motivation and Context
The missing of some intersecting regions becomes an issue especially when trying to intersect a region with the grid dimensions, to ensure that the region does not fall outside of the grid dimensions. If a PartitionRegion is created to match grid dimensions, it does not have a subtile specified since different areas of the grid can have different subtile dimensions. If a region with subtile specified is intersected with the grid PartitionRegion, the old Region intersection will return no intersection, even when the region is within the grid dimensions. The new Region intersection function solves this problem.

Another thing that should be considered is whether there is a way to check that the subtile dimensions of the region are within the subtile dimensions of the grid at the specified x, y values.

