### PR TITLE
Add a new API set_node_cost_index() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -69,11 +69,11 @@ class RRGraphBuilder {
         node_storage_.set_node_coordinates(id, x1, y1, x2, y2);
     }
 
-    /** @brief Set the node_ptc_num; This API is very powerful and developers should not use it unless it is necessary,
+    /** @brief @note Set the node_ptc_num; This API is very powerful and developers should not use it unless it is necessary,
      * e.g the node type is unknown. If the node type is known, the more specific routines, `set_node_pin_num()`,
-     * `set_node_track_num()`and `set_node_class_num()`, for different types of nodes should be used.
-     *
-     * The ptc_num carries different meanings for different node types
+     * `set_node_track_num()`and `set_node_class_num()`, for different types of nodes should be used.*/
+
+     /** @brief The ptc_num carries different meanings for different node types
      * (true in VPR RRG that is currently supported, may not be true in customized RRG)
      * CHANX or CHANY: the track id in routing channels
      * OPIN or IPIN: the index of pins in the logic block data structure

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -73,7 +73,7 @@ class RRGraphBuilder {
      * e.g the node type is unknown. If the node type is known, the more specific routines, `set_node_pin_num()`,
      * `set_node_track_num()`and `set_node_class_num()`, for different types of nodes should be used.*/
 
-     /** @brief The ptc_num carries different meanings for different node types
+    /** @brief The ptc_num carries different meanings for different node types
      * (true in VPR RRG that is currently supported, may not be true in customized RRG)
      * CHANX or CHANY: the track id in routing channels
      * OPIN or IPIN: the index of pins in the logic block data structure

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -102,6 +102,14 @@ class RRGraphBuilder {
         node_storage_.set_node_direction(id, new_direction);
     }
 
+    /** @brief set_node_cost_index gets the index of cost data in the list of cost_indexed_data data structure
+     * It contains the routing cost for different nodes in the RRGraph
+     * when used in evaluate different routing paths
+     */
+    inline void set_node_cost_index(RRNodeId id, RRIndexedDataId new_cost_index) {
+        node_storage_.set_node_cost_index(id, new_cost_index);
+    }
+
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -69,9 +69,9 @@ class RRGraphBuilder {
         node_storage_.set_node_coordinates(id, x1, y1, x2, y2);
     }
 
-    /** @brief Set the node_ptc_num; The ptc (pin, track, or class) number is an integer
-     * that allows you to differentiate between wires, pins or sources/sinks with overlapping x,y coordinates or extent.
-     * This is useful for drawing rr-graphs nicely.
+    /** @brief Set the node_ptc_num; This API is very powerful and developers should not use it unless it is necessary,
+     * e.g the node type is unknown. If the node type is known, the more specific routines, `set_node_pin_num()`,
+     * `set_node_track_num()`and `set_node_class_num()`, for different types of nodes should be used.
      *
      * The ptc_num carries different meanings for different node types
      * (true in VPR RRG that is currently supported, may not be true in customized RRG)

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -110,7 +110,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
     rr_graph_builder.set_node_class_num(node_index, ptc);
     rr_graph_builder.set_node_coordinates(node_index, x, y, x, y);
     rr_graph_builder.set_node_capacity(node_index, 1);
-    rr_graph.set_node_cost_index(node_index, RRIndexedDataId(SINK_COST_INDEX));
+    rr_graph_builder.set_node_cost_index(node_index, RRIndexedDataId(SINK_COST_INDEX));
 
     float R = 0.;
     float C = 0.;

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -316,7 +316,6 @@ int ClockRib::create_chanx_wire(int x_start,
                                 RRGraphBuilder& rr_graph_builder) {
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
-    auto node = rr_nodes->back();
     RRNodeId chanx_node = RRNodeId(node_index);
 
     rr_graph_builder.set_node_type(chanx_node, CHANX);
@@ -622,7 +621,6 @@ int ClockSpine::create_chany_wire(int y_start,
                                   int num_segments) {
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
-    auto node = rr_nodes->back();
     RRNodeId chany_node = RRNodeId(node_index);
 
     rr_graph_builder.set_node_type(chany_node, CHANY);

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -342,7 +342,7 @@ int ClockRib::create_chanx_wire(int x_start,
             VTR_ASSERT_MSG(false, "Unidentified direction type for clock rib");
             break;
     }
-    node.set_cost_index(RRIndexedDataId(CHANX_COST_INDEX_START + seg_index)); // Actual value set later
+    rr_graph_builder.set_node_cost_index(chanx_node, RRIndexedDataId(CHANX_COST_INDEX_START + seg_index)); // Actual value set later
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
@@ -648,7 +648,7 @@ int ClockSpine::create_chany_wire(int y_start,
             VTR_ASSERT_MSG(false, "Unidentified direction type for clock rib");
             break;
     }
-    node.set_cost_index(RRIndexedDataId(CHANX_COST_INDEX_START + num_segments + seg_index));
+    rr_graph_builder.set_node_cost_index(chany_node, RRIndexedDataId(CHANX_COST_INDEX_START + num_segments + seg_index));
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -231,7 +231,6 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
                           const t_chan_details& chan_details_x,
                           const t_chan_details& chan_details_y,
                           t_rr_edge_info_set& created_rr_edges,
-                          t_rr_graph_storage& L_rr_node,
                           const int wire_to_ipin_switch,
                           const enum e_directionality directionality);
 
@@ -1223,7 +1222,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
                               CHANX_COST_INDEX_START,
                               max_chan_width, grid, tracks_per_chan,
                               sblock_pattern, Fs / 3, chan_details_x, chan_details_y,
-                              rr_edges_to_create, L_rr_node,
+                              rr_edges_to_create,
                               wire_to_ipin_switch,
                               directionality);
 
@@ -1238,7 +1237,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
                               CHANX_COST_INDEX_START + num_seg_types,
                               max_chan_width, grid, tracks_per_chan,
                               sblock_pattern, Fs / 3, chan_details_x, chan_details_y,
-                              rr_edges_to_create, L_rr_node,
+                              rr_edges_to_create,
                               wire_to_ipin_switch,
                               directionality);
 
@@ -1527,7 +1526,6 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
                           const t_chan_details& chan_details_x,
                           const t_chan_details& chan_details_y,
                           t_rr_edge_info_set& rr_edges_to_create,
-                          t_rr_graph_storage& L_rr_node,
                           const int wire_to_ipin_switch,
                           const enum e_directionality directionality) {
     /* this function builds both x and y-directed channel segments, so set up our

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1410,7 +1410,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                 rr_edges_to_create.emplace_back(inode, opin_nodes[iedge], delayless_switch);
             }
 
-            L_rr_node.set_node_cost_index(inode, RRIndexedDataId(SOURCE_COST_INDEX));
+            rr_graph_builder.set_node_cost_index(inode, RRIndexedDataId(SOURCE_COST_INDEX));
             rr_graph_builder.set_node_type(inode, SOURCE);
         } else { /* SINK */
             VTR_ASSERT(class_inf[iclass].type == RECEIVER);
@@ -1428,7 +1428,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
              * - set_node_cost_index(RRNodeId, int);
              * - set_node_type(RRNodeId, t_rr_type);
              */
-            L_rr_node.set_node_cost_index(inode, RRIndexedDataId(SINK_COST_INDEX));
+            rr_graph_builder.set_node_cost_index(inode, RRIndexedDataId(SINK_COST_INDEX));
             rr_graph_builder.set_node_type(inode, SINK);
         }
 
@@ -1463,7 +1463,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                                 //Add info about the edge to be created
                                 rr_edges_to_create.emplace_back(inode, to_node, delayless_switch);
 
-                                L_rr_node.set_node_cost_index(inode, RRIndexedDataId(IPIN_COST_INDEX));
+                                rr_graph_builder.set_node_cost_index(inode, RRIndexedDataId(IPIN_COST_INDEX));
                                 rr_graph_builder.set_node_type(inode, IPIN);
                             }
                         } else {
@@ -1475,7 +1475,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                             /* Output pins may not exist on some sides, we may not always find one */
                             if (inode) {
                                 //Initially left unconnected
-                                L_rr_node.set_node_cost_index(inode, RRIndexedDataId(OPIN_COST_INDEX));
+                                rr_graph_builder.set_node_cost_index(inode, RRIndexedDataId(OPIN_COST_INDEX));
                                 rr_graph_builder.set_node_type(inode, OPIN);
                             }
                         }
@@ -1661,7 +1661,7 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
         }
 
         /* Edge arrays have now been built up.  Do everything else.  */
-        L_rr_node.set_node_cost_index(node, RRIndexedDataId(cost_index_offset + seg_details[track].index()));
+        rr_graph_builder.set_node_cost_index(node, RRIndexedDataId(cost_index_offset + seg_details[track].index()));
         rr_graph_builder.set_node_capacity(node, 1); /* GLOBAL routing handled elsewhere */
 
         if (chan_type == CHANX) {

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -703,13 +703,15 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         }
 
         auto node = (*rr_nodes_)[inode];
+        RRNodeId node_id = node.id();
+
         if (GRAPH_GLOBAL == graph_type_) {
-            node.set_cost_index(RRIndexedDataId(0));
+            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(0));
         } else if (rr_graph.node_type(node.id()) == CHANX) {
-            node.set_cost_index(RRIndexedDataId(CHANX_COST_INDEX_START + segment_id));
+            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(CHANX_COST_INDEX_START + segment_id));
             seg_index_[rr_graph.node_cost_index(node.id())] = segment_id;
         } else if (rr_graph.node_type(node.id()) == CHANY) {
-            node.set_cost_index(RRIndexedDataId(CHANX_COST_INDEX_START + segment_inf_.size() + segment_id));
+            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(CHANX_COST_INDEX_START + segment_inf_.size() + segment_id));
             seg_index_[rr_graph.node_cost_index(node.id())] = segment_id;
         }
         return inode;
@@ -772,16 +774,16 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             case CHANY:
                 break;
             case SOURCE:
-                node.set_cost_index(RRIndexedDataId(SOURCE_COST_INDEX));
+                rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(SOURCE_COST_INDEX));
                 break;
             case SINK:
-                node.set_cost_index(RRIndexedDataId(SINK_COST_INDEX));
+                rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(SINK_COST_INDEX));
                 break;
             case OPIN:
-                node.set_cost_index(RRIndexedDataId(OPIN_COST_INDEX));
+                rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(OPIN_COST_INDEX));
                 break;
             case IPIN:
-                node.set_cost_index(RRIndexedDataId(IPIN_COST_INDEX));
+                rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(IPIN_COST_INDEX));
                 break;
             default:
                 report_error(

--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -51,10 +51,6 @@ bool t_rr_node::validate() const {
     return true;
 }
 
-void t_rr_node::set_cost_index(RRIndexedDataId new_cost_index) {
-    storage_->set_node_cost_index(id_, new_cost_index);
-}
-
 void t_rr_node::set_rc_index(short new_rc_index) {
     storage_->set_node_rc_index(id_, new_rc_index);
 }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -106,7 +106,6 @@ class t_rr_node {
     bool validate() const;
 
   public: //Mutators
-    void set_cost_index(RRIndexedDataId);
     void set_rc_index(short);
 
     void set_side(e_side);


### PR DESCRIPTION
**Description**
This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discrete data structure `rr_graph_storage`.
This PR aims to fully refactored/deprecate the direct use of the legacy API `set_node_cost_index()` from the `rr_node` data structure.

After this PR, the `set_cost_index()` API is fully deprecated, and the `set_node_cost_index()` from the refactored data structure `RRGraphBuilder` is the only way to use it.

**Checklist:**
- [x]  Removed the legacy API `set_cost_index()` from `rr_node.cpp` and `rr_node.h`
- [x]  Added new APIs `set_node_cost_index` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x]  Replaced all the use of `set_cost_index()` with respective `set_node_cost_index` in builder functions

**Related Issue**
This pull request is a follow-up PR on the routing resource graph refactoring effort [#1805](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1805), [#1868](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1868)

**Motivation and Context**
This PR is a continuation of the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in the `RRGraphBuilder` data structure.
This PR refactored the set_node_cost_index() API among the other APIs in [#1847](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1847), [#1868](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1868)

**How Has This Been Tested?**
- [x]  All vtr basic and strong tests are passing.

**Types of changes**
- [x]  Bug fix (change which fixes an issue)
- [ ]  New feature (change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [ ]  My change requires a change to the documentation
- [x]  I have updated the documentation accordingly
- [ ]  I have added tests to cover my changes
- [ ]  All new and existing tests passed