### PR TITLE
CMake: add initial interchange schema sources compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(VTR_ENABLE_CAPNPROTO "Enable capnproto binary serialization support in VP
 #Allow the user to enable/disable VPR analytic placement
 #VPR option --enable_analytic_placer is also required for Analytic Placement
 option(VPR_ANALYTIC_PLACE "Enable analytic placement in VPR." ON)
+option(VPR_ENABLE_INTERCHANGE "Enable FPGA interchange." ON)
 
 option(WITH_BLIFEXPLORER "Enable build with blifexplorer" OFF)
 
@@ -365,7 +366,6 @@ if (VPR_USE_EZGL STREQUAL "auto")
         message(STATUS "VPR Graphics: Disabled (required libraries missing, on debian/ubuntu try: sudo apt install libgtk-3-dev libx11-dev")
     endif()
 endif()
-
 
 #Add the various sub-projects
 if(${WITH_ABC})

--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -8,7 +8,7 @@ add_subdirectory(libsdcparse)
 add_subdirectory(libblifparse)
 add_subdirectory(libtatum)
 
-#VPR_USE_EZGL is initialized in the root CMakeLists. 
+#VPR_USE_EZGL is initialized in the root CMakeLists.
 #compile libezgl only if the user asks for or has its dependencies installed.
 if(VPR_USE_EZGL STREQUAL "on")
     add_subdirectory(libezgl)

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -12,16 +12,23 @@ list(REMOVE_ITEM LIB_SOURCES ${EXEC_SOURCES})
 
 #Create the library
 add_library(libarchfpga STATIC
-             ${LIB_HEADERS}
-             ${LIB_SOURCES})
+    ${LIB_HEADERS}
+    ${LIB_SOURCES}
+)
+
 target_include_directories(libarchfpga PUBLIC ${LIB_INCLUDE_DIRS})
+
 set_target_properties(libarchfpga PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
 #Specify link-time dependancies
 target_link_libraries(libarchfpga
                         libvtrutil
                         libpugixml
-                        libpugiutil)
+                        libpugiutil
+                        libvtrcapnproto
+)
+
+target_compile_definitions(libarchfpga PUBLIC ${INTERCHANGE_SCHEMA_HEADERS})
 
 #Create the test executable
 add_executable(read_arch ${EXEC_SOURCES})

--- a/libs/libvtrcapnproto/CMakeLists.txt
+++ b/libs/libvtrcapnproto/CMakeLists.txt
@@ -25,20 +25,73 @@ set(CAPNP_DEFS
     gen/rr_graph_uxsdcxx.capnp
     map_lookahead.capnp
     extended_map_lookahead.capnp
-    )
+)
+
 capnp_generate_cpp(CAPNP_SRCS CAPNP_HDRS
     ${CAPNP_DEFS}
+)
+
+if (VPR_ENABLE_INTERCHANGE)
+    set(IC_DIR ${CMAKE_SOURCE_DIR}/libs/EXTERNAL/libinterchange/interchange)
+    set(CAPNPC_SRC_PREFIX ${IC_DIR})
+
+    find_program(WGET wget REQUIRED)
+
+    # Add Java schema
+    set(JAVA_SCHEMA ${CMAKE_CURRENT_BINARY_DIR}/schema/capnp/java.capnp)
+    add_custom_command(
+        OUTPUT ${JAVA_SCHEMA}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/schema/capnp/
+        COMMAND ${WGET}
+            https://raw.githubusercontent.com/capnproto/capnproto-java/master/compiler/src/main/schema/capnp/java.capnp
+            -O ${JAVA_SCHEMA}
     )
+
+    add_custom_target(
+        get_java_capnp_schema
+        DEPENDS ${JAVA_SCHEMA}
+    )
+
+    set(CAPNPC_IMPORT_DIRS)
+    list(APPEND CAPNPC_IMPORT_DIRS ${CMAKE_CURRENT_BINARY_DIR}/schema)
+
+    set(IC_PROTOS
+        LogicalNetlist.capnp
+        PhysicalNetlist.capnp
+        DeviceResources.capnp
+        References.capnp
+    )
+    set(IC_SRCS)
+    set(IC_HDRS)
+    foreach(PROTO ${IC_PROTOS})
+        capnp_generate_cpp(
+            IC_SRC
+            IC_HDR
+            ${IC_DIR}/${PROTO}
+        )
+        list(APPEND IC_SRCS ${IC_SRC})
+        list(APPEND IC_HDRS ${IC_HDR})
+        list(APPEND CAPNP_DEFS ${IC_DIR}/${PROTO})
+    endforeach()
+endif()
 
 install(FILES ${CAPNP_DEFS} DESTINATION ${CMAKE_INSTALL_DATADIR}/vtr)
 
 add_library(libvtrcapnproto STATIC
             ${CAPNP_SRCS}
+            ${IC_SRCS}
             mmap_file.h
             mmap_file.cpp
             serdes_utils.h
             serdes_utils.cpp
             )
+
+if (VPR_ENABLE_INTERCHANGE)
+    add_dependencies(libvtrcapnproto
+        get_java_capnp_schema
+    )
+endif()
+
 target_include_directories(libvtrcapnproto PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
@@ -47,4 +100,4 @@ target_include_directories(libvtrcapnproto PUBLIC
 target_link_libraries(libvtrcapnproto
     libvtrutil
     CapnProto::capnp
-    )
+)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds a very initial step towards the FPGA interchange adoption and integration within VTR.

This step currently adds the [FPGA interchange schema definitions](https://github.com/chipsalliance/fpga-interchange-schema) as a submodule and, if the cmake cache variable is defined, the various capnp schemas are compiled and their srcs and headers generated, ready to be used in the VTR codebase.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For now, the build process and cmake are enough to catch regressions when compiling the interchange schema files

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
