### PR TITLE
Add a new API set_node_capacity() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.cpp
+++ b/vpr/src/device/rr_graph_builder.cpp
@@ -54,3 +54,6 @@ void RRGraphBuilder::clear() {
 void RRGraphBuilder::set_node_coordinates(RRNodeId id, short x1, short y1, short x2, short y2) {
     node_storage_.set_node_coordinates(id, x1, y1, x2, y2);
 }
+void RRGraphBuilder::set_node_capacity(RRNodeId id, short new_capacity) {
+    node_storage_.set_node_capacity(id, new_capacity);
+}

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -55,6 +55,9 @@ class RRGraphBuilder {
     /** @brief Clear all the underlying data storage */
     void clear();
 
+    /** @brief Set capacity of this node (number of routes that can use it). */
+    void set_node_capacity(RRNodeId, short new_capacity);
+
     /** @brief Set the node coordinate */
     void set_node_coordinates(RRNodeId id, short x1, short y1, short x2, short y2);
 

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -108,7 +108,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
 
     rr_graph.set_node_ptc_num(node_index, ptc);
     rr_graph_builder.set_node_coordinates(node_index, x, y, x, y);
-    rr_graph.set_node_capacity(node_index, 1);
+    rr_graph_builder.set_node_capacity(node_index, 1);
     rr_graph.set_node_cost_index(node_index, SINK_COST_INDEX);
     rr_graph.set_node_type(node_index, SINK);
     float R = 0.;

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -321,7 +321,7 @@ int ClockRib::create_chanx_wire(int x_start,
 
     rr_graph_builder.set_node_coordinates(chanx_node, x_start, y, x_end, y);
     node.set_type(CHANX);
-    rr_graph_builder.set_node_capacity(chanx_node,1);
+    rr_graph_builder.set_node_capacity(chanx_node, 1);
     node.set_track_num(ptc_num);
     node.set_rc_index(find_create_rr_rc_data(
         x_chan_wire.layer.r_metal, x_chan_wire.layer.c_metal));
@@ -627,7 +627,7 @@ int ClockSpine::create_chany_wire(int y_start,
 
     rr_graph_builder.set_node_coordinates(chany_node, x, y_start, x, y_end);
     node.set_type(CHANY);
-    rr_graph_builder.set_node_capacity(chany_node,1);
+    rr_graph_builder.set_node_capacity(chany_node, 1);
     node.set_track_num(ptc_num);
     node.set_rc_index(find_create_rr_rc_data(
         y_chan_wire.layer.r_metal, y_chan_wire.layer.c_metal));

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -321,7 +321,7 @@ int ClockRib::create_chanx_wire(int x_start,
 
     rr_graph_builder.set_node_coordinates(chanx_node, x_start, y, x_end, y);
     node.set_type(CHANX);
-    node.set_capacity(1);
+    rr_graph_builder.set_node_capacity(chanx_node,1);
     node.set_track_num(ptc_num);
     node.set_rc_index(find_create_rr_rc_data(
         x_chan_wire.layer.r_metal, x_chan_wire.layer.c_metal));
@@ -346,7 +346,6 @@ int ClockRib::create_chanx_wire(int x_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
@@ -628,7 +627,7 @@ int ClockSpine::create_chany_wire(int y_start,
 
     rr_graph_builder.set_node_coordinates(chany_node, x, y_start, x, y_end);
     node.set_type(CHANY);
-    node.set_capacity(1);
+    rr_graph_builder.set_node_capacity(chany_node,1);
     node.set_track_num(ptc_num);
     node.set_rc_index(find_create_rr_rc_data(
         y_chan_wire.layer.r_metal, y_chan_wire.layer.c_metal));
@@ -653,7 +652,6 @@ int ClockSpine::create_chany_wire(int y_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -708,11 +708,11 @@ static void build_rr_graph(const t_graph_type graph_type,
         for (int i = 0; i < num_rr_nodes; i++) {
             if (rr_graph.node_type(RRNodeId(i)) == CHANX) {
                 int ylow = rr_graph.node_ylow(RRNodeId(i));
-                device_ctx.rr_graph_builder.set_node_capacity(RRNodeId(i),nodes_per_chan.x_list[ylow]);
+                device_ctx.rr_graph_builder.set_node_capacity(RRNodeId(i), nodes_per_chan.x_list[ylow]);
             }
             if (rr_graph.node_type(RRNodeId(i)) == CHANY) {
                 int xlow = rr_graph.node_xlow(RRNodeId(i));
-                device_ctx.rr_graph_builder.set_node_capacity(RRNodeId(i),nodes_per_chan.y_list[xlow]);
+                device_ctx.rr_graph_builder.set_node_capacity(RRNodeId(i), nodes_per_chan.y_list[xlow]);
             }
         }
     }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -708,11 +708,11 @@ static void build_rr_graph(const t_graph_type graph_type,
         for (int i = 0; i < num_rr_nodes; i++) {
             if (rr_graph.node_type(RRNodeId(i)) == CHANX) {
                 int ylow = rr_graph.node_ylow(RRNodeId(i));
-                device_ctx.rr_nodes[i].set_capacity(nodes_per_chan.x_list[ylow]);
+                device_ctx.rr_graph_builder.set_node_capacity(RRNodeId(i),nodes_per_chan.x_list[ylow]);
             }
             if (rr_graph.node_type(RRNodeId(i)) == CHANY) {
                 int xlow = rr_graph.node_xlow(RRNodeId(i));
-                device_ctx.rr_nodes[i].set_capacity(nodes_per_chan.y_list[xlow]);
+                device_ctx.rr_graph_builder.set_node_capacity(RRNodeId(i),nodes_per_chan.y_list[xlow]);
             }
         }
     }
@@ -1428,7 +1428,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
         }
 
         /* Things common to both SOURCEs and SINKs.   */
-        L_rr_node.set_node_capacity(inode, class_inf[iclass].num_pins);
+        rr_graph_builder.set_node_capacity(inode, class_inf[iclass].num_pins);
         rr_graph_builder.set_node_coordinates(inode, i, j, i + type->width - 1, j + type->height - 1);
         float R = 0.;
         float C = 0.;
@@ -1477,7 +1477,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
 
                         /* Common to both DRIVERs and RECEIVERs */
                         if (inode) {
-                            L_rr_node.set_node_capacity(inode, 1);
+                            rr_graph_builder.set_node_capacity(inode, 1);
                             float R = 0.;
                             float C = 0.;
                             L_rr_node.set_node_rc_index(inode, find_create_rr_rc_data(R, C));
@@ -1657,7 +1657,7 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
 
         /* Edge arrays have now been built up.  Do everything else.  */
         L_rr_node.set_node_cost_index(node, cost_index_offset + seg_details[track].index());
-        L_rr_node.set_node_capacity(node, 1); /* GLOBAL routing handled elsewhere */
+        rr_graph_builder.set_node_capacity(node, 1); /* GLOBAL routing handled elsewhere */
 
         if (chan_type == CHANX) {
             rr_graph_builder.set_node_coordinates(node, start, y_coord, end, y_coord);

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -763,7 +763,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         auto node = (*rr_nodes_)[id];
         RRNodeId node_id = node.id();
 
-        rr_graph_builder_->set_node_capacity(node_id,capacity);
+        rr_graph_builder_->set_node_capacity(node_id, capacity);
         node.set_type(from_uxsd_node_type(type));
 
         switch (rr_graph.node_type(node.id())) {

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -761,8 +761,9 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         const auto& rr_graph = (*rr_graph_);
         rr_nodes_->make_room_for_node(RRNodeId(id));
         auto node = (*rr_nodes_)[id];
+        RRNodeId node_id = node.id();
 
-        node.set_capacity(capacity);
+        rr_graph_builder_->set_node_capacity(node_id,capacity);
         node.set_type(from_uxsd_node_type(type));
 
         switch (rr_graph.node_type(node.id())) {

--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -79,10 +79,6 @@ void t_rr_node::set_rc_index(short new_rc_index) {
     storage_->set_node_rc_index(id_, new_rc_index);
 }
 
-void t_rr_node::set_capacity(short new_capacity) {
-    storage_->set_node_capacity(id_, new_capacity);
-}
-
 void t_rr_node::set_direction(Direction new_direction) {
     storage_->set_node_direction(id_, new_direction);
 }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -110,8 +110,6 @@ class t_rr_node {
   public: //Mutators
     void set_type(t_rr_type new_type);
 
-    void set_capacity(short);
-
     void set_ptc_num(short);
     void set_pin_num(short);   //Same as set_ptc_num() by checks type() is consistent
     void set_track_num(short); //Same as set_ptc_num() by checks type() is consistent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discreted data structure `rr_graph_storage`.
This PR aims to fully deprecate the direct use of the legacy API `set_capacity()` from `rr_node` data structure.

After this PR, the `set_capacity` API is fully deprecated and the `set_node_capacity` from the refactored data structure `RRGraphBuilder` is the only way to use.

Checklist:

- [x] Removed the legacy API `set_capacity()` from `rr_node.cpp` and `rr_node.h`
- [x] Added new APIs `set_node_capacity` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x] Replaced all the use of `set_capacity()` in builder functions by `set_node_capacity()`

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This pull request is a follow-up PR on the routing resource graph refactoring effort [ #1805 ](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1805)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR is the continuation to the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in `RRGraphBuilder` data structure.
This  PR reworks the set_node_capacity() API among the other APIs in https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1847

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] All vtr basic and strong tests are passing.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
