### PR TITLE
WIP: RRGraphView is_node_on_specific_side() Implementation

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2255,6 +2255,7 @@ static void draw_rr_pin(int inode, const ezgl::color& color, ezgl::renderer* g) 
     float xcen, ycen;
     char str[vtr::bufsize];
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
 
     int ipin = device_ctx.rr_nodes[inode].ptc_num();
 
@@ -2265,7 +2266,7 @@ static void draw_rr_pin(int inode, const ezgl::color& color, ezgl::renderer* g) 
      * - draw the pin on each side that it appears
      */
     for (const e_side& pin_side : SIDES) {
-        if (!device_ctx.rr_nodes[inode].is_node_on_specific_side(pin_side)) {
+        if (!rr_graph.is_node_on_specific_side(RRNodeId(inode), pin_side)) {
             continue;
         }
         draw_get_rr_pin_coords(inode, &xcen, &ycen, pin_side);
@@ -3185,7 +3186,7 @@ static void draw_pin_to_chan_edge(int pin_node, int chan_node, ezgl::renderer* g
      */
     std::vector<e_side> pin_candidate_sides;
     for (const e_side& pin_candidate_side : SIDES) {
-        if ((pin_rr.is_node_on_specific_side(pin_candidate_side))
+        if ((rr_graph.is_node_on_specific_side(pin_rr.id(), pin_candidate_side))
             && (grid_type->pinloc[grid_tile.width_offset][grid_tile.height_offset][pin_candidate_side][pin_rr.pin_num()])) {
             pin_candidate_sides.push_back(pin_candidate_side);
         }
@@ -3312,7 +3313,7 @@ static void draw_pin_to_pin(int opin_node, int ipin_node, ezgl::renderer* g) {
     float x1 = 0, y1 = 0;
     std::vector<e_side> opin_candidate_sides;
     for (const e_side& opin_candidate_side : SIDES) {
-        if (device_ctx.rr_nodes[opin_node].is_node_on_specific_side(opin_candidate_side)) {
+        if (rr_graph.is_node_on_specific_side(RRNodeId(opin_node), opin_candidate_side)) {
             opin_candidate_sides.push_back(opin_candidate_side);
         }
     }
@@ -3322,7 +3323,7 @@ static void draw_pin_to_pin(int opin_node, int ipin_node, ezgl::renderer* g) {
     float x2 = 0, y2 = 0;
     std::vector<e_side> ipin_candidate_sides;
     for (const e_side& ipin_candidate_side : SIDES) {
-        if (device_ctx.rr_nodes[ipin_node].is_node_on_specific_side(ipin_candidate_side)) {
+        if (rr_graph.is_node_on_specific_side(RRNodeId(ipin_node), ipin_candidate_side)) {
             ipin_candidate_sides.push_back(ipin_candidate_side);
         }
     }
@@ -3338,12 +3339,12 @@ static void draw_pin_to_pin(int opin_node, int ipin_node, ezgl::renderer* g) {
 
 static void draw_pin_to_sink(int ipin_node, int sink_node, ezgl::renderer* g) {
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
 
     float x1 = 0, y1 = 0;
     /* Draw the line for each ipin on different sides */
     for (const e_side& pin_side : SIDES) {
-        if (!device_ctx.rr_nodes[ipin_node].is_node_on_specific_side(
-                pin_side)) {
+        if (!rr_graph.is_node_on_specific_side(RRNodeId(ipin_node), pin_side)) {
             continue;
         }
 
@@ -3362,14 +3363,14 @@ static void draw_pin_to_sink(int ipin_node, int sink_node, ezgl::renderer* g) {
 
 static void draw_source_to_pin(int source_node, int opin_node, ezgl::renderer* g) {
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
 
     float x1 = 0, y1 = 0;
     draw_get_rr_src_sink_coords(device_ctx.rr_nodes[source_node], &x1, &y1);
 
     /* Draw the line for each ipin on different sides */
     for (const e_side& pin_side : SIDES) {
-        if (!device_ctx.rr_nodes[opin_node].is_node_on_specific_side(
-                pin_side)) {
+        if (!rr_graph.is_node_on_specific_side(RRNodeId(opin_node), pin_side)) {
             continue;
         }
 

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -240,7 +240,7 @@ void check_rr_graph(const t_graph_type graph_type,
                             std::string pin_name = block_type_pin_index_to_name(block_type, node.pin_num());
                             /* Print error messages for all the sides that a node may appear */
                             for (const e_side& node_side : SIDES) {
-                                if (!node.is_node_on_specific_side(node_side)) {
+                                if (!rr_graph.is_node_on_specific_side(RRNodeId(rr_node), node_side)) {
                                     continue;
                                 }
                                 VTR_LOG_ERROR("in check_rr_graph: node %d (%s) at (%d,%d) block=%s side=%s pin=%s has no fanin.\n",
@@ -591,10 +591,10 @@ static bool has_adjacent_channel(const t_rr_node& node, const DeviceGrid& grid) 
     const auto& rr_graph = g_vpr_ctx.device().rr_graph;
     VTR_ASSERT(rr_graph.node_type(node.id()) == IPIN || rr_graph.node_type(node.id()) == OPIN);
 
-    if ((rr_graph.node_xlow(node.id()) == 0 && !node.is_node_on_specific_side(RIGHT))                          //left device edge connects only along block's right side
-        || (rr_graph.node_ylow(node.id()) == int(grid.height() - 1) && !node.is_node_on_specific_side(BOTTOM)) //top device edge connects only along block's bottom side
-        || (rr_graph.node_xlow(node.id()) == int(grid.width() - 1) && !node.is_node_on_specific_side(LEFT))    //right deivce edge connects only along block's left side
-        || (rr_graph.node_ylow(node.id()) == 0 && !node.is_node_on_specific_side(TOP))                         //bottom deivce edge connects only along block's top side
+    if ((rr_graph.node_xlow(node.id()) == 0 && !rr_graph.is_node_on_specific_side(node.id(), RIGHT))                          //left device edge connects only along block's right side
+        || (rr_graph.node_ylow(node.id()) == int(grid.height() - 1) && !rr_graph.is_node_on_specific_side(node.id(), BOTTOM)) //top device edge connects only along block's bottom side
+        || (rr_graph.node_xlow(node.id()) == int(grid.width() - 1) && !rr_graph.is_node_on_specific_side(node.id(), LEFT))    //right deivce edge connects only along block's left side
+        || (rr_graph.node_ylow(node.id()) == 0 && !rr_graph.is_node_on_specific_side(node.id(), TOP))                         //bottom deivce edge connects only along block's top side
     ) {
         return false;
     }

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -1005,10 +1005,9 @@ static void adjust_rr_pin_position(const RRNodeId rr, int& x, int& y) {
      * Similarly for blocks at (*,0) we clip the minimum y to zero.
      */
     auto& device_ctx = g_vpr_ctx.device();
-    const auto& temp_rr_graph = device_ctx.rr_graph; //TODO rename to rr_graph once the rr_graph below is unneeded
-    auto& rr_graph = device_ctx.rr_nodes;
+    auto& rr_graph = device_ctx.rr_graph;
 
-    VTR_ASSERT_SAFE(is_pin(temp_rr_graph.node_type(rr)));
+    VTR_ASSERT_SAFE(is_pin(rr_graph.node_type(rr)));
     VTR_ASSERT_SAFE(rr_graph.node_xlow(rr) == rr_graph.node_xhigh(rr));
     VTR_ASSERT_SAFE(rr_graph.node_ylow(rr) == rr_graph.node_yhigh(rr));
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1380,6 +1380,9 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
     int num_pins = type->num_pins;
     const std::vector<int>& pin_class = type->pin_class;
 
+    auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+
     /* SINK and SOURCE-to-OPIN edges */
     for (int iclass = 0; iclass < num_class; ++iclass) {
         RRNodeId inode = RRNodeId::INVALID();
@@ -1492,7 +1495,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                             L_rr_node.add_node_side(inode, side);
 
                             // Sanity check
-                            VTR_ASSERT(L_rr_node.is_node_on_specific_side(inode, side));
+                            VTR_ASSERT(rr_graph.is_node_on_specific_side(RRNodeId(inode), side));
                             VTR_ASSERT(type->pinloc[width_offset][height_offset][side][L_rr_node.node_pin_num(inode)]);
                         }
                     }
@@ -2921,7 +2924,7 @@ static RRNodeId pick_best_direct_connect_target_rr_node(const t_rr_graph_storage
 
     for (const e_side& from_side : SIDES) {
         /* Bypass those side where the node does not appear */
-        if (!rr_nodes.is_node_on_specific_side(from_rr, from_side)) {
+        if (!rr_graph.is_node_on_specific_side(from_rr, from_side)) {
             continue;
         }
 
@@ -2932,7 +2935,7 @@ static RRNodeId pick_best_direct_connect_target_rr_node(const t_rr_graph_storage
 
             for (const e_side& to_side : SIDES) {
                 /* Bypass those side where the node does not appear */
-                if (!rr_nodes.is_node_on_specific_side(to_rr, to_side)) {
+                if (!rr_graph.is_node_on_specific_side(to_rr, to_side)) {
                     continue;
                 }
 

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -653,7 +653,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         if (rr_graph.node_type(node.id()) == IPIN || rr_graph.node_type(node.id()) == OPIN) {
             std::bitset<NUM_SIDES> sides_bitset;
             for (const e_side& side : SIDES) {
-                if (node.is_node_on_specific_side(side)) {
+                if (rr_graph.is_node_on_specific_side(node.id(), side)) {
                     sides_bitset.set(side);
                 }
             }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -103,8 +103,6 @@ class t_rr_node {
     RRIndexedDataId cost_index() const;
     short rc_index() const;
 
-    bool is_node_on_specific_side(e_side side) const;
-
     bool validate() const;
 
   public: //Mutators

--- a/vpr/src/route/rr_node_impl.h
+++ b/vpr/src/route/rr_node_impl.h
@@ -118,8 +118,5 @@ inline short t_rr_node::class_num() const {
     return storage_->node_class_num(id_);
 }
 
-inline bool t_rr_node::is_node_on_specific_side(e_side side) const {
-    return storage_->is_node_on_specific_side(id_, side);
-}
 
 #endif /* _RR_NODE_IMPL_H_ */


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
In this PR, I have implemented `RRGraphView::is_node_on_specific_side(node, side)` throughout VTR. Every time `device_ctx.rr_nodes[node].is_node_on_specific_side(side)` was called has been replaced with `rr_graph.is_node_on_specific_side(RRNodeId(node), side)`. In order to do this, I followed a pattern similar to that in the last PR.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes are a continuation of the RRGraphView API implementation effort.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


As this is a WIP, no testing has been completed yet.
<!---
I have run the regression tests for `vtr_reg_strong` along with the QoR testing found at `    $ ../scripts/run_vtr_task.py regression_tests/vtr_reg_nightly_test3/vtr_reg_qor_chain`. Results from these QoR tests can be found below. The file containing all results can be found [here](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/6555913/rr_graph_view_node_type.xlsx).



Only rows that are different are shown.

|	| VTR Before These Changes	|With Changes in this PR|
|---|---|---|
|vtr_flow_elapsed_time	|1|	1.013103428|
|odin_synth_time	|1|	1.004124928|
|abc_synth_time	|1|	1.009521229|
|max_vpr_mem	|1|	0.999794275|
|pack_time	|1|	0.984221145|
|place_time	|1|	1.004760669|
|min_chan_width_route_time	|1|	1.01720273|
|crit_path_route_time	|1|	1.019740612|
-->



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
