### PR TITLE
VPR: Add options for writing machine readable summary files

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -626,6 +626,12 @@ For people not working on CAD, you can probably leave all the options to their d
 
     **Default:** ``2``
 
+.. option:: --write_block_usage <file>
+
+    Writes out to the file under path <file> cluster-level block usage summary in machine
+    readable (JSON or XML) or human readable (TXT) format. Format is selected
+    based on the extension of <file>.
+
 .. _placer_options:
 
 Placer Options
@@ -1034,6 +1040,17 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
     In addition to the information that can be seen via ``--max_logged_overused_rr_nodes``, this report prints out all the net ids that are associated with each overused RR node. Also, this report does not place a threshold upon the number of RR nodes printed.
 
     **Default:** ``off``
+
+.. option:: --write_timing_summary <file>
+
+    Writes out to the file under path <file> final timing summary in machine
+    readable (JSON or XML) or human readable (TXT) format. Format is selected
+    based on the extension of <file>. The summary consists of parameters:
+
+    * `cpd` - Final critical path delay (least slack) [ns]
+    * `fmax` - Maximal frequency of the implemented circuit [MHz]
+    * `swns` - setup Worst Negative Slack (sWNS) [ns]
+    * `stns` - Setup Total Negative Slack (sTNS) [ns]
 
 .. _timing_driven_router_options:
 

--- a/doc/src/vpr/file_formats.rst
+++ b/doc/src/vpr/file_formats.rst
@@ -1046,3 +1046,159 @@ An example of what a generated routing resource graph file would look like is sh
         </rr_edges>
     </rr_graph>
 .. _end:
+
+Block types usage summary (.txt .xml or .json)
+-----------------------------------------
+
+Block types usage summary is a file written in human or machine readable format.
+It describes types and the amount of cluster-level FPGA resources that are used
+by implemented design. This file is generated after the placement step with
+option: `--write_block_usage <filename>`. It can be saved as a human readable
+text file or in XML or JSON file to provide machine readable output. Format is
+selected based on the extension of the `<filename>`.
+
+The summary consists of 4 parameters:
+
+* `nets number` - the amount of created nets
+* `blocks number` - sum of blocks used to implement the design
+* `input pins` - sum of input pins
+* `output pins` - sum of output pins
+
+and a list of `block types` followed by the number of specific block types that
+are used in the design.
+
+TXT
+~~~
+
+Presents the information in human readable format, the same as in log output:
+
+.. code-block:: none
+    :caption: TXT format of block types usage summary
+    :linenos:
+
+    Netlist num_nets: <int>
+    Netlist num_blocks: <int>
+    Netlist <block_type_name_0> blocks: <int>
+    Netlist <block_type_name_1> blocks: <int>
+    ...
+    Netlist <block_type_name_n> blocks: <int>
+    Netlist inputs pins: <int>
+    Netlist output pins: <int>
+
+.. _end:
+
+JSON
+~~~~
+
+One of two available machine readable formats. The information is written as follows:
+
+.. code-block:: json
+    :caption: JSON format of block types usage summary
+    :linenos:
+
+    {
+      "num_nets": "<int>",
+      "num_blocks": "<int>",
+      "input_pins": "<int>",
+      "output_pins": "<int>",
+      "blocks": {
+        "<block_type_name_0>": <int>,
+        "<block_type_name_1>": <int>,
+        ...
+        "<block_type_name_n>": <int>
+      }
+    }
+
+.. _end:
+
+XML
+~~~
+
+Second machine readable format. The information is written as follows:
+
+.. code-block:: xml
+    :caption: XML format of block types usage summary
+    :linenos:
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <block_usage_report>
+      <nets num="<int>"></nets>
+      <blocks num="<int>">
+        <block type="<block_type_name_0>" usage="<int>"></block>
+        <block type="<block_type_name_1>" usage="<int>"></block>
+        ...
+        <block type="<block_type_name_n>" usage="<int>"></block>
+      </blocks>
+      <input_pins num="<int>"></input_pins>
+      <output_pins num="<int>"></output_pins>
+    </block_usage_report>
+
+.. _end:
+
+Timing summary (.txt .xml or .json)
+-----------------------------------------
+
+Timing summary is a file written in human or machine readable format.
+It describes final timing parameters of design implemented for the FPGA device.
+This file is generated after the routing step with option: `--write_timing_summary <filename>`.
+It can be saved as a human readable text file or in XML or JSON file to provide
+machine readable output. Format is selected based on the extension of the `<filename>`.
+
+The summary consists of 4 parameters:
+
+* `Critical Path Delay (cpd) [ns]`
+* `Max Circuit Frequency (Fmax) [MHz]`
+* `setup Worst Negative Slack (sWNS) [ns]`
+* `setup Total Negative Slack (sTNS) [ns]`
+
+TXT
+~~~
+
+Presents the information in human readable format, the same as in log output:
+
+.. code-block:: none
+    :caption: TXT format of timing summary
+    :linenos:
+
+    Final critical path delay (least slack): <double> ns, Fmax: <double> MHz
+    Final setup Worst Negative Slack (sWNS): <double> ns
+    Final setup Total Negative Slack (sTNS): <double> ns
+
+.. _end:
+
+JSON
+~~~~
+
+One of two available machine readable formats. The information is written as follows:
+
+.. code-block:: json
+    :caption: JSON format of timing summary
+    :linenos:
+
+    {
+      "cpd": <double>,
+      "fmax": <double>,
+      "swns": <double>,
+      "stns": <double>
+    }
+
+.. _end:
+
+XML
+~~~
+
+Second machine readable format. The information is written as follows:
+
+.. code-block:: xml
+    :caption: XML format of timing summary
+    :linenos:
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <timing_summary_report>
+      <cpd value="<double>" unit="ns" description="Final critical path delay"></nets>
+      <fmax value="<double>" unit="MHz" description="Max circuit frequency"></fmax>
+      <swns value="<double>" unit="ns" description="setup Worst Negative Slack (sWNS)"></swns>
+      <stns value="<double>" unit="ns" description="setup Total Negative Slack (sTNS)"></stns>
+    </block_usage_report>
+
+.. _end:

--- a/vpr/src/analysis/timing_reports.cpp
+++ b/vpr/src/analysis/timing_reports.cpp
@@ -16,7 +16,7 @@ void generate_setup_timing_stats(const std::string& prefix, const SetupTimingInf
     auto& timing_ctx = g_vpr_ctx.timing();
     auto& atom_ctx = g_vpr_ctx.atom();
 
-    print_setup_timing_summary(*timing_ctx.constraints, *timing_info.setup_analyzer(), "Final ");
+    print_setup_timing_summary(*timing_ctx.constraints, *timing_info.setup_analyzer(), "Final ", analysis_opts.write_timing_summary);
 
     VprTimingGraphResolver resolver(atom_ctx.nlist, atom_ctx.lookup, *timing_ctx.graph, delay_calc);
     resolver.set_detail_level(analysis_opts.timing_report_detail);

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -98,6 +98,7 @@ void SetupVPR(const t_options* Options,
     FileNameOpts->out_file_prefix = Options->out_file_prefix;
     FileNameOpts->read_vpr_constraints_file = Options->read_vpr_constraints_file;
     FileNameOpts->write_vpr_constraints_file = Options->write_vpr_constraints_file;
+    FileNameOpts->write_block_usage = Options->write_block_usage;
 
     FileNameOpts->verify_file_digests = Options->verify_file_digests;
 

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -631,6 +631,7 @@ static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysi
     analysis_opts.post_synth_netlist_unconn_output_handling = Options.post_synth_netlist_unconn_output_handling;
 
     analysis_opts.timing_update_type = Options.timing_update_type;
+    analysis_opts.write_timing_summary = Options.write_timing_summary;
 }
 
 static void SetupPowerOpts(const t_options& Options, t_power_opts* power_opts, t_arch* Arch) {

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -63,23 +63,70 @@ void ShowSetup(const t_vpr_setup& vpr_setup) {
     }
 }
 
-void printClusteredNetlistStats(std::string block_usage_filename) {
+void ClusteredNetlistStats::writeHuman(std::ostream& output) const {
+    output << "Cluster level netlist and block usage statistics\n";
+    output << "Netlist num_nets: " << num_nets << "\n";
+    output << "Netlist num_blocks: " << num_blocks << "\n";
+    for (const auto& type : logical_block_types) {
+        output << "Netlist " << type.name << " blocks: " << num_blocks_type[type.index] << ".\n";
+    }
+
+    output << "Netlist inputs pins: " << L_num_p_inputs << "\n";
+    output << "Netlist output pins: " << L_num_p_outputs << "\n";
+}
+void ClusteredNetlistStats::writeJSON(std::ostream& output) const {
+    output << "{\n";
+
+    output << "  \"num_nets\": \"" << num_nets << "\",\n";
+    output << "  \"num_blocks\": \"" << num_blocks << "\",\n";
+
+    output << "  \"input_pins\": \"" << L_num_p_inputs << "\",\n";
+    output << "  \"output_pins\": \"" << L_num_p_outputs << "\",\n";
+
+    output << "  \"blocks\": {\n";
+
+    for (const auto& type : logical_block_types) {
+        output << "    \"" << type.name << "\": " << num_blocks_type[type.index];
+        if ((int)type.index < (int)logical_block_types.size() - 1)
+            output << ",\n";
+        else
+            output << "\n";
+    }
+    output << "  }\n";
+    output << "}\n";
+}
+
+void ClusteredNetlistStats::writeXML(std::ostream& output) const {
+    output << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    output << "<block_usage_report>\n";
+
+    output << "  <nets num=\"" << num_nets << "\"></nets>\n";
+    output << "  <blocks num=\"" << num_blocks << "\">\n";
+
+    for (const auto& type : logical_block_types) {
+        output << "    <block type=\"" << type.name << "\" usage=\"" << num_blocks_type[type.index] << "\"></block>\n";
+    }
+    output << "  </blocks>\n";
+
+    output << "  <input_pins num=\"" << L_num_p_inputs << "\"></input_pins>\n";
+    output << "  <output_pins num=\"" << L_num_p_outputs << "\"></output_pins>\n";
+
+    output << "</block_usage_report>\n";
+}
+
+ClusteredNetlistStats::ClusteredNetlistStats() {
     auto& device_ctx = g_vpr_ctx.device();
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
-    int j, L_num_p_inputs, L_num_p_outputs, num_nets, num_blocks;
-    std::vector<int> num_blocks_type(device_ctx.logical_block_types.size(), 0);
-    num_nets = (int)cluster_ctx.clb_nlist.nets().size();
-    num_blocks = (int)cluster_ctx.clb_nlist.blocks().size();
-
-    VTR_LOG("\n");
-    VTR_LOG("Netlist num_nets: %d\n", num_nets);
-    VTR_LOG("Netlist num_blocks: %d\n", num_blocks);
-
-    /* Count I/O input and output pads */
+    int j;
     L_num_p_inputs = 0;
     L_num_p_outputs = 0;
+    num_blocks_type = std::vector<int>(device_ctx.logical_block_types.size(), 0);
+    num_nets = (int)cluster_ctx.clb_nlist.nets().size();
+    num_blocks = (int)cluster_ctx.clb_nlist.blocks().size();
+    logical_block_types = device_ctx.logical_block_types;
 
+    /* Count I/O input and output pads */
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
         auto logical_block = cluster_ctx.clb_nlist.block_type(blk_id);
         auto physical_tile = pick_physical_type(logical_block);
@@ -101,77 +148,51 @@ void printClusteredNetlistStats(std::string block_usage_filename) {
             }
         }
     }
-
-    for (const auto& type : device_ctx.logical_block_types) {
-        VTR_LOG("Netlist %s blocks: %d.\n", type.name, num_blocks_type[type.index]);
-    }
-
-    /* Print out each block separately instead */
-    VTR_LOG("Netlist inputs pins: %d\n", L_num_p_inputs);
-    VTR_LOG("Netlist output pins: %d\n", L_num_p_outputs);
-    VTR_LOG("\n");
-    if (!block_usage_filename.empty())
-        writeClusteredNetlistStats(block_usage_filename, num_nets, num_blocks,
-                                   L_num_p_inputs, L_num_p_outputs,
-                                   num_blocks_type,
-                                   device_ctx.logical_block_types);
-
-    num_blocks_type.clear();
 }
 
-void writeClusteredNetlistStats(std::string block_usage_filename,
-                                int num_nets,
-                                int num_blocks,
-                                int L_num_p_inputs,
-                                int L_num_p_outputs,
-                                std::vector<int> num_blocks_type,
-                                std::vector<t_logical_block_type> logical_block_types) {
-    if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".json")) {
-        // write report in JSON format
-        std::fstream fp;
-        fp.open(block_usage_filename, std::fstream::out | std::fstream::trunc);
-        fp << "{\n";
+void ClusteredNetlistStats::write(OutputFormat fmt, std::ostream& output) const {
+    switch (fmt) {
+        case HumanReadable:
+            writeHuman(output);
+            break;
+        case JSON:
+            writeJSON(output);
+            break;
+        case XML:
+            writeXML(output);
+            break;
+        default:
+            VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                            "Unknown extension on in block usage summary file");
+            break;
+    }
+}
 
-        fp << "  \"num_nets\": \"" << num_nets << "\",\n";
-        fp << "  \"num_blocks\": \"" << num_blocks << "\",\n";
+void writeClusteredNetlistStats(std::string block_usage_filename) {
+    const auto stats = ClusteredNetlistStats();
 
-        fp << "  \"input_pins\": \"" << L_num_p_inputs << "\",\n";
-        fp << "  \"output_pins\": \"" << L_num_p_outputs << "\",\n";
+    // Print out the human readable version to stdout
 
-        fp << "  \"blocks\": {\n";
+    stats.write(ClusteredNetlistStats::OutputFormat::HumanReadable, std::cout);
 
-        for (const auto& type : logical_block_types) {
-            fp << "    \"" << type.name << "\": " << num_blocks_type[type.index];
-            if ((int)type.index < (int)logical_block_types.size() - 1)
-                fp << ",\n";
-            else
-                fp << "\n";
+    if (block_usage_filename.size() > 0) {
+        ClusteredNetlistStats::OutputFormat fmt;
+
+        if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".json")) {
+            fmt = ClusteredNetlistStats::OutputFormat::JSON;
+        } else if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".xml")) {
+            fmt = ClusteredNetlistStats::OutputFormat::XML;
+        } else if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".txt")) {
+            fmt = ClusteredNetlistStats::OutputFormat::HumanReadable;
+        } else {
+            VPR_FATAL_ERROR(VPR_ERROR_PACK, "Unknown extension on output %s", block_usage_filename.c_str());
         }
-        fp << "  }\n";
-        fp << "}\n";
-    } else if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".xml")) {
-        // write report in XML format
+
         std::fstream fp;
+
         fp.open(block_usage_filename, std::fstream::out | std::fstream::trunc);
-        fp << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-        fp << "<block_usage_report>\n";
-
-        fp << "  <nets num=\"" << num_nets << "\"></nets>\n";
-        fp << "  <blocks num=\"" << num_blocks << "\">\n";
-
-        for (const auto& type : logical_block_types) {
-            fp << "    <block type=\"" << type.name << "\" usage=\"" << num_blocks_type[type.index] << "\"></block>\n";
-        }
-        fp << "  </blocks>\n";
-
-        fp << "  <input_pins num=\"" << L_num_p_inputs << "\"></input_pins>\n";
-        fp << "  <output_pins num=\"" << L_num_p_outputs << "\"></output_pins>\n";
-
-        fp << "</block_usage_report>\n";
-    } else {
-        VPR_FATAL_ERROR(VPR_ERROR_PACK,
-                        "Unknown extension on output %s",
-                        block_usage_filename.c_str());
+        stats.write(fmt, fp);
+        fp.close();
     }
 }
 

--- a/vpr/src/base/ShowSetup.h
+++ b/vpr/src/base/ShowSetup.h
@@ -2,6 +2,13 @@
 #define SHOWSETUP_H
 
 void ShowSetup(const t_vpr_setup& vpr_setup);
-void printClusteredNetlistStats();
+void printClusteredNetlistStats(std::string block_usage_filename);
+void writeClusteredNetlistStats(std::string block_usage_filename,
+                                int num_nets,
+                                int num_blocks,
+                                int L_num_p_inputs,
+                                int L_num_p_outputs,
+                                std::vector<int> num_blocks_type,
+                                std::vector<t_logical_block_type> logical_block_types);
 
 #endif

--- a/vpr/src/base/ShowSetup.h
+++ b/vpr/src/base/ShowSetup.h
@@ -1,14 +1,32 @@
 #ifndef SHOWSETUP_H
 #define SHOWSETUP_H
 
+struct ClusteredNetlistStats {
+  private:
+    void writeHuman(std::ostream& output) const;
+    void writeJSON(std::ostream& output) const;
+    void writeXML(std::ostream& output) const;
+
+  public:
+    ClusteredNetlistStats();
+
+    enum OutputFormat {
+        HumanReadable,
+        JSON,
+        XML
+    };
+
+    int num_nets;
+    int num_blocks;
+    int L_num_p_inputs;
+    int L_num_p_outputs;
+    std::vector<int> num_blocks_type;
+    std::vector<t_logical_block_type> logical_block_types;
+
+    void write(OutputFormat fmt, std::ostream& output) const;
+};
+
 void ShowSetup(const t_vpr_setup& vpr_setup);
-void printClusteredNetlistStats(std::string block_usage_filename);
-void writeClusteredNetlistStats(std::string block_usage_filename,
-                                int num_nets,
-                                int num_blocks,
-                                int L_num_p_inputs,
-                                int L_num_p_outputs,
-                                std::vector<int> num_blocks_type,
-                                std::vector<t_logical_block_type> logical_block_types);
+void writeClusteredNetlistStats(std::string block_usage_filename);
 
 #endif

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2568,6 +2568,10 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("unconnected")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    analysis_grp.add_argument(args.write_timing_summary, "--write_timing_summary")
+        .help("Writes implemented design final timing summary to the specified JSON or XML file.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& power_grp = parser.add_argument_group("power analysis options");
 
     power_grp.add_argument<bool, ParseOnOff>(args.do_power, "--power")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1560,6 +1560,10 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .help("Prefix for output files")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    file_grp.add_argument(args.write_block_usage, "--write_block_usage")
+        .help("Writes the cluster-level block types usage summary to the specified JSON or XML file.")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     auto& netlist_grp = parser.add_argument_group("netlist options");
 
     netlist_grp.add_argument<bool, ParseOnOff>(args.absorb_buffer_luts, "--absorb_buffer_luts")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2569,7 +2569,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     analysis_grp.add_argument(args.write_timing_summary, "--write_timing_summary")
-        .help("Writes implemented design final timing summary to the specified JSON or XML file.")
+        .help("Writes implemented design final timing summary to the specified JSON, XML or TXT file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     auto& power_grp = parser.add_argument_group("power analysis options");

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1561,7 +1561,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     file_grp.add_argument(args.write_block_usage, "--write_block_usage")
-        .help("Writes the cluster-level block types usage summary to the specified JSON or XML file.")
+        .help("Writes the cluster-level block types usage summary to the specified JSON, XML or TXT file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     auto& netlist_grp = parser.add_argument_group("netlist options");

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -36,6 +36,8 @@ struct t_options {
     argparse::ArgValue<std::string> write_router_lookahead;
     argparse::ArgValue<std::string> read_router_lookahead;
 
+    argparse::ArgValue<std::string> write_block_usage;
+
     /* Stage Options */
     argparse::ArgValue<bool> do_packing;
     argparse::ArgValue<bool> do_placement;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -212,6 +212,7 @@ struct t_options {
     argparse::ArgValue<std::string> echo_dot_timing_graph_node;
     argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_input_handling;
     argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_output_handling;
+    argparse::ArgValue<std::string> write_timing_summary;
 };
 
 argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& args);

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -517,7 +517,7 @@ bool vpr_pack_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         check_netlist(packer_opts.pack_verbosity);
 
         /* Output the netlist stats to console and optionally to file. */
-        printClusteredNetlistStats(vpr_setup.FileNameOpts.write_block_usage.c_str());
+        writeClusteredNetlistStats(vpr_setup.FileNameOpts.write_block_usage.c_str());
 
         // print the total number of used physical blocks for each
         // physical block type after finishing the packing stage

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -516,8 +516,8 @@ bool vpr_pack_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         /* Sanity check the resulting netlist */
         check_netlist(packer_opts.pack_verbosity);
 
-        /* Output the netlist stats to console. */
-        printClusteredNetlistStats();
+        /* Output the netlist stats to console and optionally to file. */
+        printClusteredNetlistStats(vpr_setup.FileNameOpts.write_block_usage.c_str());
 
         // print the total number of used physical blocks for each
         // physical block type after finishing the packing stage

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -753,6 +753,7 @@ struct t_file_name_opts {
     std::string out_file_prefix;
     std::string read_vpr_constraints_file;
     std::string write_vpr_constraints_file;
+    std::string write_block_usage;
     bool verify_file_digests;
 };
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1299,6 +1299,7 @@ struct t_analysis_opts {
     e_timing_report_detail timing_report_detail;
     bool timing_report_skew;
     std::string echo_dot_timing_graph_node;
+    std::string write_timing_summary;
 
     e_timing_update_type timing_update_type;
 };

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -950,7 +950,7 @@ void try_place(const t_placer_opts& placer_opts,
         /* Print critical path delay metrics */
         VTR_LOG("\n");
         print_setup_timing_summary(*timing_ctx.constraints,
-                                   *timing_info->setup_analyzer(), "Placement estimated ");
+                                   *timing_info->setup_analyzer(), "Placement estimated ", "");
     }
 
     sprintf(msg,

--- a/vpr/src/timing/timing_util.h
+++ b/vpr/src/timing/timing_util.h
@@ -50,12 +50,6 @@ std::vector<HistogramBucket> create_criticality_histogram(const SetupTimingInfo&
 //Print a useful summary of timing information
 void print_setup_timing_summary(const tatum::TimingConstraints& constraints, const tatum::SetupTimingAnalyzer& setup_analyzer, std::string prefix, std::string timing_summary_filename);
 
-//Write a useful summary of timing information to JSON file
-void write_setup_timing_summary(std::string timing_summary_filename,
-                                double least_slack_cpd,
-                                double fmax,
-                                double setup_worst_neg_slack,
-                                double setup_total_neg_slack);
 /*
  * Hold-time related statistics
  */
@@ -218,5 +212,32 @@ tatum::NodeId pin_name_to_tnode(std::string name);
 
 void write_setup_timing_graph_dot(std::string filename, SetupTimingInfo& timing_info, tatum::NodeId debug_node = tatum::NodeId::INVALID());
 void write_hold_timing_graph_dot(std::string filename, HoldTimingInfo& timing_info, tatum::NodeId debug_node = tatum::NodeId::INVALID());
+
+struct TimingStats {
+  private:
+    void writeHuman(std::ostream& output) const;
+    void writeJSON(std::ostream& output) const;
+    void writeXML(std::ostream& output) const;
+
+  public:
+    TimingStats(std::string prefix, double least_slack_cpd_delay, double fmax, double setup_worst_neg_slack, double setup_total_neg_slack);
+
+    enum OutputFormat {
+        HumanReadable,
+        JSON,
+        XML
+    };
+
+    double least_slack_cpd_delay;
+    double fmax;
+    double setup_worst_neg_slack;
+    double setup_total_neg_slack;
+    std::string prefix;
+
+    void write(OutputFormat fmt, std::ostream& output) const;
+};
+
+//Write a useful summary of timing information to JSON file
+void write_setup_timing_summary(std::string timing_summary_filename, const TimingStats& stats);
 
 #endif

--- a/vpr/src/timing/timing_util.h
+++ b/vpr/src/timing/timing_util.h
@@ -48,8 +48,14 @@ std::vector<HistogramBucket> create_criticality_histogram(const SetupTimingInfo&
                                                           size_t num_bins = 10);
 
 //Print a useful summary of timing information
-void print_setup_timing_summary(const tatum::TimingConstraints& constraints, const tatum::SetupTimingAnalyzer& setup_analyzer, std::string prefix);
+void print_setup_timing_summary(const tatum::TimingConstraints& constraints, const tatum::SetupTimingAnalyzer& setup_analyzer, std::string prefix, std::string timing_summary_filename);
 
+//Write a useful summary of timing information to JSON file
+void write_setup_timing_summary(std::string timing_summary_filename,
+                                double least_slack_cpd,
+                                double fmax,
+                                double setup_worst_neg_slack,
+                                double setup_total_neg_slack);
 /*
  * Hold-time related statistics
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds 2 new options:
* `--write_block_usage`
* `--write_timing_summary`
which enable VPR to write two summary files in JSON format.
The first one reports the usage of specific blocks of given architecture for implemented design during packing step in format:
```
{
  "num_nets": "<int>",
  "num_blocks": "<int>",
  "input_pins": "<int>",
  "output_pins": "<int>",
  "blocks": {
    "<block_type_name_0>": <int>,
    "<block_type_name_1>": <int>,
    ...
    "<block_type_name_n>": <int>
  }
}
```

Second option writes final timing summary for the design evaluated in routing step. It consist of Critical Path Delay (cpd), Max Circuit Frequency (Fmax), setup Worst Negative Slack (sWNS), setup Total Negative Slack (sTNS). The format is as follows:
```
{
  "cpd": <double>,
  "fmax": <double>,
  "swns": <double>,
  "stns": <double>
}
```

#### Related Issue
This feature was suggested in https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1944
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Information provided in generated JSON files is used in [SymbiFlow](https://github.com/SymbiFlow/symbiflow-arch-defs) to perform tests that verify the block usage and timings against reference values in order to catch possible regression.
Current way of getting the information from VPR requires parsing the log output in search of timing summary and block usage info. It would be better solution to let VPR prepare the output in easy to read format so that we won't rely on log output that could be changed in the future and cause failures in log parsers.


#### How Has This Been Tested?
This was tested locally by adding new options to calls to VPR in symbiflow and inspecting the resulting files.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
