### PR TITLE
Small improvements to string description of rr nodes

### DIFF
--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -202,11 +202,11 @@ class RRGraphView {
             // and the end to the lower coordinate
             start_x = " (" + std::to_string(node_xhigh(node)) + ","; //start and end coordinates are the same for OPINs and IPINs
             start_y = std::to_string(node_yhigh(node)) + ")";
-            end_x = "";
-            end_y = "";
-            arrow = "";
-        }
-        if (node_type(node) == CHANX || node_type(node) == CHANY) { //for channels, we would like to describe the component with segment specific information
+        } else if (node_type(node) == SOURCE || node_type(node) == SINK) {
+            // For SOURCE and SINK the starting and ending coordinate are identical, so just use start
+            start_x = "(" + std::to_string(node_xhigh(node)) + ",";
+            start_y = std::to_string(node_yhigh(node)) + ")";
+        } else if (node_type(node) == CHANX || node_type(node) == CHANY) { //for channels, we would like to describe the component with segment specific information
             RRIndexedDataId cost_index = node_cost_index(node);
             int seg_index = rr_indexed_data_[cost_index].seg_index;
             coordinate_string += rr_segments_[seg_index].name;                   //Write the segment name

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2464,7 +2464,7 @@ std::string describe_rr_node(int inode) {
     msg += vtr::string_fmt(" fan-in: %d", rr_graph.node_fan_in(RRNodeId(inode)));
     msg += vtr::string_fmt(" fan-out: %d", rr_node.num_edges());
 
-    msg += rr_graph.node_coordinate_to_string(RRNodeId(inode));
+    msg += " " + rr_graph.node_coordinate_to_string(RRNodeId(inode));
 
     return msg;
 }


### PR DESCRIPTION
This fixes two issues with the string description of rr nodes (describe_rr_node)
1. Adds a missing space character.
2. Adds the x,y location for SINK and SOURCE rr nodes.  This was previously missing and it made it difficult to locate a given SOURCE/SINK rr node from an error message (in my case it was failed routing error message that only printed SOURCE and SINK description).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
