### PR TITLE
Add a new API init_fan_in() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -117,6 +117,14 @@ class RRGraphBuilder {
         return node_storage_.count_rr_switches(num_arch_switches, arch_switch_inf, arch_switch_fanins);
     }
 
+    /** @brief Init per node fan-in data.  Should only be called after all edges have
+     * been allocated.
+     * @note
+     * This is an expensive, O(N), operation so it should be called once you
+     * have a complete rr-graph and not called often. */
+    inline void init_fan_in() {
+        node_storage_.init_fan_in();
+    }
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1263,7 +1263,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
         };
     }
 
-    L_rr_node.init_fan_in();
+    rr_graph_builder.init_fan_in();
 
     return update_chan_width;
 }

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -1546,7 +1546,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     void finish_load() final {
         process_rr_node_indices();
 
-        rr_nodes_->init_fan_in();
+        rr_graph_builder_->init_fan_in();
 
         alloc_and_load_rr_indexed_data(
             segment_inf_,


### PR DESCRIPTION
**Description**
This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discrete data structure `rr_graph_storage`.
This PR aims to fully refactored/deprecate the direct use of the legacy API `init_fan_in()` from the `rr_node` data structure.

After this PR, the `init_fan_in()` from the refactored data structure `RRGraphBuilder` is the only way to use it.

**Checklist:**
- [x]  Removed the legacy API `init_fan_in()` from `rr_node.cpp` and `rr_node.h` (if present)
- [x]  Added new API `init_fan_in()` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x]  Replaced all the use of `init_fan_in()` in respective functions (if needed)

**Related Issue**
This pull request is a follow-up PR on the routing resource graph refactoring effort #1805, #1868

**Motivation and Context**
This PR is a continuation of the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in the `RRGraphBuilder` data structure.
This PR refactored the `init_fan_in()` API among the other APIs in #1847, #1868

**How Has This Been Tested?**
- [ ]  All vtr basic and strong tests are passing.

**Types of changes**
- [x]  Bug fix (change which fixes an issue)
- [ ]  New feature (change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [ ]  My change requires a change to the documentation
- [x]  I have updated the documentation accordingly
- [ ]  I have added tests to cover my changes
- [ ]  All new and existing tests passed