### PR TITLE
route_common: Fix cost check assertion

### DIFF
--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -83,7 +83,7 @@ inline float get_single_rr_cong_cost(int inode, float pres_fac) {
     float cost = device_ctx.rr_indexed_data[cost_index].base_cost * route_ctx.rr_node_route_inf[inode].acc_cost * pres_cost;
 
     VTR_ASSERT_DEBUG_MSG(
-        cost == get_single_rr_cong_base_cost(inode) * get_single_rr_cong_base_cost(inode) * get_single_rr_cong_pres_cost(inode, pres_fac),
+        cost == get_single_rr_cong_base_cost(inode) * get_single_rr_cong_acc_cost(inode) * get_single_rr_cong_pres_cost(inode, pres_fac),
         "Single rr node congestion cost is inaccurate");
 
     return cost;


### PR DESCRIPTION
I was looking through the VPR router to compare it to nextpnr's one and noticed a small issue in one of the assertions, base cost was being multiplied twice instead of by the accumulated historical cost. This caused an assertion failure when debug assertions are enabled.