### PR TITLE
Global variable removal

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2940,7 +2940,7 @@ void act_on_mouse_press(ezgl::application* app, GdkEventButton* event, double x,
 
 void act_on_mouse_move(ezgl::application* app, GdkEventButton* event, double x, double y) {
     //  std::cout << "Mouse move at coordinates (" << x << "," << y << ") "<< std::endl;
-
+    auto& device_ctx = g_vpr_ctx.device();
     // user has clicked the window button, in window mode
     if (window_point_1_collected) {
         // draw a grey, dashed-line box to indicate the zoom-in region
@@ -2962,7 +2962,7 @@ void act_on_mouse_move(ezgl::application* app, GdkEventButton* event, double x, 
         if (hit_node != OPEN) {
             //Update message
 
-            std::string info = describe_rr_node(hit_node);
+            std::string info = describe_rr_node(hit_node,device_ctx);
             std::string msg = vtr::string_fmt("Moused over %s", info.c_str());
             app->update_message(msg.c_str());
         } else {

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2962,7 +2962,7 @@ void act_on_mouse_move(ezgl::application* app, GdkEventButton* event, double x, 
         if (hit_node != OPEN) {
             //Update message
 
-            std::string info = describe_rr_node(hit_node,device_ctx);
+            std::string info = describe_rr_node(hit_node, device_ctx);
             std::string msg = vtr::string_fmt("Moused over %s", info.c_str());
             app->update_message(msg.c_str());
         } else {

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -127,7 +127,7 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
 
 bool highlight_rr_nodes(int hit_node) {
     t_draw_state* draw_state = get_draw_state_vars();
-
+    auto& device_ctx = g_vpr_ctx.device();
     char message[250] = "";
 
     if (hit_node != OPEN) {
@@ -147,11 +147,11 @@ bool highlight_rr_nodes(int hit_node) {
                 draw_state->draw_rr_node[node].node_highlighted = false;
             }
             //Print info about all nodes to terminal
-            VTR_LOG("%s\n", describe_rr_node(node).c_str());
+            VTR_LOG("%s\n", describe_rr_node(node,device_ctx).c_str());
         }
 
         //Show info about *only* hit node to graphics
-        std::string info = describe_rr_node(hit_node);
+        std::string info = describe_rr_node(hit_node,device_ctx);
 
         sprintf(message, "Selected %s", info.c_str());
         rr_highlight_message = message;

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -147,11 +147,11 @@ bool highlight_rr_nodes(int hit_node) {
                 draw_state->draw_rr_node[node].node_highlighted = false;
             }
             //Print info about all nodes to terminal
-            VTR_LOG("%s\n", describe_rr_node(node,device_ctx).c_str());
+            VTR_LOG("%s\n", describe_rr_node(node, device_ctx).c_str());
         }
 
         //Show info about *only* hit node to graphics
-        std::string info = describe_rr_node(hit_node,device_ctx);
+        std::string info = describe_rr_node(hit_node, device_ctx);
 
         sprintf(message, "Selected %s", info.c_str());
         rr_highlight_message = message;

--- a/vpr/src/route/annotate_routing.cpp
+++ b/vpr/src/route/annotate_routing.cpp
@@ -59,7 +59,7 @@ vtr::vector<RRNodeId, ClusterNetId> annotate_rr_node_nets(const DeviceContext& d
                                     clustering_ctx.clb_nlist.net_name(net_id).c_str(),
                                     clustering_ctx.clb_nlist.net_name(rr_node_nets[rr_node]).c_str(),
                                     size_t(rr_node),
-                                    describe_rr_node(((int)size_t(rr_node)),device_ctx).c_str());
+                                    describe_rr_node(((int)size_t(rr_node)), device_ctx).c_str());
                 } else {
                     rr_node_nets[rr_node] = net_id;
                 }

--- a/vpr/src/route/annotate_routing.cpp
+++ b/vpr/src/route/annotate_routing.cpp
@@ -59,7 +59,7 @@ vtr::vector<RRNodeId, ClusterNetId> annotate_rr_node_nets(const DeviceContext& d
                                     clustering_ctx.clb_nlist.net_name(net_id).c_str(),
                                     clustering_ctx.clb_nlist.net_name(rr_node_nets[rr_node]).c_str(),
                                     size_t(rr_node),
-                                    describe_rr_node((int)size_t(rr_node)).c_str());
+                                    describe_rr_node(((int)size_t(rr_node)),device_ctx).c_str());
                 } else {
                     rr_node_nets[rr_node] = net_id;
                 }

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -130,8 +130,8 @@ void check_route(enum e_route_type route_type, e_check_route_option check_route_
                               "  %s\n"
                               "  %s\n",
                               size_t(net_id),
-                              describe_rr_node(prev_node,device_ctx).c_str(),
-                              describe_rr_node(inode,device_ctx).c_str());
+                              describe_rr_node(prev_node, device_ctx).c_str(),
+                              describe_rr_node(inode, device_ctx).c_str());
                 }
 
                 connected_to_route[inode] = true; /* Mark as in path. */
@@ -679,7 +679,7 @@ static bool check_non_configurable_edges(ClusterNetId net, const t_non_configura
                     cluster_ctx.clb_nlist.net_name(net).c_str(), size_t(net));
 
                 for (auto inode : difference) {
-                    msg += vtr::string_fmt("  Missing %s\n", describe_rr_node(inode,device_ctx).c_str());
+                    msg += vtr::string_fmt("  Missing %s\n", describe_rr_node(inode, device_ctx).c_str());
                 }
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
@@ -747,8 +747,8 @@ static bool check_non_configurable_edges(ClusterNetId net, const t_non_configura
                 for (t_node_edge missing_edge : dedupped_difference) {
                     msg += vtr::string_fmt("  Expected RR Node: %d and RR Node: %d to be non-configurably connected, but edge missing from routing:\n",
                                            missing_edge.from_node, missing_edge.to_node);
-                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.from_node,device_ctx).c_str());
-                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.to_node,device_ctx).c_str());
+                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.from_node, device_ctx).c_str());
+                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.to_node, device_ctx).c_str());
                 }
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
@@ -798,7 +798,7 @@ void check_net_for_stubs(ClusterNetId net) {
         std::string msg = vtr::string_fmt("Route tree for net '%s' (#%zu) contains stub branches rooted at:\n",
                                           cluster_ctx.clb_nlist.net_name(net).c_str(), size_t(net));
         for (int inode : stub_finder.stub_nodes()) {
-            msg += vtr::string_fmt("    %s\n", describe_rr_node(inode,device_ctx).c_str());
+            msg += vtr::string_fmt("    %s\n", describe_rr_node(inode, device_ctx).c_str());
         }
 
         VPR_THROW(VPR_ERROR_ROUTE, msg.c_str());

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -130,8 +130,8 @@ void check_route(enum e_route_type route_type, e_check_route_option check_route_
                               "  %s\n"
                               "  %s\n",
                               size_t(net_id),
-                              describe_rr_node(prev_node).c_str(),
-                              describe_rr_node(inode).c_str());
+                              describe_rr_node(prev_node,device_ctx).c_str(),
+                              describe_rr_node(inode,device_ctx).c_str());
                 }
 
                 connected_to_route[inode] = true; /* Mark as in path. */
@@ -616,7 +616,7 @@ static void check_all_non_configurable_edges() {
 static bool check_non_configurable_edges(ClusterNetId net, const t_non_configurable_rr_sets& non_configurable_rr_sets) {
     auto& route_ctx = g_vpr_ctx.routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
-
+    auto& device_ctx = g_vpr_ctx.device();
     t_trace* head = route_ctx.trace[net].head;
 
     //Collect all the edges used by this net's routing
@@ -679,7 +679,7 @@ static bool check_non_configurable_edges(ClusterNetId net, const t_non_configura
                     cluster_ctx.clb_nlist.net_name(net).c_str(), size_t(net));
 
                 for (auto inode : difference) {
-                    msg += vtr::string_fmt("  Missing %s\n", describe_rr_node(inode).c_str());
+                    msg += vtr::string_fmt("  Missing %s\n", describe_rr_node(inode,device_ctx).c_str());
                 }
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
@@ -747,8 +747,8 @@ static bool check_non_configurable_edges(ClusterNetId net, const t_non_configura
                 for (t_node_edge missing_edge : dedupped_difference) {
                     msg += vtr::string_fmt("  Expected RR Node: %d and RR Node: %d to be non-configurably connected, but edge missing from routing:\n",
                                            missing_edge.from_node, missing_edge.to_node);
-                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.from_node).c_str());
-                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.to_node).c_str());
+                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.from_node,device_ctx).c_str());
+                    msg += vtr::string_fmt("    %s\n", describe_rr_node(missing_edge.to_node,device_ctx).c_str());
                 }
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
@@ -791,14 +791,14 @@ class StubFinder {
 //We treat any configurable stubs as an error.
 void check_net_for_stubs(ClusterNetId net) {
     StubFinder stub_finder;
-
+    auto& device_ctx = g_vpr_ctx.device();
     bool any_stubs = stub_finder.CheckNet(net);
     if (any_stubs) {
         auto& cluster_ctx = g_vpr_ctx.clustering();
         std::string msg = vtr::string_fmt("Route tree for net '%s' (#%zu) contains stub branches rooted at:\n",
                                           cluster_ctx.clb_nlist.net_name(net).c_str(), size_t(net));
         for (int inode : stub_finder.stub_nodes()) {
-            msg += vtr::string_fmt("    %s\n", describe_rr_node(inode).c_str());
+            msg += vtr::string_fmt("    %s\n", describe_rr_node(inode,device_ctx).c_str());
         }
 
         VPR_THROW(VPR_ERROR_ROUTE, msg.c_str());

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -499,7 +499,7 @@ void check_rr_node(int inode, enum e_route_type route_type, const DeviceContext&
             }
 
             if (check_for_out_edges) {
-                std::string info = describe_rr_node(inode);
+                std::string info = describe_rr_node(inode,device_ctx);
                 VTR_LOG_WARN("in check_rr_node: %s has no out-going edges.\n", info.c_str());
             }
         }
@@ -616,7 +616,7 @@ static void check_rr_edge(int from_node, int iedge, int to_node) {
                 std::string msg = "Non-configurable BUFFER type switch must have only one driver. ";
                 msg += vtr::string_fmt(" Actual fan-in was %d (expected 1).\n", to_fanin);
                 msg += "  Possible cause is complex block output pins connecting to:\n";
-                msg += "    " + describe_rr_node(to_node);
+                msg += "    " + describe_rr_node(to_node,device_ctx);
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
             }

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -499,7 +499,7 @@ void check_rr_node(int inode, enum e_route_type route_type, const DeviceContext&
             }
 
             if (check_for_out_edges) {
-                std::string info = describe_rr_node(inode,device_ctx);
+                std::string info = describe_rr_node(inode, device_ctx);
                 VTR_LOG_WARN("in check_rr_node: %s has no out-going edges.\n", info.c_str());
             }
         }
@@ -616,7 +616,7 @@ static void check_rr_edge(int from_node, int iedge, int to_node) {
                 std::string msg = "Non-configurable BUFFER type switch must have only one driver. ";
                 msg += vtr::string_fmt(" Actual fan-in was %d (expected 1).\n", to_fanin);
                 msg += "  Possible cause is complex block output pins connecting to:\n";
-                msg += "    " + describe_rr_node(to_node,device_ctx);
+                msg += "    " + describe_rr_node(to_node, device_ctx);
 
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE, msg.c_str());
             }

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -204,7 +204,7 @@ t_heap* ConnectionRouter<Heap>::timing_driven_route_connection_from_heap(int sin
     }
 
     auto& route_ctx = g_vpr_ctx.mutable_routing();
-
+    auto& device_ctx = g_vpr_ctx.device();
     t_heap* cheapest = nullptr;
     while (!heap_.is_empty_heap()) {
         // cheapest t_heap in current route tree to be expanded on
@@ -224,7 +224,7 @@ t_heap* ConnectionRouter<Heap>::timing_driven_route_connection_from_heap(int sin
                 rcv_path_manager.insert_backwards_path_into_traceback(cheapest->path_data, cheapest->cost, cheapest->backward_path_cost, route_ctx);
             }
 
-            VTR_LOGV_DEBUG(router_debug_, "  Found target %8d (%s)\n", inode, describe_rr_node(inode).c_str());
+            VTR_LOGV_DEBUG(router_debug_, "  Found target %8d (%s)\n", inode, describe_rr_node(inode,device_ctx).c_str());
             break;
         }
 
@@ -524,7 +524,7 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params 
                                                        const RREdgeId from_edge,
                                                        const int target_node) {
     t_heap next;
-
+    auto& device_ctx = g_vpr_ctx.device();
     // Initalize RCV data struct if needed, otherwise it's set to nullptr
     rcv_path_manager.alloc_path_struct(next.path_data);
 
@@ -540,7 +540,7 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params 
 
     next.R_upstream = current->R_upstream;
 
-    VTR_LOGV_DEBUG(router_debug_, "      Expanding to node %d (%s)\n", to_node, describe_rr_node(to_node).c_str());
+    VTR_LOGV_DEBUG(router_debug_, "      Expanding to node %d (%s)\n", to_node, describe_rr_node(to_node,device_ctx).c_str());
 
     evaluate_timing_driven_node_costs(&next,
                                       cost_params,
@@ -676,7 +676,7 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
      *
      * new_costs.R_upstream: is the upstream resistance at the end of this node
      */
-
+    auto& device_ctx = g_vpr_ctx.device();
     //Info for the switch connecting from_node to_node
     int iswitch = rr_nodes_.edge_switch(from_edge);
     bool switch_buffered = rr_switch_inf_[iswitch].buffered();
@@ -764,8 +764,8 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
         float expected_cost = router_lookahead_.get_expected_cost(RRNodeId(to_node), RRNodeId(target_node), cost_params, to->R_upstream);
         VTR_LOGV_DEBUG(router_debug_ && !std::isfinite(expected_cost),
                        "        Lookahead from %s (%s) to %s (%s) is non-finite, expected_cost = %f, to->R_upstream = %f\n",
-                       rr_node_arch_name(to_node).c_str(), describe_rr_node(to_node).c_str(),
-                       rr_node_arch_name(target_node).c_str(), describe_rr_node(target_node).c_str(),
+                       rr_node_arch_name(to_node).c_str(), describe_rr_node(to_node,device_ctx).c_str(),
+                       rr_node_arch_name(target_node).c_str(), describe_rr_node(target_node,device_ctx).c_str(),
                        expected_cost, to->R_upstream);
         total_cost += to->backward_path_cost + cost_params.astar_fac * expected_cost;
     }
@@ -835,7 +835,7 @@ void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
     const t_conn_cost_params cost_params) {
     int inode = rt_node->inode;
     float backward_path_cost = cost_params.criticality * rt_node->Tdel;
-
+    auto& device_ctx = g_vpr_ctx.device();
     float R_upstream = rt_node->R_upstream;
 
     //after budgets are loaded, calculate delay cost as described by RCV paper
@@ -849,7 +849,7 @@ void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
         float tot_cost = backward_path_cost
                          + cost_params.astar_fac
                                * router_lookahead_.get_expected_cost(RRNodeId(inode), RRNodeId(target_node), cost_params, R_upstream);
-        VTR_LOGV_DEBUG(router_debug_, "  Adding node %8d to heap from init route tree with cost %g (%s)\n", inode, tot_cost, describe_rr_node(inode).c_str());
+        VTR_LOGV_DEBUG(router_debug_, "  Adding node %8d to heap from init route tree with cost %g (%s)\n", inode, tot_cost, describe_rr_node(inode,device_ctx).c_str());
 
         push_back_node(&heap_, rr_node_route_inf_,
                        inode, tot_cost, NO_PREVIOUS, RREdgeId::INVALID(),

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -224,7 +224,7 @@ t_heap* ConnectionRouter<Heap>::timing_driven_route_connection_from_heap(int sin
                 rcv_path_manager.insert_backwards_path_into_traceback(cheapest->path_data, cheapest->cost, cheapest->backward_path_cost, route_ctx);
             }
 
-            VTR_LOGV_DEBUG(router_debug_, "  Found target %8d (%s)\n", inode, describe_rr_node(inode,device_ctx).c_str());
+            VTR_LOGV_DEBUG(router_debug_, "  Found target %8d (%s)\n", inode, describe_rr_node(inode, device_ctx).c_str());
             break;
         }
 
@@ -540,7 +540,7 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params 
 
     next.R_upstream = current->R_upstream;
 
-    VTR_LOGV_DEBUG(router_debug_, "      Expanding to node %d (%s)\n", to_node, describe_rr_node(to_node,device_ctx).c_str());
+    VTR_LOGV_DEBUG(router_debug_, "      Expanding to node %d (%s)\n", to_node, describe_rr_node(to_node, device_ctx).c_str());
 
     evaluate_timing_driven_node_costs(&next,
                                       cost_params,
@@ -764,8 +764,8 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
         float expected_cost = router_lookahead_.get_expected_cost(RRNodeId(to_node), RRNodeId(target_node), cost_params, to->R_upstream);
         VTR_LOGV_DEBUG(router_debug_ && !std::isfinite(expected_cost),
                        "        Lookahead from %s (%s) to %s (%s) is non-finite, expected_cost = %f, to->R_upstream = %f\n",
-                       rr_node_arch_name(to_node).c_str(), describe_rr_node(to_node,device_ctx).c_str(),
-                       rr_node_arch_name(target_node).c_str(), describe_rr_node(target_node,device_ctx).c_str(),
+                       rr_node_arch_name(to_node).c_str(), describe_rr_node(to_node, device_ctx).c_str(),
+                       rr_node_arch_name(target_node).c_str(), describe_rr_node(target_node, device_ctx).c_str(),
                        expected_cost, to->R_upstream);
         total_cost += to->backward_path_cost + cost_params.astar_fac * expected_cost;
     }
@@ -849,7 +849,7 @@ void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
         float tot_cost = backward_path_cost
                          + cost_params.astar_fac
                                * router_lookahead_.get_expected_cost(RRNodeId(inode), RRNodeId(target_node), cost_params, R_upstream);
-        VTR_LOGV_DEBUG(router_debug_, "  Adding node %8d to heap from init route tree with cost %g (%s)\n", inode, tot_cost, describe_rr_node(inode,device_ctx).c_str());
+        VTR_LOGV_DEBUG(router_debug_, "  Adding node %8d to heap from init route tree with cost %g (%s)\n", inode, tot_cost, describe_rr_node(inode, device_ctx).c_str());
 
         push_back_node(&heap_, rr_node_route_inf_,
                        inode, tot_cost, NO_PREVIOUS, RREdgeId::INVALID(),

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -1615,7 +1615,7 @@ void print_invalid_routing_info() {
         int occ = route_ctx.rr_node_route_inf[inode].occ();
         int cap = rr_graph.node_capacity(RRNodeId(inode));
         if (occ > cap) {
-            VTR_LOG("  %s is overused (occ=%d capacity=%d)\n", describe_rr_node(inode,device_ctx).c_str(), occ, cap);
+            VTR_LOG("  %s is overused (occ=%d capacity=%d)\n", describe_rr_node(inode, device_ctx).c_str(), occ, cap);
 
             auto range = rr_node_nets.equal_range(inode);
             for (auto itr = range.first; itr != range.second; ++itr) {
@@ -1732,8 +1732,8 @@ std::string describe_unrouteable_connection(const int source_node, const int sin
     std::string msg = vtr::string_fmt(
         "Cannot route from %s (%s) to "
         "%s (%s) -- no possible path",
-        rr_node_arch_name(source_node).c_str(), describe_rr_node(source_node,device_ctx).c_str(),
-        rr_node_arch_name(sink_node).c_str(), describe_rr_node(sink_node,device_ctx).c_str());
+        rr_node_arch_name(source_node).c_str(), describe_rr_node(source_node, device_ctx).c_str(),
+        rr_node_arch_name(sink_node).c_str(), describe_rr_node(sink_node, device_ctx).c_str());
 
     return msg;
 }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -1615,7 +1615,7 @@ void print_invalid_routing_info() {
         int occ = route_ctx.rr_node_route_inf[inode].occ();
         int cap = rr_graph.node_capacity(RRNodeId(inode));
         if (occ > cap) {
-            VTR_LOG("  %s is overused (occ=%d capacity=%d)\n", describe_rr_node(inode).c_str(), occ, cap);
+            VTR_LOG("  %s is overused (occ=%d capacity=%d)\n", describe_rr_node(inode,device_ctx).c_str(), occ, cap);
 
             auto range = rr_node_nets.equal_range(inode);
             for (auto itr = range.first; itr != range.second; ++itr) {
@@ -1728,11 +1728,12 @@ bool router_needs_lookahead(enum e_router_algorithm router_algorithm) {
 }
 
 std::string describe_unrouteable_connection(const int source_node, const int sink_node) {
+    auto& device_ctx = g_vpr_ctx.device();
     std::string msg = vtr::string_fmt(
         "Cannot route from %s (%s) to "
         "%s (%s) -- no possible path",
-        rr_node_arch_name(source_node).c_str(), describe_rr_node(source_node).c_str(),
-        rr_node_arch_name(sink_node).c_str(), describe_rr_node(sink_node).c_str());
+        rr_node_arch_name(source_node).c_str(), describe_rr_node(source_node,device_ctx).c_str(),
+        rr_node_arch_name(sink_node).c_str(), describe_rr_node(sink_node,device_ctx).c_str());
 
     return msg;
 }

--- a/vpr/src/route/route_profiling.cpp
+++ b/vpr/src/route/route_profiling.cpp
@@ -214,6 +214,7 @@ void conn_start() {
     conn_start_time = clock();
 }
 void conn_finish(int src_rr, int sink_rr, float criticality) {
+    auto& device_ctx = g_vpr_ctx.device();    
     float route_time = static_cast<float>(clock() - conn_start_time) / CLOCKS_PER_SEC;
     if (route_time > worst_conn_time) {
         worst_src_rr = src_rr;
@@ -223,16 +224,17 @@ void conn_finish(int src_rr, int sink_rr, float criticality) {
     }
 
     VTR_LOG("%s to %s (crit: %f) took %f\n",
-            describe_rr_node(src_rr).c_str(),
-            describe_rr_node(sink_rr).c_str(),
+            describe_rr_node(src_rr,device_ctx).c_str(),
+            describe_rr_node(sink_rr,device_ctx).c_str(),
             criticality,
             route_time);
 }
 void net_finish() {
     if (worst_conn_time > 0.f) {
+        auto& device_ctx = g_vpr_ctx.device(); 
         VTR_LOG("Worst conn was %s to %s (crit: %f) took %f\n",
-                describe_rr_node(worst_src_rr).c_str(),
-                describe_rr_node(worst_sink_rr).c_str(),
+                describe_rr_node(worst_src_rr,device_ctx).c_str(),
+                describe_rr_node(worst_sink_rr,device_ctx).c_str(),
                 worst_crit,
                 worst_conn_time);
     }

--- a/vpr/src/route/route_profiling.cpp
+++ b/vpr/src/route/route_profiling.cpp
@@ -213,7 +213,9 @@ void profiling_initialization(unsigned max_fanout) {
 void conn_start() {
     conn_start_time = clock();
 }
+
 void conn_finish(int src_rr, int sink_rr, float criticality) {
+    
     auto& device_ctx = g_vpr_ctx.device();    
     float route_time = static_cast<float>(clock() - conn_start_time) / CLOCKS_PER_SEC;
     if (route_time > worst_conn_time) {
@@ -231,7 +233,9 @@ void conn_finish(int src_rr, int sink_rr, float criticality) {
 }
 void net_finish() {
     if (worst_conn_time > 0.f) {
+
         auto& device_ctx = g_vpr_ctx.device(); 
+        
         VTR_LOG("Worst conn was %s to %s (crit: %f) took %f\n",
                 describe_rr_node(worst_src_rr, device_ctx).c_str(),
                 describe_rr_node(worst_sink_rr, device_ctx).c_str(),

--- a/vpr/src/route/route_profiling.cpp
+++ b/vpr/src/route/route_profiling.cpp
@@ -224,8 +224,8 @@ void conn_finish(int src_rr, int sink_rr, float criticality) {
     }
 
     VTR_LOG("%s to %s (crit: %f) took %f\n",
-            describe_rr_node(src_rr,device_ctx).c_str(),
-            describe_rr_node(sink_rr,device_ctx).c_str(),
+            describe_rr_node(src_rr, device_ctx).c_str(),
+            describe_rr_node(sink_rr, device_ctx).c_str(),
             criticality,
             route_time);
 }
@@ -233,8 +233,8 @@ void net_finish() {
     if (worst_conn_time > 0.f) {
         auto& device_ctx = g_vpr_ctx.device(); 
         VTR_LOG("Worst conn was %s to %s (crit: %f) took %f\n",
-                describe_rr_node(worst_src_rr,device_ctx).c_str(),
-                describe_rr_node(worst_sink_rr,device_ctx).c_str(),
+                describe_rr_node(worst_src_rr, device_ctx).c_str(),
+                describe_rr_node(worst_sink_rr, device_ctx).c_str(),
                 worst_crit,
                 worst_conn_time);
     }

--- a/vpr/src/route/route_profiling.cpp
+++ b/vpr/src/route/route_profiling.cpp
@@ -215,8 +215,7 @@ void conn_start() {
 }
 
 void conn_finish(int src_rr, int sink_rr, float criticality) {
-    
-    auto& device_ctx = g_vpr_ctx.device();    
+    auto& device_ctx = g_vpr_ctx.device();
     float route_time = static_cast<float>(clock() - conn_start_time) / CLOCKS_PER_SEC;
     if (route_time > worst_conn_time) {
         worst_src_rr = src_rr;
@@ -233,9 +232,7 @@ void conn_finish(int src_rr, int sink_rr, float criticality) {
 }
 void net_finish() {
     if (worst_conn_time > 0.f) {
-
-        auto& device_ctx = g_vpr_ctx.device(); 
-        
+        auto& device_ctx = g_vpr_ctx.device();
         VTR_LOG("Worst conn was %s to %s (crit: %f) took %f\n",
                 describe_rr_node(worst_src_rr, device_ctx).c_str(),
                 describe_rr_node(worst_sink_rr, device_ctx).c_str(),

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1183,12 +1183,11 @@ static bool timing_driven_pre_route_to_clock_root(
     int high_fanout_threshold,
     t_rt_node* rt_root,
     SpatialRouteTreeLookup& spatial_rt_lookup,
-    RouterStats& router_stats) {
-        
+    RouterStats& router_stats) {  
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& m_route_ctx = g_vpr_ctx.mutable_routing();
-    auto& device_ctx = g_vpr_ctx.device(); 
+    auto& device_ctx = g_vpr_ctx.device();
 
     bool high_fanout = is_high_fanout(cluster_ctx.clb_nlist.net_sinks(net_id).size(), high_fanout_threshold);
 
@@ -1283,14 +1282,12 @@ static bool timing_driven_route_sink(
     SpatialRouteTreeLookup& spatial_rt_lookup,
     RouterStats& router_stats,
     route_budgets& budgeting_inf,
-    const RoutingPredictor& routing_predictor) {
-     
+    const RoutingPredictor& routing_predictor) { 
     /* Build a path from the existing route tree rooted at rt_root to the target_node
      * add this branch to the existing route tree and update pathfinder costs and rr_node_route_inf to reflect this */
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& device_ctx = g_vpr_ctx.device(); 
-
+    auto& device_ctx = g_vpr_ctx.device();
     profiling::sink_criticality_start();
 
     int sink_node = route_ctx.net_rr_terminals[net_id][target_pin];

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1190,7 +1190,7 @@ static bool timing_driven_pre_route_to_clock_root(
     auto& device_ctx = g_vpr_ctx.device(); 
     bool high_fanout = is_high_fanout(cluster_ctx.clb_nlist.net_sinks(net_id).size(), high_fanout_threshold);
 
-    VTR_LOGV_DEBUG(f_router_debug, "Net %zu pre-route to (%s)\n", size_t(net_id), describe_rr_node(sink_node,device_ctx).c_str());
+    VTR_LOGV_DEBUG(f_router_debug, "Net %zu pre-route to (%s)\n", size_t(net_id), describe_rr_node(sink_node, device_ctx).c_str());
 
     profiling::sink_criticality_start();
 
@@ -1214,7 +1214,7 @@ static bool timing_driven_pre_route_to_clock_root(
         ClusterBlockId src_block = cluster_ctx.clb_nlist.net_driver_block(net_id);
         VTR_LOG("Failed to route connection from '%s' to '%s' for net '%s' (#%zu)\n",
                 cluster_ctx.clb_nlist.block_name(src_block).c_str(),
-                describe_rr_node(sink_node,device_ctx).c_str(),
+                describe_rr_node(sink_node, device_ctx).c_str(),
                 cluster_ctx.clb_nlist.net_name(net_id).c_str(),
                 size_t(net_id));
         if (f_router_debug) {

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1184,10 +1184,12 @@ static bool timing_driven_pre_route_to_clock_root(
     t_rt_node* rt_root,
     SpatialRouteTreeLookup& spatial_rt_lookup,
     RouterStats& router_stats) {
+        
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& m_route_ctx = g_vpr_ctx.mutable_routing();
     auto& device_ctx = g_vpr_ctx.device(); 
+
     bool high_fanout = is_high_fanout(cluster_ctx.clb_nlist.net_sinks(net_id).size(), high_fanout_threshold);
 
     VTR_LOGV_DEBUG(f_router_debug, "Net %zu pre-route to (%s)\n", size_t(net_id), describe_rr_node(sink_node, device_ctx).c_str());
@@ -1282,16 +1284,17 @@ static bool timing_driven_route_sink(
     RouterStats& router_stats,
     route_budgets& budgeting_inf,
     const RoutingPredictor& routing_predictor) {
-     auto& device_ctx = g_vpr_ctx.device(); 
+     
     /* Build a path from the existing route tree rooted at rt_root to the target_node
      * add this branch to the existing route tree and update pathfinder costs and rr_node_route_inf to reflect this */
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
+    auto& device_ctx = g_vpr_ctx.device(); 
 
     profiling::sink_criticality_start();
 
     int sink_node = route_ctx.net_rr_terminals[net_id][target_pin];
-    VTR_LOGV_DEBUG(f_router_debug, "Net %zu Target %d (%s)\n", size_t(net_id), itarget, describe_rr_node(sink_node,device_ctx).c_str());
+    VTR_LOGV_DEBUG(f_router_debug, "Net %zu Target %d (%s)\n", size_t(net_id), itarget, describe_rr_node(sink_node, device_ctx).c_str());
 
     VTR_ASSERT_DEBUG(verify_traceback_route_tree_equivalent(route_ctx.trace[net_id].head, rt_root));
 

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1183,7 +1183,7 @@ static bool timing_driven_pre_route_to_clock_root(
     int high_fanout_threshold,
     t_rt_node* rt_root,
     SpatialRouteTreeLookup& spatial_rt_lookup,
-    RouterStats& router_stats) {  
+    RouterStats& router_stats) {
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& m_route_ctx = g_vpr_ctx.mutable_routing();
@@ -1282,7 +1282,7 @@ static bool timing_driven_route_sink(
     SpatialRouteTreeLookup& spatial_rt_lookup,
     RouterStats& router_stats,
     route_budgets& budgeting_inf,
-    const RoutingPredictor& routing_predictor) { 
+    const RoutingPredictor& routing_predictor) {
     /* Build a path from the existing route tree rooted at rt_root to the target_node
      * add this branch to the existing route tree and update pathfinder costs and rr_node_route_inf to reflect this */
     auto& route_ctx = g_vpr_ctx.mutable_routing();

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1187,10 +1187,10 @@ static bool timing_driven_pre_route_to_clock_root(
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& m_route_ctx = g_vpr_ctx.mutable_routing();
-
+    auto& device_ctx = g_vpr_ctx.device(); 
     bool high_fanout = is_high_fanout(cluster_ctx.clb_nlist.net_sinks(net_id).size(), high_fanout_threshold);
 
-    VTR_LOGV_DEBUG(f_router_debug, "Net %zu pre-route to (%s)\n", size_t(net_id), describe_rr_node(sink_node).c_str());
+    VTR_LOGV_DEBUG(f_router_debug, "Net %zu pre-route to (%s)\n", size_t(net_id), describe_rr_node(sink_node,device_ctx).c_str());
 
     profiling::sink_criticality_start();
 
@@ -1214,7 +1214,7 @@ static bool timing_driven_pre_route_to_clock_root(
         ClusterBlockId src_block = cluster_ctx.clb_nlist.net_driver_block(net_id);
         VTR_LOG("Failed to route connection from '%s' to '%s' for net '%s' (#%zu)\n",
                 cluster_ctx.clb_nlist.block_name(src_block).c_str(),
-                describe_rr_node(sink_node).c_str(),
+                describe_rr_node(sink_node,device_ctx).c_str(),
                 cluster_ctx.clb_nlist.net_name(net_id).c_str(),
                 size_t(net_id));
         if (f_router_debug) {
@@ -1282,6 +1282,7 @@ static bool timing_driven_route_sink(
     RouterStats& router_stats,
     route_budgets& budgeting_inf,
     const RoutingPredictor& routing_predictor) {
+     auto& device_ctx = g_vpr_ctx.device(); 
     /* Build a path from the existing route tree rooted at rt_root to the target_node
      * add this branch to the existing route tree and update pathfinder costs and rr_node_route_inf to reflect this */
     auto& route_ctx = g_vpr_ctx.mutable_routing();
@@ -1290,7 +1291,7 @@ static bool timing_driven_route_sink(
     profiling::sink_criticality_start();
 
     int sink_node = route_ctx.net_rr_terminals[net_id][target_pin];
-    VTR_LOGV_DEBUG(f_router_debug, "Net %zu Target %d (%s)\n", size_t(net_id), itarget, describe_rr_node(sink_node).c_str());
+    VTR_LOGV_DEBUG(f_router_debug, "Net %zu Target %d (%s)\n", size_t(net_id), itarget, describe_rr_node(sink_node,device_ctx).c_str());
 
     VTR_ASSERT_DEBUG(verify_traceback_route_tree_equivalent(route_ctx.trace[net_id].head, rt_root));
 

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -135,7 +135,7 @@ std::pair<float, float> ExtendedMapLookahead::get_src_opin_cost(RRNodeId from_no
     VTR_ASSERT_SAFE_MSG(false,
                         vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
                                         rr_node_arch_name(size_t(from_node)).c_str(),
-                                        describe_rr_node(size_t(from_node)).c_str())
+                                        describe_rr_node(size_t(from_node),device_ctx).c_str())
                             .c_str());
 }
 

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -135,7 +135,7 @@ std::pair<float, float> ExtendedMapLookahead::get_src_opin_cost(RRNodeId from_no
     VTR_ASSERT_SAFE_MSG(false,
                         vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
                                         rr_node_arch_name(size_t(from_node)).c_str(),
-                                        describe_rr_node(size_t(from_node),device_ctx).c_str())
+                                        describe_rr_node(size_t(from_node), device_ctx).c_str())
                             .c_str());
 }
 

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -328,7 +328,7 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
         VTR_ASSERT_SAFE_MSG(std::isfinite(expected_delay_cost),
                             vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
                                             rr_node_arch_name(size_t(from_node)).c_str(),
-                                            describe_rr_node(size_t(from_node)).c_str())
+                                            describe_rr_node(size_t(from_node),device_ctx).c_str())
                                 .c_str());
 
     } else if (from_type == CHANX || from_type == CHANY) {
@@ -352,7 +352,7 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
         VTR_ASSERT_SAFE_MSG(std::isfinite(expected_delay_cost),
                             vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
                                             rr_node_arch_name(size_t(from_node)).c_str(),
-                                            describe_rr_node(size_t(from_node)).c_str())
+                                            describe_rr_node(size_t(from_node),device_ctx).c_str())
                                 .c_str());
     } else if (from_type == IPIN) { /* Change if you're allowing route-throughs */
         return std::make_pair(0., device_ctx.rr_indexed_data[SINK_COST_INDEX].base_cost);

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -328,7 +328,7 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
         VTR_ASSERT_SAFE_MSG(std::isfinite(expected_delay_cost),
                             vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
                                             rr_node_arch_name(size_t(from_node)).c_str(),
-                                            describe_rr_node(size_t(from_node),device_ctx).c_str())
+                                            describe_rr_node(size_t(from_node), device_ctx).c_str())
                                 .c_str());
 
     } else if (from_type == CHANX || from_type == CHANY) {
@@ -352,7 +352,7 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
         VTR_ASSERT_SAFE_MSG(std::isfinite(expected_delay_cost),
                             vtr::string_fmt("Lookahead failed to estimate cost from %s: %s",
                                             rr_node_arch_name(size_t(from_node)).c_str(),
-                                            describe_rr_node(size_t(from_node),device_ctx).c_str())
+                                            describe_rr_node(size_t(from_node), device_ctx).c_str())
                                 .c_str());
     } else if (from_type == IPIN) { /* Change if you're allowing route-throughs */
         return std::make_pair(0., device_ctx.rr_indexed_data[SINK_COST_INDEX].base_cost);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2422,8 +2422,8 @@ static vtr::NdMatrix<std::vector<int>, 4> alloc_and_load_track_to_pin_lookup(vtr
 }
 
 /* TODO: This function should adapt RRNodeId */
-std::string describe_rr_node(int inode) {
-    auto& device_ctx = g_vpr_ctx.device();
+std::string describe_rr_node(int inode,const DeviceContext& device_ctx) {
+  // auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
     std::string msg = vtr::string_fmt("RR node: %d", inode);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2420,12 +2420,9 @@ static vtr::NdMatrix<std::vector<int>, 4> alloc_and_load_track_to_pin_lookup(vtr
 
     return track_to_pin_lookup;
 }
-
 /* TODO: This function should adapt RRNodeId */
 std::string describe_rr_node(int inode, const DeviceContext& device_ctx) {
-
-  // auto& device_ctx = g_vpr_ctx.device();
-
+    // auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
     std::string msg = vtr::string_fmt("RR node: %d", inode);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2423,7 +2423,9 @@ static vtr::NdMatrix<std::vector<int>, 4> alloc_and_load_track_to_pin_lookup(vtr
 
 /* TODO: This function should adapt RRNodeId */
 std::string describe_rr_node(int inode,const DeviceContext& device_ctx) {
+    
   // auto& device_ctx = g_vpr_ctx.device();
+
     const auto& rr_graph = device_ctx.rr_graph;
 
     std::string msg = vtr::string_fmt("RR node: %d", inode);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2422,8 +2422,8 @@ static vtr::NdMatrix<std::vector<int>, 4> alloc_and_load_track_to_pin_lookup(vtr
 }
 
 /* TODO: This function should adapt RRNodeId */
-std::string describe_rr_node(int inode,const DeviceContext& device_ctx) {
-    
+std::string describe_rr_node(int inode, const DeviceContext& device_ctx) {
+
   // auto& device_ctx = g_vpr_ctx.device();
 
     const auto& rr_graph = device_ctx.rr_graph;

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -41,6 +41,7 @@ void create_rr_graph(const t_graph_type graph_type,
 void free_rr_graph();
 
 //Returns a brief one-line summary of an RR node
+
 std::string describe_rr_node(int inode,const DeviceContext& device_ctx);
 
 // Sets the spec for the rr_switch based on the arch switch

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -41,8 +41,7 @@ void create_rr_graph(const t_graph_type graph_type,
 void free_rr_graph();
 
 //Returns a brief one-line summary of an RR node
-
-std::string describe_rr_node(int inode,const DeviceContext& device_ctx);
+std::string describe_rr_node(int inode, const DeviceContext& device_ctx);
 
 // Sets the spec for the rr_switch based on the arch switch
 void load_rr_switch_from_arch_switch(int arch_switch_idx,

--- a/vpr/src/route/rr_graph.h
+++ b/vpr/src/route/rr_graph.h
@@ -8,7 +8,7 @@
 
 #include "device_grid.h"
 #include "vpr_types.h"
-
+#include "vpr_context.h"
 enum e_graph_type {
     GRAPH_GLOBAL, /* One node per channel with wire capacity > 1 and full connectivity */
     GRAPH_BIDIR,  /* Detailed bidirectional graph */
@@ -41,7 +41,7 @@ void create_rr_graph(const t_graph_type graph_type,
 void free_rr_graph();
 
 //Returns a brief one-line summary of an RR node
-std::string describe_rr_node(int inode);
+std::string describe_rr_node(int inode,const DeviceContext& device_ctx);
 
 // Sets the spec for the rr_switch based on the arch switch
 void load_rr_switch_from_arch_switch(int arch_switch_idx,

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1176,7 +1176,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                             const RRGraphView& rr_graph,
                             const t_rr_graph_storage& rr_nodes) {
     std::unordered_map<RRNodeId, int> rr_node_counts;
-
+    auto& device_ctx = g_vpr_ctx.device();
     int width = grid.width();
     int height = grid.height();
 
@@ -1197,7 +1197,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                         VPR_ERROR(VPR_ERROR_ROUTE, "RR node type does not match between rr_nodes and rr_node_indices (%s/%s): %s",
                                   rr_node_typename[rr_graph.node_type(inode)],
                                   rr_node_typename[rr_type],
-                                  describe_rr_node(size_t(inode)).c_str());
+                                  describe_rr_node(size_t(inode),device_ctx).c_str());
                     }
 
                     if (rr_graph.node_type(inode) == CHANX) {
@@ -1207,7 +1207,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                             VPR_ERROR(VPR_ERROR_ROUTE, "RR node y position does not agree between rr_nodes (%d) and rr_node_indices (%d): %s",
                                       rr_graph.node_ylow(inode),
                                       y,
-                                      describe_rr_node(size_t(inode)).c_str());
+                                      describe_rr_node(size_t(inode),device_ctx).c_str());
                         }
 
                         if (!rr_graph.x_in_node_range(x, inode)) {
@@ -1215,7 +1215,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_xlow(inode),
                                       rr_graph.node_xlow(inode),
                                       x,
-                                      describe_rr_node(size_t(inode)).c_str());
+                                      describe_rr_node(size_t(inode),device_ctx).c_str());
                         }
                     } else if (rr_graph.node_type(inode) == CHANY) {
                         VTR_ASSERT_MSG(rr_graph.node_xlow(inode) == rr_graph.node_xhigh(inode), "CHANY should be veritcal");
@@ -1224,7 +1224,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                             VPR_ERROR(VPR_ERROR_ROUTE, "RR node x position does not agree between rr_nodes (%d) and rr_node_indices (%d): %s",
                                       rr_graph.node_xlow(inode),
                                       x,
-                                      describe_rr_node(size_t(inode)).c_str());
+                                      describe_rr_node(size_t(inode),device_ctx).c_str());
                         }
 
                         if (!rr_graph.y_in_node_range(y, inode)) {
@@ -1232,7 +1232,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_ylow(inode),
                                       rr_graph.node_ylow(inode),
                                       y,
-                                      describe_rr_node(size_t(inode)).c_str());
+                                      describe_rr_node(size_t(inode),device_ctx).c_str());
                         }
                     } else if (rr_graph.node_type(inode) == SOURCE || rr_graph.node_type(inode) == SINK) {
                         //Sources have co-ordintes covering the entire block they are in
@@ -1241,7 +1241,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_xlow(inode),
                                       rr_graph.node_xlow(inode),
                                       x,
-                                      describe_rr_node(size_t(inode)).c_str());
+                                      describe_rr_node(size_t(inode),device_ctx).c_str());
                         }
 
                         if (!rr_graph.y_in_node_range(y, inode)) {
@@ -1249,7 +1249,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_ylow(inode),
                                       rr_graph.node_ylow(inode),
                                       y,
-                                      describe_rr_node(size_t(inode)).c_str());
+                                      describe_rr_node(size_t(inode),device_ctx).c_str());
                         }
 
                     } else {
@@ -1311,7 +1311,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                           rr_area,
                           rr_node.length(),
                           count,
-                          describe_rr_node(size_t(inode)).c_str());
+                          describe_rr_node(size_t(inode),device_ctx).c_str());
             }
             /* As we allow a pin to be indexable on multiple sides,
              * This check code should not be applied to input and output pins
@@ -1321,7 +1321,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                 VPR_ERROR(VPR_ERROR_ROUTE, "Mismatch between RR node length (%d) and count within rr_node_indices (%d, should be length + 1): %s",
                           rr_node.length(),
                           count,
-                          describe_rr_node(size_t(inode)).c_str());
+                          describe_rr_node(size_t(inode),device_ctx).c_str());
             }
         }
     }

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1197,7 +1197,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                         VPR_ERROR(VPR_ERROR_ROUTE, "RR node type does not match between rr_nodes and rr_node_indices (%s/%s): %s",
                                   rr_node_typename[rr_graph.node_type(inode)],
                                   rr_node_typename[rr_type],
-                                  describe_rr_node(size_t(inode),device_ctx).c_str());
+                                  describe_rr_node(size_t(inode), device_ctx).c_str());
                     }
 
                     if (rr_graph.node_type(inode) == CHANX) {
@@ -1207,7 +1207,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                             VPR_ERROR(VPR_ERROR_ROUTE, "RR node y position does not agree between rr_nodes (%d) and rr_node_indices (%d): %s",
                                       rr_graph.node_ylow(inode),
                                       y,
-                                      describe_rr_node(size_t(inode),device_ctx).c_str());
+                                      describe_rr_node(size_t(inode), device_ctx).c_str());
                         }
 
                         if (!rr_graph.x_in_node_range(x, inode)) {
@@ -1215,7 +1215,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_xlow(inode),
                                       rr_graph.node_xlow(inode),
                                       x,
-                                      describe_rr_node(size_t(inode),device_ctx).c_str());
+                                      describe_rr_node(size_t(inode), device_ctx).c_str());
                         }
                     } else if (rr_graph.node_type(inode) == CHANY) {
                         VTR_ASSERT_MSG(rr_graph.node_xlow(inode) == rr_graph.node_xhigh(inode), "CHANY should be veritcal");
@@ -1224,7 +1224,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                             VPR_ERROR(VPR_ERROR_ROUTE, "RR node x position does not agree between rr_nodes (%d) and rr_node_indices (%d): %s",
                                       rr_graph.node_xlow(inode),
                                       x,
-                                      describe_rr_node(size_t(inode),device_ctx).c_str());
+                                      describe_rr_node(size_t(inode), device_ctx).c_str());
                         }
 
                         if (!rr_graph.y_in_node_range(y, inode)) {
@@ -1232,7 +1232,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_ylow(inode),
                                       rr_graph.node_ylow(inode),
                                       y,
-                                      describe_rr_node(size_t(inode),device_ctx).c_str());
+                                      describe_rr_node(size_t(inode), device_ctx).c_str());
                         }
                     } else if (rr_graph.node_type(inode) == SOURCE || rr_graph.node_type(inode) == SINK) {
                         //Sources have co-ordintes covering the entire block they are in
@@ -1241,7 +1241,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_xlow(inode),
                                       rr_graph.node_xlow(inode),
                                       x,
-                                      describe_rr_node(size_t(inode),device_ctx).c_str());
+                                      describe_rr_node(size_t(inode), device_ctx).c_str());
                         }
 
                         if (!rr_graph.y_in_node_range(y, inode)) {
@@ -1249,7 +1249,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                                       rr_graph.node_ylow(inode),
                                       rr_graph.node_ylow(inode),
                                       y,
-                                      describe_rr_node(size_t(inode),device_ctx).c_str());
+                                      describe_rr_node(size_t(inode), device_ctx).c_str());
                         }
 
                     } else {
@@ -1311,7 +1311,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                           rr_area,
                           rr_node.length(),
                           count,
-                          describe_rr_node(size_t(inode),device_ctx).c_str());
+                          describe_rr_node(size_t(inode), device_ctx).c_str());
             }
             /* As we allow a pin to be indexable on multiple sides,
              * This check code should not be applied to input and output pins
@@ -1321,7 +1321,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                 VPR_ERROR(VPR_ERROR_ROUTE, "Mismatch between RR node length (%d) and count within rr_node_indices (%d, should be length + 1): %s",
                           rr_node.length(),
                           count,
-                          describe_rr_node(size_t(inode),device_ctx).c_str());
+                          describe_rr_node(size_t(inode), device_ctx).c_str());
             }
         }
     }

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -401,7 +401,7 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
                                             "Uni-directional RR node driven by non-configurable "
                                             "BUFFER has fan in %d (expected 1)\n",
                                             fan_in);
-                                        msg += "  " + describe_rr_node(size_t(to_node));
+                                        msg += "  " + describe_rr_node(size_t(to_node),device_ctx);
                                         VPR_FATAL_ERROR(VPR_ERROR_OTHER, msg.c_str());
                                     }
 

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -401,7 +401,7 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
                                             "Uni-directional RR node driven by non-configurable "
                                             "BUFFER has fan in %d (expected 1)\n",
                                             fan_in);
-                                        msg += "  " + describe_rr_node(size_t(to_node),device_ctx);
+                                        msg += "  " + describe_rr_node(size_t(to_node), device_ctx);
                                         VPR_FATAL_ERROR(VPR_ERROR_OTHER, msg.c_str());
                                     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The purpose of this PR is to remove the use of global variables from any function for modularization of VTR. This effort is started from the describe_rr_node() function defined in rr_graph.cpp in route directory. After removing global variables from routers, we will move on to placers, GUI, timing analyzer etc.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use of global variables is not a recommended way. Removing them will benefit in modularization and less usage of memory.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 - [x] All vtr basic and strong tests are passing.
 - [x] VTR and Titan tests are passed.QoR comparison sheets are attached.  
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
