### PR TITLE
Update the vqm2blif parser to add support for Stratix 10 and Agliex vqm files

### DIFF
--- a/libs/libvqm/vqm_parser.l
+++ b/libs/libvqm/vqm_parser.l
@@ -39,6 +39,7 @@
 %%
 ^[ \t]*\/\/[^\n\r]*(\n|\r\n)                /* skip one-line comments */
 [ \t]+                                      /* skip white spaces */
+!					    /* skip the logical operator ! applied on the input ports of the lut - this results in lut mask not being valid anoymore */
 (\n|\r\n)                                   /* skip empty lines */
 module                                      return TOKEN_MODULE;
 endmodule                                   return TOKEN_ENDMODULE;

--- a/libs/libvqm/vqm_parser.l
+++ b/libs/libvqm/vqm_parser.l
@@ -38,6 +38,7 @@
 
 %%
 ^[ \t]*\/\/[^\n\r]*(\n|\r\n)                /* skip one-line comments */
+^[ \t]*\(\*[^\n\r]*\*\)                     /* skip synthesis attributes and directives */
 [ \t]+                                      /* skip white spaces */
 !					    /* skip the logical operator ! applied on the input ports of the lut - this results in lut mask not being valid anoymore */
 (\n|\r\n)                                   /* skip empty lines */

--- a/libs/libvqm/vqm_parser.l
+++ b/libs/libvqm/vqm_parser.l
@@ -61,7 +61,7 @@ assign                                      return TOKEN_ASSIGN;
                                                 yylval.value = atoi(yytext); 
                                                 return TOKEN_INTCONSTANT;
                                             }
-\\[^ ^\t]+                                  {
+\\[^ ^\t^;]+                                  {
                                                 yylval.string = (char *)malloc(yyleng);
                                                 strcpy(yylval.string, yytext+1);
                                                 return TOKEN_ESCAPEDID;

--- a/libs/libvqm/vqm_parser.l
+++ b/libs/libvqm/vqm_parser.l
@@ -62,7 +62,7 @@ assign                                      return TOKEN_ASSIGN;
                                                 yylval.value = atoi(yytext); 
                                                 return TOKEN_INTCONSTANT;
                                             }
-\\[^ ^\t^;]+                                  {
+\\[^ ^\t^;]+                                {
                                                 yylval.string = (char *)malloc(yyleng);
                                                 strcpy(yylval.string, yytext+1);
                                                 return TOKEN_ESCAPEDID;
@@ -73,7 +73,7 @@ assign                                      return TOKEN_ASSIGN;
                                                 yylval.string[yyleng-2] = 0;
                                                 return TOKEN_STRING;
                                             }
-[1-9][0-9]*'[b|h][0-9|A-F]+                         {
+[1-9][0-9]*'[b|h][0-9|A-F]+                 { /* bit strings can be in binary or hexadecimal format */ 
                                                 yylval.string = (char *)malloc(yyleng+1);
                                                 strcpy(yylval.string, yytext);
                                                 return TOKEN_BITSTRING;

--- a/libs/libvqm/vqm_parser.l
+++ b/libs/libvqm/vqm_parser.l
@@ -72,7 +72,7 @@ assign                                      return TOKEN_ASSIGN;
                                                 yylval.string[yyleng-2] = 0;
                                                 return TOKEN_STRING;
                                             }
-[1-9][0-9]*'b[0-9]+                         {
+[1-9][0-9]*'[b|h][0-9|A-F]+                         {
                                                 yylval.string = (char *)malloc(yyleng+1);
                                                 strcpy(yylval.string, yytext);
                                                 return TOKEN_BITSTRING;

--- a/libs/libvqm/vqm_parser.y
+++ b/libs/libvqm/vqm_parser.y
@@ -84,7 +84,7 @@ modules:	/* Empty */ {}
 			|	modules module {}
 			;
 
-module:		header declarations statements footer
+module:		header body footer
 			{
                 if(parse_info->pass_type == COUNT_PASS) {
                     parse_info->number_of_modules++;
@@ -126,10 +126,16 @@ header:		TOKEN_MODULE TOKEN_REGULARID '(' IdentifierList ')' ';'
 			}
 			;
 
-
-declarations:	/* Empty */ {}
-			|	declarations declaration {}
+body:           /* Empty */ {}
+			|	body declaration_statement {}
 			;
+
+
+declaration_statement:	        declaration
+			|
+                                statement  
+			;
+
 
 declaration:	PinType IdentifierList ';'
 				{
@@ -158,9 +164,7 @@ declaration:	PinType IdentifierList ';'
 footer:		TOKEN_ENDMODULE	{}
 			;
 
-statements:	/* Empty */ {}
-			| statements statement {}
-			;
+
 
 statement:		AssignStatement {}
 			|	TriStatement {}

--- a/libs/libvqm/vqm_parser.y
+++ b/libs/libvqm/vqm_parser.y
@@ -677,7 +677,16 @@ IdentifierList:		Identifier
 					}
 				;
 
-Identifier:		TOKEN_ESCAPEDID
+Identifier:	TOKEN_ESCAPEDID '[' TOKEN_INTCONSTANT ']'
+				{
+                    if(parse_info->pass_type == COUNT_PASS) {
+                        //pass
+                    } else {
+                        /* Allocate space for an identifier. Specify index used */
+                        $$ = (uintptr_t) allocate_identifier($1, T_TRUE, $3);
+                    }
+				}
+			|	TOKEN_ESCAPEDID
 				{
                     if(parse_info->pass_type == COUNT_PASS) {
                         //pass

--- a/libs/libvqm/vqm_parser.y
+++ b/libs/libvqm/vqm_parser.y
@@ -127,7 +127,7 @@ header:		TOKEN_MODULE TOKEN_REGULARID '(' IdentifierList ')' ';'
 			;
 
 body:           /* Empty */ {}
-			|	body declaration_statement {}
+			|	body declaration_statement {} /* the body consists of a mix of declarations and statements */
 			;
 
 

--- a/utils/vqm2blif/src/base/vqm2blif_util.h
+++ b/utils/vqm2blif/src/base/vqm2blif_util.h
@@ -197,7 +197,9 @@ extern t_boolean buffd_outs;	//user-set flag that regulates whether to keep buff
 */
 const map<std::string, DeviceInfo> device_parameter_database {
     // stratix 4 device
-    {"stratixiv", {"stratixiv_lcell_comb", "combout", 1, "dffeas", "q" }}
+    {"stratixiv", {"stratixiv_lcell_comb", "combout", 1, "dffeas", "q" }},
+    {"stratix10", {"fourteennm_lcell_comb", "combout", 1, "fourteennm_ff", "q" }},
+    {"agilex", {"tennm_lcell_comb", "combout", 1, "tennm_ff", "q" }}
 };
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This PR includes a few minor modifications to the vqm2blif parser.  Small changes have been made to the parser grammar files (vqm_parser.l and vqm_parser.y) in order to achieve the following objectives:

- The synthesis attributes and directives inside (* and *) delimiters should be ignored

- The names that start with \ (called TOKEN_ESCAPEID) should be allowed to be used for declaration of a vector. Currently the name of the vectors can only start with alphabetic characters and _ (TOKEN_REGULARID).

- If a line in the code ends with a TOKEN_ESCAPEID and there is no space between the token and the ; at the end of the line, ; should not be considered part of the TOKEN_ESCAPEID. 

- The ! operator is escaped. Though it should be noted that this results in the lut_mask parameter being incorrect after conversion from VQM to BLIF. 

- Bit strings in hexadecimal format (nh’[0-9|A-F]+) should be accepted by the parser. 

-  If the declarations and statements appear in a mixed order the parser should still be able to successfully parse the VQM file. 


#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR is related to the issue #1931 

#### Motivation and Context
The purpose of these modifications is to enable the tool to parse the Quartus VQM files targeting Stratix 10 and Agilex. The current version of the parser grammar is written based on the VQM files targeting Stratix IV devices. The new VQM files cannot successfully go through the parser as they differ slightly in formatting.
#### How Has This Been Tested?

In order to be able to test the changes, the architecture description of Stratix 10 or Agilex is required. The tests will be included in a different pull request once the architecture capture of one of these two devices has reached a major milestone. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
