### PR TITLE
dev scripts should not depend on ci scripts

### DIFF
--- a/dev/check-format-py.sh
+++ b/dev/check-format-py.sh
@@ -1,33 +1,3 @@
 #!/usr/bin/env bash
 
-clean=$(git status -s -uno | wc -l) #Short ignore untracked
-
-if [ $clean -ne 0 ]; then
-    echo "Current working tree was not clean! This tool only works on clean checkouts"
-    exit 2
-else
-    echo "Code Formatting Check"
-    echo "====================="
-    make format-py > /dev/null 2>&1
-
-    valid_format=$(git diff | wc -l)
-
-    if [ $valid_format -ne 0 ]; then
-        echo "FAILED"
-        echo ""
-        echo "You *must* make the following changes to match the formatting style"
-        echo "-------------------------------------------------------------------"
-        echo ""
-
-        git diff
-
-        echo ""
-        echo "Run 'make format-py' to apply these changes"
-
-        git reset --hard > /dev/null
-        exit 1
-    else
-        echo "OK"
-    fi
-fi
-exit 0
+$(dirname "$0")/check-format.sh -py

--- a/dev/check-format-py.sh
+++ b/dev/check-format-py.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-source $(dirname "$0")/../.github/scripts/common.sh
-
 clean=$(git status -s -uno | wc -l) #Short ignore untracked
 
 if [ $clean -ne 0 ]; then

--- a/dev/check-format.sh
+++ b/dev/check-format.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-source $(dirname "$0")/../.github/scripts/common.sh
-
 clean=$(git status -s -uno | wc -l) #Short ignore untracked
 
 if [ $clean -ne 0 ]; then

--- a/dev/check-format.sh
+++ b/dev/check-format.sh
@@ -8,7 +8,7 @@ if [ $clean -ne 0 ]; then
 else
     echo "Code Formatting Check"
     echo "====================="
-    make format > /dev/null
+    make format"$1" > /dev/null 2>&1
 
     valid_format=$(git diff | wc -l)
 
@@ -22,7 +22,7 @@ else
         git diff
 
         echo ""
-        echo "Run 'make format' to apply these changes"
+        echo "Run 'make format$1' to apply these changes"
 
         git reset --hard > /dev/null
         exit 1


### PR DESCRIPTION
As discussed in https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1804#discussion_r672426293, maybe the common CI script does not need to be sourced in the `dev/check-format*` scripts.

/cc @mithro 