### PR TITLE
[CI] Logs Memory during CI Run

### DIFF
--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -488,9 +488,14 @@ def vtr_command_main(arg_list, prog=None):
 
     finally:
         seconds = datetime.now() - start
+        with open(temp_dir/"vpr.out","r") as fpmem:
+            for line in fpmem.readlines():
+                if "Maximum resident set size" in line:
+                    mem_usage = int(line.split()[-1])//1024
         print(
-            "{status} (took {time})".format(
-                status=error_status, time=vtr.format_elapsed_time(seconds)
+            "{status} (took {time}, vpr run consumed {max_mem} MB memory)".format(
+                status=error_status, time=vtr.format_elapsed_time(seconds),
+                max_mem=mem_usage
             )
         )
         temp_dir.mkdir(parents=True, exist_ok=True)

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -414,11 +414,12 @@ def vtr_command_argparser(prog=None):
 def format_human_readable_memory(num_kbytes):
     """format the number of bytes given as a human readable value"""
     if num_kbytes < 1024:
-        return "%.2f KiB" % (num_kbytes)
+        value = "%.2f KiB" % (num_kbytes)
     elif num_kbytes < (1024 ** 2):
-        return "%.2f MiB" % (num_kbytes / (1024 ** 1))
+        value = "%.2f MiB" % (num_kbytes / (1024 ** 1))
     else:
-        return "%.2f GiB" % (num_kbytes / (1024 ** 2))
+        value = "%.2f GiB" % (num_kbytes / (1024 ** 2))
+    return value
 
 
 # pylint: enable=too-many-statements

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -422,6 +422,15 @@ def format_human_readable_memory(num_kbytes):
     return value
 
 
+def get_memory_usage(logfile):
+    """Extrats the memory usage from the *.out log files"""
+    with open(logfile, "r") as fpmem:
+        for line in fpmem.readlines():
+            if "Maximum resident set size" in line:
+                return format_human_readable_memory(int(line.split()[-1]))
+    return "--"
+
+
 # pylint: enable=too-many-statements
 
 
@@ -499,13 +508,12 @@ def vtr_command_main(arg_list, prog=None):
 
     finally:
         seconds = datetime.now() - start
-        with open(temp_dir / "vpr.out", "r") as fpmem:
-            for line in fpmem.readlines():
-                if "Maximum resident set size" in line:
-                    mem_usage = format_human_readable_memory(int(line.split()[-1]))
+
         print(
             "{status} (took {time}, vpr run consumed {max_mem} memory)".format(
-                status=error_status, time=vtr.format_elapsed_time(seconds), max_mem=mem_usage
+                status=error_status,
+                time=vtr.format_elapsed_time(seconds),
+                max_mem=get_memory_usage(temp_dir / "vpr.out"),
             )
         )
         temp_dir.mkdir(parents=True, exist_ok=True)

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -411,6 +411,16 @@ def vtr_command_argparser(prog=None):
     return parser
 
 
+def format_human_readable_memory(num_kbytes):
+    """format the number of bytes given as a human readable value"""
+    if num_kbytes < 1024:
+        return "%.2f KiB" % (num_kbytes)
+    elif num_kbytes < (1024 ** 2):
+        return "%.2f MiB" % (num_kbytes / (1024 ** 1))
+    else:
+        return "%.2f GiB" % (num_kbytes / (1024 ** 2))
+
+
 # pylint: enable=too-many-statements
 
 
@@ -491,9 +501,9 @@ def vtr_command_main(arg_list, prog=None):
         with open(temp_dir / "vpr.out", "r") as fpmem:
             for line in fpmem.readlines():
                 if "Maximum resident set size" in line:
-                    mem_usage = int(line.split()[-1]) // 1024
+                    mem_usage = format_human_readable_memory(int(line.split()[-1]))
         print(
-            "{status} (took {time}, vpr run consumed {max_mem} MB memory)".format(
+            "{status} (took {time}, vpr run consumed {max_mem} memory)".format(
                 status=error_status, time=vtr.format_elapsed_time(seconds), max_mem=mem_usage
             )
         )

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -488,14 +488,13 @@ def vtr_command_main(arg_list, prog=None):
 
     finally:
         seconds = datetime.now() - start
-        with open(temp_dir/"vpr.out","r") as fpmem:
+        with open(temp_dir / "vpr.out", "r") as fpmem:
             for line in fpmem.readlines():
                 if "Maximum resident set size" in line:
-                    mem_usage = int(line.split()[-1])//1024
+                    mem_usage = int(line.split()[-1]) // 1024
         print(
             "{status} (took {time}, vpr run consumed {max_mem} MB memory)".format(
-                status=error_status, time=vtr.format_elapsed_time(seconds),
-                max_mem=mem_usage
+                status=error_status, time=vtr.format_elapsed_time(seconds), max_mem=mem_usage
             )
         )
         temp_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Logs peak memory usage during VPR CI run. The information is extracted from the `vpr.out` (which I assumed obtained using valgrid)

#### Related Issue
Addresses part of issue  #1808 
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1808#issuecomment-904022281

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested locally, I have attached the screenshot.
![image](https://user-images.githubusercontent.com/6169914/133653858-2049f9af-3dbb-4ca1-ae38-06fc6df80ad4.png)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
