### PR TITLE
Enable wire segments to only be one direction; X,Y or both

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1382,6 +1382,11 @@ enum e_directionality {
     UNI_DIRECTIONAL,
     BI_DIRECTIONAL
 };
+enum e_segment_adjacency {
+    COL_ROW_SEGMENT,
+    COLLUMN_SEGMENT,
+    ROW_SEGMENT
+};
 enum e_switch_block_type {
     SUBSET,
     WILTON,
@@ -1432,6 +1437,7 @@ struct t_segment_inf {
     float Rmetal;
     float Cmetal;
     enum e_directionality directionality;
+    enum e_segment_adjacency channel_adjacency;
     std::vector<bool> cb;
     std::vector<bool> sb;
     //float Cmetal_per_m; /* Wire capacitance (per meter) */

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -457,7 +457,11 @@ static void build_rr_graph(const t_graph_type graph_type,
     /* START SEG_DETAILS */
     device_ctx.rr_segments = segment_inf;
     int num_seg_details = 0;
+    int num_seg_details_x = 0;
+    int num_seg_details_y = 0;
     t_seg_details* seg_details = nullptr;
+    t_seg_details* seg_details_x = nullptr;
+    t_seg_details* seg_details_y = nullptr;
 
     if (is_global_graph) {
         /* Sets up a single unit length segment type for global routing. */
@@ -468,10 +472,10 @@ static void build_rr_graph(const t_graph_type graph_type,
          * changed. Warning should be singled to caller if this happens. */
         size_t max_dim = std::max(grid.width(), grid.height()) - 2; //-2 for no perim channels
 
-        seg_details = alloc_and_load_seg_details(&max_chan_width,
+        seg_details_x = alloc_and_load_seg_details(&max_chan_width,
                                                  max_dim, segment_inf,
                                                  use_full_seg_groups, is_global_graph, directionality,
-                                                 &num_seg_details);
+                                                 &num_seg_details_x, ROW_SEGMENT);
         if (nodes_per_chan.max != max_chan_width) {
             nodes_per_chan.max = max_chan_width;
             *Warnings |= RR_GRAPH_WARN_CHAN_WIDTH_CHANGED;

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -81,7 +81,8 @@ t_seg_details* alloc_and_load_seg_details(int* max_chan_width,
                                           const bool use_full_seg_groups,
                                           const bool is_global_graph,
                                           const enum e_directionality directionality,
-                                          int* num_seg_details = nullptr);
+                                          int* num_seg_details = nullptr,
+                                          const enum e_segment_adjacency seg_details_type);
 
 void alloc_and_load_chan_details(const DeviceGrid& grid,
                                  const t_chan_width* nodes_per_chan,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In this draft I added to the type that is made from reading the XML. Also changed the XML reader to accept the new parameter.
#### Description
<!--- Describe your changes in detail -->
Made a new enumeration type to include X wires, Y wires, and wires that go in both directions. Included this in the t_segment_inf data type to store the data in. 
Added code to read in this parameter from an XML document. It is processed at the same time as the other aspects of a given wire segment (just after frequency). Parameter is optional and is default to both X and Y if not specified. Throws an error if an incorrect option is entered

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1769
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will eventually allow make different wires of different length in only X direction, only Y direction or both. Newer FPGA architectures use this in their design. Additionally this will allow for different frequencies in the different directions.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by running basic and strong tests. Zero fails.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
