### PR TITLE
Deploy ``RRGraphBuilder`` in Client Functions to replace the use of ``rr_node_indices``

### DIFF
--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -77,6 +77,9 @@ RRNodeId RRSpatialLookup::find_node(int x,
 std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
                                                           int y,
                                                           t_rr_type type) const {
+    /* TODO: The implementation of this API should be worked 
+     * when rr_node_indices adapts RRNodeId natively!
+     */
     std::vector<RRNodeId> channel_nodes;
 
     /* Pre-check: the x, y, type are valid! Otherwise, return an empty vector */

--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -124,7 +124,9 @@ std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
     }
 
     for (const auto& node : rr_node_indices_[type][node_x][node_y][node_side]) {
-        channel_nodes.push_back(RRNodeId(node));
+        if (RRNodeId(node)) {
+            channel_nodes.push_back(RRNodeId(node));
+        }
     }
 
     return channel_nodes;

--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -29,7 +29,7 @@ RRNodeId RRSpatialLookup::find_node(int x,
     }
 
     /* Pre-check: the x, y, side and ptc should be non negative numbers! Otherwise, return an invalid id */
-    if ((0 > x) || (0 > y) || (NUM_SIDES == node_side) || (0 > ptc)) {
+    if ((x < 0) || (y < 0) || (node_side == NUM_SIDES) || (ptc < 0)) {
         return RRNodeId::INVALID();
     }
 
@@ -41,7 +41,7 @@ RRNodeId RRSpatialLookup::find_node(int x,
      */
     size_t node_x = x;
     size_t node_y = y;
-    if (CHANX == type) {
+    if (type == CHANX) {
         std::swap(node_x, node_y);
     }
 
@@ -83,7 +83,7 @@ std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
     std::vector<RRNodeId> channel_nodes;
 
     /* Pre-check: the x, y, type are valid! Otherwise, return an empty vector */
-    if ((0 > x || 0 > y) && (CHANX == type || CHANY == type)) {
+    if ((x < 0 || y < 0) && (type == CHANX || type == CHANY)) {
         return channel_nodes;
     }
 
@@ -95,7 +95,7 @@ std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
      */
     size_t node_x = x;
     size_t node_y = y;
-    if (CHANX == type) {
+    if (type == CHANX) {
         std::swap(node_x, node_y);
     }
 
@@ -194,8 +194,8 @@ void RRSpatialLookup::resize_nodes(int x,
      * should ensure the fast look-up well organized  
      */
     VTR_ASSERT(type < rr_node_indices_.size());
-    VTR_ASSERT(0 <= x);
-    VTR_ASSERT(0 <= y);
+    VTR_ASSERT(x >= 0);
+    VTR_ASSERT(y >= 0);
 
     if ((x >= int(rr_node_indices_[type].dim_size(0)))
         || (y >= int(rr_node_indices_[type].dim_size(1)))

--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -130,6 +130,32 @@ std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
     return channel_nodes;
 }
 
+std::vector<RRNodeId> RRSpatialLookup::find_nodes_at_all_sides(int x,
+                                                               int y,
+                                                               t_rr_type rr_type,
+                                                               int ptc) const {
+    std::vector<RRNodeId> indices;
+
+    /* TODO: Consider to access the raw data like find_node() rather than calling find_node() many times, which hurts runtime */
+    if (rr_type == IPIN || rr_type == OPIN) {
+        //For pins we need to look at all the sides of the current grid tile
+        for (e_side side : SIDES) {
+            RRNodeId rr_node_index = find_node(x, y, rr_type, ptc, side);
+            if (rr_node_index) {
+                indices.push_back(rr_node_index);
+            }
+        }
+    } else {
+        //Sides do not effect non-pins so there should only be one per ptc
+        RRNodeId rr_node_index = find_node(x, y, rr_type, ptc);
+        if (rr_node_index) {
+            indices.push_back(rr_node_index);
+        }
+    }
+
+    return indices;
+}
+
 void RRSpatialLookup::add_node(RRNodeId node,
                                int x,
                                int y,

--- a/vpr/src/device/rr_spatial_lookup.h
+++ b/vpr/src/device/rr_spatial_lookup.h
@@ -63,6 +63,23 @@ class RRSpatialLookup {
                        int ptc,
                        e_side side = NUM_SIDES) const;
 
+    /**
+     * Returns the indices of the specified routing resource nodes,
+     * representing routing tracks in a channel.  
+     * - (x, y) are the coordinate of the routing channel within the FPGA
+     * - rr_type specifies the type of routing channel, either x-direction or y-direction
+     *
+     * Note: 
+     * - Return an empty list if there are no routing channel at the given (x, y) location
+     * - The node list returned may contain some holes (invalid ids), which means that
+     *   the routing track does not exist at a specific location
+     *   For example, if the 2nd element is an invalid id, it means the 2nd routing track does not exist
+     *   in a routing channel at (x, y) location
+     */
+    std::vector<RRNodeId> find_channel_nodes(int x,
+                                             int y,
+                                             t_rr_type type) const;
+
     /* -- Mutators -- */
   public:
     /**

--- a/vpr/src/device/rr_spatial_lookup.h
+++ b/vpr/src/device/rr_spatial_lookup.h
@@ -71,10 +71,11 @@ class RRSpatialLookup {
      *
      * Note: 
      * - Return an empty list if there are no routing channel at the given (x, y) location
-     * - The node list returned may contain some holes (invalid ids), which means that
-     *   the routing track does not exist at a specific location
-     *   For example, if the 2nd element is an invalid id, it means the 2nd routing track does not exist
-     *   in a routing channel at (x, y) location
+     * - The node list returned only contain valid ids
+     *   For example, if the 2nd routing track does not exist in a routing channel at (x, y) location,
+     *   while the 3rd routing track does exist in a routing channel at (x, y) location,
+     *   the node list will not contain the node for the 2nd routing track, but the 2nd element in the list
+     *   will be the node for the 3rd routing track
      */
     std::vector<RRNodeId> find_channel_nodes(int x,
                                              int y,

--- a/vpr/src/device/rr_spatial_lookup.h
+++ b/vpr/src/device/rr_spatial_lookup.h
@@ -80,6 +80,16 @@ class RRSpatialLookup {
                                              int y,
                                              t_rr_type type) const;
 
+    /**
+     * Like find_node() but returns all matching nodes on all the sides.
+     * This is particularly useful for getting all instances
+     * of a specific IPIN/OPIN at a specific gird tile (x,y) location.
+     */
+    std::vector<RRNodeId> find_nodes_at_all_sides(int x,
+                                                  int y,
+                                                  t_rr_type rr_type,
+                                                  int ptc) const;
+
     /* -- Mutators -- */
   public:
     /**

--- a/vpr/src/pack/post_routing_pb_pin_fixup.cpp
+++ b/vpr/src/pack/post_routing_pb_pin_fixup.cpp
@@ -152,12 +152,10 @@ static void update_cluster_pin_with_post_routing_results(const DeviceContext& de
         short valid_routing_net_cnt = 0;
         for (const e_side& pin_side : pin_sides) {
             /* Find the net mapped to this pin in routing results */
-            const int& rr_node = get_rr_node_index(device_ctx.rr_node_indices,
-                                                   grid_coord.x(), grid_coord.y(),
-                                                   rr_node_type, physical_pin, pin_side);
+            RRNodeId rr_node = device_ctx.rr_graph.node_lookup().find_node(grid_coord.x(), grid_coord.y(), rr_node_type, physical_pin, pin_side);
 
             /* Bypass invalid nodes, after that we must have a valid rr_node id */
-            if (OPEN == rr_node) {
+            if (!rr_node) {
                 continue;
             }
             VTR_ASSERT((size_t)rr_node < device_ctx.rr_nodes.size());
@@ -179,19 +177,19 @@ static void update_cluster_pin_with_post_routing_results(const DeviceContext& de
              * - A invalid net id (others should be all invalid as well)
              *   assume that this pin is not used by router
              */
-            if (rr_node_nets[RRNodeId(rr_node)]) {
+            if (rr_node_nets[rr_node]) {
                 if (routing_net_id) {
-                    if (routing_net_id != rr_node_nets[RRNodeId(rr_node)]) {
+                    if (routing_net_id != rr_node_nets[rr_node]) {
                         VTR_LOG_ERROR("Pin '%s' is mapped to two nets: '%s' and '%s'\n",
                                       pb_graph_pin->to_string().c_str(),
                                       clustering_ctx.clb_nlist.net_name(routing_net_id).c_str(),
-                                      clustering_ctx.clb_nlist.net_name(rr_node_nets[RRNodeId(rr_node)]).c_str());
+                                      clustering_ctx.clb_nlist.net_name(rr_node_nets[rr_node]).c_str());
                     }
-                    VTR_ASSERT(routing_net_id == rr_node_nets[RRNodeId(rr_node)]);
+                    VTR_ASSERT(routing_net_id == rr_node_nets[rr_node]);
                 }
-                routing_net_id = rr_node_nets[RRNodeId(rr_node)];
+                routing_net_id = rr_node_nets[rr_node];
                 valid_routing_net_cnt++;
-                visited_rr_nodes.push_back(RRNodeId(rr_node));
+                visited_rr_nodes.push_back(rr_node);
             }
         }
 

--- a/vpr/src/pack/post_routing_pb_pin_fixup.cpp
+++ b/vpr/src/pack/post_routing_pb_pin_fixup.cpp
@@ -55,6 +55,7 @@ static void update_cluster_pin_with_post_routing_results(const DeviceContext& de
                                                          const int& sub_tile_z,
                                                          size_t& num_mismatches,
                                                          const bool& verbose) {
+    const auto& node_lookup = device_ctx.rr_graph.node_lookup();
     /* Handle each pin */
     auto logical_block = clustering_ctx.clb_nlist.block_type(blk_id);
     auto physical_tile = device_ctx.grid[grid_coord.x()][grid_coord.y()].type;
@@ -152,7 +153,7 @@ static void update_cluster_pin_with_post_routing_results(const DeviceContext& de
         short valid_routing_net_cnt = 0;
         for (const e_side& pin_side : pin_sides) {
             /* Find the net mapped to this pin in routing results */
-            RRNodeId rr_node = device_ctx.rr_graph.node_lookup().find_node(grid_coord.x(), grid_coord.y(), rr_node_type, physical_pin, pin_side);
+            RRNodeId rr_node = node_lookup.find_node(grid_coord.x(), grid_coord.y(), rr_node_type, physical_pin, pin_side);
 
             /* Bypass invalid nodes, after that we must have a valid rr_node id */
             if (!rr_node) {

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -962,6 +962,7 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
 
     auto& device_ctx = g_vpr_ctx.device();
     auto& grid = device_ctx.grid;
+    const auto& node_lookup = device_ctx.rr_graph.node_lookup();
 
     //Search the grid for an instance of from/to blocks which satisfy this direct connect offsets,
     //and which has the appropriate pins
@@ -979,10 +980,10 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
             //(with multi-width/height blocks pins may not exist at all locations)
             bool from_pin_found = false;
             if (direct->from_side != NUM_SIDES) {
-                RRNodeId from_pin_rr = device_ctx.rr_graph.node_lookup().find_node(from_x, from_y, OPIN, from_pin, direct->from_side);
+                RRNodeId from_pin_rr = node_lookup.find_node(from_x, from_y, OPIN, from_pin, direct->from_side);
                 from_pin_found = (from_pin_rr != RRNodeId::INVALID());
             } else {
-                (*scratch) = device_ctx.rr_graph.node_lookup().find_nodes_at_all_sides(from_x, from_y, OPIN, from_pin);
+                (*scratch) = node_lookup.find_nodes_at_all_sides(from_x, from_y, OPIN, from_pin);
                 from_pin_found = !(*scratch).empty();
             }
             if (!from_pin_found) continue;
@@ -996,10 +997,10 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
             //(with multi-width/height blocks pins may not exist at all locations)
             bool to_pin_found = false;
             if (direct->to_side != NUM_SIDES) {
-                RRNodeId to_pin_rr = device_ctx.rr_graph.node_lookup().find_node(to_x, to_y, IPIN, to_pin, direct->to_side);
+                RRNodeId to_pin_rr = node_lookup.find_node(to_x, to_y, IPIN, to_pin, direct->to_side);
                 to_pin_found = (to_pin_rr != RRNodeId::INVALID());
             } else {
-                (*scratch) = device_ctx.rr_graph.node_lookup().find_nodes_at_all_sides(to_x, to_y, IPIN, to_pin);
+                (*scratch) = node_lookup.find_nodes_at_all_sides(to_x, to_y, IPIN, to_pin);
                 to_pin_found = !(*scratch).empty();
             }
             if (!to_pin_found) continue;
@@ -1037,13 +1038,13 @@ static bool find_direct_connect_sample_locations(const t_direct_inf* direct,
     //
 
     {
-        (*scratch) = device_ctx.rr_graph.node_lookup().find_nodes_at_all_sides(from_x, from_y, SOURCE, from_pin_class);
+        (*scratch) = node_lookup.find_nodes_at_all_sides(from_x, from_y, SOURCE, from_pin_class);
         VTR_ASSERT((*scratch).size() > 0);
         *src_rr = size_t((*scratch)[0]);
     }
 
     {
-        (*scratch) = device_ctx.rr_graph.node_lookup().find_nodes_at_all_sides(to_x, to_y, SINK, to_pin_class);
+        (*scratch) = node_lookup.find_nodes_at_all_sides(to_x, to_y, SINK, to_pin_class);
         VTR_ASSERT((*scratch).size() > 0);
         *sink_rr = size_t((*scratch)[0]);
     }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -90,8 +90,8 @@ static t_trace_branch traceback_branch(int node, int target_net_pin_index, std::
 static std::pair<t_trace*, t_trace*> add_trace_non_configurable(t_trace* head, t_trace* tail, int node, std::unordered_set<int>& visited);
 static std::pair<t_trace*, t_trace*> add_trace_non_configurable_recurr(int node, std::unordered_set<int>& visited, int depth = 0);
 
-static vtr::vector<ClusterNetId, std::vector<int>> load_net_rr_terminals(const t_rr_node_indices& L_rr_node_indices);
-static vtr::vector<ClusterBlockId, std::vector<int>> load_rr_clb_sources(const t_rr_node_indices& L_rr_node_indices);
+static vtr::vector<ClusterNetId, std::vector<int>> load_net_rr_terminals(const RRGraphView& rr_graph);
+static vtr::vector<ClusterBlockId, std::vector<int>> load_rr_clb_sources(const RRGraphView& rr_graph);
 
 static t_clb_opins_used alloc_and_load_clb_opins_used_locally();
 static void adjust_one_rr_occ_and_acc_cost(int inode, int add_or_sub, float acc_fac);
@@ -477,10 +477,10 @@ void init_route_structs(int bb_factor) {
     route_ctx.trace_nodes.resize(cluster_ctx.clb_nlist.nets().size());
 
     //Various look-ups
-    route_ctx.net_rr_terminals = load_net_rr_terminals(device_ctx.rr_node_indices);
+    route_ctx.net_rr_terminals = load_net_rr_terminals(device_ctx.rr_graph);
     route_ctx.is_clock_net = load_is_clock_net();
     route_ctx.route_bb = load_route_bb(bb_factor);
-    route_ctx.rr_blk_source = load_rr_clb_sources(device_ctx.rr_node_indices);
+    route_ctx.rr_blk_source = load_rr_clb_sources(device_ctx.rr_graph);
     route_ctx.clb_opins_used_locally = alloc_and_load_clb_opins_used_locally();
     route_ctx.net_status.resize(cluster_ctx.clb_nlist.nets().size());
 }
@@ -966,7 +966,7 @@ void reset_rr_node_route_structs() {
 /* Allocates and loads the route_ctx.net_rr_terminals data structure. For each net it stores the rr_node   *
  * index of the SOURCE of the net and all the SINKs of the net [clb_nlist.nets()][clb_nlist.net_pins()].    *
  * Entry [inet][pnum] stores the rr index corresponding to the SOURCE (opin) or SINK (ipin) of the pin.     */
-static vtr::vector<ClusterNetId, std::vector<int>> load_net_rr_terminals(const t_rr_node_indices& L_rr_node_indices) {
+static vtr::vector<ClusterNetId, std::vector<int>> load_net_rr_terminals(const RRGraphView& rr_graph) {
     vtr::vector<ClusterNetId, std::vector<int>> net_rr_terminals;
 
     auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -993,9 +993,9 @@ static vtr::vector<ClusterNetId, std::vector<int>> load_net_rr_terminals(const t
 
             int iclass = type->pin_class[phys_pin];
 
-            int inode = get_rr_node_index(L_rr_node_indices, i, j, (pin_count == 0 ? SOURCE : SINK), /* First pin is driver */
-                                          iclass);
-            net_rr_terminals[net_id][pin_count] = inode;
+            RRNodeId inode = rr_graph.node_lookup().find_node(i, j, (pin_count == 0 ? SOURCE : SINK), /* First pin is driver */
+                                                              iclass);
+            net_rr_terminals[net_id][pin_count] = size_t(inode);
             pin_count++;
         }
     }
@@ -1008,10 +1008,10 @@ static vtr::vector<ClusterNetId, std::vector<int>> load_net_rr_terminals(const t
  * they are used only to reserve pins for locally used OPINs in the router. *
  * [0..cluster_ctx.clb_nlist.blocks().size()-1][0..num_class-1].            *
  * The values for blocks that are padsare NOT valid.                        */
-static vtr::vector<ClusterBlockId, std::vector<int>> load_rr_clb_sources(const t_rr_node_indices& L_rr_node_indices) {
+static vtr::vector<ClusterBlockId, std::vector<int>> load_rr_clb_sources(const RRGraphView& rr_graph) {
     vtr::vector<ClusterBlockId, std::vector<int>> rr_blk_source;
 
-    int i, j, iclass, inode;
+    int i, j, iclass;
     t_rr_type rr_type;
 
     auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -1036,8 +1036,8 @@ static vtr::vector<ClusterBlockId, std::vector<int>> load_rr_clb_sources(const t
                 else
                     rr_type = SINK;
 
-                inode = get_rr_node_index(L_rr_node_indices, i, j, rr_type, iclass);
-                rr_blk_source[blk_id][iclass] = inode;
+                RRNodeId inode = rr_graph.node_lookup().find_node(i, j, rr_type, iclass);
+                rr_blk_source[blk_id][iclass] = size_t(inode);
             } else {
                 rr_blk_source[blk_id][iclass] = OPEN;
             }

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -546,6 +546,7 @@ static RRNodeId get_start_node(int start_x, int start_y, int target_x, int targe
     auto& device_ctx = g_vpr_ctx.device();
     const auto& temp_rr_graph = device_ctx.rr_graph; //TODO rename to rr_graph once the rr_graph below is unneeded
     auto& rr_graph = device_ctx.rr_nodes;
+    const auto& node_lookup = device_ctx.rr_graph.node_lookup();
 
     RRNodeId result = RRNodeId::INVALID();
 
@@ -563,7 +564,7 @@ static RRNodeId get_start_node(int start_x, int start_y, int target_x, int targe
     int start_lookup_y = start_y;
 
     /* find first node in channel that has specified segment index and goes in the desired direction */
-    for (const RRNodeId& node_id : device_ctx.rr_graph.node_lookup().find_channel_nodes(start_lookup_x, start_lookup_y, rr_type)) {
+    for (const RRNodeId& node_id : node_lookup.find_channel_nodes(start_lookup_x, start_lookup_y, rr_type)) {
         VTR_ASSERT(temp_rr_graph.node_type(node_id) == rr_type);
 
         e_direction node_direction = rr_graph.node_direction(node_id);

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -562,7 +562,6 @@ static RRNodeId get_start_node(int start_x, int start_y, int target_x, int targe
     int start_lookup_x = start_x;
     int start_lookup_y = start_y;
 
-
     /* find first node in channel that has specified segment index and goes in the desired direction */
     for (const RRNodeId& node_id : device_ctx.rr_graph.node_lookup().find_channel_nodes(start_lookup_x, start_lookup_y, rr_type)) {
         if (!node_id) continue;

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -564,8 +564,6 @@ static RRNodeId get_start_node(int start_x, int start_y, int target_x, int targe
 
     /* find first node in channel that has specified segment index and goes in the desired direction */
     for (const RRNodeId& node_id : device_ctx.rr_graph.node_lookup().find_channel_nodes(start_lookup_x, start_lookup_y, rr_type)) {
-        if (!node_id) continue;
-
         VTR_ASSERT(temp_rr_graph.node_type(node_id) == rr_type);
 
         e_direction node_direction = rr_graph.node_direction(node_id);

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -405,8 +405,6 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead() {
             for (int iy = min_y; iy < max_y; iy++) {
                 for (auto rr_type : {CHANX, CHANY}) {
                     for (const RRNodeId& node_id : device_ctx.rr_graph.node_lookup().find_channel_nodes(ix, iy, rr_type)) {
-                        if (!node_id) continue;
-
                         //Find the IPINs which are reachable from the wires within the bounding box
                         //around the selected tile location
                         dijkstra_flood_to_ipins(node_id, chan_ipins_delays);

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -382,8 +382,6 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead() {
 
     chan_ipins_delays.resize(device_ctx.physical_tile_types.size());
 
-    std::vector<int> rr_nodes_at_loc;
-
     //We assume that the routing connectivity of each instance of a physical tile is the same,
     //and so only measure one instance of each type
     for (auto tile_type : device_ctx.physical_tile_types) {
@@ -406,13 +404,8 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead() {
         for (int ix = min_x; ix < max_x; ix++) {
             for (int iy = min_y; iy < max_y; iy++) {
                 for (auto rr_type : {CHANX, CHANY}) {
-                    rr_nodes_at_loc.clear();
-
-                    get_rr_node_indices(device_ctx.rr_node_indices, ix, iy, rr_type, &rr_nodes_at_loc);
-                    for (int inode : rr_nodes_at_loc) {
-                        if (inode < 0) continue;
-
-                        RRNodeId node_id(inode);
+                    for (const RRNodeId& node_id : device_ctx.rr_graph.node_lookup().find_channel_nodes(ix, iy, rr_type)) {
+                        if (!node_id) continue;
 
                         //Find the IPINs which are reachable from the wires within the bounding box
                         //around the selected tile location

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -377,6 +377,7 @@ t_src_opin_delays compute_router_src_opin_lookahead() {
 t_chan_ipins_delays compute_router_chan_ipin_lookahead() {
     vtr::ScopedStartFinishTimer timer("Computing chan/ipin lookahead");
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& node_lookup = device_ctx.rr_graph.node_lookup();
 
     t_chan_ipins_delays chan_ipins_delays;
 
@@ -404,7 +405,7 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead() {
         for (int ix = min_x; ix < max_x; ix++) {
             for (int iy = min_y; iy < max_y; iy++) {
                 for (auto rr_type : {CHANX, CHANY}) {
-                    for (const RRNodeId& node_id : device_ctx.rr_graph.node_lookup().find_channel_nodes(ix, iy, rr_type)) {
+                    for (const RRNodeId& node_id : node_lookup.find_channel_nodes(ix, iy, rr_type)) {
                         //Find the IPINs which are reachable from the wires within the bounding box
                         //around the selected tile location
                         dijkstra_flood_to_ipins(node_id, chan_ipins_delays);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR focuses on updating client functions of the ``rr_node_indices``, which are ``placer``, ``router`` and post-routing synchronizer.
We use the refactored data structure ``RRGraphBuilder`` to replace the legacy data structure ``rr_node_indices``.
This PR aims to eliminate the use of ``rr_node_indices`` in the client functions, as one step further in deprecating the legacy data structure.

Checklist:

- [X] Added a new API ``find_channe_nodes()`` for placer functions
- [X] Added a new API ``find_nodes_at_all_sides()`` for router functions
- [x] Eliminate the use of ``rr_node_indices`` for placer functions 
- [x] Eliminate the use of ``rr_node_indices`` for the router functions
- [x] Eliminate the use of ``rr_node_indices`` for the post-routing packing result synchronization functions

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This pull request is a follow-up PR on the routing resource graph refactoring effort https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1693

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After the previous PR #1747 , we start reworking all the source files that use the legacy data structure ``rr_node_indices`` in a high priority, in order to deprecate the legacy data structure as soon as possible.
Current statistics on the files that use ``rr_node_indices`` (in total there are 242 lines related):
- ./base/vpr_context.h
- ./base/vpr_types.h
- ./device/rr_graph_view.h
- ./device/rr_spatial_lookup.cpp
- ./device/rr_spatial_lookup.h
- ./pack/post_routing_pb_pin_fixup.cpp
- ./place/timing_place_lookup.cpp
- ./route/clock_connection_builders.cpp
- ./route/clock_network_builders.cpp
- ./route/clock_network_builders.h
- ./route/route_common.cpp
- ./route/router_lookahead_map.cpp
- ./route/router_lookahead_map_utils.cpp
- ./route/rr_graph.cpp
- ./route/rr_graph2.cpp
- ./route/rr_graph2.h
- ./route/rr_graph_clock.cpp
- ./route/rr_graph_clock.h
- ./route/rr_graph_reader.cpp
- ./route/rr_graph_util.cpp
- ./route/rr_graph_uxsdcxx_serializer.h
- ./route/rr_graph_writer.cpp

This PR will remove the use in 
- [X] ./route/route_common.cpp
- [X] ./pack/post_routing_pb_pin_fixup.cpp
- [X] ./place/timing_place_lookup.cpp
- [X] ./route/router_lookahead_map_utils.cpp
- [X] ./route/router_lookahead_map.cpp

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Considering this is all about refactoring, this PR does not need to create new tests. Expect all the existing tests to pass.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
