### PR TITLE
Add a new API set_node_direction() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.cpp
+++ b/vpr/src/device/rr_graph_builder.cpp
@@ -50,3 +50,7 @@ void RRGraphBuilder::add_node_to_all_locs(RRNodeId node) {
 void RRGraphBuilder::clear() {
     node_lookup_.clear();
 }
+
+void RRGraphBuilder::set_node_direction(RRNodeId id, Direction new_direction) {
+    node_storage_.set_node_direction(id, new_direction);
+}

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -55,6 +55,9 @@ class RRGraphBuilder {
     /** @brief Clear all the underlying data storage */
     void clear();
 
+    /** @brief Set the nod direction  */
+    void set_node_direction(RRNodeId, Direction new_direction);
+
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -317,6 +317,7 @@ int ClockRib::create_chanx_wire(int x_start,
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
     auto node = rr_nodes->back();
+    RRNodeId chanx_node = RRNodeId(node_index);
 
     node.set_coordinates(x_start, y, x_end, y);
     node.set_type(CHANX);
@@ -324,7 +325,7 @@ int ClockRib::create_chanx_wire(int x_start,
     node.set_track_num(ptc_num);
     node.set_rc_index(find_create_rr_rc_data(
         x_chan_wire.layer.r_metal, x_chan_wire.layer.c_metal));
-    node.set_direction(direction);
+    rr_graph_builder.set_node_direction(chanx_node, direction);
 
     short seg_index = 0;
     switch (direction) {
@@ -345,7 +346,7 @@ int ClockRib::create_chanx_wire(int x_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-    RRNodeId chanx_node = RRNodeId(node_index);
+
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
@@ -630,7 +631,7 @@ int ClockSpine::create_chany_wire(int y_start,
     node.set_track_num(ptc_num);
     node.set_rc_index(find_create_rr_rc_data(
         y_chan_wire.layer.r_metal, y_chan_wire.layer.c_metal));
-    node.set_direction(direction);
+    rr_graph_builder.set_node_direction(chanx_node, direction);
 
     short seg_index = 0;
     switch (direction) {

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -624,6 +624,7 @@ int ClockSpine::create_chany_wire(int y_start,
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
     auto node = rr_nodes->back();
+    RRNodeId chanx_node = RRNodeId(node_index);
 
     node.set_coordinates(x, y_start, x, y_end);
     node.set_type(CHANY);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1673,7 +1673,7 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
 
         L_rr_node.set_node_ptc_num(node, track);
         L_rr_node.set_node_type(node, chan_type);
-        L_rr_node.set_node_direction(node, seg_details[track].direction());
+        rr_graph_builder.set_node_direction(node, seg_details[track].direction());
     }
 }
 

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -816,6 +816,8 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     inline void set_node_direction(uxsd::enum_node_direction direction, int& inode) final {
         const auto& rr_graph = (*rr_graph_);
         auto node = (*rr_nodes_)[inode];
+        RRNodeId node_id = node.id();
+
         if (direction == uxsd::enum_node_direction::UXSD_INVALID) {
             if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
                 report_error(
@@ -823,7 +825,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                     inode, rr_graph.node_type(node.id()));
             }
         } else {
-            node.set_direction(from_uxsd_node_direction(direction));
+            rr_graph_builder_->set_node_direction(node_id, from_uxsd_node_direction(direction));
         }
     }
     inline uxsd::enum_node_direction get_node_direction(const t_rr_node& node) final {

--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -91,10 +91,6 @@ void t_rr_node::set_capacity(short new_capacity) {
     storage_->set_node_capacity(id_, new_capacity);
 }
 
-void t_rr_node::set_direction(Direction new_direction) {
-    storage_->set_node_direction(id_, new_direction);
-}
-
 void t_rr_node::add_side(e_side new_side) {
     storage_->add_node_side(id_, new_side);
 }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -122,7 +122,6 @@ class t_rr_node {
     void set_cost_index(size_t);
     void set_rc_index(short);
 
-    void set_direction(Direction);
     void set_side(e_side);
     void add_side(e_side);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discrete data structure `rr_graph_storage`.
This PR aims to fully deprecate the direct use of the legacy API `set_direction()` from the `rr_node` data structure.

After this PR, the `set_direction` API is fully deprecated and the `set_node_direction` from the refactored data structure `RRGraphBuilder` is the only way to use it.

**Checklist:**

- [x]  Removed the legacy API `set_direction()` from `rr_node.cpp` and `rr_node.h`
- [x]  Added new APIs `set_node_direction` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x]  Replaced all the use of `set_direction()` in builder functions by `set_node_direction()`

#### Related Issue
This pull request is a follow-up PR on the routing resource graph refactoring effort [#1805](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1805)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR is the continuation of the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in the `RRGraphBuilder` data structure.
This PR reworks the `set_node_direction()` API among the other APIs in [#1847](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1847)

#### How Has This Been Tested?

- [ ] All vtr basic and strong tests are passing.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
