### PR TITLE
Add unconnected port options for Verilog netlist

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1237,6 +1237,26 @@ Analysis Options
 
     **Default:** ``off``
 
+.. option:: --post_synth_netlist_unconn_inputs { unconnected | nets | gnd | vcc }
+
+    Controls how unconnected input cell ports are handled in the post-synthesis netlist
+
+     * unconnected: leave unconnected
+     * nets: connect each unconnected input pin to its own separate undriven net named: ``__vpr__unconn<ID>``, where ``<ID>`` is index assigned to this occurrence of unconnected port in design
+     * gnd: tie all to ground (``1'b0``)
+     * vcc: tie all to VCC (``1'b1``)
+
+    **Default:** ``unconnected``
+
+.. option:: --post_synth_netlist_unconn_outputs { unconnected | nets }
+
+    Controls how unconnected output cell ports are handled in the post-synthesis netlist
+
+     * unconnected: leave unconnected
+     * nets: connect each unconnected output pin to its own separate undriven net named: ``__vpr__unconn<ID>``, where ``<ID>`` is index assigned to this occurrence of unconnected port in design
+
+    **Default:** ``unconnected``
+
 .. option:: --timing_report_npaths <int>
 
     Controls how many timing paths are reported.

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -623,6 +623,9 @@ static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysi
     analysis_opts.timing_report_skew = Options.timing_report_skew;
     analysis_opts.echo_dot_timing_graph_node = Options.echo_dot_timing_graph_node;
 
+    analysis_opts.post_synth_netlist_unconn_input_handling = Options.post_synth_netlist_unconn_input_handling;
+    analysis_opts.post_synth_netlist_unconn_output_handling = Options.post_synth_netlist_unconn_output_handling;
+
     analysis_opts.timing_update_type = Options.timing_update_type;
 }
 

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -604,6 +604,31 @@ static void ShowAnalysisOpts(const t_analysis_opts& AnalysisOpts) {
         default:
             VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown timing_report_detail\n");
     }
+
+    const auto opts = {
+        std::make_tuple(&AnalysisOpts.post_synth_netlist_unconn_input_handling, "post_synth_netlist_unconn_input_handling"),
+        std::make_tuple(&AnalysisOpts.post_synth_netlist_unconn_output_handling, "post_synth_netlist_unconn_output_handling"),
+    };
+    for (const auto& opt : opts) {
+        auto value = *std::get<0>(opt);
+        VTR_LOG("AnalysisOpts.%s: ", std::get<1>(opt));
+        switch (value) {
+            case e_post_synth_netlist_unconn_handling::UNCONNECTED:
+                VTR_LOG("UNCONNECTED\n");
+                break;
+            case e_post_synth_netlist_unconn_handling::NETS:
+                VTR_LOG("NETS\n");
+                break;
+            case e_post_synth_netlist_unconn_handling::GND:
+                VTR_LOG("GND\n");
+                break;
+            case e_post_synth_netlist_unconn_handling::VCC:
+                VTR_LOG("VCC\n");
+                break;
+            default:
+                VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown post_synth_netlist_unconn_handling\n");
+        }
+    }
     VTR_LOG("\n");
 }
 

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -18,6 +18,7 @@
 #include "vtr_version.h"
 
 #include "vpr_error.h"
+#include "vpr_types.h"
 
 #include "netlist_walker.h"
 #include "netlist_writer.h"
@@ -110,7 +111,7 @@ std::string indent(size_t depth);
 double get_delay_ps(double delay_sec);
 
 void print_blif_port(std::ostream& os, size_t& unconn_count, const std::string& port_name, const std::vector<std::string>& nets, int depth);
-void print_verilog_port(std::ostream& os, const std::string& port_name, const std::vector<std::string>& nets, PortType type, int depth);
+void print_verilog_port(std::ostream& os, size_t& unconn_count, const std::string& port_name, const std::vector<std::string>& nets, PortType type, int depth, struct t_analysis_opts& opts);
 
 std::string create_unconn_net(size_t& unconn_count);
 std::string escape_verilog_identifier(const std::string id);
@@ -187,7 +188,7 @@ class Instance {
     virtual void print_blif(std::ostream& os, size_t& unconn_count, int depth = 0) = 0;
 
     ///@brief Print the current instanse in Verilog, see print_blif() for argument descriptions
-    virtual void print_verilog(std::ostream& os, int depth = 0) = 0;
+    virtual void print_verilog(std::ostream& os, size_t& unconn_count, int depth = 0) = 0;
 
     ///@brief Print the current instanse in SDF, see print_blif() for argument descriptions
     virtual void print_sdf(std::ostream& os, int depth = 0) = 0;
@@ -200,13 +201,15 @@ class LutInst : public Instance {
             LogicVec lut_mask,                                          ///<The LUT mask representing the logic function
             std::string inst_name,                                      ///<The name of this instance
             std::map<std::string, std::vector<std::string>> port_conns, ///<The port connections of this instance. Key: port name, Value: connected nets
-            std::vector<Arc> timing_arc_values)                         ///<The timing arcs of this instance
+            std::vector<Arc> timing_arc_values,                         ///<The timing arcs of this instance
+            struct t_analysis_opts opts)
         : type_("LUT_K")
         , lut_size_(lut_size)
         , lut_mask_(lut_mask)
         , inst_name_(inst_name)
         , port_conns_(port_conns)
-        , timing_arcs_(timing_arc_values) {
+        , timing_arcs_(timing_arc_values)
+        , opts_(opts) {
     }
 
     //Accessors
@@ -215,7 +218,7 @@ class LutInst : public Instance {
     std::string type() { return type_; }
 
   public: //Instance interface method implementations
-    void print_verilog(std::ostream& os, int depth) override {
+    void print_verilog(std::ostream& os, size_t& unconn_count, int depth) override {
         //Instantiate the lut
         os << indent(depth) << type_ << " #(\n";
 
@@ -231,10 +234,10 @@ class LutInst : public Instance {
         VTR_ASSERT(port_conns_.count("out"));
         VTR_ASSERT(port_conns_.size() == 2);
 
-        print_verilog_port(os, "in", port_conns_["in"], PortType::INPUT, depth + 1);
+        print_verilog_port(os, unconn_count, "in", port_conns_["in"], PortType::INPUT, depth + 1, opts_);
         os << ","
            << "\n";
-        print_verilog_port(os, "out", port_conns_["out"], PortType::OUTPUT, depth + 1);
+        print_verilog_port(os, unconn_count, "out", port_conns_["out"], PortType::OUTPUT, depth + 1, opts_);
         os << "\n";
 
         os << indent(depth) << ");\n\n";
@@ -376,6 +379,7 @@ class LutInst : public Instance {
     std::string inst_name_;
     std::map<std::string, std::vector<std::string>> port_conns_;
     std::vector<Arc> timing_arcs_;
+    struct t_analysis_opts opts_;
 };
 
 class LatchInst : public Instance {
@@ -462,7 +466,7 @@ class LatchInst : public Instance {
         os << "\n";
     }
 
-    void print_verilog(std::ostream& os, int depth = 0) override {
+    void print_verilog(std::ostream& os, size_t& /*unconn_count*/, int depth = 0) override {
         //Currently assume a standard DFF
         VTR_ASSERT(type_ == Type::RISING_EDGE);
 
@@ -560,7 +564,8 @@ class BlackBoxInst : public Instance {
                  std::vector<Arc> timing_arcs,                                      ///<Combinational timing arcs
                  std::map<std::string, sequential_port_delay_pair> ports_tsu,       ///<Port setup checks
                  std::map<std::string, sequential_port_delay_pair> ports_thld,      ///<Port hold checks
-                 std::map<std::string, sequential_port_delay_pair> ports_tcq)       ///<Port clock-to-q delays
+                 std::map<std::string, sequential_port_delay_pair> ports_tcq,       ///<Port clock-to-q delays
+                 struct t_analysis_opts opts)
         : type_name_(type_name)
         , inst_name_(inst_name)
         , params_(params)
@@ -570,7 +575,8 @@ class BlackBoxInst : public Instance {
         , timing_arcs_(timing_arcs)
         , ports_tsu_(ports_tsu)
         , ports_thld_(ports_thld)
-        , ports_tcq_(ports_tcq) {}
+        , ports_tcq_(ports_tcq)
+        , opts_(opts) {}
 
     void print_blif(std::ostream& os, size_t& unconn_count, int depth = 0) override {
         os << indent(depth) << ".subckt " << type_name_ << " \\"
@@ -613,7 +619,7 @@ class BlackBoxInst : public Instance {
         os << "\n";
     }
 
-    void print_verilog(std::ostream& os, int depth = 0) override {
+    void print_verilog(std::ostream& os, size_t& unconn_count, int depth = 0) override {
         //Instance type
         os << indent(depth) << type_name_ << " #(\n";
 
@@ -633,7 +639,7 @@ class BlackBoxInst : public Instance {
         for (auto iter = input_port_conns_.begin(); iter != input_port_conns_.end(); ++iter) {
             auto& port_name = iter->first;
             auto& nets = iter->second;
-            print_verilog_port(os, port_name, nets, PortType::INPUT, depth + 1);
+            print_verilog_port(os, unconn_count, port_name, nets, PortType::INPUT, depth + 1, opts_);
             if (!(iter == --input_port_conns_.end() && output_port_conns_.empty())) {
                 os << ",";
             }
@@ -644,7 +650,7 @@ class BlackBoxInst : public Instance {
         for (auto iter = output_port_conns_.begin(); iter != output_port_conns_.end(); ++iter) {
             auto& port_name = iter->first;
             auto& nets = iter->second;
-            print_verilog_port(os, port_name, nets, PortType::OUTPUT, depth + 1);
+            print_verilog_port(os, unconn_count, port_name, nets, PortType::OUTPUT, depth + 1, opts_);
             if (!(iter == --output_port_conns_.end())) {
                 os << ",";
             }
@@ -755,6 +761,7 @@ class BlackBoxInst : public Instance {
     std::map<std::string, sequential_port_delay_pair> ports_tsu_;
     std::map<std::string, sequential_port_delay_pair> ports_thld_;
     std::map<std::string, sequential_port_delay_pair> ports_tcq_;
+    struct t_analysis_opts opts_;
 };
 
 /**
@@ -793,11 +800,13 @@ class NetlistWriterVisitor : public NetlistVisitor {
     NetlistWriterVisitor(std::ostream& verilog_os, ///<Output stream for verilog netlist
                          std::ostream& blif_os,    ///<Output stream for blif netlist
                          std::ostream& sdf_os,     ///<Output stream for SDF
-                         std::shared_ptr<const AnalysisDelayCalculator> delay_calc)
+                         std::shared_ptr<const AnalysisDelayCalculator> delay_calc,
+                         struct t_analysis_opts opts)
         : verilog_os_(verilog_os)
         , blif_os_(blif_os)
         , sdf_os_(sdf_os)
-        , delay_calc_(delay_calc) {
+        , delay_calc_(delay_calc)
+        , opts_(opts) {
         auto& atom_ctx = g_vpr_ctx.atom();
 
         //Initialize the pin to tnode look-up
@@ -931,10 +940,11 @@ class NetlistWriterVisitor : public NetlistVisitor {
         }
 
         //All the cell instances
+        size_t unconn_count = 0;
         verilog_os_ << "\n";
         verilog_os_ << indent(depth + 1) << "//Cell instances\n";
         for (auto& inst : cell_instances_) {
-            inst->print_verilog(verilog_os_, depth + 1);
+            inst->print_verilog(verilog_os_, unconn_count, depth + 1);
         }
 
         verilog_os_ << "\n";
@@ -1213,7 +1223,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
             port_conns["out"].push_back(net);
         }
 
-        auto inst = std::make_shared<LutInst>(lut_size, lut_mask, inst_name, port_conns, timing_arcs);
+        auto inst = std::make_shared<LutInst>(lut_size, lut_mask, inst_name, port_conns, timing_arcs, opts_);
 
         return inst;
     }
@@ -1413,7 +1423,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
             }
         }
 
-        return std::make_shared<BlackBoxInst>(type, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq);
+        return std::make_shared<BlackBoxInst>(type, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq, opts_);
     }
 
     ///@brief Returns an Instance object representing a Multiplier
@@ -1509,7 +1519,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
 
         VTR_ASSERT(pb_graph_node->num_clock_ports == 0); //No clocks
 
-        return std::make_shared<BlackBoxInst>(type_name, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq);
+        return std::make_shared<BlackBoxInst>(type_name, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq, opts_);
     }
 
     ///@brief Returns an Instance object representing an Adder
@@ -1609,7 +1619,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
             }
         }
 
-        return std::make_shared<BlackBoxInst>(type_name, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq);
+        return std::make_shared<BlackBoxInst>(type_name, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq, opts_);
     }
 
     std::shared_ptr<Instance> make_blackbox_instance(const t_pb* atom) {
@@ -1747,7 +1757,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
             attrs[attr.first] = attr.second;
         }
 
-        return std::make_shared<BlackBoxInst>(type_name, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq);
+        return std::make_shared<BlackBoxInst>(type_name, inst_name, params, attrs, input_port_conns, output_port_conns, timing_arcs, ports_tsu, ports_thld, ports_tcq, opts_);
     }
 
     ///@brief Returns the top level pb_route associated with the given pb
@@ -2067,6 +2077,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
     std::map<std::pair<ClusterBlockId, int>, tatum::NodeId> pin_id_to_tnode_lookup_;
 
     std::shared_ptr<const AnalysisDelayCalculator> delay_calc_;
+    struct t_analysis_opts opts_;
 };
 
 //
@@ -2074,7 +2085,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
 //
 
 ///@brief Main routing for this file. See netlist_writer.h for details.
-void netlist_writer(const std::string basename, std::shared_ptr<const AnalysisDelayCalculator> delay_calc) {
+void netlist_writer(const std::string basename, std::shared_ptr<const AnalysisDelayCalculator> delay_calc, struct t_analysis_opts opts) {
     std::string verilog_filename = basename + "_post_synthesis.v";
     std::string blif_filename = basename + "_post_synthesis.blif";
     std::string sdf_filename = basename + "_post_synthesis.sdf";
@@ -2087,7 +2098,7 @@ void netlist_writer(const std::string basename, std::shared_ptr<const AnalysisDe
     std::ofstream blif_os(blif_filename);
     std::ofstream sdf_os(sdf_filename);
 
-    NetlistWriterVisitor visitor(verilog_os, blif_os, sdf_os, delay_calc);
+    NetlistWriterVisitor visitor(verilog_os, blif_os, sdf_os, delay_calc, opts);
 
     NetlistWalker nl_walker(visitor);
 
@@ -2159,7 +2170,7 @@ void print_blif_port(std::ostream& os, size_t& unconn_count, const std::string& 
  *
  * Handles special cases like multi-bit and disconnected ports
  */
-void print_verilog_port(std::ostream& os, const std::string& port_name, const std::vector<std::string>& nets, PortType type, int depth) {
+void print_verilog_port(std::ostream& os, size_t& unconn_count, const std::string& port_name, const std::vector<std::string>& nets, PortType type, int depth, struct t_analysis_opts& opts) {
     //Port name
     os << indent(depth) << "." << port_name << "(";
 
@@ -2169,10 +2180,30 @@ void print_verilog_port(std::ostream& os, const std::string& port_name, const st
         if (nets[0].empty()) {
             //Disconnected
             if (type == PortType::INPUT || type == PortType::CLOCK) {
-                os << "1'b0";
+                switch (opts.post_synth_netlist_unconn_input_handling) {
+                    case e_post_synth_netlist_unconn_handling::GND:
+                        os << "1'b0";
+                        break;
+                    case e_post_synth_netlist_unconn_handling::VCC:
+                        os << "1'b1";
+                        break;
+                    case e_post_synth_netlist_unconn_handling::NETS:
+                        os << create_unconn_net(unconn_count);
+                        break;
+                    case e_post_synth_netlist_unconn_handling::UNCONNECTED:
+                    default:
+                        os << "1'bX";
+                }
             } else {
                 VTR_ASSERT(type == PortType::OUTPUT);
-                os << "DummyOut";
+                switch (opts.post_synth_netlist_unconn_output_handling) {
+                    case e_post_synth_netlist_unconn_handling::NETS:
+                        os << create_unconn_net(unconn_count);
+                        break;
+                    case e_post_synth_netlist_unconn_handling::UNCONNECTED:
+                    default:
+                        os << "1'bX";
+                }
             }
         } else {
             //Connected

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -912,8 +912,6 @@ class NetlistWriterVisitor : public NetlistVisitor {
             }
         }
 
-        verilog_os_ << indent(depth + 1) << "wire DummyOut;\n";
-
         //connections between primary I/Os and their internal wires
         verilog_os_ << "\n";
         verilog_os_ << indent(depth + 1) << "//IO assignments\n";
@@ -2222,7 +2220,7 @@ void print_verilog_port(std::ostream& os, size_t& unconn_count, const std::strin
                     os << "1'b0";
                 } else {
                     VTR_ASSERT(type == PortType::OUTPUT);
-                    os << "DummyOut";
+                    os << "";
                 }
             } else {
                 //Connected

--- a/vpr/src/base/netlist_writer.h
+++ b/vpr/src/base/netlist_writer.h
@@ -15,6 +15,6 @@
  * All written filenames end in {basename}_post_synthesis.{fmt} where {basename} is the
  * basename argument and {fmt} is the file format (e.g. v, blif, sdf)
  */
-void netlist_writer(const std::string basename, std::shared_ptr<const AnalysisDelayCalculator> delay_calc);
+void netlist_writer(const std::string basename, std::shared_ptr<const AnalysisDelayCalculator> delay_calc, struct t_analysis_opts opts);
 
 #endif

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1111,6 +1111,76 @@ struct ParseTimingUpdateType {
     }
 };
 
+struct ParsePostSynthNetlistUnconnInputHandling {
+    ConvertedValue<e_post_synth_netlist_unconn_handling> from_str(std::string str) {
+        ConvertedValue<e_post_synth_netlist_unconn_handling> conv_value;
+        if (str == "unconnected")
+            conv_value.set_value(e_post_synth_netlist_unconn_handling::UNCONNECTED);
+        else if (str == "nets")
+            conv_value.set_value(e_post_synth_netlist_unconn_handling::NETS);
+        else if (str == "gnd")
+            conv_value.set_value(e_post_synth_netlist_unconn_handling::GND);
+        else if (str == "vcc")
+            conv_value.set_value(e_post_synth_netlist_unconn_handling::VCC);
+        else {
+            std::stringstream msg;
+            msg << "Invalid conversion from '" << str << "' to e_post_synth_netlist_unconn_handling (expected one of: " << argparse::join(default_choices(), ", ") << ")";
+            conv_value.set_error(msg.str());
+        }
+        return conv_value;
+    }
+
+    ConvertedValue<std::string> to_str(e_post_synth_netlist_unconn_handling val) {
+        ConvertedValue<std::string> conv_value;
+        if (val == e_post_synth_netlist_unconn_handling::NETS)
+            conv_value.set_value("nets");
+        else if (val == e_post_synth_netlist_unconn_handling::GND)
+            conv_value.set_value("gnd");
+        else if (val == e_post_synth_netlist_unconn_handling::VCC)
+            conv_value.set_value("vcc");
+        else {
+            VTR_ASSERT(val == e_post_synth_netlist_unconn_handling::UNCONNECTED);
+            conv_value.set_value("unconnected");
+        }
+        return conv_value;
+    }
+
+    std::vector<std::string> default_choices() {
+        return {"unconnected", "nets", "gnd", "vcc"};
+    }
+};
+
+struct ParsePostSynthNetlistUnconnOutputHandling {
+    ConvertedValue<e_post_synth_netlist_unconn_handling> from_str(std::string str) {
+        ConvertedValue<e_post_synth_netlist_unconn_handling> conv_value;
+        if (str == "unconnected")
+            conv_value.set_value(e_post_synth_netlist_unconn_handling::UNCONNECTED);
+        else if (str == "nets")
+            conv_value.set_value(e_post_synth_netlist_unconn_handling::NETS);
+        else {
+            std::stringstream msg;
+            msg << "Invalid conversion from '" << str << "' to e_post_synth_netlist_unconn_handling (expected one of: " << argparse::join(default_choices(), ", ") << ")";
+            conv_value.set_error(msg.str());
+        }
+        return conv_value;
+    }
+
+    ConvertedValue<std::string> to_str(e_post_synth_netlist_unconn_handling val) {
+        ConvertedValue<std::string> conv_value;
+        if (val == e_post_synth_netlist_unconn_handling::NETS)
+            conv_value.set_value("nets");
+        else {
+            VTR_ASSERT(val == e_post_synth_netlist_unconn_handling::UNCONNECTED);
+            conv_value.set_value("unconnected");
+        }
+        return conv_value;
+    }
+
+    std::vector<std::string> default_choices() {
+        return {"unconnected", "nets"};
+    }
+};
+
 argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args) {
     std::string description =
         "Implements the specified circuit onto the target FPGA architecture"
@@ -2470,6 +2540,28 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
             " * >= 0: Only the transitive fanin/fanout of the node is dumped (easier to view)\n"
             " * a string: Interpretted as a VPR pin name which is converted to a node id, and dumped as above\n")
         .default_value("-1")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    analysis_grp.add_argument<e_post_synth_netlist_unconn_handling, ParsePostSynthNetlistUnconnInputHandling>(args.post_synth_netlist_unconn_input_handling, "--post_synth_netlist_unconn_inputs")
+        .help(
+            "Controls how unconnected input cell ports are handled in the post-synthesis netlist\n"
+            " * unconnected: leave unconnected\n"
+            " * nets: connect each unconnected input pin to its own separate\n"
+            "         undriven net named: __vpr__unconn<ID>, where <ID> is index\n"
+            "         assigned to this occurrence of unconnected port in design\n"
+            " * gnd: tie all to ground (1'b0)\n"
+            " * vcc: tie all to VCC (1'b1)\n")
+        .default_value("unconnected")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    analysis_grp.add_argument<e_post_synth_netlist_unconn_handling, ParsePostSynthNetlistUnconnOutputHandling>(args.post_synth_netlist_unconn_output_handling, "--post_synth_netlist_unconn_outputs")
+        .help(
+            "Controls how unconnected output cell ports are handled in the post-synthesis netlist\n"
+            " * unconnected: leave unconnected\n"
+            " * nets: connect each unconnected input pin to its own separate\n"
+            "         undriven net named: __vpr__unconn<ID>, where <ID> is index\n"
+            "         assigned to this occurrence of unconnected port in design\n")
+        .default_value("unconnected")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     auto& power_grp = parser.add_argument_group("power analysis options");

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -208,6 +208,8 @@ struct t_options {
     argparse::ArgValue<e_timing_report_detail> timing_report_detail;
     argparse::ArgValue<bool> timing_report_skew;
     argparse::ArgValue<std::string> echo_dot_timing_graph_node;
+    argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_input_handling;
+    argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_output_handling;
 };
 
 argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args);

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1277,7 +1277,8 @@ void vpr_analysis(t_vpr_setup& vpr_setup, const t_arch& Arch, const RouteStatus&
 
         //Write the post-syntesis netlist
         if (vpr_setup.AnalysisOpts.gen_post_synthesis_netlist) {
-            netlist_writer(atom_ctx.nlist.netlist_name().c_str(), analysis_delay_calc);
+            netlist_writer(atom_ctx.nlist.netlist_name().c_str(), analysis_delay_calc,
+                           vpr_setup.AnalysisOpts);
         }
 
         //Do power analysis

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1191,6 +1191,13 @@ enum class e_timing_report_detail {
     DEBUG,            //Show additional internal debugging information
 };
 
+enum class e_post_synth_netlist_unconn_handling {
+    UNCONNECTED, // Leave unrouted ports unconnected
+    NETS,        // Leave unrouted ports unconnected but add new named nets to each of them
+    GND,         // Tie unrouted ports to ground (only for input ports)
+    VCC          // Tie unrouted ports to VCC (only for input ports)
+};
+
 struct t_timing_analysis_profile_info {
     double timing_analysis_wallclock_time() const {
         return sta_wallclock_time + slack_wallclock_time;
@@ -1286,6 +1293,8 @@ struct t_analysis_opts {
     e_stage_action doAnalysis;
 
     bool gen_post_synthesis_netlist;
+    e_post_synth_netlist_unconn_handling post_synth_netlist_unconn_input_handling;
+    e_post_synth_netlist_unconn_handling post_synth_netlist_unconn_output_handling;
 
     int timing_report_npaths;
     e_timing_report_detail timing_report_detail;


### PR DESCRIPTION
#### Description
This PR adds two options:

- post_synth_netlist_unconn_inputs {unconnected, nets, gnd, vcc}
- post_synth_netlist_unconn_outputs {unconnected, nets}

These options can be used to enforce how unconnected ports are treated in Verilog output. They can be tied to vcc, gnd, 1'bX (unconnected) or to a special net named __vpr__unconnXX (XX number is incremented to generate unique net for each port).

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1721

#### Motivation and Context
Previously unconnected input ports were always tied to 1'b0 and output ports were tied to a common net DummyOut which is incorrect.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These options were tested with **symbiflow-arch-defs**
To reproduce the test, build the vpr end set env variable:
```
make -j `nproc`
export VPR=$PWD/build/vpr/vpr
```
Then, in a different directory, clone and build symbiflow-arch-defs:
```
git clone --recursive git@github.com:antmicro/symbiflow-arch-defs.git -b test-vpr-unconnected-ports
cd symbiflow-arch-defs
make -j `nproc` env
```
Run an example with unconnected ports
```
cd build/quicklogic/qlf_k4n8/tests/design_flow/and2
make -j `nproc` and2_test-umc22-adder_analysis
```
Check out resulting _and2_post_synthesis.v_ file.

You can change **post_synth_netlist_unconn** options in _quicklogic/qlf_k4n8/CMakeLists.txt_ file.

#### Types of changes
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
