### PR TITLE
Adding temporary kokoro configuration files for `yosys_test` runner.

### DIFF
--- a/.github/kokoro/continuous/yosys_test.cfg
+++ b/.github/kokoro/continuous/yosys_test.cfg
@@ -1,0 +1,69 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# vtr_reg_yosys_odin test runs the VTR benchmarks through 
+# the entire VTR with Yosys+Odin-II as the first CAD tool 
+
+build_file: "vtr-verilog-to-routing/.github/kokoro/run-vtr.sh"
+
+# 72 hours
+timeout_mins: 4320
+
+action {
+  define_artifacts {
+    # File types
+    regex: "**/*.out"
+    regex: "**/vpr_stdout.log"
+    regex: "**/parse_results.txt"
+    regex: "**/qor_results.txt"
+    regex: "**/pack.log"
+    regex: "**/place.log"
+    regex: "**/route.log"
+    regex: "**/*_qor.csv"
+    regex: "**/*.out.gz"
+    regex: "**/vpr_stdout.log.gz"
+    regex: "**/parse_results.txt.gz"
+    regex: "**/qor_results.txt.gz"
+    regex: "**/pack.log.gz"
+    regex: "**/place.log.gz"
+    regex: "**/route.log.gz"
+    regex: "**/*_qor.csv.gz"
+    strip_prefix: "github/vtr-verilog-to-routing/"
+  }
+}
+
+env_vars {
+  key: "KOKORO_TYPE"
+  value: "continuous"
+}
+
+env_vars {
+  key: "KOKORO_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+env_vars {
+  key: "VTR_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+#Use default build configuration
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: ""
+}
+
+env_vars {
+  key: "VTR_TEST"
+  value: "odin_reg_strong"
+}
+
+#Options for run_reg_test.py
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
+env_vars {
+  key: "NUM_CORES"
+  value: "3"
+}

--- a/.github/kokoro/presubmit/yosys_test.cfg
+++ b/.github/kokoro/presubmit/yosys_test.cfg
@@ -1,0 +1,69 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# vtr_reg_yosys_odin test runs the VTR benchmarks through 
+# the entire VTR with Yosys+Odin-II as the first CAD tool
+
+build_file: "vtr-verilog-to-routing/.github/kokoro/run-vtr.sh"
+
+# 72 hours
+timeout_mins: 4320
+
+action {
+  define_artifacts {
+    # File types
+    regex: "**/*.out"
+    regex: "**/vpr_stdout.log"
+    regex: "**/parse_results.txt"
+    regex: "**/qor_results.txt"
+    regex: "**/pack.log"
+    regex: "**/place.log"
+    regex: "**/route.log"
+    regex: "**/*_qor.csv"
+    regex: "**/*.out.gz"
+    regex: "**/vpr_stdout.log.gz"
+    regex: "**/parse_results.txt.gz"
+    regex: "**/qor_results.txt.gz"
+    regex: "**/pack.log.gz"
+    regex: "**/place.log.gz"
+    regex: "**/route.log.gz"
+    regex: "**/*_qor.csv.gz"
+    strip_prefix: "github/vtr-verilog-to-routing/"
+  }
+}
+
+env_vars {
+  key: "KOKORO_TYPE"
+  value: "presubmit"
+}
+
+env_vars {
+  key: "KOKORO_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+env_vars {
+  key: "VTR_DIR"
+  value: "vtr-verilog-to-routing"
+}
+
+#Use default build configuration
+env_vars {
+  key: "VTR_CMAKE_PARAMS"
+  value: ""
+}
+
+env_vars {
+  key: "VTR_TEST"
+  value: "odin_reg_strong"
+}
+
+#Options for run_reg_test.py
+# -show_failures: show tool failures in main log output
+env_vars {
+  key: "VTR_TEST_OPTIONS"
+  value: "-show_failures"
+}
+
+env_vars {
+  key: "NUM_CORES"
+  value: "8"
+}


### PR DESCRIPTION
The real configuration will be landed in
https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1844

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>