### PR TITLE
Add a missing operator.

### DIFF
--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -160,6 +160,11 @@ class edge_sort_iterator {
         return *this;
     }
 
+    edge_sort_iterator& operator-=(ssize_t n) {
+        swapper_.idx_ -= n;
+        return *this;
+    }
+
     edge_sort_iterator& operator++() {
         ++swapper_.idx_;
         return *this;


### PR DESCRIPTION
This turned out to be needed with a different std::sort
algorithm.

Signed-off-by: Henner Zeller <hzeller@google.com>