### PR TITLE
Issue #1797: Change VTR_LOG to VTR_LOG_WARN and remove the string "Error"

### DIFF
--- a/vpr/src/base/read_activity.cpp
+++ b/vpr/src/base/read_activity.cpp
@@ -19,8 +19,8 @@ static bool add_activity_to_net(const AtomNetlist& netlist, std::unordered_map<A
         return false;
     }
 
-    VTR_LOG(
-        "Error: net %s found in activity file, but it does not exist in the .blif file.\n",
+    VTR_LOG_WARN(
+        "Net %s found in activity file, but it does not exist in the .blif file.\n",
         net_name);
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The power flow currently prints an info message containing the word "error". This needs to be warning as discussed in the related issue.

#### Related Issue
Issue #1797 
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
Removes confusing error message from log files
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Minor change. I checked that the message prints as a warning.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
