### PR TITLE
RRGraphView rr_segments() Implementation

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -174,7 +174,7 @@ struct DeviceContext : public Context {
     std::vector<t_rr_switch_inf> rr_switch_inf;
 
     ///@brief Wire segment types in RR graph
-    std::vector<t_segment_inf> rr_segments;
+    vtr::vector<RRSegmentId, t_segment_inf> rr_segments;
 
     int num_arch_switches;
     t_arch_switch_inf* arch_switch_inf; // [0..(num_arch_switches-1)]

--- a/vpr/src/device/rr_graph_view.cpp
+++ b/vpr/src/device/rr_graph_view.cpp
@@ -2,7 +2,7 @@
 #include "rr_node.h"
 #include "physical_types.h"
 
-RRGraphView::RRGraphView(const t_rr_graph_storage& node_storage, const RRSpatialLookup& node_lookup, const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data, const std::vector<t_segment_inf>& rr_segments)
+RRGraphView::RRGraphView(const t_rr_graph_storage& node_storage, const RRSpatialLookup& node_lookup, const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data, const vtr::vector<RRSegmentId, t_segment_inf>& rr_segments)
     : node_storage_(node_storage)
     , node_lookup_(node_lookup)
     , rr_indexed_data_(rr_indexed_data)

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -38,7 +38,7 @@ class RRGraphView {
     RRGraphView(const t_rr_graph_storage& node_storage,
                 const RRSpatialLookup& node_lookup,
                 const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
-                const std::vector<t_segment_inf>& rr_segments);
+                const vtr::vector<RRSegmentId, t_segment_inf>& rr_segments);
 
     /* Disable copy constructors and copy assignment operator
      * This is to avoid accidental copy because it could be an expensive operation considering that the 
@@ -209,7 +209,7 @@ class RRGraphView {
         } else if (node_type(node) == CHANX || node_type(node) == CHANY) { //for channels, we would like to describe the component with segment specific information
             RRIndexedDataId cost_index = node_cost_index(node);
             int seg_index = rr_indexed_data_[cost_index].seg_index;
-            coordinate_string += rr_segments_[seg_index].name;                   //Write the segment name
+            coordinate_string += rr_segments(RRSegmentId(seg_index)).name;       //Write the segment name
             coordinate_string += " length:" + std::to_string(node_length(node)); //add the length of the segment
             //Figure out the starting and ending coordinate of the segment depending on the direction
 
@@ -258,7 +258,13 @@ class RRGraphView {
      * This API is very powerful and developers should not use it unless it is necessary, 
      * e.g the node type is unknown. If the node type is known, the more specific routines, `node_pin_num()`, 
      * `node_track_num()`and `node_class_num()`, for different types of nodes should be used.*/
+    /** @brief Return detailed routing segment information with a given id* @note The routing segments here may not be exactly same as those defined in architecture file. They have been
+     * adapted to fit the context of routing resource graphs.
+     */
 
+    inline const t_segment_inf& rr_segments(RRSegmentId seg_id) const {
+        return rr_segments_[seg_id];
+    }
     inline short node_ptc_num(RRNodeId node) const {
         return node_storage_.node_ptc_num(node);
     }
@@ -303,7 +309,7 @@ class RRGraphView {
     const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data_;
 
     /* Segment info for rr nodes */
-    const std::vector<t_segment_inf>& rr_segments_;
+    const vtr::vector<RRSegmentId, t_segment_inf>& rr_segments_;
 };
 
 #endif

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -912,7 +912,7 @@ static void power_usage_routing(t_power_usage* power_usage,
                     wire_length = rr_graph.node_yhigh(rr_node) - rr_graph.node_ylow(rr_node) + 1;
                 }
                 int seg_index = device_ctx.rr_indexed_data[rr_graph.node_cost_index(rr_node)].seg_index;
-                C_wire = wire_length * device_ctx.rr_segments[seg_index].Cmetal;
+                C_wire = wire_length * rr_graph.rr_segments(RRSegmentId(seg_index)).Cmetal;
                 //(double)power_ctx.commonly_used->tile_length);
                 VTR_ASSERT(node_power->selected_input < node_fan_in);
 

--- a/vpr/src/power/power_sizing.cpp
+++ b/vpr/src/power/power_sizing.cpp
@@ -378,19 +378,19 @@ static double power_count_transistors_switchbox() {
                            power_ctx.arch->mux_transistor_size));
 
     auto& device_ctx = g_vpr_ctx.device();
-
+    const auto& rr_graph = device_ctx.rr_graph;
     for (size_t seg_idx = 0; seg_idx < device_ctx.rr_segments.size(); seg_idx++) {
         /* In each switchbox, the different types of segments occur with relative freqencies.
          * Thus the total number of wires of each segment type is (#tracks * freq * 2).
          * The (x2) factor accounts for vertical and horizontal tracks.
          * Of the wires of each segment type only (1/seglength) will have a mux&buffer.
          */
-        float freq_frac = (float)device_ctx.rr_segments[seg_idx].frequency
+        float freq_frac = (float)rr_graph.rr_segments(RRSegmentId(seg_idx)).frequency
                           / (float)MAX_CHANNEL_WIDTH;
 
         transistor_cnt += transistors_per_buf_mux * 2 * freq_frac
                           * power_ctx.solution_inf.channel_width
-                          * (1 / (float)device_ctx.rr_segments[seg_idx].length);
+                          * (1 / (float)rr_graph.rr_segments(RRSegmentId(seg_idx)).length);
     }
 
     return transistor_cnt;

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -229,7 +229,7 @@ std::pair<float, float> ExtendedMapLookahead::get_expected_delay_and_cong(RRNode
     float expected_cost = expected_delay_cost + expected_cong_cost;
 
     VTR_LOGV_DEBUG(f_router_debug, "Requested lookahead from node %d to %d\n", size_t(from_node), size_t(to_node));
-    const std::string& segment_name = device_ctx.rr_segments[from_seg_index].name;
+    const std::string& segment_name = rr_graph.rr_segments(RRSegmentId(from_seg_index)).name;
     VTR_LOGV_DEBUG(f_router_debug, "Lookahead returned %s (%d) with distance (%d, %d)\n",
                    segment_name.c_str(), from_seg_index,
                    dx, dy);

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1354,6 +1354,8 @@ void free_rr_graph() {
 
     device_ctx.rr_switch_inf.clear();
 
+    device_ctx.rr_segments.clear();
+
     device_ctx.switch_fanin_remap.clear();
 
     device_ctx.rr_node_metadata.clear();

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -444,7 +444,11 @@ static void build_rr_graph(const t_graph_type graph_type,
     }
 
     /* START SEG_DETAILS */
-    device_ctx.rr_segments = segment_inf;
+    size_t num_segments = segment_inf.size();
+    device_ctx.rr_segments.reserve(num_segments);
+    for (long unsigned int iseg = 0; iseg < num_segments; ++iseg) {
+        device_ctx.rr_segments.push_back(segment_inf[(iseg)]);
+    }
     int num_seg_details = 0;
     t_seg_details* seg_details = nullptr;
 
@@ -2439,7 +2443,7 @@ std::string describe_rr_node(int inode) {
         if (seg_index < (int)device_ctx.rr_segments.size()) {
             msg += vtr::string_fmt(" track: %d longline: %d",
                                    rr_graph.node_track_num(RRNodeId(inode)),
-                                   device_ctx.rr_segments[seg_index].longline);
+                                   rr_graph.rr_segments(RRSegmentId(seg_index)).longline);
         } else {
             msg += vtr::string_fmt(" track: %d seg_type: ILLEGAL_SEG_INDEX %d",
                                    rr_graph.node_track_num(RRNodeId(inode)),

--- a/vpr/src/route/rr_graph_reader.cpp
+++ b/vpr/src/route/rr_graph_reader.cpp
@@ -47,7 +47,11 @@ void load_rr_file(const t_graph_type graph_type,
 
     auto& device_ctx = g_vpr_ctx.mutable_device();
 
-    device_ctx.rr_segments = segment_inf;
+    size_t num_segments = segment_inf.size();
+    device_ctx.rr_segments.reserve(num_segments);
+    for (long unsigned int iseg = 0; iseg < num_segments; ++iseg) {
+        device_ctx.rr_segments.push_back(segment_inf[(iseg)]);
+    }
 
     RrGraphSerializer reader(
         graph_type,

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -16,7 +16,7 @@
 #include "check_rr_graph.h"
 #include "rr_graph2.h"
 #include "rr_graph_indexed_data.h"
-
+#include "globals.h"
 class MetadataBind {
   public:
     MetadataBind(vtr::string_internment* strings, vtr::interned_string empty)
@@ -265,7 +265,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         vtr::vector<RRIndexedDataId, t_rr_indexed_data>* rr_indexed_data,
         const size_t num_arch_switches,
         const t_arch_switch_inf* arch_switch_inf,
-        const std::vector<t_segment_inf>& segment_inf,
+        const vtr::vector<RRSegmentId, t_segment_inf>& segment_inf,
         const std::vector<t_physical_tile_type>& physical_tile_types,
         const DeviceGrid& grid,
         MetadataStorage<int>* rr_node_metadata,
@@ -1152,7 +1152,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
      * </xs:complexType>
      */
     inline int get_segment_id(const t_segment_inf*& segment) final {
-        return segment - &segment_inf_.at(0);
+        return segment - &segment_inf_.at(RRSegmentId(0));
     }
     inline const char* get_segment_name(const t_segment_inf*& segment) final {
         return segment->name.c_str();
@@ -1180,14 +1180,14 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         }
     }
     inline const t_segment_inf* add_segments_segment(void*& /*ctx*/, int id) final {
-        return &segment_inf_.at(id);
+        return &segment_inf_.at(RRSegmentId(id));
     }
     inline void finish_segments_segment(const t_segment_inf*& /*iter*/) final {}
     inline size_t num_segments_segment(void*& /*iter*/) final {
         return segment_inf_.size();
     }
     inline const t_segment_inf* get_segments_segment(int n, void*& /*ctx*/) final {
-        return &segment_inf_.at(n);
+        return &segment_inf_.at(RRSegmentId(n));
     }
 
     inline void* init_rr_graph_segments(void*& /*ctx*/) final {
@@ -1547,12 +1547,24 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     }
 
     void finish_load() final {
+        auto& device_ctx = g_vpr_ctx.mutable_device();
         process_rr_node_indices();
 
         rr_graph_builder_->init_fan_in();
+        /* Create a temp copy to convert from vtr::vector to std::vector
+         * This is required because the ``alloc_and_load_rr_indexed_data()`` function supports only std::vector data
+         * type for ``rr_segments``
+         * Note that this is a dirty fix (to avoid massive code changes)
+         * TODO: The ``alloc_and_load_rr_indexed_data()`` function should embrace ``vtr::vector`` for ``rr_segments``
+         */
+        std::vector<t_segment_inf> temp_rr_segs;
+        temp_rr_segs.reserve(segment_inf_.size());
+        for (auto& rr_seg : device_ctx.rr_segments) {
+            temp_rr_segs.push_back(rr_seg);
+        }
 
         alloc_and_load_rr_indexed_data(
-            segment_inf_,
+            temp_rr_segs,
             *wire_to_rr_ipin_switch_,
             base_cost_type_);
 
@@ -1873,7 +1885,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
     const size_t num_arch_switches_;
     const t_arch_switch_inf* arch_switch_inf_;
-    const std::vector<t_segment_inf>& segment_inf_;
+    const vtr::vector<RRSegmentId, t_segment_inf>& segment_inf_;
     const std::vector<t_physical_tile_type>& physical_tile_types_;
     const DeviceGrid& grid_;
     MetadataStorage<int>* rr_node_metadata_;

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -16,7 +16,6 @@
 #include "check_rr_graph.h"
 #include "rr_graph2.h"
 #include "rr_graph_indexed_data.h"
-#include "globals.h"
 class MetadataBind {
   public:
     MetadataBind(vtr::string_internment* strings, vtr::interned_string empty)
@@ -1547,7 +1546,6 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     }
 
     void finish_load() final {
-        auto& device_ctx = g_vpr_ctx.mutable_device();
         process_rr_node_indices();
 
         rr_graph_builder_->init_fan_in();
@@ -1559,7 +1557,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
          */
         std::vector<t_segment_inf> temp_rr_segs;
         temp_rr_segs.reserve(segment_inf_.size());
-        for (auto& rr_seg : device_ctx.rr_segments) {
+        for (auto& rr_seg : segment_inf_) {
             temp_rr_segs.push_back(rr_seg);
         }
 

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -219,7 +219,7 @@ std::string rr_node_arch_name(int inode) {
         auto cost_index = rr_graph.node_cost_index(RRNodeId(inode));
         int seg_index = device_ctx.rr_indexed_data[cost_index].seg_index;
 
-        rr_node_arch_name += device_ctx.rr_segments[seg_index].name;
+        rr_node_arch_name += rr_graph.rr_segments(RRSegmentId(seg_index)).name;
     }
 
     return rr_node_arch_name;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
In this PR, I am implementing RRGraphView::rr_segments(PRSegmentId Seg_Id ) throughout VTR. Every time device_ctx.rr_segment[Seg_Id] was called has been replaced with rr_graph.rr_segment(Seg_Id). In order to do this, I followed a pattern similar to that in the last PR.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
These changes are a continuation of the RRGraphView API implementation effort.

#### How Has This Been Tested?

- [x]  All vtr basic and strong tests are passing.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
