### PR TITLE
Add a new API set_node_ptc_num() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -65,9 +65,11 @@ class RRGraphBuilder {
         node_storage_.set_node_coordinates(id, x1, y1, x2, y2);
     }
 
-    /** @brief Set the node ptc num */
+    /** @brief Set the node_ptc_num; The ptc (pin, track, or class) number is an integer
+     *  that allows you to differentiate between wires, pins or sources/sinks with overlapping x,y coordinates or extent.
+     *  This is useful for drawing rr-graphs nicely.*/
     inline void set_node_ptc_num(RRNodeId id, short new_ptc_num) {
-    	node_storage_.set_node_ptc_num(id, new_ptc_num);
+        node_storage_.set_node_ptc_num(id, new_ptc_num);
     }
 
     /* -- Internal data storage -- */

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -65,6 +65,11 @@ class RRGraphBuilder {
         node_storage_.set_node_coordinates(id, x1, y1, x2, y2);
     }
 
+    /** @brief Set the node ptc num */
+    inline void set_node_ptc_num(RRNodeId id, short new_ptc_num) {
+    	node_storage_.set_node_ptc_num(id, new_ptc_num);
+    }
+
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -106,7 +106,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
     }
     int ptc = max_ptc + 1;
 
-    rr_graph.set_node_ptc_num(node_index, ptc);
+    rr_graph_builder.set_node_ptc_num(node_index, ptc);
     rr_graph_builder.set_node_coordinates(node_index, x, y, x, y);
     rr_graph_builder.set_node_capacity(node_index, 1);
     rr_graph.set_node_cost_index(node_index, RRIndexedDataId(SINK_COST_INDEX));

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1433,7 +1433,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
         float R = 0.;
         float C = 0.;
         L_rr_node.set_node_rc_index(inode, find_create_rr_rc_data(R, C));
-        L_rr_node.set_node_ptc_num(inode, iclass);
+        rr_graph_builder.set_node_ptc_num(inode, iclass);
     }
 
     /* Connect IPINS to SINKS and initialize OPINS */
@@ -1481,7 +1481,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                             float R = 0.;
                             float C = 0.;
                             L_rr_node.set_node_rc_index(inode, find_create_rr_rc_data(R, C));
-                            L_rr_node.set_node_ptc_num(inode, ipin);
+                            rr_graph_builder.set_node_ptc_num(inode, ipin);
 
                             //Note that we store the grid tile location and side where the pin is located,
                             //which greatly simplifies the drawing code
@@ -1671,7 +1671,7 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
         float C = length * seg_details[track].Cmetal();
         L_rr_node.set_node_rc_index(node, find_create_rr_rc_data(R, C));
 
-        L_rr_node.set_node_ptc_num(node, track);
+        rr_graph_builder.set_node_ptc_num(node, track);
         L_rr_node.set_node_type(node, chan_type);
         L_rr_node.set_node_direction(node, seg_details[track].direction());
     }

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -604,7 +604,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         RRNodeId node_id = node.id();
 
         rr_graph_builder_->set_node_coordinates(node_id, xlow, ylow, xhigh, yhigh);
-        rr_graph_builder_>set_node_ptc_num(node_id, ptc);
+        rr_graph_builder_->set_node_ptc_num(node_id, ptc);
         return inode;
     }
     inline void finish_node_loc(int& /*inode*/) final {}

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -604,7 +604,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         RRNodeId node_id = node.id();
 
         rr_graph_builder_->set_node_coordinates(node_id, xlow, ylow, xhigh, yhigh);
-        node.set_ptc_num(ptc);
+        rr_graph_builder_>set_node_ptc_num(node_id, ptc);
         return inode;
     }
     inline void finish_node_loc(int& /*inode*/) final {}

--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -55,10 +55,6 @@ void t_rr_node::set_type(t_rr_type new_type) {
     storage_->set_node_type(id_, new_type);
 }
 
-void t_rr_node::set_ptc_num(short new_ptc_num) {
-    storage_->set_node_ptc_num(id_, new_ptc_num);
-}
-
 void t_rr_node::set_pin_num(short new_pin_num) {
     storage_->set_node_pin_num(id_, new_pin_num);
 }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -110,7 +110,6 @@ class t_rr_node {
   public: //Mutators
     void set_type(t_rr_type new_type);
 
-    void set_ptc_num(short);
     void set_pin_num(short);   //Same as set_ptc_num() by checks type() is consistent
     void set_track_num(short); //Same as set_ptc_num() by checks type() is consistent
     void set_class_num(short); //Same as set_ptc_num() by checks type() is consistent


### PR DESCRIPTION
**Description**

This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discrete data structure `rr_graph_storage`.
This PR aims to fully deprecate the direct use of the legacy API `set_ptc_num()` from the `rr_node` data structure.

After this PR, the `set_ptc_num` API is fully deprecated and the `set_node_ptc_num` from the refactored data structure `RRGraphBuilder` is the only way to use it.

**Checklist**:

- [x]  Removed the legacy API `set_ptc_num()` from `rr_node.cpp` and `rr_node.h`
- [x]  Added new APIs `set_node_ptc_num` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x]  Replaced all the use of `set_ptc_num()` in builder functions by `set_node_ptc_num()`

**Related Issue**

This pull request is a follow-up PR on the routing resource graph refactoring effort #[1805
](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1805)

**Motivation and Context**

This PR is the continuation of the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in the `RRGraphBuilder` data structure.
This PR reworks the `set_node_ptc_num()` API among the other APIs in #[1847](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1847)

**How Has This Been Tested?**

- [ ]  All vtr basic and strong tests are passing.

**Types of changes**

- [x]  Bug fix (change which fixes an issue)
- [ ]  New feature (change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**

- [ ]  My change requires a change to the documentation
- [x]  I have updated the documentation accordingly
- [ ]  I have added tests to cover my changes
- [ ]  All new and existing tests passed