### PR TITLE
RRGraphView edge_sink_node()/edge_switch() Implementation

### DIFF
--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -257,7 +257,7 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
         for(size_t inode = 0; inode < device_ctx.rr_nodes.size(); ++inode) {
             for(t_edge_size iedge = 0; iedge < device_ctx.rr_nodes[inode].num_edges(); ++iedge) {
                 auto sink_inode = device_ctx.rr_nodes[inode].edge_sink_node(iedge);
-                auto switch_id = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                auto switch_id = rr_graph.edge_switch(RREdgeId(iedge));
                 auto value = vtr::string_fmt("%d_%d_%zu",
                             inode, sink_inode, switch_id);
 

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -281,6 +281,10 @@ class RRGraphView {
         return node_storage_.node_class_num(node);
     }
 
+    inline short edge_switch(const RREdgeId& edge) const {
+        return node_storage_.edge_switch(edge);
+    }
+
     /** @brief Get the cost index of a routing resource node. This function is inlined for runtime optimization. */
     RRIndexedDataId node_cost_index(RRNodeId node) const {
         return node_storage_.node_cost_index(node);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1789,7 +1789,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
                         } else {
                             g->set_color(blk_DARKGREEN);
                         }
-                        switch_type = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                        switch_type = rr_graph.edge_switch(RREdgeId(iedge));
                         draw_chanx_to_chany_edge(inode, from_ptc_num, to_node,
                                                  to_ptc_num, FROM_X_TO_Y, switch_type, g);
                         break;
@@ -1842,7 +1842,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
                         } else {
                             g->set_color(blk_DARKGREEN);
                         }
-                        switch_type = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                        switch_type = rr_graph.edge_switch(RREdgeId(iedge));
                         draw_chanx_to_chany_edge(to_node, to_ptc_num, inode,
                                                  from_ptc_num, FROM_Y_TO_X, switch_type, g);
                         break;

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1772,7 +1772,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
                         } else {
                             g->set_color(blk_DARKGREEN);
                         }
-                        switch_type = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                        switch_type = rr_graph.edge_switch(RREdgeId(iedge));
                         draw_chanx_to_chanx_edge(RRNodeId(inode), RRNodeId(to_node),
                                                  to_ptc_num, switch_type, g);
                         break;
@@ -2519,7 +2519,7 @@ void draw_partial_route(const std::vector<int>& rr_nodes_to_draw, ezgl::renderer
         auto prev_type = rr_graph.node_type(RRNodeId(prev_node));
 
         auto iedge = find_edge(prev_node, inode);
-        auto switch_type = device_ctx.rr_nodes[prev_node].edge_switch(iedge);
+        auto switch_type = rr_graph.edge_switch(RREdgeId(iedge));
 
         switch (rr_type) {
             case OPIN: {

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1860,7 +1860,7 @@ static void draw_rr_edges(int inode, ezgl::renderer* g) {
                         } else {
                             g->set_color(blk_DARKGREEN);
                         }
-                        switch_type = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                        switch_type =rr_graph.edge_switch(RREdgeId(iedge));
                         draw_chany_to_chany_edge(RRNodeId(inode), RRNodeId(to_node),
                                                  to_ptc_num, switch_type, g);
                         break;

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -1265,7 +1265,7 @@ void power_routing_init(const t_det_routing_arch* routing_arch) {
                 if (rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type == OPEN) {
                     rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type = rr_graph.edge_switch(RREdgeId(edge_idx));
                 } else {
-                    VTR_ASSERT(rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type == node.edge_switch(edge_idx));
+                    VTR_ASSERT(rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type == rr_graph.edge_switch(RREdgeId(edge_idx)));
                 }
             }
         }

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -982,7 +982,7 @@ static void power_usage_routing(t_power_usage* power_usage,
                 connectionbox_fanout = 0;
                 switchbox_fanout = 0;
                 for (t_edge_size iedge = 0; iedge < node.num_edges(); iedge++) {
-                    if (node.edge_switch(iedge) == routing_arch->wire_to_rr_ipin_switch) {
+                    if (rr_graph.edge_switch(RREdgeId(iedge)) == routing_arch->wire_to_rr_ipin_switch) {
                         connectionbox_fanout++;
                     } else if (node.edge_switch(iedge) == routing_arch->delayless_switch) {
                         /* Do nothing */
@@ -1226,7 +1226,7 @@ void power_routing_init(const t_det_routing_arch* routing_arch) {
             case CHANX:
             case CHANY:
                 for (t_edge_size iedge = 0; iedge < node.num_edges(); iedge++) {
-                    if (node.edge_switch(iedge) == routing_arch->wire_to_rr_ipin_switch) {
+                    if (rr_graph.edge_switch(RREdgeId(iedge)) == routing_arch->wire_to_rr_ipin_switch) {
                         fanout_to_IPIN++;
                     } else if (node.edge_switch(iedge) != routing_arch->delayless_switch) {
                         fanout_to_seg++;

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -984,7 +984,7 @@ static void power_usage_routing(t_power_usage* power_usage,
                 for (t_edge_size iedge = 0; iedge < node.num_edges(); iedge++) {
                     if (rr_graph.edge_switch(RREdgeId(iedge)) == routing_arch->wire_to_rr_ipin_switch) {
                         connectionbox_fanout++;
-                    } else if (node.edge_switch(iedge) == routing_arch->delayless_switch) {
+                    } else if (rr_graph.edge_switch(RREdgeId(iedge)) == routing_arch->delayless_switch) {
                         /* Do nothing */
                     } else {
                         switchbox_fanout++;
@@ -1228,7 +1228,7 @@ void power_routing_init(const t_det_routing_arch* routing_arch) {
                 for (t_edge_size iedge = 0; iedge < node.num_edges(); iedge++) {
                     if (rr_graph.edge_switch(RREdgeId(iedge)) == routing_arch->wire_to_rr_ipin_switch) {
                         fanout_to_IPIN++;
-                    } else if (node.edge_switch(iedge) != routing_arch->delayless_switch) {
+                    } else if (rr_graph.edge_switch(RREdgeId(iedge)) != routing_arch->delayless_switch) {
                         fanout_to_seg++;
                     }
                 }
@@ -1263,7 +1263,7 @@ void power_routing_init(const t_det_routing_arch* routing_arch) {
         for (t_edge_size edge_idx = 0; edge_idx < node.num_edges(); edge_idx++) {
             if (node.edge_sink_node(edge_idx) != OPEN) {
                 if (rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type == OPEN) {
-                    rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type = node.edge_switch(edge_idx);
+                    rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type = rr_graph.edge_switch(RREdgeId(edge_idx));
                 } else {
                     VTR_ASSERT(rr_node_power[node.edge_sink_node(edge_idx)].driver_switch_type == node.edge_switch(edge_idx));
                 }

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -94,7 +94,7 @@ void check_rr_graph(const t_graph_type graph_type,
             edges.emplace_back(to_node, iedge);
             total_edges_to_node[to_node]++;
 
-            auto switch_type = device_ctx.rr_nodes[inode].edge_switch(iedge);
+            auto switch_type =rr_graph.edge_switch(RREdgeId(iedge));
 
             if (switch_type < 0 || switch_type >= num_rr_switches) {
                 VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
@@ -553,7 +553,7 @@ static void check_unbuffered_edges(int from_node) {
         if (to_rr_type != CHANX && to_rr_type != CHANY)
             continue;
 
-        from_switch_type = device_ctx.rr_nodes[from_node].edge_switch(from_edge);
+        from_switch_type = rr_graph.edge_switch(RREdgeId(from_edge));
 
         if (device_ctx.rr_switch_inf[from_switch_type].buffered())
             continue;
@@ -606,7 +606,7 @@ static void check_rr_edge(int from_node, int iedge, int to_node) {
     const auto& rr_graph = device_ctx.rr_graph;
 
     //Check that to to_node's fan-in is correct, given the switch type
-    int iswitch = device_ctx.rr_nodes[from_node].edge_switch(iedge);
+    int iswitch = rr_graph.edge_switch(RREdgeId(iedge));
     auto switch_type = device_ctx.rr_switch_inf[iswitch].type();
 
     int to_fanin = rr_graph.node_fan_in(RRNodeId(to_node));

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -158,7 +158,7 @@ void check_rr_graph(const t_graph_type graph_type,
             std::map<short, int> switch_counts;
             for (const auto& to_edge : vtr::Range<decltype(edges)::const_iterator>(range.first, range.second)) {
                 auto edge = to_edge.second;
-                auto edge_switch = device_ctx.rr_nodes[inode].edge_switch(edge);
+                auto edge_switch = rr_graph.edge_switch(RREdgeId(edge));
 
                 switch_counts[edge_switch]++;
             }
@@ -567,7 +567,7 @@ static void check_unbuffered_edges(int from_node) {
 
         for (to_edge = 0; to_edge < to_num_edges; to_edge++) {
             if (device_ctx.rr_nodes[to_node].edge_sink_node(to_edge) == from_node
-                && device_ctx.rr_nodes[to_node].edge_switch(to_edge) == from_switch_type) {
+                && rr_graph.edge_switch(RREdgeId(to_edge)) == from_switch_type) {
                 trans_matched = true;
                 break;
             }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -627,6 +627,7 @@ static std::pair<t_trace*, t_trace*> add_trace_non_configurable_recurr(int node,
     //Record the non-configurable out-going edges
     std::vector<t_edge_size> unvisited_non_configurable_edges;
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph=device_ctx.rr_graph;
     for (auto iedge : device_ctx.rr_nodes[node].non_configurable_edges()) {
         VTR_ASSERT_SAFE(!device_ctx.rr_nodes[node].edge_is_configurable(iedge));
 
@@ -654,7 +655,7 @@ static std::pair<t_trace*, t_trace*> add_trace_non_configurable_recurr(int node,
         //Recursive case: intermediate node with non-configurable edges
         for (auto iedge : unvisited_non_configurable_edges) {
             int to_node = device_ctx.rr_nodes[node].edge_sink_node(iedge);
-            int iswitch = device_ctx.rr_nodes[node].edge_switch(iedge);
+            int iswitch = rr_graph.edge_switch(RREdgeId(iedge));
 
             VTR_ASSERT(!trace_nodes.count(to_node));
             trace_nodes.insert(node);
@@ -1561,7 +1562,7 @@ bool validate_traceback_recurr(t_trace* trace, std::set<int>& seen_rr_nodes) {
             //Check there is an edge connecting trace and next
 
             auto& device_ctx = g_vpr_ctx.device();
-
+            const auto& rr_graph=device_ctx.rr_graph;
             bool found = false;
             for (t_edge_size iedge = 0; iedge < device_ctx.rr_nodes[trace->index].num_edges(); ++iedge) {
                 int to_node = device_ctx.rr_nodes[trace->index].edge_sink_node(iedge);
@@ -1570,7 +1571,7 @@ bool validate_traceback_recurr(t_trace* trace, std::set<int>& seen_rr_nodes) {
                     found = true;
 
                     //Verify that the switch matches
-                    int rr_iswitch = device_ctx.rr_nodes[trace->index].edge_switch(iedge);
+                    int rr_iswitch = rr_graph.edge_switch(RREdgeId(iedge));
                     if (trace->iswitch != rr_iswitch) {
                         VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Traceback mismatched switch type: traceback %d rr_graph %d (RR nodes %d -> %d)\n",
                                         trace->iswitch, rr_iswitch,

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -428,7 +428,7 @@ static t_rt_node* add_non_configurable_to_route_tree(const int rr_node, const bo
             t_rt_node* child_rt_node = add_non_configurable_to_route_tree(to_rr_node, true, visited);
 
             if (!child_rt_node) continue;
-            int iswitch = device_ctx.rr_nodes[rr_node].edge_switch(iedge);
+            int iswitch = rr_graph.edge_switch(RREdgeId(iedge));
 
             //Create the edge
             t_linked_rt_edge* linked_rt_edge = alloc_linked_rt_edge();

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -311,8 +311,8 @@ bool ExtendedMapLookahead::add_paths(RRNodeId start_node,
             delta};
 
         if (size_t(this_node) != size_t(start_node)) {
-            auto& parent_node = device_ctx.rr_nodes[size_t(parent)];
-            start_to_here = Entry(this_node, parent_node.edge_switch(paths[*it].edge), &start_to_here);
+            //auto& parent_node = device_ctx.rr_nodes[size_t(parent)];
+            start_to_here = Entry(this_node, rr_graph.edge_switch(RREdgeId(paths[*it].edge)), &start_to_here);
             parent = this_node;
         }
 

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -260,12 +260,13 @@ void expand_dijkstra_neighbours(const t_rr_graph_storage& rr_nodes,
                                                     std::vector<Entry>,
                                                     std::greater<Entry>>* pq) {
     RRNodeId parent = parent_entry.rr_node;
-
+    auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
     auto& parent_node = rr_nodes[size_t(parent)];
 
     for (int iedge = 0; iedge < parent_node.num_edges(); iedge++) {
         int child_node_ind = parent_node.edge_sink_node(iedge);
-        int switch_ind = parent_node.edge_switch(iedge);
+        int switch_ind = rr_graph.edge_switch(RREdgeId(iedge));
 
         /* skip this child if it has already been expanded from */
         if ((*node_expanded)[child_node_ind]) {

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -178,7 +178,7 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
                     switch (to_rr_type) {
                         case CHANX:
                         case CHANY:
-                            iswitch = device_ctx.rr_nodes[from_node].edge_switch(iedge);
+                            iswitch = rr_graph.edge_switch(RREdgeId(iedge));
 
                             if (device_ctx.rr_switch_inf[iswitch].buffered()) {
                                 iseg = seg_index_of_sblock(from_node, size_t(to_node));
@@ -377,7 +377,7 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
                         case CHANX:
                         case CHANY:
                             if (!chan_node_switch_done[size_t(to_node)]) {
-                                int switch_index = device_ctx.rr_nodes[from_node].edge_switch(iedge);
+                                int switch_index = rr_graph.edge_switch(RREdgeId(iedge));
                                 auto switch_type = device_ctx.rr_switch_inf[switch_index].type();
 
                                 int fan_in = rr_graph.node_fan_in(to_node);

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -253,7 +253,7 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
                 shared_opin_buffer_trans = 0.;
 
                 for (iedge = 0; iedge < num_edges; iedge++) {
-                    iswitch = device_ctx.rr_nodes[from_node].edge_switch(iedge);
+                    iswitch = rr_graph.edge_switch(RREdgeId(iedge));
                     ntrans_no_sharing += unsharable_switch_trans[iswitch]
                                          + sharable_switch_trans[iswitch];
                     ntrans_sharing += unsharable_switch_trans[iswitch];

--- a/vpr/src/route/rr_graph_timing_params.cpp
+++ b/vpr/src/route/rr_graph_timing_params.cpp
@@ -59,7 +59,7 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
                 to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
                 if (to_rr_type == CHANX || to_rr_type == CHANY) {
-                    switch_index = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                    switch_index = rr_graph.edge_switch(RREdgeId(iedge));
                     Cin = device_ctx.rr_switch_inf[switch_index].Cin;
                     Cout = device_ctx.rr_switch_inf[switch_index].Cout;
                     buffered = device_ctx.rr_switch_inf[switch_index].buffered();

--- a/vpr/src/route/rr_graph_timing_params.cpp
+++ b/vpr/src/route/rr_graph_timing_params.cpp
@@ -150,7 +150,7 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
         /* End node is CHANX or CHANY */
         else if (from_rr_type == OPIN) {
             for (t_edge_size iedge = 0; iedge < device_ctx.rr_nodes[inode].num_edges(); iedge++) {
-                switch_index = device_ctx.rr_nodes[inode].edge_switch(iedge);
+                switch_index = rr_graph.edge_switch(RREdgeId(iedge));
                 to_node = device_ctx.rr_nodes[inode].edge_sink_node(iedge);
                 to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
@@ -174,7 +174,7 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
     Couts_to_add = (float*)vtr::calloc(device_ctx.rr_nodes.size(), sizeof(float));
     for (size_t inode = 0; inode < device_ctx.rr_nodes.size(); inode++) {
         for (t_edge_size iedge = 0; iedge < device_ctx.rr_nodes[inode].num_edges(); iedge++) {
-            switch_index = device_ctx.rr_nodes[inode].edge_switch(iedge);
+            switch_index = rr_graph.edge_switch(RREdgeId(iedge));
             to_node = device_ctx.rr_nodes[inode].edge_sink_node(iedge);
             to_rr_type = rr_graph.node_type(RRNodeId(to_node));
             if (to_rr_type == CHANX || to_rr_type == CHANY) {

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -151,7 +151,6 @@ class EdgeWalker {
         current_src_inode_ = 0;
         current_edge_ = 0;
         current_idx_ = 0;
-
         for (const auto& node : *nodes) {
             num_edges_ += node.num_edges();
         }
@@ -169,8 +168,9 @@ class EdgeWalker {
         return (*nodes_)[current_src_inode_].edge_sink_node(current_edge_);
     }
     int current_switch_id_node() const {
+
         VTR_ASSERT(current_src_inode_ < nodes_->size());
-        return (*nodes_)[current_src_inode_].edge_switch(current_edge_);
+        return (*rr_graph_).edge_switch(RREdgeId(current_edge_));
     }
 
     size_t advance(int n) {
@@ -204,6 +204,7 @@ class EdgeWalker {
 
   private:
     const t_rr_graph_storage* nodes_;
+    const RRGraphView* rr_graph_;
     size_t num_edges_;
     size_t current_src_inode_;
     size_t current_edge_;

--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -11,9 +11,11 @@ short t_rr_node::length() const {
 }
 
 bool t_rr_node::edge_is_configurable(t_edge_size iedge) const {
-    auto iswitch = edge_switch(iedge);
+
 
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph=device_ctx.rr_graph;
+    auto iswitch = rr_graph.edge_switch(RREdgeId(iedge));
 
     return device_ctx.rr_switch_inf[iswitch].configurable();
 }

--- a/vpr/src/route/rr_node_impl.h
+++ b/vpr/src/route/rr_node_impl.h
@@ -98,8 +98,8 @@ inline int t_rr_node::edge_sink_node(t_edge_size iedge) const {
     size_t inode = (size_t)storage_->edge_sink_node(id_, iedge);
     return inode;
 }
-inline short t_rr_node::edge_switch(t_edge_size iedge) const {
-    return storage_->edge_switch(id_, iedge);
-}
+//inline short t_rr_node::edge_switch(t_edge_size iedge) const {
+  //  return storage_->edge_switch(id_, iedge);
+//}
 
 #endif /* _RR_NODE_IMPL_H_ */

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1788,6 +1788,7 @@ static int convert_switch_index(int* switch_index, int* fanin) {
  */
 void print_switch_usage() {
     auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph=device_ctx.rr_graph;
 
     if (device_ctx.switch_fanin_remap.empty()) {
         VTR_LOG_WARN("Cannot print switch usage stats: device_ctx.switch_fanin_remap is empty\n");
@@ -1804,7 +1805,7 @@ void print_switch_usage() {
         const t_rr_node& from_node = device_ctx.rr_nodes[inode];
         int num_edges = from_node.num_edges();
         for (int iedge = 0; iedge < num_edges; iedge++) {
-            int switch_index = from_node.edge_switch(iedge);
+            int switch_index = rr_graph.edge_switch(RREdgeId(iedge));
             int to_node_index = from_node.edge_sink_node(iedge);
             // Assumption: suppose for a L4 wire (bi-directional): ----+----+----+----, it can be driven from any point (0, 1, 2, 3).
             //             physically, the switch driving from point 1 & 3 should be the same. But we will assign then different switch

--- a/vpr/test/test_vpr.cpp
+++ b/vpr/test/test_vpr.cpp
@@ -144,7 +144,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
 
         REQUIRE(src_inode >= 0);
         sink_inode = device_ctx.rr_nodes[src_inode].edge_sink_node(0);
-        switch_id = device_ctx.rr_nodes[src_inode].edge_switch(0);
+        switch_id = rr_graph.edge_switch(RREdgeId(0));
 
         vpr::add_rr_node_metadata(src_inode, vtr::string_view("node"), vtr::string_view("test node"));
         vpr::add_rr_edge_metadata(src_inode, sink_inode, switch_id, vtr::string_view("edge"), vtr::string_view("test edge"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
In this PR, I am implementing RRGraphView::edge_switch(const RREdgeId& edge) throughout VTR. Every time device_ctx.rr_nodes[from_node].edge_switch(iedge);  was called has been replaced with rr_graph.edge_switch(edgeId). In order to do this, I followed a pattern similar to that in the last PR.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
These changes are a continuation of the RRGraphView API implementation effort.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
