### PR TITLE
fix track_memory_usage no use bug

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -406,7 +406,7 @@ def vtr_command_main(arg_list, prog=None):
         temp_dir = Path(args.temp_dir)
     # Specify how command should be run
     command_runner = vtr.CommandRunner(
-        track_memory=True,
+        track_memory=args.track_memory_usage,
         max_memory_mb=args.limit_memory_usage,
         timeout_sec=args.timeout,
         verbose=args.verbose,


### PR DESCRIPTION
#### Expected Behaviour
the run_vtr_flow.py get a parameter track_memory_usage and it decides whether to track memory.

#### Current Behaviour
this parameter has not be inputed in vtr command

#### Possible Solution
input into vtr.CommandRunner

#### Steps to Reproduce
<!--- Provide an unambiguous set of steps to reproduce this bug. -->
<!--- Include the exact command line arguments and source files -->
<!-- (e.g. architecture file, netlist) to reproduce, if relevant. -->
1. run run_vtr_flow.py --track_memory_usage false


