### PR TITLE
Deploy ``RRGraphBuilder`` in RRGraph Clock Builder to replace the use of ``rr_node_indices``

### DIFF
--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -74,17 +74,18 @@ RRNodeId RRSpatialLookup::find_node(int x,
     return RRNodeId(rr_node_indices_[type][node_x][node_y][node_side][ptc]);
 }
 
-std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
-                                                          int y,
-                                                          t_rr_type type) const {
+std::vector<RRNodeId> RRSpatialLookup::find_nodes(int x,
+                                                  int y,
+                                                  t_rr_type type,
+                                                  e_side side) const {
     /* TODO: The implementation of this API should be worked 
      * when rr_node_indices adapts RRNodeId natively!
      */
-    std::vector<RRNodeId> channel_nodes;
+    std::vector<RRNodeId> nodes;
 
     /* Pre-check: the x, y, type are valid! Otherwise, return an empty vector */
-    if ((x < 0 || y < 0) && (type == CHANX || type == CHANY)) {
-        return channel_nodes;
+    if (x < 0 || y < 0) {
+        return nodes;
     }
 
     /* Currently need to swap x and y for CHANX because of chan, seg convention 
@@ -106,76 +107,44 @@ std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
      * - Return an empty list if any out-of-range is detected
      */
     if (size_t(type) >= rr_node_indices_.size()) {
-        return channel_nodes;
+        return nodes;
     }
 
     if (node_x >= rr_node_indices_[type].dim_size(0)) {
-        return channel_nodes;
+        return nodes;
     }
 
     if (node_y >= rr_node_indices_[type].dim_size(1)) {
-        return channel_nodes;
+        return nodes;
     }
 
-    /* By default, we always added the channel nodes to the TOP side (to save memory) */
-    e_side node_side = TOP;
-    if (node_side >= rr_node_indices_[type].dim_size(2)) {
-        return channel_nodes;
+    if (side >= rr_node_indices_[type].dim_size(2)) {
+        return nodes;
     }
 
-    for (const auto& node : rr_node_indices_[type][node_x][node_y][node_side]) {
+    for (const auto& node : rr_node_indices_[type][node_x][node_y][side]) {
         if (RRNodeId(node)) {
-            channel_nodes.push_back(RRNodeId(node));
+            nodes.push_back(RRNodeId(node));
         }
     }
 
-    return channel_nodes;
+    return nodes;
+}
+
+std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
+                                                          int y,
+                                                          t_rr_type type) const {
+    /* Pre-check: node type should be routing tracks! */
+    if (type != CHANX && type != CHANY) {
+        return std::vector<RRNodeId>();
+    }
+
+    return find_nodes(x, y, type);
 }
 
 std::vector<RRNodeId> RRSpatialLookup::find_sink_nodes(int x,
                                                        int y) const {
-    /* TODO: The implementation of this API should be worked 
-     * when rr_node_indices adapts RRNodeId natively!
-     */
-    std::vector<RRNodeId> sink_nodes;
-
-    /* Pre-check: the x, y, type are valid! Otherwise, return an empty vector */
-    if (x < 0 || y < 0) {
-        return sink_nodes;
-    }
-
-    VTR_ASSERT_SAFE(3 == rr_node_indices_[SINK].ndims());
-
-    /* Sanity check to ensure the x, y, side are in range 
-     * - Return a list of valid ids by searching in look-up when all the parameters are in range
-     * - Return an empty list if any out-of-range is detected
-     */
-    if (size_t(SINK) >= rr_node_indices_.size()) {
-        return sink_nodes;
-    }
-
-    if (size_t(x) >= rr_node_indices_[SINK].dim_size(0)) {
-        return sink_nodes;
-    }
-
-    if (size_t(y) >= rr_node_indices_[SINK].dim_size(1)) {
-        return sink_nodes;
-    }
-
-    /* By default, we always added the sink nodes to the TOP side (to save memory) */
-    e_side node_side = TOP;
-    if (node_side >= rr_node_indices_[SINK].dim_size(2)) {
-        return sink_nodes;
-    }
-
-    /* Only insert valid ids in the returned vector */
-    for (const auto& node : rr_node_indices_[SINK][x][y][node_side]) {
-        if (RRNodeId(node)) {
-            sink_nodes.push_back(RRNodeId(node));
-        }
-    }
-
-    return sink_nodes;
+    return find_nodes(x, y, SINK);
 }
 
 std::vector<RRNodeId> RRSpatialLookup::find_nodes_at_all_sides(int x,

--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -162,12 +162,13 @@ std::vector<RRNodeId> RRSpatialLookup::find_sink_nodes(int x,
         return sink_nodes;
     }
 
-    /* By default, we always added the channel nodes to the TOP side (to save memory) */
+    /* By default, we always added the sink nodes to the TOP side (to save memory) */
     e_side node_side = TOP;
     if (node_side >= rr_node_indices_[SINK].dim_size(2)) {
         return sink_nodes;
     }
 
+    /* Only insert valid ids in the returned vector */
     for (const auto& node : rr_node_indices_[SINK][x][y][node_side]) {
         if (RRNodeId(node)) {
             sink_nodes.push_back(RRNodeId(node));
@@ -211,6 +212,11 @@ void RRSpatialLookup::add_node(RRNodeId node,
                                e_side side) {
     VTR_ASSERT(node); /* Must have a valid node id to be added */
     VTR_ASSERT_SAFE(3 == rr_node_indices_[type].ndims());
+
+    /* For non-IPIN/OPIN nodes, the side should always be the TOP side which follows the convention in find_node() API! */
+    if (type != IPIN && type != OPIN) {
+        VTR_ASSERT(side == SIDES[0]);
+    }
 
     resize_nodes(x, y, type, side);
 

--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -132,6 +132,51 @@ std::vector<RRNodeId> RRSpatialLookup::find_channel_nodes(int x,
     return channel_nodes;
 }
 
+std::vector<RRNodeId> RRSpatialLookup::find_sink_nodes(int x,
+                                                       int y) const {
+    /* TODO: The implementation of this API should be worked 
+     * when rr_node_indices adapts RRNodeId natively!
+     */
+    std::vector<RRNodeId> sink_nodes;
+
+    /* Pre-check: the x, y, type are valid! Otherwise, return an empty vector */
+    if (x < 0 || y < 0) {
+        return sink_nodes;
+    }
+
+    VTR_ASSERT_SAFE(3 == rr_node_indices_[SINK].ndims());
+
+    /* Sanity check to ensure the x, y, side are in range 
+     * - Return a list of valid ids by searching in look-up when all the parameters are in range
+     * - Return an empty list if any out-of-range is detected
+     */
+    if (size_t(SINK) >= rr_node_indices_.size()) {
+        return sink_nodes;
+    }
+
+    if (x >= rr_node_indices_[SINK].dim_size(0)) {
+        return sink_nodes;
+    }
+
+    if (y >= rr_node_indices_[SINK].dim_size(1)) {
+        return sink_nodes;
+    }
+
+    /* By default, we always added the channel nodes to the TOP side (to save memory) */
+    e_side node_side = TOP;
+    if (node_side >= rr_node_indices_[SINK].dim_size(2)) {
+        return sink_nodes;
+    }
+
+    for (const auto& node : rr_node_indices_[SINK][x][y][node_side]) {
+        if (RRNodeId(node)) {
+            sink_nodes.push_back(RRNodeId(node));
+        }
+    }
+
+    return sink_nodes;
+}
+
 std::vector<RRNodeId> RRSpatialLookup::find_nodes_at_all_sides(int x,
                                                                int y,
                                                                t_rr_type rr_type,

--- a/vpr/src/device/rr_spatial_lookup.cpp
+++ b/vpr/src/device/rr_spatial_lookup.cpp
@@ -154,11 +154,11 @@ std::vector<RRNodeId> RRSpatialLookup::find_sink_nodes(int x,
         return sink_nodes;
     }
 
-    if (x >= rr_node_indices_[SINK].dim_size(0)) {
+    if (size_t(x) >= rr_node_indices_[SINK].dim_size(0)) {
         return sink_nodes;
     }
 
-    if (y >= rr_node_indices_[SINK].dim_size(1)) {
+    if (size_t(y) >= rr_node_indices_[SINK].dim_size(1)) {
         return sink_nodes;
     }
 

--- a/vpr/src/device/rr_spatial_lookup.h
+++ b/vpr/src/device/rr_spatial_lookup.h
@@ -82,6 +82,18 @@ class RRSpatialLookup {
                                              t_rr_type type) const;
 
     /**
+     * Returns the indices of the specified routing resource nodes,
+     * representing virtual sinks.  
+     * - (x, y) are the coordinate of the sink nodes within the FPGA
+     *
+     * Note: 
+     * - Return an empty list if there are no sinks at the given (x, y) location
+     * - The node list returned only contain valid ids
+     */
+    std::vector<RRNodeId> find_sink_nodes(int x,
+                                          int y) const;
+
+    /**
      * Like find_node() but returns all matching nodes on all the sides.
      * This is particularly useful for getting all instances
      * of a specific IPIN/OPIN at a specific gird tile (x,y) location.

--- a/vpr/src/device/rr_spatial_lookup.h
+++ b/vpr/src/device/rr_spatial_lookup.h
@@ -88,7 +88,7 @@ class RRSpatialLookup {
      *
      * Note: 
      * - Return an empty list if there are no sinks at the given (x, y) location
-     * - The node list returned only contain valid ids
+     * - The node list returned only contains valid ids
      */
     std::vector<RRNodeId> find_sink_nodes(int x,
                                           int y) const;
@@ -130,7 +130,7 @@ class RRSpatialLookup {
                   int y,
                   t_rr_type type,
                   int ptc,
-                  e_side side);
+                  e_side side = SIDES[0]);
 
     /**
      * Mirror the last dimension of a look-up, i.e., a list of nodes, from a source coordinate to 
@@ -191,7 +191,7 @@ class RRSpatialLookup {
      * or inside the data structures to be changed later.
      * That explains why the reference is used here temporarily
      */
-    /* Fast look-up */
+    /* Fast look-up: TODO: Should rework the data type. Currently it is based on a 3-dimensional arrqay mater where some dimensions must always be accessed with a specific index. Such limitation should be overcome */
     t_rr_node_indices& rr_node_indices_;
 };
 

--- a/vpr/src/device/rr_spatial_lookup.h
+++ b/vpr/src/device/rr_spatial_lookup.h
@@ -180,6 +180,18 @@ class RRSpatialLookup {
                       t_rr_type type,
                       e_side side);
 
+    /* -- Internal data queries -- */
+  private:
+    /* An internal API to find all the nodes in a specific location with a given type
+     * For OPIN/IPIN nodes that may exist on multiple sides, a specific side must be provided  
+     * This API is NOT public because its too powerful for developers with very limited sanity checks 
+     * But it is used to build the public APIs find_channel_nodes() etc., where sufficient sanity checks are applied
+     */
+    std::vector<RRNodeId> find_nodes(int x,
+                                     int y,
+                                     t_rr_type type,
+                                     e_side side = SIDES[0]) const;
+
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -52,7 +52,7 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
     std::srand(seed);
 
     auto& device_ctx = g_vpr_ctx.device();
-    auto& rr_node_indices = device_ctx.rr_node_indices;
+    const auto& node_lookup = device_ctx.rr_graph.node_lookup();
 
     int virtual_clock_network_root_idx = create_virtual_clock_network_sink_node(switch_location.x, switch_location.y);
     {
@@ -61,10 +61,8 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
     }
 
     // rr_node indices for x and y channel routing wires and clock wires to connect to
-    auto x_wire_indices = get_rr_node_chan_wires_at_location(
-        rr_node_indices, CHANX, switch_location.x, switch_location.y);
-    auto y_wire_indices = get_rr_node_chan_wires_at_location(
-        rr_node_indices, CHANY, switch_location.x, switch_location.y);
+    auto x_wire_indices = node_lookup.find_channel_nodes(switch_location.x, switch_location.y, CHANX);
+    auto y_wire_indices = node_lookup.find_channel_nodes(switch_location.x, switch_location.y, CHANY);
     auto clock_indices = clock_graph.get_rr_node_indices_at_switch_location(
         clock_to_connect_to, switch_point_name, switch_location.x, switch_location.y);
 
@@ -76,13 +74,13 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
         // Connect to x-channel wires
         unsigned num_wires_x = x_wire_indices.size() * fc;
         for (size_t i = 0; i < num_wires_x; i++) {
-            clock_graph.add_edge(rr_edges_to_create, x_wire_indices[i], clock_index, arch_switch_idx);
+            clock_graph.add_edge(rr_edges_to_create, size_t(x_wire_indices[i]), clock_index, arch_switch_idx);
         }
 
         // Connect to y-channel wires
         unsigned num_wires_y = y_wire_indices.size() * fc;
         for (size_t i = 0; i < num_wires_y; i++) {
-            clock_graph.add_edge(rr_edges_to_create, y_wire_indices[i], clock_index, arch_switch_idx);
+            clock_graph.add_edge(rr_edges_to_create, size_t(y_wire_indices[i]), clock_index, arch_switch_idx);
         }
 
         // Connect to virtual clock sink node
@@ -95,35 +93,38 @@ int RoutingToClockConnection::create_virtual_clock_network_sink_node(
     int x,
     int y) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
-    auto& rr_nodes = device_ctx.rr_nodes;
-    rr_nodes.emplace_back();
-    auto node_index = rr_nodes.size() - 1;
+    auto& rr_graph = device_ctx.rr_nodes;
+    auto& node_lookup = device_ctx.rr_graph_builder.node_lookup();
+    rr_graph.emplace_back();
+    RRNodeId node_index = RRNodeId(rr_graph.size() - 1);
 
     //Determine the a valid PTC
-    std::vector<int> nodes_at_loc;
-    get_rr_node_indices(device_ctx.rr_node_indices,
-                        x, y,
-                        SINK,
-                        &nodes_at_loc);
+    std::vector<RRNodeId> nodes_at_loc = node_lookup.find_sink_nodes(x, y);
 
     int max_ptc = 0;
-    for (int inode : nodes_at_loc) {
-        max_ptc = std::max<int>(max_ptc, device_ctx.rr_nodes[inode].ptc_num());
+    for (RRNodeId inode : nodes_at_loc) {
+        max_ptc = std::max<int>(max_ptc, rr_graph.node_ptc_num(inode));
     }
     int ptc = max_ptc + 1;
 
-    rr_nodes[node_index].set_ptc_num(ptc);
-    rr_nodes[node_index].set_coordinates(x, y, x, y);
-    rr_nodes[node_index].set_capacity(1);
-    rr_nodes[node_index].set_cost_index(SINK_COST_INDEX);
-    rr_nodes[node_index].set_type(SINK);
+    rr_graph.set_node_ptc_num(node_index, ptc);
+    rr_graph.set_node_coordinates(node_index, x, y, x, y);
+    rr_graph.set_node_capacity(node_index, 1);
+    rr_graph.set_node_cost_index(node_index, SINK_COST_INDEX);
+    rr_graph.set_node_type(node_index, SINK);
     float R = 0.;
     float C = 0.;
-    rr_nodes[node_index].set_rc_index(find_create_rr_rc_data(R, C));
+    rr_graph.set_node_rc_index(node_index, find_create_rr_rc_data(R, C));
 
-    add_to_rr_node_indices(device_ctx.rr_node_indices, rr_nodes, node_index);
+    // Use a generic way when adding nodes to lookup. 
+    // However, since the SINK node has the same xhigh/xlow as well as yhigh/ylow, we can probably use a shortcut
+    for (int ix = rr_graph.node_xlow(node_index); ix <= rr_graph.node_xhigh(node_index); ++ix) {
+        for (int iy = rr_graph.node_ylow(node_index); iy <= rr_graph.node_yhigh(node_index); ++iy) {
+            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), rr_graph.node_ptc_num(node_index), SIDES[0]);
+        }
+    }
 
-    return node_index;
+    return size_t(node_index);
 }
 
 /*
@@ -243,7 +244,7 @@ size_t ClockToPinsConnection::estimate_additional_nodes() {
 
 void ClockToPinsConnection::create_switches(const ClockRRGraphBuilder& clock_graph, t_rr_edge_info_set* rr_edges_to_create) {
     auto& device_ctx = g_vpr_ctx.device();
-    auto& rr_node_indices = device_ctx.rr_node_indices;
+    const auto& node_lookup = device_ctx.rr_graph.node_lookup();
     auto& grid = clock_graph.grid();
 
     for (size_t x = 0; x < grid.width(); x++) {
@@ -304,13 +305,11 @@ void ClockToPinsConnection::create_switches(const ClockRRGraphBuilder& clock_gra
                         clock_y_offset = -1; // pick the chanx below the block
                     }
 
-                    auto clock_pin_node_idx = get_rr_node_index(
-                        rr_node_indices,
-                        x,
-                        y,
-                        IPIN,
-                        clock_pin_idx,
-                        side);
+                    auto clock_pin_node_idx = node_lookup.find_node(x,
+                                                                    y,
+                                                                    IPIN,
+                                                                    clock_pin_idx,
+                                                                    side);
 
                     auto clock_network_indices = clock_graph.get_rr_node_indices_at_switch_location(
                         clock_to_connect_from,
@@ -320,7 +319,7 @@ void ClockToPinsConnection::create_switches(const ClockRRGraphBuilder& clock_gra
 
                     //Create edges depending on Fc
                     for (size_t i = 0; i < clock_network_indices.size() * fc; i++) {
-                        clock_graph.add_edge(rr_edges_to_create, clock_network_indices[i], clock_pin_node_idx, arch_switch_idx);
+                        clock_graph.add_edge(rr_edges_to_create, clock_network_indices[i], size_t(clock_pin_node_idx), arch_switch_idx);
                     }
                 }
             }

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -54,10 +54,10 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
     auto& device_ctx = g_vpr_ctx.device();
     const auto& node_lookup = device_ctx.rr_graph.node_lookup();
 
-    int virtual_clock_network_root_idx = create_virtual_clock_network_sink_node(switch_location.x, switch_location.y);
+    RRNodeId virtual_clock_network_root_idx = create_virtual_clock_network_sink_node(switch_location.x, switch_location.y);
     {
         auto& mut_device_ctx = g_vpr_ctx.mutable_device();
-        mut_device_ctx.virtual_clock_network_root_idx = virtual_clock_network_root_idx;
+        mut_device_ctx.virtual_clock_network_root_idx = size_t(virtual_clock_network_root_idx);
     }
 
     // rr_node indices for x and y channel routing wires and clock wires to connect to
@@ -85,13 +85,11 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
 
         // Connect to virtual clock sink node
         // used by the two stage router
-        clock_graph.add_edge(rr_edges_to_create, clock_index, virtual_clock_network_root_idx, arch_switch_idx);
+        clock_graph.add_edge(rr_edges_to_create, clock_index, size_t(virtual_clock_network_root_idx), arch_switch_idx);
     }
 }
 
-int RoutingToClockConnection::create_virtual_clock_network_sink_node(
-    int x,
-    int y) {
+RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x, int y) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
     auto& rr_graph = device_ctx.rr_nodes;
     auto& node_lookup = device_ctx.rr_graph_builder.node_lookup();
@@ -120,11 +118,11 @@ int RoutingToClockConnection::create_virtual_clock_network_sink_node(
     // However, since the SINK node has the same xhigh/xlow as well as yhigh/ylow, we can probably use a shortcut
     for (int ix = rr_graph.node_xlow(node_index); ix <= rr_graph.node_xhigh(node_index); ++ix) {
         for (int iy = rr_graph.node_ylow(node_index); iy <= rr_graph.node_yhigh(node_index); ++iy) {
-            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), rr_graph.node_ptc_num(node_index), SIDES[0]);
+            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), rr_graph.node_ptc_num(node_index));
         }
     }
 
-    return size_t(node_index);
+    return node_index;
 }
 
 /*

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -116,7 +116,7 @@ int RoutingToClockConnection::create_virtual_clock_network_sink_node(
     float C = 0.;
     rr_graph.set_node_rc_index(node_index, find_create_rr_rc_data(R, C));
 
-    // Use a generic way when adding nodes to lookup. 
+    // Use a generic way when adding nodes to lookup.
     // However, since the SINK node has the same xhigh/xlow as well as yhigh/ylow, we can probably use a shortcut
     for (int ix = rr_graph.node_xlow(node_index); ix <= rr_graph.node_xhigh(node_index); ++ix) {
         for (int iy = rr_graph.node_ylow(node_index); iy <= rr_graph.node_yhigh(node_index); ++iy) {

--- a/vpr/src/route/clock_connection_builders.h
+++ b/vpr/src/route/clock_connection_builders.h
@@ -57,7 +57,7 @@ class RoutingToClockConnection : public ClockConnection {
     /* Connects the inter-block routing to the clock source at the specified coordinates */
     void create_switches(const ClockRRGraphBuilder& clock_graph, t_rr_edge_info_set* rr_edges_to_create) override;
     size_t estimate_additional_nodes() override;
-    int create_virtual_clock_network_sink_node(int x, int y);
+    RRNodeId create_virtual_clock_network_sink_node(int x, int y);
 };
 
 class ClockToClockConneciton : public ClockConnection {

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -349,7 +349,7 @@ int ClockRib::create_chanx_wire(int x_start,
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
             //TODO: CHANX uses odd swapped x/y indices here. Will rework once rr_node_indices is shadowed
-            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_ptc_num(chanx_node), SIDES[0]); 
+            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_ptc_num(chanx_node), SIDES[0]);
         }
     }
 
@@ -653,7 +653,7 @@ int ClockSpine::create_chany_wire(int y_start,
     RRNodeId chany_node = RRNodeId(node_index);
     for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {
-            rr_graph_builder.node_lookup().add_node(chany_node, ix, iy, rr_graph.node_type(chany_node), rr_graph.node_ptc_num(chany_node), SIDES[0]); 
+            rr_graph_builder.node_lookup().add_node(chany_node, ix, iy, rr_graph.node_type(chany_node), rr_graph.node_ptc_num(chany_node), SIDES[0]);
         }
     }
 

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -346,10 +346,11 @@ int ClockRib::create_chanx_wire(int x_start,
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
     RRNodeId chanx_node = RRNodeId(node_index);
+    /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
             //TODO: CHANX uses odd swapped x/y indices here. Will rework once rr_node_indices is shadowed
-            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_ptc_num(chanx_node), SIDES[0]);
+            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_ptc_num(chanx_node));
         }
     }
 
@@ -651,9 +652,10 @@ int ClockSpine::create_chany_wire(int y_start,
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
     RRNodeId chany_node = RRNodeId(node_index);
+    /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {
-            rr_graph_builder.node_lookup().add_node(chany_node, ix, iy, rr_graph.node_type(chany_node), rr_graph.node_ptc_num(chany_node), SIDES[0]);
+            rr_graph_builder.node_lookup().add_node(chany_node, ix, iy, rr_graph.node_type(chany_node), rr_graph.node_ptc_num(chany_node));
         }
     }
 

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -62,11 +62,11 @@ void ClockNetwork::set_num_instance(int num_inst) {
 
 void ClockNetwork::create_rr_nodes_for_clock_network_wires(ClockRRGraphBuilder& clock_graph,
                                                            t_rr_graph_storage* rr_nodes,
-                                                           t_rr_node_indices* rr_node_indices,
+                                                           RRGraphBuilder& rr_graph_builder,
                                                            t_rr_edge_info_set* rr_edges_to_create,
                                                            int num_segments) {
     for (int inst_num = 0; inst_num < get_num_inst(); inst_num++) {
-        create_rr_nodes_and_internal_edges_for_one_instance(clock_graph, rr_nodes, rr_node_indices, rr_edges_to_create, num_segments);
+        create_rr_nodes_and_internal_edges_for_one_instance(clock_graph, rr_nodes, rr_graph_builder, rr_edges_to_create, num_segments);
     }
 }
 
@@ -217,7 +217,7 @@ size_t ClockRib::estimate_additional_nodes(const DeviceGrid& grid) {
 
 void ClockRib::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                                    t_rr_graph_storage* rr_nodes,
-                                                                   t_rr_node_indices* rr_node_indices,
+                                                                   RRGraphBuilder& rr_graph_builder,
                                                                    t_rr_edge_info_set* rr_edges_to_create,
                                                                    int num_segments) {
     // Only chany wires need to know the number of segments inorder
@@ -275,7 +275,7 @@ void ClockRib::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphB
                                                     ptc_num,
                                                     Direction::BIDIR,
                                                     rr_nodes,
-                                                    rr_node_indices);
+                                                    rr_graph_builder);
             clock_graph.add_switch_location(get_name(), drive.name, drive_x, y, drive_node_idx);
 
             // create rib wire to the right and left of the drive point
@@ -285,14 +285,14 @@ void ClockRib::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphB
                                                    ptc_num,
                                                    Direction::DEC,
                                                    rr_nodes,
-                                                   rr_node_indices);
+                                                   rr_graph_builder);
             auto right_node_idx = create_chanx_wire(drive_x + 1,
                                                     x_end,
                                                     y,
                                                     ptc_num,
                                                     Direction::INC,
                                                     rr_nodes,
-                                                    rr_node_indices);
+                                                    rr_graph_builder);
             record_tap_locations(x_start + x_offset,
                                  x_end,
                                  y,
@@ -313,7 +313,7 @@ int ClockRib::create_chanx_wire(int x_start,
                                 int ptc_num,
                                 Direction direction,
                                 t_rr_graph_storage* rr_nodes,
-                                t_rr_node_indices* rr_node_indices) {
+                                RRGraphBuilder& rr_graph_builder) {
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
     auto node = rr_nodes->back();
@@ -343,7 +343,15 @@ int ClockRib::create_chanx_wire(int x_start,
     }
     node.set_cost_index(CHANX_COST_INDEX_START + seg_index); // Actual value set later
 
-    add_to_rr_node_indices(*rr_node_indices, *rr_nodes, node_index);
+    /* Add the node to spatial lookup */
+    auto& rr_graph = (*rr_nodes);
+    RRNodeId chanx_node = RRNodeId(node_index);
+    for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
+        for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
+            //TODO: CHANX uses odd swapped x/y indices here. Will rework once rr_node_indices is shadowed
+            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_ptc_num(chanx_node), SIDES[0]); 
+        }
+    }
 
     return node_index;
 }
@@ -511,7 +519,7 @@ size_t ClockSpine::estimate_additional_nodes(const DeviceGrid& grid) {
 
 void ClockSpine::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                                      t_rr_graph_storage* rr_nodes,
-                                                                     t_rr_node_indices* rr_node_indices,
+                                                                     RRGraphBuilder& rr_graph_builder,
                                                                      t_rr_edge_info_set* rr_edges_to_create,
                                                                      int num_segments) {
     auto& grid = clock_graph.grid();
@@ -565,7 +573,7 @@ void ClockSpine::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGrap
                                                     ptc_num,
                                                     Direction::BIDIR,
                                                     rr_nodes,
-                                                    rr_node_indices,
+                                                    rr_graph_builder,
                                                     num_segments);
             clock_graph.add_switch_location(get_name(), drive.name, x, drive_y, drive_node_idx);
 
@@ -576,7 +584,7 @@ void ClockSpine::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGrap
                                                    ptc_num,
                                                    Direction::DEC,
                                                    rr_nodes,
-                                                   rr_node_indices,
+                                                   rr_graph_builder,
                                                    num_segments);
             auto right_node_idx = create_chany_wire(drive_y + 1,
                                                     y_end,
@@ -584,7 +592,7 @@ void ClockSpine::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGrap
                                                     ptc_num,
                                                     Direction::INC,
                                                     rr_nodes,
-                                                    rr_node_indices,
+                                                    rr_graph_builder,
                                                     num_segments);
 
             // Keep a record of the rr_node idx that we will use to connects switches to at
@@ -609,7 +617,7 @@ int ClockSpine::create_chany_wire(int y_start,
                                   int ptc_num,
                                   Direction direction,
                                   t_rr_graph_storage* rr_nodes,
-                                  t_rr_node_indices* rr_node_indices,
+                                  RRGraphBuilder& rr_graph_builder,
                                   int num_segments) {
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
@@ -640,7 +648,14 @@ int ClockSpine::create_chany_wire(int y_start,
     }
     node.set_cost_index(CHANX_COST_INDEX_START + num_segments + seg_index);
 
-    add_to_rr_node_indices(*rr_node_indices, *rr_nodes, node_index);
+    /* Add the node to spatial lookup */
+    auto& rr_graph = (*rr_nodes);
+    RRNodeId chany_node = RRNodeId(node_index);
+    for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
+        for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {
+            rr_graph_builder.node_lookup().add_node(chany_node, ix, iy, rr_graph.node_type(chany_node), rr_graph.node_ptc_num(chany_node), SIDES[0]); 
+        }
+    }
 
     return node_index;
 }
@@ -678,14 +693,14 @@ size_t ClockHTree::estimate_additional_nodes(const DeviceGrid& /*grid*/) {
 
 void ClockHTree::create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                                      t_rr_graph_storage* rr_nodes,
-                                                                     t_rr_node_indices* rr_node_indices,
+                                                                     RRGraphBuilder& rr_graph_builder,
                                                                      t_rr_edge_info_set* rr_edges_to_create,
                                                                      int num_segments) {
     //Remove unused parameter warning
     (void)clock_graph;
     (void)num_segments;
     (void)rr_nodes;
-    (void)rr_node_indices;
+    (void)rr_graph_builder;
     (void)rr_edges_to_create;
 
     VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "HTrees are not yet supported.\n");

--- a/vpr/src/route/clock_network_builders.h
+++ b/vpr/src/route/clock_network_builders.h
@@ -8,6 +8,7 @@
 
 #include "vpr_types.h"
 
+#include "rr_graph_builder.h"
 #include "rr_graph2.h"
 #include "rr_graph_clock.h"
 
@@ -104,13 +105,13 @@ class ClockNetwork {
      * in ClockRRGraphBuilder. The reverse lookup maps the nodes to their switch point locations */
     void create_rr_nodes_for_clock_network_wires(ClockRRGraphBuilder& clock_graph,
                                                  t_rr_graph_storage* rr_nodes,
-                                                 t_rr_node_indices* rr_node_indices,
+                                                 RRGraphBuilder& rr_graph_builder,
                                                  t_rr_edge_info_set* rr_edges_to_create,
                                                  int num_segments);
     virtual void create_segments(std::vector<t_segment_inf>& segment_inf) = 0;
     virtual void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                                      t_rr_graph_storage* rr_nodes,
-                                                                     t_rr_node_indices* rr_node_indices,
+                                                                     RRGraphBuilder& rr_graph_builder,
                                                                      t_rr_edge_info_set* rr_edges_to_create,
                                                                      int num_segments)
         = 0;
@@ -166,7 +167,7 @@ class ClockRib : public ClockNetwork {
     void create_segments(std::vector<t_segment_inf>& segment_inf) override;
     void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                              t_rr_graph_storage* rr_nodes,
-                                                             t_rr_node_indices* rr_node_indices,
+                                                             RRGraphBuilder& rr_graph_builder,
                                                              t_rr_edge_info_set* rr_edges_to_create,
                                                              int num_segments) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;
@@ -176,7 +177,7 @@ class ClockRib : public ClockNetwork {
                           int ptc_num,
                           Direction direction,
                           t_rr_graph_storage* rr_nodes,
-                          t_rr_node_indices* rr_node_indices);
+                          RRGraphBuilder& rr_graph_builder);
     void record_tap_locations(unsigned x_start,
                               unsigned x_end,
                               unsigned y,
@@ -227,7 +228,7 @@ class ClockSpine : public ClockNetwork {
     void create_segments(std::vector<t_segment_inf>& segment_inf) override;
     void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                              t_rr_graph_storage* rr_nodes,
-                                                             t_rr_node_indices* rr_node_indices,
+                                                             RRGraphBuilder& rr_graph_builder,
                                                              t_rr_edge_info_set* rr_edges_to_create,
                                                              int num_segments) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;
@@ -237,7 +238,7 @@ class ClockSpine : public ClockNetwork {
                           int ptc_num,
                           Direction direction,
                           t_rr_graph_storage* rr_nodes,
-                          t_rr_node_indices* rr_node_indices,
+                          RRGraphBuilder& rr_graph_builder,
                           int num_segments);
     void record_tap_locations(unsigned y_start,
                               unsigned y_end,
@@ -264,7 +265,7 @@ class ClockHTree : private ClockNetwork {
     void create_segments(std::vector<t_segment_inf>& segment_inf) override;
     void create_rr_nodes_and_internal_edges_for_one_instance(ClockRRGraphBuilder& clock_graph,
                                                              t_rr_graph_storage* rr_nodes,
-                                                             t_rr_node_indices* rr_node_indices,
+                                                             RRGraphBuilder& rr_graph_builder,
                                                              t_rr_edge_info_set* rr_edges_to_create,
                                                              int num_segments) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;

--- a/vpr/src/route/rr_edge.h
+++ b/vpr/src/route/rr_edge.h
@@ -1,6 +1,7 @@
 #ifndef RR_EDGE_H
 #define RR_EDGE_H
 
+/* TODO: MUST change the node id to RRNodeId before refactoring is finished! */
 struct t_rr_edge_info {
     t_rr_edge_info(int from, int to, short type) noexcept
         : from_node(from)

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1266,7 +1266,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
     std::function<void(t_chan_width*)> update_chan_width = [](t_chan_width*) {
     };
     if (clock_modeling == DEDICATED_NETWORK) {
-        ClockRRGraphBuilder builder(chan_width, grid, &L_rr_node, &L_rr_node_indices);
+        ClockRRGraphBuilder builder(chan_width, grid, &L_rr_node, &rr_graph_builder);
         builder.create_and_append_clock_rr_graph(num_seg_types, &rr_edges_to_create);
         uniquify_edges(rr_edges_to_create);
         alloc_and_load_edges(L_rr_node, rr_edges_to_create);

--- a/vpr/src/route/rr_graph_clock.cpp
+++ b/vpr/src/route/rr_graph_clock.cpp
@@ -30,7 +30,7 @@ void ClockRRGraphBuilder::create_clock_networks_wires(const std::vector<std::uni
                                                       t_rr_edge_info_set* rr_edges_to_create) {
     // Add rr_nodes for each clock network wire
     for (auto& clock_network : clock_networks) {
-        clock_network->create_rr_nodes_for_clock_network_wires(*this, rr_nodes_, rr_node_indices_, rr_edges_to_create, num_segments);
+        clock_network->create_rr_nodes_for_clock_network_wires(*this, rr_nodes_, *rr_graph_builder_, rr_edges_to_create, num_segments);
     }
 
     // Reduce the capacity of rr_nodes for performance

--- a/vpr/src/route/rr_graph_clock.h
+++ b/vpr/src/route/rr_graph_clock.h
@@ -8,6 +8,8 @@
 #include <set>
 #include <utility>
 
+
+#include "rr_graph_builder.h"
 #include "clock_fwd.h"
 
 #include "clock_network_builders.h"
@@ -78,11 +80,11 @@ class ClockRRGraphBuilder {
         const t_chan_width& chan_width,
         const DeviceGrid& grid,
         t_rr_graph_storage* rr_nodes,
-        t_rr_node_indices* rr_node_indices)
+        RRGraphBuilder* rr_graph_builder)
         : chan_width_(chan_width)
         , grid_(grid)
         , rr_nodes_(rr_nodes)
-        , rr_node_indices_(rr_node_indices)
+        , rr_graph_builder_(rr_graph_builder)
         , chanx_ptc_idx_(0)
         , chany_ptc_idx_(0) {
     }
@@ -136,7 +138,7 @@ class ClockRRGraphBuilder {
     const t_chan_width& chan_width_;
     const DeviceGrid& grid_;
     t_rr_graph_storage* rr_nodes_;
-    t_rr_node_indices* rr_node_indices_;
+    RRGraphBuilder* rr_graph_builder_;
 
     int chanx_ptc_idx_;
     int chany_ptc_idx_;

--- a/vpr/src/route/rr_graph_clock.h
+++ b/vpr/src/route/rr_graph_clock.h
@@ -8,7 +8,6 @@
 #include <set>
 #include <utility>
 
-
 #include "rr_graph_builder.h"
 #include "clock_fwd.h"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR focuses on updating RRGraph clock builder functions, where we use the refactored data structure ``RRGraphBuilder`` to replace the legacy data structure ``rr_node_indices``.
This PR aims to eliminate the use of ``rr_node_indices`` in the RRGraph clock builder, as one step further in deprecating the legacy data structure.

Checklist:

- [x] Added a new API ``find_sink_nodes()`` to ``RRSpatialLookup``
- [x] Eliminate the use of ``rr_node_indices`` for RRGraph Clock Builder
- [x] Delete obsoleted functions in ``rr_graph2.cpp`` which are replaced by built-in APIs in ``RRSpatialLookup``

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This pull request is a follow-up PR on the routing resource graph refactoring effort https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1779

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After the previous PR #1779  , we start reworking all the source files that use the legacy data structure ``rr_node_indices`` in a high priority, in order to deprecate the legacy data structure as soon as possible.
Current statistics on the files that use ``rr_node_indices`` (in total there are 143 lines related):
- ./route/clock_connection_builders.cpp
- ./route/clock_network_builders.cpp
- ./route/clock_network_builders.h
- ./route/router_lookahead_map_utils.cpp
- ./route/rr_graph.cpp
- ./route/rr_graph2.cpp
- ./route/rr_graph2.h
- ./route/rr_graph_clock.cpp
- ./route/rr_graph_clock.h
- ./route/rr_graph_reader.cpp
- ./route/rr_graph_util.cpp
- ./route/rr_graph_uxsdcxx_serializer.h
- ./route/rr_graph_writer.cpp

This PR will remove the use in 
- [X] ./route/clock_connection_builders.cpp
- [X] ./route/clock_network_builders.cpp
- [X] ./route/clock_network_builders.h
- [X] ./route/rr_graph_clock.cpp
- [X] ./route/rr_graph_clock.h

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
