### PR TITLE
Add a new API remap_rr_node_switch_indices() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -108,6 +108,11 @@ class RRGraphBuilder {
         node_storage_.add_node_side(id, new_side);
     }
 
+    /** @brief It maps arch_switch_inf indicies to rr_switch_inf indicies. */
+    inline void remap_rr_node_switch_indices(const t_arch_switch_fanin& switch_fanin) {
+        node_storage_.remap_rr_node_switch_indices(switch_fanin);
+    }
+
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -893,7 +893,7 @@ void load_rr_switch_from_arch_switch(int arch_switch_idx,
 static void remap_rr_node_switch_indices(const t_arch_switch_fanin& switch_fanin) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
 
-    device_ctx.rr_nodes.remap_rr_node_switch_indices(switch_fanin);
+    device_ctx.rr_graph_builder.remap_rr_node_switch_indices(switch_fanin);
 }
 
 static void rr_graph_externals(const std::vector<t_segment_inf>& segment_inf,


### PR DESCRIPTION
**Description**
This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discrete data structure `rr_graph_storage`.
This PR aims to fully refactored/deprecate the direct use of the legacy API `remap_rr_node_switch_indices()` from the `rr_node` data structure.

After this PR, the `remap_rr_node_switch_indices()` from the refactored data structure `RRGraphBuilder` is the only way to use it.

**Checklist:**
- [x]  Removed the legacy API `remap_rr_node_switch_indices()` from `rr_node.cpp` and `rr_node.h` (if present)
- [x]  Added new API `remap_rr_node_switch_indices()` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x]  Replaced all the use of `remap_rr_node_switch_indices()` in respective functions

**Related Issue**
This pull request is a follow-up PR on the routing resource graph refactoring effort #1805, #1868

**Motivation and Context**
This PR is a continuation of the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in the `RRGraphBuilder` data structure.
This PR refactored the `remap_rr_node_switch_indices()` API among the other APIs in #1847, #1868

**How Has This Been Tested?**
- [x]  All vtr basic and strong tests are passing.

**Types of changes**
- [x]  Bug fix (change which fixes an issue)
- [ ]  New feature (change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [ ]  My change requires a change to the documentation
- [x]  I have updated the documentation accordingly
- [ ]  I have added tests to cover my changes
- [ ]  All new and existing tests passed