### PR TITLE
[nix] drop python 2.7

### DIFF
--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -7,7 +7,6 @@ let
     lxml
     python-utils
   ];
-  python27 = pkgs.python27.withPackages python_packages;
   python3 = pkgs.python3.withPackages python_packages;
 in
 stdenv.mkDerivation rec {
@@ -27,7 +26,6 @@ stdenv.mkDerivation rec {
     clang-tools
     gperftools
     perl
-    python27
     python3
     time
   ];


### PR DESCRIPTION
~Pins the local nix shell channel to 20.09, a known working version.~
Drop Python 2.7 in the the nix shell

#### Description

There are issues with Python 2.7 deprecations in the latest 21.05 channel, that cause errors
in nix-shell startup. ~I have not investigated further, just want to build VTR :)~

#### Related Issue
N/A

#### Motivation and Context

The described actions in: https://docs.verilogtorouting.org/en/latest/building/building/#using-nix
did not work as expected.

#### How Has This Been Tested?

Local tests using:
```
nix-shell dev/nix/shell.nix
make
```


#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

N/A for the above.
