### PR TITLE
RRGraphView node_ptc_num(), node_pin_num(), node_class_num(), node_track_num() Implementation

### DIFF
--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -192,7 +192,7 @@ static std::string get_pin_feature (size_t inode) {
     int ilow = rr_graph.node_xlow(RRNodeId(inode));
     int jlow = rr_graph.node_ylow(RRNodeId(inode));
     auto physical_tile = device_ctx.grid[ilow][jlow].type;
-    int pin_num = rr_graph.node_ptc_num(RRNodeId(inode));
+    int pin_num = rr_graph.node_pin_num(RRNodeId(inode));
 
     // Get the sub tile (type, not instance) and index of its pin that matches
     // the node index.

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -192,7 +192,7 @@ static std::string get_pin_feature (size_t inode) {
     int ilow = rr_graph.node_xlow(RRNodeId(inode));
     int jlow = rr_graph.node_ylow(RRNodeId(inode));
     auto physical_tile = device_ctx.grid[ilow][jlow].type;
-    int pin_num = device_ctx.rr_nodes[inode].ptc_num();
+    int pin_num = rr_graph.node_ptc_num(RRNodeId(inode));
 
     // Get the sub tile (type, not instance) and index of its pin that matches
     // the node index.

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -249,7 +249,6 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
         } else if (tokens[0] == "Node:") {
             /*An actual line, go through each node and add it to the route tree*/
             inode = atoi(tokens[1].c_str());
-            auto node = device_ctx.rr_nodes[inode];
 
             /*First node needs to be source. It is isolated to correctly set heap head.*/
             if (node_count == 0 && tokens[2] != "SOURCE") {
@@ -309,7 +308,7 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
             }
 
             ptc = atoi(tokens[5 + offset].c_str());
-            if (node.ptc_num() != ptc) {
+            if (rr_graph.node_ptc_num(RRNodeId(inode)) != ptc) {
                 vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                           "The ptc num of node %d does not match the rr graph", inode);
             }
@@ -318,7 +317,7 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
             if (tokens[6 + offset] != "Switch:") {
                 /*This is an opin or ipin, process its pin nums*/
                 if (!is_io_type(device_ctx.grid[x][y].type) && (tokens[2] == "IPIN" || tokens[2] == "OPIN")) {
-                    int pin_num = device_ctx.rr_nodes[inode].ptc_num();
+                    int pin_num = rr_graph.node_ptc_num(RRNodeId(inode));
 
                     auto type = device_ctx.grid[x][y].type;
                     int height_offset = device_ctx.grid[x][y].height_offset;

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -317,7 +317,7 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
             if (tokens[6 + offset] != "Switch:") {
                 /*This is an opin or ipin, process its pin nums*/
                 if (!is_io_type(device_ctx.grid[x][y].type) && (tokens[2] == "IPIN" || tokens[2] == "OPIN")) {
-                    int pin_num = rr_graph.node_ptc_num(RRNodeId(inode));
+                    int pin_num = rr_graph.node_pin_num(RRNodeId(inode));
 
                     auto type = device_ctx.grid[x][y].type;
                     int height_offset = device_ctx.grid[x][y].height_offset;

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -249,6 +249,26 @@ class RRGraphView {
         return node_storage_.node_side_string(node);
     }
 
+    /** @brief Get the ptc num of a routing resource node. This function is inlined for runtime optimization. */
+    inline short node_ptc_num(RRNodeId node) const {
+        return node_storage_.node_ptc_num(node);
+    }
+
+    /** @brief Get the pin num of a routing resource node. This function is inlined for runtime optimization. */
+    inline short node_pin_num(RRNodeId node) const {
+        return node_storage_.node_pin_num(node);
+    }
+
+    /** @brief Get the track num of a routing resource node. This function is inlined for runtime optimization. */
+    inline short node_track_num(RRNodeId node) const {
+        return node_storage_.node_track_num(node);
+    }
+
+    /** @brief Get the class num of a routing resource node. This function is inlined for runtime optimization. */
+    inline short node_class_num(RRNodeId node) const {
+        return node_storage_.node_class_num(node);
+    }
+
     /** @brief Get the cost index of a routing resource node. This function is inlined for runtime optimization. */
     RRIndexedDataId node_cost_index(RRNodeId node) const {
         return node_storage_.node_cost_index(node);

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -248,16 +248,16 @@ class RRGraphView {
     inline const char* node_side_string(RRNodeId node) const {
         return node_storage_.node_side_string(node);
     }
-    
+
     /** @brief The ptc_num carries different meanings for different node types 
-      * (true in VPR RRG that is currently supported, may not be true in customized RRG) 
-      * CHANX or CHANY: the track id in routing channels 
-      * OPIN or IPIN: the index of pins in the logic block data structure 
-      * SOURCE and SINK: the class id of a pin (indicating logic equivalence of pins) in the logic block data structure  
-      * @note  
-      * This API is very powerful and developers should not use it unless it is necessary, 
-      * e.g the node type is unknown. If the node type is known, the more specific routines, `node_pin_num()`, 
-      * `node_track_num()`and `node_class_num()`, for different types of nodes should be used.*/ 
+     * (true in VPR RRG that is currently supported, may not be true in customized RRG) 
+     * CHANX or CHANY: the track id in routing channels 
+     * OPIN or IPIN: the index of pins in the logic block data structure 
+     * SOURCE and SINK: the class id of a pin (indicating logic equivalence of pins) in the logic block data structure  
+     * @note  
+     * This API is very powerful and developers should not use it unless it is necessary, 
+     * e.g the node type is unknown. If the node type is known, the more specific routines, `node_pin_num()`, 
+     * `node_track_num()`and `node_class_num()`, for different types of nodes should be used.*/
 
     inline short node_ptc_num(RRNodeId node) const {
         return node_storage_.node_ptc_num(node);
@@ -274,7 +274,7 @@ class RRGraphView {
     inline short node_track_num(RRNodeId node) const {
         return node_storage_.node_track_num(node);
     }
-    
+
     /** @brief Get the class num of a routing resource node. This is designed for routing source and sinks,
      *  which are SOURCE and SINK nodes. This function is inlined for runtime optimization. */
     inline short node_class_num(RRNodeId node) const {

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -248,23 +248,35 @@ class RRGraphView {
     inline const char* node_side_string(RRNodeId node) const {
         return node_storage_.node_side_string(node);
     }
+    
+    /** @brief The ptc_num carries different meanings for different node types 
+      * (true in VPR RRG that is currently supported, may not be true in customized RRG) 
+      * CHANX or CHANY: the track id in routing channels 
+      * OPIN or IPIN: the index of pins in the logic block data structure 
+      * SOURCE and SINK: the class id of a pin (indicating logic equivalence of pins) in the logic block data structure  
+      * @note  
+      * This API is very powerful and developers should not use it unless it is necessary, 
+      * e.g the node type is unknown. If the node type is known, the more specific routines, `node_pin_num()`, 
+      * `node_track_num()`and `node_class_num()`, for different types of nodes should be used.*/ 
 
-    /** @brief Get the ptc num of a routing resource node. This function is inlined for runtime optimization. */
     inline short node_ptc_num(RRNodeId node) const {
         return node_storage_.node_ptc_num(node);
     }
 
-    /** @brief Get the pin num of a routing resource node. This function is inlined for runtime optimization. */
+    /** @brief Get the pin num of a routing resource node. This is designed for logic blocks, 
+     * which are IPIN and OPIN nodes. This function is inlined for runtime optimization. */
     inline short node_pin_num(RRNodeId node) const {
         return node_storage_.node_pin_num(node);
     }
 
-    /** @brief Get the track num of a routing resource node. This function is inlined for runtime optimization. */
+    /** @brief Get the track num of a routing resource node. This is designed for routing tracks, 
+     * which are CHANX and CHANY nodes. This function is inlined for runtime optimization. */
     inline short node_track_num(RRNodeId node) const {
         return node_storage_.node_track_num(node);
     }
-
-    /** @brief Get the class num of a routing resource node. This function is inlined for runtime optimization. */
+    
+    /** @brief Get the class num of a routing resource node. This is designed for routing source and sinks,
+     *  which are SOURCE and SINK nodes. This function is inlined for runtime optimization. */
     inline short node_class_num(RRNodeId node) const {
         return node_storage_.node_class_num(node);
     }

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2193,18 +2193,18 @@ ezgl::rectangle draw_get_rr_chan_bbox(int inode) {
                     + draw_coords->get_tile_width();
             bottom = draw_coords->tile_y[rr_graph.node_ylow(rr_node)]
                      + draw_coords->get_tile_width()
-                     + (1. + rr_graph.node_ptc_num(rr_node));
+                     + (1. + rr_graph.node_track_num(rr_node));
             top = draw_coords->tile_y[rr_graph.node_ylow(rr_node)]
                   + draw_coords->get_tile_width()
-                  + (1. + rr_graph.node_ptc_num(rr_node));
+                  + (1. + rr_graph.node_track_num(rr_node));
             break;
         case CHANY:
             left = draw_coords->tile_x[rr_graph.node_xlow(rr_node)]
                    + draw_coords->get_tile_width()
-                   + (1. + rr_graph.node_ptc_num(rr_node));
+                   + (1. + rr_graph.node_track_num(rr_node));
             right = draw_coords->tile_x[rr_graph.node_xlow(rr_node)]
                     + draw_coords->get_tile_width()
-                    + (1. + rr_graph.node_ptc_num(rr_node));
+                    + (1. + rr_graph.node_track_num(rr_node));
             bottom = draw_coords->tile_y[rr_graph.node_ylow(rr_node)];
             top = draw_coords->tile_y[rr_graph.node_yhigh(rr_node)]
                   + draw_coords->get_tile_width();
@@ -2257,7 +2257,7 @@ static void draw_rr_pin(int inode, const ezgl::color& color, ezgl::renderer* g) 
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
-    int ipin = rr_graph.node_ptc_num(RRNodeId(inode));
+    int ipin = rr_graph.node_pin_num(RRNodeId(inode));
 
     g->set_color(color);
 
@@ -2305,7 +2305,7 @@ void draw_get_rr_pin_coords(const t_rr_node& node, float* xcen, float* ycen, con
     xc = draw_coords->tile_x[i];
     yc = draw_coords->tile_y[j];
 
-    ipin = rr_graph.node_ptc_num(rr_node);
+    ipin = rr_graph.node_pin_num(rr_node);
     type = device_ctx.grid[i][j].type;
     pins_per_sub_tile = type->num_pins / type->capacity;
     k = ipin / pins_per_sub_tile;
@@ -2364,7 +2364,7 @@ static void draw_rr_src_sink(int inode, ezgl::color color, ezgl::renderer* g) {
         {xcen + draw_coords->pin_size, ycen + draw_coords->pin_size});
 
     std::string str = vtr::string_fmt("%d",
-                                      rr_graph.node_ptc_num(RRNodeId(inode)));
+                                      rr_graph.node_class_num(RRNodeId(inode)));
     g->set_color(ezgl::BLACK);
     g->draw_text({xcen, ycen}, str.c_str(), 2 * draw_coords->pin_size,
                  2 * draw_coords->pin_size);
@@ -2620,7 +2620,7 @@ static int get_track_num(int inode, const vtr::OffsetMatrix<int>& chanx_track, c
     RRNodeId rr_node = RRNodeId(inode);
 
     if (get_draw_state_vars()->draw_route_type == DETAILED)
-        return (rr_graph.node_ptc_num(rr_node));
+        return (rr_graph.node_track_num(rr_node));
 
     /* GLOBAL route stuff below. */
 
@@ -2766,7 +2766,7 @@ static int draw_check_rr_node_hit(float click_x, float click_y) {
                 t_physical_tile_type_ptr type = device_ctx.grid[i][j].type;
                 int width_offset = device_ctx.grid[i][j].width_offset;
                 int height_offset = device_ctx.grid[i][j].height_offset;
-                int ipin = rr_graph.node_ptc_num(rr_node);
+                int ipin = rr_graph.node_pin_num(rr_node);
                 float xcen, ycen;
                 for (const e_side& iside : SIDES) {
                     // If pin exists on this side of the block, then get pin coordinates

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -192,7 +192,7 @@ void auto_zoom_rr_node(int rr_node_id) {
             t_physical_tile_type_ptr type = device_ctx.grid[i][j].type;
             int width_offset = device_ctx.grid[i][j].width_offset;
             int height_offset = device_ctx.grid[i][j].height_offset;
-            int ipin = device_ctx.rr_nodes[rr_node_id].ptc_num();
+            int ipin = rr_graph.node_ptc_num(RRNodeId(rr_node_id));
             float xcen, ycen;
 
             for (const e_side& iside : SIDES) {

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -214,7 +214,7 @@ static void check_source(RRNodeId inode, ClusterNetId net_id) {
     int i = rr_graph.node_xlow(inode);
     int j = rr_graph.node_ylow(inode);
     /* for sinks and sources, ptc_num is class */
-    int ptc_num = device_ctx.rr_nodes[size_t(inode)].ptc_num();
+    int ptc_num = rr_graph.node_ptc_num(inode);
     /* First node_block for net is the source */
     ClusterBlockId blk_id = cluster_ctx.clb_nlist.net_driver_block(net_id);
     auto type = device_ctx.grid[i][j].type;
@@ -325,18 +325,20 @@ static bool check_adjacent(int from_node, int to_node) {
 
     num_adj = 0;
 
-    from_type = rr_graph.node_type(RRNodeId(from_node));
-    from_xlow = rr_graph.node_xlow(RRNodeId(from_node));
-    from_ylow = rr_graph.node_ylow(RRNodeId(from_node));
-    from_xhigh = rr_graph.node_xhigh(RRNodeId(from_node));
-    from_yhigh = rr_graph.node_yhigh(RRNodeId(from_node));
-    from_ptc = device_ctx.rr_nodes[from_node].ptc_num();
-    to_type = rr_graph.node_type(RRNodeId(to_node));
-    to_xlow = rr_graph.node_xlow(RRNodeId(to_node));
-    to_ylow = rr_graph.node_ylow(RRNodeId(to_node));
-    to_xhigh = rr_graph.node_xhigh(RRNodeId(to_node));
-    to_yhigh = rr_graph.node_yhigh(RRNodeId(to_node));
-    to_ptc = device_ctx.rr_nodes[to_node].ptc_num();
+    auto from_rr = RRNodeId(from_node);
+    auto to_rr = RRNodeId(to_node);
+    from_type = rr_graph.node_type(from_rr);
+    from_xlow = rr_graph.node_xlow(from_rr);
+    from_ylow = rr_graph.node_ylow(from_rr);
+    from_xhigh = rr_graph.node_xhigh(from_rr);
+    from_yhigh = rr_graph.node_yhigh(from_rr);
+    from_ptc = rr_graph.node_ptc_num(from_rr);
+    to_type = rr_graph.node_type(to_rr);
+    to_xlow = rr_graph.node_xlow(to_rr);
+    to_ylow = rr_graph.node_ylow(to_rr);
+    to_xhigh = rr_graph.node_xhigh(to_rr);
+    to_yhigh = rr_graph.node_yhigh(to_rr);
+    to_ptc = rr_graph.node_ptc_num(to_rr);
 
     switch (from_type) {
         case SOURCE:
@@ -393,8 +395,8 @@ static bool check_adjacent(int from_node, int to_node) {
             if (to_type == IPIN) {
                 num_adj += 1; //adjacent
             } else if (to_type == CHANX) {
-                from_xhigh = rr_graph.node_xhigh(RRNodeId(from_node));
-                to_xhigh = rr_graph.node_xhigh(RRNodeId(to_node));
+                from_xhigh = rr_graph.node_xhigh(from_rr);
+                to_xhigh = rr_graph.node_xhigh(to_rr);
                 if (from_ylow == to_ylow) {
                     /* UDSD Modification by WMF Begin */
                     /*For Fs > 3, can connect to overlapping wire segment */
@@ -426,8 +428,8 @@ static bool check_adjacent(int from_node, int to_node) {
             if (to_type == IPIN) {
                 num_adj += 1; //adjacent
             } else if (to_type == CHANY) {
-                from_yhigh = rr_graph.node_yhigh(RRNodeId(from_node));
-                to_yhigh = rr_graph.node_yhigh(RRNodeId(to_node));
+                from_yhigh = rr_graph.node_yhigh(from_rr);
+                to_yhigh = rr_graph.node_yhigh(to_rr);
                 if (from_xlow == to_xlow) {
                     /* UDSD Modification by WMF Begin */
                     if (to_yhigh == from_ylow - 1 || from_yhigh == to_ylow - 1) {
@@ -572,7 +574,7 @@ static void check_locally_used_clb_opins(const t_clb_opins_used& clb_opins_used_
                                     size_t(blk_id), cluster_ctx.clb_nlist.block_name(blk_id).c_str(), iclass, inode, rr_type);
                 }
 
-                ipin = device_ctx.rr_nodes[inode].ptc_num();
+                ipin = rr_graph.node_ptc_num(RRNodeId(inode));
                 if (physical_tile_type(blk_id)->pin_class[ipin] != iclass) {
                     VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
                                     "in check_locally_used_opins: block #%lu (%s):\n"

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -214,7 +214,7 @@ static void check_source(RRNodeId inode, ClusterNetId net_id) {
     int i = rr_graph.node_xlow(inode);
     int j = rr_graph.node_ylow(inode);
     /* for sinks and sources, ptc_num is class */
-    int ptc_num = rr_graph.node_ptc_num(inode);
+    int ptc_num = rr_graph.node_class_num(inode);
     /* First node_block for net is the source */
     ClusterBlockId blk_id = cluster_ctx.clb_nlist.net_driver_block(net_id);
     auto type = device_ctx.grid[i][j].type;
@@ -574,7 +574,7 @@ static void check_locally_used_clb_opins(const t_clb_opins_used& clb_opins_used_
                                     size_t(blk_id), cluster_ctx.clb_nlist.block_name(blk_id).c_str(), iclass, inode, rr_type);
                 }
 
-                ipin = rr_graph.node_ptc_num(RRNodeId(inode));
+                ipin = rr_graph.node_pin_num(RRNodeId(inode));
                 if (physical_tile_type(blk_id)->pin_class[ipin] != iclass) {
                     VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
                                     "in check_locally_used_opins: block #%lu (%s):\n"

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -282,7 +282,7 @@ static bool rr_node_is_global_clb_ipin(RRNodeId inode) {
     if (rr_graph.node_type(inode) != IPIN)
         return (false);
 
-    ipin = rr_graph.node_ptc_num(inode);
+    ipin = rr_graph.node_pin_num(inode);
 
     return type->is_ignored_pin[ipin];
 }

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -237,7 +237,7 @@ void check_rr_graph(const t_graph_type graph_type,
                     if (rr_graph.node_type(rr_node) == IPIN || rr_graph.node_type(rr_node) == OPIN) {
                         if (has_adjacent_channel(node, device_ctx.grid)) {
                             auto block_type = device_ctx.grid[rr_graph.node_xlow(rr_node)][rr_graph.node_ylow(rr_node)].type;
-                            std::string pin_name = block_type_pin_index_to_name(block_type, node.pin_num());
+                            std::string pin_name = block_type_pin_index_to_name(block_type, rr_graph.node_pin_num(rr_node));
                             /* Print error messages for all the sides that a node may appear */
                             for (const e_side& node_side : SIDES) {
                                 if (!rr_graph.is_node_on_specific_side(rr_node, node_side)) {
@@ -282,7 +282,7 @@ static bool rr_node_is_global_clb_ipin(RRNodeId inode) {
     if (rr_graph.node_type(inode) != IPIN)
         return (false);
 
-    ipin = device_ctx.rr_nodes[size_t(inode)].ptc_num();
+    ipin = rr_graph.node_ptc_num(inode);
 
     return type->is_ignored_pin[ipin];
 }
@@ -306,7 +306,7 @@ void check_rr_node(int inode, enum e_route_type route_type, const DeviceContext&
     xhigh = rr_graph.node_xhigh(rr_node);
     ylow = rr_graph.node_ylow(rr_node);
     yhigh = rr_graph.node_yhigh(rr_node);
-    ptc_num = device_ctx.rr_nodes[inode].ptc_num();
+    ptc_num = rr_graph.node_ptc_num(rr_node);
     capacity = rr_graph.node_capacity(rr_node);
     cost_index = rr_graph.node_cost_index(rr_node);
     type = nullptr;

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -103,7 +103,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
 
     int max_ptc = 0;
     for (RRNodeId inode : nodes_at_loc) {
-        max_ptc = std::max<int>(max_ptc, temp_rr_graph.node_ptc_num(inode));
+        max_ptc = std::max<int>(max_ptc, temp_rr_graph.node_class_num(inode));
     }
     int ptc = max_ptc + 1;
 

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -92,6 +92,7 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
 RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x, int y) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
     auto& rr_graph = device_ctx.rr_nodes;
+    auto& temp_rr_graph = device_ctx.rr_graph; //  replace this with rr_graph once device_ctx.rr_nodes is unused
     auto& rr_graph_builder = device_ctx.rr_graph_builder;
     auto& node_lookup = device_ctx.rr_graph_builder.node_lookup();
     rr_graph.emplace_back();
@@ -102,7 +103,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
 
     int max_ptc = 0;
     for (RRNodeId inode : nodes_at_loc) {
-        max_ptc = std::max<int>(max_ptc, rr_graph.node_ptc_num(inode));
+        max_ptc = std::max<int>(max_ptc, temp_rr_graph.node_ptc_num(inode));
     }
     int ptc = max_ptc + 1;
 
@@ -120,7 +121,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
     // However, since the SINK node has the same xhigh/xlow as well as yhigh/ylow, we can probably use a shortcut
     for (int ix = rr_graph.node_xlow(node_index); ix <= rr_graph.node_xhigh(node_index); ++ix) {
         for (int iy = rr_graph.node_ylow(node_index); iy <= rr_graph.node_yhigh(node_index); ++iy) {
-            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), rr_graph.node_ptc_num(node_index));
+            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), temp_rr_graph.node_ptc_num(node_index));
         }
     }
 

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -121,7 +121,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
     // However, since the SINK node has the same xhigh/xlow as well as yhigh/ylow, we can probably use a shortcut
     for (int ix = rr_graph.node_xlow(node_index); ix <= rr_graph.node_xhigh(node_index); ++ix) {
         for (int iy = rr_graph.node_ylow(node_index); iy <= rr_graph.node_yhigh(node_index); ++iy) {
-            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), temp_rr_graph.node_ptc_num(node_index));
+            node_lookup.add_node(node_index, ix, iy, rr_graph.node_type(node_index), temp_rr_graph.node_class_num(node_index));
         }
     }
 

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -350,7 +350,7 @@ int ClockRib::create_chanx_wire(int x_start,
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
             //TODO: CHANX uses odd swapped x/y indices here. Will rework once rr_node_indices is shadowed
-            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_ptc_num(chanx_node));
+            rr_graph_builder.node_lookup().add_node(chanx_node, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_track_num(chanx_node));
         }
     }
 

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -344,7 +344,8 @@ int ClockRib::create_chanx_wire(int x_start,
     rr_graph_builder.set_node_cost_index(chanx_node, RRIndexedDataId(CHANX_COST_INDEX_START + seg_index)); // Actual value set later
 
     /* Add the node to spatial lookup */
-    auto& rr_graph = (*rr_nodes);
+    //auto& rr_graph = (*rr_nodes);
+    const auto& rr_graph = g_vpr_ctx.device().rr_graph;
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
@@ -649,7 +650,8 @@ int ClockSpine::create_chany_wire(int y_start,
     rr_graph_builder.set_node_cost_index(chany_node, RRIndexedDataId(CHANX_COST_INDEX_START + num_segments + seg_index));
 
     /* Add the node to spatial lookup */
-    auto& rr_graph = (*rr_nodes);
+    //auto& rr_graph = (*rr_nodes);
+    const auto& rr_graph = g_vpr_ctx.device().rr_graph;
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -159,7 +159,7 @@ static void report_overused_ipin_opin(std::ostream& os, RRNodeId node_id) {
         grid_x == rr_graph.node_xhigh(node_id) && grid_y == rr_graph.node_yhigh(node_id),
         "Non-track RR node should not span across multiple grid blocks.");
 
-    os << "Pin number = " << device_ctx.rr_nodes.node_pin_num(node_id) << '\n';
+    os << "Pin number = " << rr_graph.node_pin_num(node_id) << '\n';
     os << "Side = " << rr_graph.node_side_string(node_id) << "\n\n";
 
     //Add block type for IPINs/OPINs in overused rr-node report
@@ -190,7 +190,7 @@ static void report_overused_chanx_chany(std::ostream& os, RRNodeId node_id) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
-    os << "Track number = " << device_ctx.rr_nodes.node_track_num(node_id) << '\n';
+    os << "Track number = " <<  rr_graph.node_track_num(node_id) << '\n';
     //Print out associated RC characteristics as they will be non-zero
     os << "Resistance = " << rr_graph.node_R(node_id) << '\n';
     os << "Capacitance = " << rr_graph.node_C(node_id) << '\n';
@@ -210,7 +210,7 @@ static void report_overused_source_sink(std::ostream& os, RRNodeId node_id) {
         grid_x == rr_graph.node_xhigh(node_id) && grid_y == rr_graph.node_yhigh(node_id),
         "Non-track RR node should not span across multiple grid blocks.");
 
-    os << "Class number = " << device_ctx.rr_nodes.node_class_num(node_id) << '\n';
+    os << "Class number = " << rr_graph.node_class_num(node_id) << '\n';
     os << "Grid location: X = " << grid_x << ", Y = " << grid_y << '\n';
 }
 
@@ -286,7 +286,7 @@ static void log_single_overused_node_status(int overuse_index, RRNodeId node_id)
     }
 
     //PTC number
-    VTR_LOG(" %7d", device_ctx.rr_nodes.node_ptc_num(node_id));
+    VTR_LOG(" %7d", rr_graph.node_ptc_num(node_id));
 
     //X_low
     VTR_LOG(" %7d", rr_graph.node_xlow(node_id));

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -190,7 +190,7 @@ static void report_overused_chanx_chany(std::ostream& os, RRNodeId node_id) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
-    os << "Track number = " <<  rr_graph.node_track_num(node_id) << '\n';
+    os << "Track number = " << rr_graph.node_track_num(node_id) << '\n';
     //Print out associated RC characteristics as they will be non-zero
     os << "Resistance = " << rr_graph.node_R(node_id) << '\n';
     os << "Capacitance = " << rr_graph.node_C(node_id) << '\n';

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -1283,7 +1283,7 @@ void print_route(FILE* fp, const vtr::vector<ClusterNetId, t_traceback>& traceba
 
                     auto physical_tile = device_ctx.grid[ilow][jlow].type;
                     if (!is_io_type(physical_tile) && (rr_type == IPIN || rr_type == OPIN)) {
-                        int pin_num = rr_graph.node_ptc_num(rr_node);
+                        int pin_num = rr_graph.node_pin_num(rr_node);
                         int xoffset = device_ctx.grid[ilow][jlow].width_offset;
                         int yoffset = device_ctx.grid[ilow][jlow].height_offset;
                         int sub_tile_offset = physical_tile->get_sub_tile_loc_from_pin(pin_num);

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -193,7 +193,7 @@ void get_serial_num() {
             serial_num += (size_t(net_id) + 1)
                           * (rr_graph.node_xlow(RRNodeId(inode)) * (device_ctx.grid.width()) - rr_graph.node_yhigh(RRNodeId(inode)));
 
-            serial_num -= device_ctx.rr_nodes[inode].ptc_num() * (size_t(net_id) + 1) * 10;
+            serial_num -= rr_graph.node_ptc_num(RRNodeId(inode)) * (size_t(net_id) + 1) * 10;
 
             serial_num -= rr_graph.node_type(RRNodeId(inode)) * (size_t(net_id) + 1) * 100;
             serial_num %= 2000000000; /* Prevent overflow */
@@ -1279,11 +1279,11 @@ void print_route(FILE* fp, const vtr::vector<ClusterNetId, t_traceback>& traceba
                             break;
                     }
 
-                    fprintf(fp, "%d  ", device_ctx.rr_nodes[inode].ptc_num());
+                    fprintf(fp, "%d  ", rr_graph.node_ptc_num(rr_node));
 
                     auto physical_tile = device_ctx.grid[ilow][jlow].type;
                     if (!is_io_type(physical_tile) && (rr_type == IPIN || rr_type == OPIN)) {
-                        int pin_num = device_ctx.rr_nodes[inode].ptc_num();
+                        int pin_num = rr_graph.node_ptc_num(rr_node);
                         int xoffset = device_ctx.grid[ilow][jlow].width_offset;
                         int yoffset = device_ctx.grid[ilow][jlow].height_offset;
                         int sub_tile_offset = physical_tile->get_sub_tile_loc_from_pin(pin_num);

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -66,7 +66,7 @@ static std::pair<float, int> run_dijkstra(RRNodeId start_node,
 
 std::pair<float, float> ExtendedMapLookahead::get_src_opin_cost(RRNodeId from_node, int delta_x, int delta_y, const t_conn_cost_params& params) const {
     auto& device_ctx = g_vpr_ctx.device();
-    auto& rr_graph = device_ctx.rr_nodes;
+    auto& rr_graph = device_ctx.rr_graph;
 
     //When estimating costs from a SOURCE/OPIN we look-up to find which wire types (and the
     //cost to reach them) in f_src_opin_delays. Once we know what wire types are
@@ -141,7 +141,7 @@ std::pair<float, float> ExtendedMapLookahead::get_src_opin_cost(RRNodeId from_no
 
 float ExtendedMapLookahead::get_chan_ipin_delays(RRNodeId to_node) const {
     auto& device_ctx = g_vpr_ctx.device();
-    auto& rr_graph = device_ctx.rr_nodes;
+    auto& rr_graph = device_ctx.rr_graph;
 
     e_rr_type to_type = rr_graph.node_type(to_node);
     VTR_ASSERT(to_type == SINK || to_type == IPIN);

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -255,8 +255,7 @@ float MapLookahead::get_expected_cost(RRNodeId current_node, RRNodeId target_nod
  * from the specified source to the specified target */
 std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_node, RRNodeId to_node, const t_conn_cost_params& params, float /*R_upstream*/) const {
     auto& device_ctx = g_vpr_ctx.device();
-    const auto& temp_rr_graph = device_ctx.rr_graph; //TODO rename to rr_graph once the variable on the next line is unneeded
-    auto& rr_graph = device_ctx.rr_nodes;
+    auto& rr_graph = device_ctx.rr_graph;
 
     int delta_x, delta_y;
     get_xy_deltas(from_node, to_node, &delta_x, &delta_y);
@@ -266,7 +265,7 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
     float expected_delay_cost = std::numeric_limits<float>::infinity();
     float expected_cong_cost = std::numeric_limits<float>::infinity();
 
-    e_rr_type from_type = temp_rr_graph.node_type(from_node);
+    e_rr_type from_type = rr_graph.node_type(from_node);
     if (from_type == SOURCE || from_type == OPIN) {
         //When estimating costs from a SOURCE/OPIN we look-up to find which wire types (and the
         //cost to reach them) in src_opin_delays. Once we know what wire types are
@@ -336,7 +335,7 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
         VTR_ASSERT_SAFE(from_type == CHANX || from_type == CHANY);
         //When estimating costs from a wire, we directly look-up the result in the wire lookahead (f_wire_cost_map)
 
-        auto from_cost_index = temp_rr_graph.node_cost_index(from_node);
+        auto from_cost_index = rr_graph.node_cost_index(from_node);
         int from_seg_index = device_ctx.rr_indexed_data[from_cost_index].seg_index;
 
         VTR_ASSERT(from_seg_index >= 0);

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -304,7 +304,7 @@ template void expand_dijkstra_neighbours(const t_rr_graph_storage& rr_nodes,
 t_src_opin_delays compute_router_src_opin_lookahead() {
     vtr::ScopedStartFinishTimer timer("Computing src/opin lookahead");
     auto& device_ctx = g_vpr_ctx.device();
-    auto& rr_graph = device_ctx.rr_nodes;
+    auto& rr_graph = device_ctx.rr_graph;
 
     t_src_opin_delays src_opin_delays;
 
@@ -436,7 +436,7 @@ static void dijkstra_flood_to_wires(int itile, RRNodeId node, util::t_src_opin_d
     root.delay = 0.;
     root.node = node;
 
-    int ptc = rr_graph.node_ptc_num(node);
+    int ptc = temp_rr_graph.node_ptc_num(node);
 
     /*
      * Perform Djikstra from the SOURCE/OPIN of interest, stopping at the the first
@@ -565,13 +565,13 @@ static void dijkstra_flood_to_ipins(RRNodeId node, util::t_chan_ipins_delays& ch
 
         e_rr_type curr_rr_type = temp_rr_graph.node_type(curr.node);
         if (curr_rr_type == IPIN) {
-            int node_x = rr_graph.node_xlow(curr.node);
-            int node_y = rr_graph.node_ylow(curr.node);
+            int node_x = temp_rr_graph.node_xlow(curr.node);
+            int node_y = temp_rr_graph.node_ylow(curr.node);
 
             auto tile_type = device_ctx.grid[node_x][node_y].type;
             int itile = tile_type->index;
 
-            int ptc = rr_graph.node_ptc_num(curr.node);
+            int ptc = temp_rr_graph.node_ptc_num(curr.node);
 
             if (ptc >= int(chan_ipins_delays[itile].size())) {
                 chan_ipins_delays[itile].resize(ptc + 1); //Inefficient but functional...

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1497,7 +1497,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
 
                             // Sanity check
                             VTR_ASSERT(rr_graph.is_node_on_specific_side(RRNodeId(inode), side));
-                            VTR_ASSERT(type->pinloc[width_offset][height_offset][side][L_rr_node.node_pin_num(inode)]);
+                            VTR_ASSERT(type->pinloc[width_offset][height_offset][side][rr_graph.node_pin_num(RRNodeId(inode))]);
                         }
                     }
                 }
@@ -2440,24 +2440,24 @@ std::string describe_rr_node(int inode) {
 
         if (seg_index < (int)device_ctx.rr_segments.size()) {
             msg += vtr::string_fmt(" track: %d longline: %d",
-                                   rr_node.track_num(),
+                                   rr_graph.node_track_num(RRNodeId(inode)),
                                    device_ctx.rr_segments[seg_index].longline);
         } else {
             msg += vtr::string_fmt(" track: %d seg_type: ILLEGAL_SEG_INDEX %d",
-                                   rr_node.track_num(),
+                                   rr_graph.node_track_num(RRNodeId(inode)),
                                    seg_index);
         }
     } else if (rr_graph.node_type(RRNodeId(inode)) == IPIN || rr_graph.node_type(RRNodeId(inode)) == OPIN) {
         auto type = device_ctx.grid[rr_graph.node_xlow(rr_node.id())][rr_graph.node_ylow(rr_node.id())].type;
-        std::string pin_name = block_type_pin_index_to_name(type, rr_node.pin_num());
+        std::string pin_name = block_type_pin_index_to_name(type, rr_graph.node_pin_num(rr_node.id()));
 
         msg += vtr::string_fmt(" pin: %d pin_name: %s",
-                               rr_node.pin_num(),
+                               rr_graph.node_pin_num(rr_node.id()),
                                pin_name.c_str());
     } else {
         VTR_ASSERT(rr_graph.node_type(RRNodeId(inode)) == SOURCE || rr_graph.node_type(RRNodeId(inode)) == SINK);
 
-        msg += vtr::string_fmt(" class: %d", rr_node.class_num());
+        msg += vtr::string_fmt(" class: %d", rr_graph.node_class_num(RRNodeId(inode)));
     }
 
     msg += vtr::string_fmt(" capacity: %d", rr_graph.node_capacity(RRNodeId(inode)));

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -210,7 +210,6 @@ static std::vector<std::vector<bool>> alloc_and_load_perturb_ipins(const int L_n
 static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                                    const int i,
                                    const int j,
-                                   t_rr_graph_storage& L_rr_node,
                                    t_rr_edge_info_set& rr_edges_to_create,
                                    const int delayless_switch,
                                    const DeviceGrid& grid);
@@ -1173,7 +1172,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
     /* Connection SINKS and SOURCES to their pins. */
     for (size_t i = 0; i < grid.width(); ++i) {
         for (size_t j = 0; j < grid.height(); ++j) {
-            build_rr_sinks_sources(rr_graph_builder, i, j, L_rr_node, rr_edges_to_create,
+            build_rr_sinks_sources(rr_graph_builder, i, j, rr_edges_to_create,
                                    delayless_switch, grid);
 
             //Create the actual SOURCE->OPIN, IPIN->SINK edges
@@ -1363,7 +1362,6 @@ void free_rr_graph() {
 static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                                    const int i,
                                    const int j,
-                                   t_rr_graph_storage& L_rr_node,
                                    t_rr_edge_info_set& rr_edges_to_create,
                                    const int delayless_switch,
                                    const DeviceGrid& grid) {

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -613,7 +613,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     }
 
     inline int get_node_loc_ptc(const t_rr_node& node) final {
-        return node.ptc_num();
+        return rr_graph_->node_ptc_num(node.id());
     }
     inline int get_node_loc_xhigh(const t_rr_node& node) final {
         return rr_graph_->node_xhigh(node.id());

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -92,11 +92,6 @@ class t_rr_node {
 
     signed short length() const;
 
-    short ptc_num() const;
-    short pin_num() const;   //Same as ptc_num() but checks that type() is consistent
-    short track_num() const; //Same as ptc_num() but checks that type() is consistent
-    short class_num() const; //Same as ptc_num() but checks that type() is consistent
-
     RRIndexedDataId cost_index() const;
     short rc_index() const;
 

--- a/vpr/src/route/rr_node_impl.h
+++ b/vpr/src/route/rr_node_impl.h
@@ -102,20 +102,4 @@ inline short t_rr_node::edge_switch(t_edge_size iedge) const {
     return storage_->edge_switch(id_, iedge);
 }
 
-inline short t_rr_node::ptc_num() const {
-    return storage_->node_ptc_num(id_);
-}
-
-inline short t_rr_node::pin_num() const {
-    return storage_->node_pin_num(id_);
-}
-
-inline short t_rr_node::track_num() const {
-    return storage_->node_track_num(id_);
-}
-
-inline short t_rr_node::class_num() const {
-    return storage_->node_class_num(id_);
-}
-
 #endif /* _RR_NODE_IMPL_H_ */

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -193,17 +193,17 @@ std::string rr_node_arch_name(int inode) {
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
-    const t_rr_node& rr_node = device_ctx.rr_nodes[inode];
+    auto rr_node = RRNodeId(inode);
 
     std::string rr_node_arch_name;
     if (rr_graph.node_type(RRNodeId(inode)) == OPIN || rr_graph.node_type(RRNodeId(inode)) == IPIN) {
         //Pin names
-        auto type = device_ctx.grid[rr_graph.node_xlow(rr_node.id())][rr_graph.node_ylow(rr_node.id())].type;
-        rr_node_arch_name += block_type_pin_index_to_name(type, rr_node.ptc_num());
+        auto type = device_ctx.grid[rr_graph.node_xlow(rr_node)][rr_graph.node_ylow(rr_node)].type;
+        rr_node_arch_name += block_type_pin_index_to_name(type, rr_graph.node_ptc_num(rr_node));
     } else if (rr_graph.node_type(RRNodeId(inode)) == SOURCE || rr_graph.node_type(RRNodeId(inode)) == SINK) {
         //Set of pins associated with SOURCE/SINK
-        auto type = device_ctx.grid[rr_graph.node_xlow(rr_node.id())][rr_graph.node_ylow(rr_node.id())].type;
-        auto pin_names = block_type_class_index_to_pin_names(type, rr_node.ptc_num());
+        auto type = device_ctx.grid[rr_graph.node_xlow(rr_node)][rr_graph.node_ylow(rr_node)].type;
+        auto pin_names = block_type_class_index_to_pin_names(type, rr_graph.node_ptc_num(rr_node));
         if (pin_names.size() > 1) {
             rr_node_arch_name += rr_graph.node_type_string(RRNodeId(inode));
             rr_node_arch_name += " connected to ";

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -199,11 +199,11 @@ std::string rr_node_arch_name(int inode) {
     if (rr_graph.node_type(RRNodeId(inode)) == OPIN || rr_graph.node_type(RRNodeId(inode)) == IPIN) {
         //Pin names
         auto type = device_ctx.grid[rr_graph.node_xlow(rr_node)][rr_graph.node_ylow(rr_node)].type;
-        rr_node_arch_name += block_type_pin_index_to_name(type, rr_graph.node_ptc_num(rr_node));
+        rr_node_arch_name += block_type_pin_index_to_name(type, rr_graph.node_pin_num(rr_node));
     } else if (rr_graph.node_type(RRNodeId(inode)) == SOURCE || rr_graph.node_type(RRNodeId(inode)) == SINK) {
         //Set of pins associated with SOURCE/SINK
         auto type = device_ctx.grid[rr_graph.node_xlow(rr_node)][rr_graph.node_ylow(rr_node)].type;
-        auto pin_names = block_type_class_index_to_pin_names(type, rr_graph.node_ptc_num(rr_node));
+        auto pin_names = block_type_class_index_to_pin_names(type, rr_graph.node_class_num(rr_node));
         if (pin_names.size() > 1) {
             rr_node_arch_name += rr_graph.node_type_string(RRNodeId(inode));
             rr_node_arch_name += " connected to ";


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
In this PR, I have implemented `RRGraphView::node_ptc_num()`, `RRGraphView::node_pin_num()`, `RRGraphView::node_class_num()`, `RRGraphView::node_track_num()` throughout VTR. Every time `device_ctx.rr_nodes[node].node_ptc_num()` was called has been replaced with `rr_graph.node_ptc_num(RRNodeId(node))`. The same pattern was followed for the other functions in this PR. In order to do this, I followed a pattern similar to that in the last PR.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes are a continuation of the RRGraphView API implementation effort.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


I have run the regression tests for `vtr_reg_strong` along with the QoR testing found at `    $ ../scripts/run_vtr_task.py regression_tests/vtr_reg_nightly_test3/vtr_reg_qor_chain`. Results from these QoR tests can be found below. The file containing all results can be found [here](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/6555913/rr_graph_view_node_type.xlsx).



Only rows that are different are shown. For some reason, `vtr_flow_elapsed_time` was empty in the spreadsheet.

|	| VTR Before These Changes	|With Changes in this PR|
|---|---|---|
|odin_synth_time	|1|	0.984647269|
|abc_synth_time	|1|	1.001007005|
|max_vpr_mem	|1|	0.999800843|
|pack_time	|1|	0.997122006|
|place_time	|1|	0.992015738|
|min_chan_width_route_time	|1|	0.996755548|
|crit_path_route_time	|1|	1.01858794|




#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed