### PR TITLE
fix_track_memory_usage

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -184,7 +184,7 @@ def vtr_command_argparser(prog=None):
 
     house_keeping.add_argument(
         "-track_memory_usage",
-        default=False,
+        default=True,
         action="store_true",
         dest="track_memory_usage",
         help="Track the memory usage for each stage."
@@ -406,7 +406,7 @@ def vtr_command_main(arg_list, prog=None):
         temp_dir = Path(args.temp_dir)
     # Specify how command should be run
     command_runner = vtr.CommandRunner(
-        track_memory=True,
+        track_memory=args.track_memory_usage,
         max_memory_mb=args.limit_memory_usage,
         timeout_sec=args.timeout,
         verbose=args.verbose,


### PR DESCRIPTION
The change in this pull request is the same as PR #1827. Added the change to a new branch because I wasn't able to checkout the other remote branch as it was on a fork off of the main remote repo verilog-to-routing/vtr-verilog-to-routing.

The original change was to make sure the runner looks at the argument track_memory_usage to see whether memory tracking should be turned on or off, instead of just always making it on.
An additional change was made that was requested in a comment on #1827 - the default value of track_memory_usage was set to "True" so that track_memory_usage is always on unless the argument specifies that it should be off.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


