### PR TITLE
[Infra]: fix missing VTR time in parse_results 

### DIFF
--- a/vtr_flow/parse/parse_config/common/vtr_flow.txt
+++ b/vtr_flow/parse/parse_config/common/vtr_flow.txt
@@ -1,3 +1,3 @@
 #Flow Run-time Metrics
-vtr_flow_elapsed_time;vtr_flow.out;.* \(took (.*) seconds\)
+vtr_flow_elapsed_time;vtr_flow.out;.* \(took (.*) seconds, .*\)
 error;output.txt;error=(.*)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
While a new VPR memory usage stat is added to the run_vtr_flow output, the value of VTR elapsed time is no longer read by parse scripts due to a mismatch in the corresponding regex expressions.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
