### PR TITLE
added flags to ignore warnings when compiling unit tests that use the catch2 framework

### DIFF
--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -49,3 +49,12 @@ if(${VTR_ENABLE_CAPNPROTO})
       $<INSTALL_INTERFACE:include>
     )
 endif()
+
+# Some catch2 headers generate warnings, so treat them as system headers to suppress warnings
+target_include_directories(Catch2
+  SYSTEM
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libcatch2/src>
+    $<INSTALL_INTERFACE:include>
+)
+


### PR DESCRIPTION
added flags to ignore warnings when compiling unit tests that use the catch2 framework

<!--- Provide a general summary of your changes in the Title above -->
VTR currently uses the catch2 framework for unit tests. But compiling any project with the catch2 framework causes warnings to appear that are within the catch2 project. This PR removes the warnings due to the catch2 framework so they do not appear during compilation.

#### Description
<!--- Describe your changes in detail -->
The "-w" flag has been added to all unit test projects so that any warnings related to the catch2 framework are ignored.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR is related to issue 1935.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is preferred to have a warning free build.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by compiling VTR locally and verifying that all the warnings related to the catch2 framework do not appear.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
