### PR TITLE
Fixing up minor errors within the documentation

### DIFF
--- a/doc/src/arch/reference.rst
+++ b/doc/src/arch/reference.rst
@@ -378,7 +378,7 @@ Grid Location Tags
 
         **Default:** ``0``
 
-    :opt_param incry:
+    :opt_param incrx:
         An expression specifying the horizontal increment between block instantiations within the region.
 
         **Default:** ``w``
@@ -442,7 +442,7 @@ Grid Location Tags
         An expression specifying the vertical repeat factor of the column.
 
     :opt_param incry:
-        An expression specifying the horizontal increment between block instantiations within the region.
+        An expression specifying the vertical increment between block instantiations within the region.
 
         **Default:** ``h``
 
@@ -965,7 +965,7 @@ The following tags are common to all ``<tile>`` tags:
                 Desctibes the mapping of a physical tile's port on the logical block's (pb_type) port.
                 ``direct`` is an option sub-tag of ``site``.
 
-                .. note:: This tag is need only if the pin_mapping of the ``site`` is defined as ``custom``
+                .. note:: This tag is needed only if the pin_mapping of the ``site`` is defined as ``custom``
 
                 Attributes:
                     - ``from`` is relative to the physical tile pins

--- a/doc/src/tutorials/arch/fracturable_multiplier_bus.rst
+++ b/doc/src/tutorials/arch/fracturable_multiplier_bus.rst
@@ -59,7 +59,7 @@ The mode and slice is declared here:
           <clock name="clk"/>
 
 This is followed by a description of the primitives within the slice.
-There are two sets of 36 flip-flops for the input ports and one set of 64 flip-flops for the output port.
+There are two sets of 36 flip-flops for the input ports and one set of 72 flip-flops for the output port.
 There is one 36x36 multiplier primitive.
 These primitives are described by four *pb_types* as follows:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed documentation errors found within the architecture modelling tutorials section and the architectural reference section.

#### Description
<!--- Describe your changes in detail -->
- Within the Tutorials section
	- Under the Fracturable Multiplier Bus-Based Complete Example
		- When describing the primitives within the DSP slice, number of flip-flops to be instantiated was 64, but should be 72
- Within the Architecture Reference section
	- Under the <row> tag 
		- The optional attributes for spaces between tiles should be incrx not incry 
	- Under the <region> tag
		- The descritpion for incry should be "An expression specifying the vertical increment between block instantiations
		  within the region." instead of "An expression specifying the horizontal increment between block instantiations
		  within the region." 
	- Under the <equivalent_sites> tag
		- The note for <site> should have "need" replaced with "needed" 

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixed errors within the VTR documentation. These changes were necessary as they help create a more clearer documentation for other users

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The documentation was built after the changes and visual confirmation was done to make sure the changes were applied and that there were no build issues with the documentation.

Additionally, the basic and strong tests were done to ensure proper functionality. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
