### PR TITLE
RRGraphView::node_fan_in() Implementation

### DIFF
--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -77,7 +77,7 @@ class RRGraphView {
         return node_storage_.node_direction_string(node);
     }
 
-    /* Get the direction string of a routing resource node. This function is inlined for runtime optimization. */
+    /* Get the fan in of a routing resource node. This function is inlined for runtime optimization. */
     inline t_edge_size node_fan_in(RRNodeId node) const {
         return node_storage_.fan_in(node);
     }

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -77,6 +77,11 @@ class RRGraphView {
         return node_storage_.node_direction_string(node);
     }
 
+    /* Get the direction string of a routing resource node. This function is inlined for runtime optimization. */
+    inline t_edge_size node_fan_in(RRNodeId node) const {
+        return node_storage_.fan_in(node);
+    }
+
     /* Return the fast look-up data structure for queries from client functions */
     const RRSpatialLookup& node_lookup() const {
         return node_lookup_;

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1499,11 +1499,11 @@ static void draw_rr_chan(int inode, const ezgl::color color, ezgl::renderer* g) 
             float sb_ymax = draw_coords->tile_y[k] + draw_coords->get_tile_height();
             arrow_loc_max = {start.x, sb_ymax - arrow_offset};
         }
-
+        
         if (switchpoint_min == 0) {
             if (dir != BI_DIRECTION) {
                 //Draw a mux at the start of each wire, labelled with it's size (#inputs)
-                draw_mux_with_size(start, mux_dir, WIRE_DRAWING_WIDTH, device_ctx.rr_nodes[inode].fan_in(), g);
+                draw_mux_with_size(start, mux_dir, WIRE_DRAWING_WIDTH, rr_graph.node_fan_in(RRNodeId(inode)), g);
             }
         } else {
             //Draw arrows and label with switch point
@@ -1529,7 +1529,7 @@ static void draw_rr_chan(int inode, const ezgl::color color, ezgl::renderer* g) 
         if (switchpoint_max == 0) {
             if (dir != BI_DIRECTION) {
                 //Draw a mux at the start of each wire, labelled with it's size (#inputs)
-                draw_mux_with_size(start, mux_dir, WIRE_DRAWING_WIDTH, device_ctx.rr_nodes[inode].fan_in(), g);
+                draw_mux_with_size(start, mux_dir, WIRE_DRAWING_WIDTH, rr_graph.node_fan_in(RRNodeId(inode)), g);
             }
         } else {
             //Draw arrows and label with switch point

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1499,7 +1499,7 @@ static void draw_rr_chan(int inode, const ezgl::color color, ezgl::renderer* g) 
             float sb_ymax = draw_coords->tile_y[k] + draw_coords->get_tile_height();
             arrow_loc_max = {start.x, sb_ymax - arrow_offset};
         }
-        
+
         if (switchpoint_min == 0) {
             if (dir != Direction::BIDIR) {
                 //Draw a mux at the start of each wire, labelled with it's size (#inputs)

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -1174,10 +1174,10 @@ void power_pb_pins_uninit() {
 }
 
 void power_routing_init(const t_det_routing_arch* routing_arch) {
-    int max_fanin;
-    int max_IPIN_fanin;
-    int max_seg_to_IPIN_fanout;
-    int max_seg_to_seg_fanout;
+    t_edge_size max_fanin;
+    t_edge_size max_IPIN_fanin;
+    t_edge_size max_seg_to_IPIN_fanout;
+    t_edge_size max_seg_to_seg_fanout;
     auto& power_ctx = g_vpr_ctx.mutable_power();
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
@@ -1206,17 +1206,16 @@ void power_routing_init(const t_det_routing_arch* routing_arch) {
     max_seg_to_seg_fanout = 0;
     max_seg_to_IPIN_fanout = 0;
     for (size_t rr_node_idx = 0; rr_node_idx < device_ctx.rr_nodes.size(); rr_node_idx++) {
-        int fanout_to_IPIN = 0;
-        int fanout_to_seg = 0;
+        t_edge_size fanout_to_IPIN = 0;
+        t_edge_size fanout_to_seg = 0;
         auto node = device_ctx.rr_nodes[rr_node_idx];
         t_rr_node_power* node_power = &rr_node_power[rr_node_idx];
         const t_edge_size node_fan_in = rr_graph.node_fan_in(RRNodeId(rr_node_idx));
 
         switch (rr_graph.node_type(RRNodeId(rr_node_idx))) {
             case IPIN:
-                max_IPIN_fanin = std::max(max_IPIN_fanin,
-                                          static_cast<int>(node_fan_in));
-                max_fanin = std::max(max_fanin, static_cast<int>(node_fan_in));
+                max_IPIN_fanin = std::max(max_IPIN_fanin, node_fan_in);
+                max_fanin = std::max(max_fanin, node_fan_in);
 
                 node_power->in_dens = (float*)vtr::calloc(node_fan_in,
                                                           sizeof(float));
@@ -1235,7 +1234,7 @@ void power_routing_init(const t_det_routing_arch* routing_arch) {
                 max_seg_to_IPIN_fanout = std::max(max_seg_to_IPIN_fanout,
                                                   fanout_to_IPIN);
                 max_seg_to_seg_fanout = std::max(max_seg_to_seg_fanout, fanout_to_seg);
-                max_fanin = std::max(max_fanin, static_cast<int>(node_fan_in));
+                max_fanin = std::max(max_fanin, node_fan_in);
 
                 node_power->in_dens = (float*)vtr::calloc(node_fan_in,
                                                           sizeof(float));

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -830,23 +830,21 @@ static void power_usage_routing(t_power_usage* power_usage,
                     switch (rr_graph.node_type(RRNodeId(next_node_id))) {
                         case CHANX:
                         case CHANY:
-                        case IPIN:
-                            {
-                                if (next_node_power->net_num == node_power->net_num) {
-                                    next_node_power->selected_input = next_node_power->num_inputs;
-                                }
-                                next_node_power->in_dens[next_node_power->num_inputs] = clb_net_density(node_power->net_num);
-                                next_node_power->in_prob[next_node_power->num_inputs] = clb_net_prob(node_power->net_num);
-                                next_node_power->num_inputs++;
-                                const t_edge_size next_node_fan_in = rr_graph.node_fan_in(RRNodeId(next_node_id));
-                                if (next_node_power->num_inputs > next_node_fan_in) {
-                                    VTR_LOG("%d %d\n", next_node_power->num_inputs,
-                                            next_node_fan_in);
-                                    fflush(nullptr);
-                                    VTR_ASSERT(0);
-                                }
+                        case IPIN: {
+                            if (next_node_power->net_num == node_power->net_num) {
+                                next_node_power->selected_input = next_node_power->num_inputs;
                             }
-                            break;
+                            next_node_power->in_dens[next_node_power->num_inputs] = clb_net_density(node_power->net_num);
+                            next_node_power->in_prob[next_node_power->num_inputs] = clb_net_prob(node_power->net_num);
+                            next_node_power->num_inputs++;
+                            const t_edge_size next_node_fan_in = rr_graph.node_fan_in(RRNodeId(next_node_id));
+                            if (next_node_power->num_inputs > next_node_fan_in) {
+                                VTR_LOG("%d %d\n", next_node_power->num_inputs,
+                                        next_node_fan_in);
+                                fflush(nullptr);
+                                VTR_ASSERT(0);
+                            }
+                        } break;
                         default:
                             /* Do nothing */
                             break;

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -824,7 +824,6 @@ static void power_usage_routing(t_power_usage* power_usage,
             for (t_edge_size edge_idx = 0; edge_idx < node.num_edges(); edge_idx++) {
                 const auto& next_node_id = node.edge_sink_node(edge_idx);
                 if (next_node_id != OPEN) {
-                    auto next_node = device_ctx.rr_nodes[next_node_id];
                     t_rr_node_power* next_node_power = &rr_node_power[next_node_id];
 
                     switch (rr_graph.node_type(RRNodeId(next_node_id))) {
@@ -1364,7 +1363,6 @@ bool power_uninit() {
     bool error = false;
 
     for (size_t rr_node_idx = 0; rr_node_idx < device_ctx.rr_nodes.size(); rr_node_idx++) {
-        auto node = device_ctx.rr_nodes[rr_node_idx];
         t_rr_node_power* node_power = &rr_node_power[rr_node_idx];
 
         switch (rr_graph.node_type(RRNodeId(rr_node_idx))) {

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -601,12 +601,13 @@ static bool has_adjacent_channel(const t_rr_node& node, const DeviceGrid& grid) 
 
 static void check_rr_edge(int from_node, int iedge, int to_node) {
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
 
     //Check that to to_node's fan-in is correct, given the switch type
     int iswitch = device_ctx.rr_nodes[from_node].edge_switch(iedge);
     auto switch_type = device_ctx.rr_switch_inf[iswitch].type();
 
-    int to_fanin = device_ctx.rr_nodes[to_node].fan_in();
+    int to_fanin = rr_graph.node_fan_in(RRNodeId(to_node));
     switch (switch_type) {
         case SwitchType::BUFFER:
             //Buffer switches are non-configurable, and uni-directional -- they must have only one driver

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -507,7 +507,6 @@ static void build_rr_graph(const t_graph_type graph_type,
     /* get maximum number of pins across all blocks */
     int max_pins = types[0].num_pins;
     for (const auto& type : types) {
-
         if (is_empty_type(&type)) {
             continue;
         }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -507,6 +507,8 @@ static void build_rr_graph(const t_graph_type graph_type,
     /* get maximum number of pins across all blocks */
     int max_pins = types[0].num_pins;
     for (const auto& type : types) {
+        VTR_LOG("%s\n", type.name);
+
         if (is_empty_type(&type)) {
             continue;
         }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -507,7 +507,6 @@ static void build_rr_graph(const t_graph_type graph_type,
     /* get maximum number of pins across all blocks */
     int max_pins = types[0].num_pins;
     for (const auto& type : types) {
-        VTR_LOG("%s\n", type.name);
 
         if (is_empty_type(&type)) {
             continue;

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2496,7 +2496,7 @@ std::string describe_rr_node(int inode) {
     }
 
     msg += vtr::string_fmt(" capacity: %d", rr_graph.node_capacity(RRNodeId(inode)));
-    msg += vtr::string_fmt(" fan-in: %d", rr_node.fan_in());
+    msg += vtr::string_fmt(" fan-in: %d", rr_graph.node_fan_in(RRNodeId(inode)));
     msg += vtr::string_fmt(" fan-out: %d", rr_node.num_edges());
 
     return msg;

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -382,7 +382,7 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
                                 int switch_index = device_ctx.rr_nodes[from_node].edge_switch(iedge);
                                 auto switch_type = device_ctx.rr_switch_inf[switch_index].type();
 
-                                int fan_in = device_ctx.rr_nodes[to_node].fan_in();
+                                int fan_in = rr_graph.node_fan_in(RRNodeId(to_node));
 
                                 if (device_ctx.rr_switch_inf[switch_index].type() == SwitchType::MUX) {
                                     /* Each wire segment begins with a multipexer followed by a driver for unidirectional */

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -92,7 +92,6 @@ class t_rr_node {
     short edge_switch(t_edge_size iedge) const;
 
     bool edge_is_configurable(t_edge_size iedge) const;
-    t_edge_size fan_in() const;
 
     short xlow() const;
     short ylow() const;

--- a/vpr/src/route/rr_node_impl.h
+++ b/vpr/src/route/rr_node_impl.h
@@ -102,10 +102,6 @@ inline short t_rr_node::edge_switch(t_edge_size iedge) const {
     return storage_->edge_switch(id_, iedge);
 }
 
-inline t_edge_size t_rr_node::fan_in() const {
-    return storage_->fan_in(id_);
-}
-
 inline short t_rr_node::xlow() const {
     return storage_->node_xlow(id_);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In this PR, I have implemented `RRGraphView::node_fan_in()` throughout VTR. Every time `device_ctx.rr_nodes[index].fan_in()` was called has been replaced with `rr_graph.node_direction(RRNodeId(index))`. In order to do this, I followed a pattern similar to that in the last PR.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes are a continuation of the RRGraphView API implementation effort.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have run the regression tests for `vtr_reg_strong` along with the QoR testing found at `    $ ../scripts/run_vtr_task.py regression_tests/vtr_reg_nightly_test3/vtr_reg_qor_chain`. Results from these QoR tests can be found below. The file containing all results can be found [here](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/6810934/node_fan_in.xlsx)





Only rows that are different are shown.

|	| VTR Before These Changes	|With Changes in this PR|
|---|---|---|
|vtr_flow_elapsed_time	|1|	0.998931189|
|odin_synth_time	|1|	0.989230519|
|abc_synth_time	|1|	0.994648961|
|max_vpr_mem	|1|	0.99915845|
|pack_time	|1|	0.997989839|
|place_time	|1|	0.995451755|
|min_chan_width_route_time	|1|1.001024542|
|crit_path_route_time	|1|	0.999048907|


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
