### PR TITLE
RRGraphView::node_first_edge() Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ tags
 #
 .vscode
 .history
+#eclipse project
+.project

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -123,7 +123,7 @@ class RRGraphView {
     inline short node_yhigh(RRNodeId node) const {
         return node_storage_.node_yhigh(node);
     }
-       /** @brief Get the first edge of resource node. This function is inlined for runtime optimization. */
+    /** @brief Get the first edge of resource node. This function is inlined for runtime optimization. */
     inline RREdgeId node_first_edge(RRNodeId node) const {
         return node_storage_.first_edge(node);
     }

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -123,10 +123,12 @@ class RRGraphView {
     inline short node_yhigh(RRNodeId node) const {
         return node_storage_.node_yhigh(node);
     }
+
     /** @brief Get the first edge of resource node. This function is inlined for runtime optimization. */
     inline RREdgeId node_first_edge(RRNodeId node) const {
         return node_storage_.first_edge(node);
     }
+
     /** @brief Get the length (number of grid tile units spanned by the wire, including the endpoints) of a routing resource node.
      * node_length() only applies to CHANX or CHANY and is always a positive number
      * This function is inlined for runtime optimization.
@@ -144,8 +146,6 @@ class RRGraphView {
                  && (node_xlow(node) == -1) && (node_ylow(node) == -1)
                  && (node_xhigh(node) == -1) && (node_yhigh(node) == -1));
     }
-
-    
 
     /** @brief Check if two routing resource nodes are adjacent (must be a CHANX and a CHANY). 
      * This function is used for error checking; it checks if two nodes are physically adjacent (could be connected) based on their geometry.

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -124,7 +124,7 @@ class RRGraphView {
         return node_storage_.node_yhigh(node);
     }
 
-    /** @brief Get the first edge of resource node. This function is inlined for runtime optimization. */
+    /** @brief Get the first out coming edge of resource node. This function is inlined for runtime optimization. */
     inline RREdgeId node_first_edge(RRNodeId node) const {
         return node_storage_.first_edge(node);
     }

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -123,7 +123,10 @@ class RRGraphView {
     inline short node_yhigh(RRNodeId node) const {
         return node_storage_.node_yhigh(node);
     }
-
+       /** @brief Get the first edge of resource node. This function is inlined for runtime optimization. */
+    inline RREdgeId node_first_edge(RRNodeId node) const {
+        return node_storage_.first_edge(node);
+    }
     /** @brief Get the length (number of grid tile units spanned by the wire, including the endpoints) of a routing resource node.
      * node_length() only applies to CHANX or CHANY and is always a positive number
      * This function is inlined for runtime optimization.
@@ -141,6 +144,8 @@ class RRGraphView {
                  && (node_xlow(node) == -1) && (node_ylow(node) == -1)
                  && (node_xhigh(node) == -1) && (node_yhigh(node) == -1));
     }
+
+    
 
     /** @brief Check if two routing resource nodes are adjacent (must be a CHANX and a CHANY). 
      * This function is used for error checking; it checks if two nodes are physically adjacent (could be connected) based on their geometry.

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -129,6 +129,11 @@ class RRGraphView {
         return node_storage_.first_edge(node);
     }
 
+    /** @brief Get the last edge of resource node. This function is inlined for runtime optimization. */
+    inline RREdgeId node_last_edge(RRNodeId node) const {
+        return node_storage_.last_edge(node);
+    }
+
     /** @brief Get the length (number of grid tile units spanned by the wire, including the endpoints) of a routing resource node.
      * node_length() only applies to CHANX or CHANY and is always a positive number
      * This function is inlined for runtime optimization.

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -129,7 +129,7 @@ class RRGraphView {
         return node_storage_.first_edge(node);
     }
 
-    /** @brief Get the last edge of resource node. This function is inlined for runtime optimization. */
+    /** @brief Get the last out coming edge of resource node. This function is inlined for runtime optimization. */
     inline RREdgeId node_last_edge(RRNodeId node) const {
         return node_storage_.last_edge(node);
     }

--- a/vpr/src/route/rr_graph_util.cpp
+++ b/vpr/src/route/rr_graph_util.cpp
@@ -98,6 +98,7 @@ int seg_index_of_sblock(int from_node, int to_node) {
 void reorder_rr_graph_nodes(const t_router_opts& router_opts) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
     auto& graph = device_ctx.rr_nodes;
+    auto& rr_graph = device_ctx.rr_graph;
     size_t v_num = graph.size();
 
     if (router_opts.reorder_rr_graph_nodes_algorithm == DONT_REORDER) return;
@@ -129,7 +130,7 @@ void reorder_rr_graph_nodes(const t_router_opts& router_opts) {
                 RRNodeId u = que.front();
                 que.pop();
                 degree[u] += graph.num_edges(u);
-                for (RREdgeId edge = graph.first_edge(u); edge < graph.last_edge(u); edge = RREdgeId(size_t(edge) + 1)) {
+                for (RREdgeId edge = rr_graph.node_first_edge(u); edge < graph.last_edge(u); edge = RREdgeId(size_t(edge) + 1)) {
                     RRNodeId v = graph.edge_sink_node(edge);
                     degree[v]++;
                     if (bfs_idx[v]) continue;

--- a/vpr/src/route/rr_graph_util.cpp
+++ b/vpr/src/route/rr_graph_util.cpp
@@ -130,7 +130,7 @@ void reorder_rr_graph_nodes(const t_router_opts& router_opts) {
                 RRNodeId u = que.front();
                 que.pop();
                 degree[u] += graph.num_edges(u);
-                for (RREdgeId edge = rr_graph.node_first_edge(u); edge < graph.last_edge(u); edge = RREdgeId(size_t(edge) + 1)) {
+                for (RREdgeId edge = rr_graph.node_first_edge(u); edge < rr_graph.node_last_edge(u); edge = RREdgeId(size_t(edge) + 1)) {
                     RRNodeId v = graph.edge_sink_node(edge);
                     degree[v]++;
                     if (bfs_idx[v]) continue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
In this PR, I have implemented RRGraphView::node_first_edge() throughout VTR. Every time device_ctx.graph.first_edge() was called has been replaced with rr_graph.node_first_edge( RRNodeId (index)). In order to do this, I followed a pattern similar to that in the last PR.
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
These changes are a continuation of the RRGraphView API implementation effort.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
