### PR TITLE
Refactor the Clustering code 

### DIFF
--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -475,8 +475,8 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
     vtr::vector<AtomBlockId, float> atom_criticality(atom_ctx.nlist.blocks().size(), 0.);
 
     if (packer_opts.timing_driven) {
-        calc_init_packing_timing (packer_opts, analysis_opts, expected_lowest_cost_pb_gnode, 
-              clustering_delay_calc, timing_info, atom_criticality);
+        calc_init_packing_timing(packer_opts, analysis_opts, expected_lowest_cost_pb_gnode,
+                                 clustering_delay_calc, timing_info, atom_criticality);
     }
 
     auto seed_atoms = initialize_seed_atoms(packer_opts.cluster_seed_type, atom_molecules, max_molecule_stats, atom_criticality);
@@ -741,24 +741,12 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
         print_le_count(le_count, le_pb_type);
     }
 
-    /****************************************************************
-     * Free Data Structures
-     *****************************************************************/
+    //check clustering and output it
     check_and_output_clustering(packer_opts, is_clock, arch, num_clb, intra_lb_routing);
-/*
-    VTR_ASSERT(num_clb == (int)cluster_ctx.clb_nlist.blocks().size());
-    check_clustering();
 
-    if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_CLUSTERS)) {
-        echo_clusters(getEchoFileName(E_ECHO_CLUSTERS));
-    }
-
-    output_clustering(intra_lb_routing, packer_opts.global_clocks, is_clock, arch->architecture_id, packer_opts.output_file.c_str(), false);
-
-    VTR_ASSERT(cluster_ctx.clb_nlist.blocks().size() == intra_lb_routing.size());
-*/
-    free_clustering_data(packer_opts, intra_lb_routing, hill_climbing_inputs_avail, cluster_placement_stats, 
-                      unclustered_list_head, memory_pool, primitives_list);
+    // Free Data Structures
+    free_clustering_data(packer_opts, intra_lb_routing, hill_climbing_inputs_avail, cluster_placement_stats,
+                         unclustered_list_head, memory_pool, primitives_list);
 
     return num_used_type_instances;
 }

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -53,6 +53,7 @@
 #include "atom_netlist.h"
 #include "pack_types.h"
 #include "cluster.h"
+#include "cluster_util.h"
 #include "output_clustering.h"
 #include "SetupGrid.h"
 #include "read_xml_arch_file.h"
@@ -526,48 +527,8 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
     vtr::vector<AtomBlockId, float> atom_criticality(atom_ctx.nlist.blocks().size(), 0.);
 
     if (packer_opts.timing_driven) {
-        /*
-         * Initialize the timing analyzer
-         */
-        clustering_delay_calc = std::make_shared<PreClusterDelayCalculator>(atom_ctx.nlist, atom_ctx.lookup, packer_opts.inter_cluster_net_delay, expected_lowest_cost_pb_gnode);
-        timing_info = make_setup_timing_info(clustering_delay_calc, packer_opts.timing_update_type);
-
-        //Calculate the initial timing
-        timing_info->update();
-
-        if (isEchoFileEnabled(E_ECHO_PRE_PACKING_TIMING_GRAPH)) {
-            auto& timing_ctx = g_vpr_ctx.timing();
-            tatum::write_echo(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH),
-                              *timing_ctx.graph, *timing_ctx.constraints, *clustering_delay_calc, timing_info->analyzer());
-
-            tatum::NodeId debug_tnode = id_or_pin_name_to_tnode(analysis_opts.echo_dot_timing_graph_node);
-            write_setup_timing_graph_dot(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH) + std::string(".dot"),
-                                         *timing_info, debug_tnode);
-        }
-
-        {
-            auto& timing_ctx = g_vpr_ctx.timing();
-            PreClusterTimingGraphResolver resolver(atom_ctx.nlist,
-                                                   atom_ctx.lookup, *timing_ctx.graph, *clustering_delay_calc);
-            resolver.set_detail_level(analysis_opts.timing_report_detail);
-
-            tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph,
-                                                  *timing_ctx.constraints);
-
-            timing_reporter.report_timing_setup(
-                "pre_pack.report_timing.setup.rpt",
-                *timing_info->setup_analyzer(),
-                analysis_opts.timing_report_npaths);
-        }
-
-        //Calculate true criticalities of each block
-        for (AtomBlockId blk : atom_ctx.nlist.blocks()) {
-            for (AtomPinId in_pin : atom_ctx.nlist.block_input_pins(blk)) {
-                //Max criticality over incoming nets
-                float crit = timing_info->setup_pin_criticality(in_pin);
-                atom_criticality[blk] = std::max(atom_criticality[blk], crit);
-            }
-        }
+        calc_init_packing_timing (packer_opts, analysis_opts, expected_lowest_cost_pb_gnode, 
+              clustering_delay_calc, timing_info, atom_criticality);
     }
 
     auto seed_atoms = initialize_seed_atoms(packer_opts.cluster_seed_type, atom_molecules, max_molecule_stats, atom_criticality);

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -77,52 +77,6 @@
 //Constant allowing all cluster pins to be used
 const t_ext_pin_util FULL_EXTERNAL_PIN_UTIL(1., 1.);
 
-enum e_gain_update {
-    GAIN,
-    NO_GAIN
-};
-enum e_feasibility {
-    FEASIBLE,
-    INFEASIBLE
-};
-enum e_gain_type {
-    HILL_CLIMBING,
-    NOT_HILL_CLIMBING
-};
-enum e_removal_policy {
-    REMOVE_CLUSTERED,
-    LEAVE_CLUSTERED
-};
-/* TODO: REMOVE_CLUSTERED no longer used, remove */
-enum e_net_relation_to_clustered_block {
-    INPUT,
-    OUTPUT
-};
-
-enum e_detailed_routing_stages {
-    E_DETAILED_ROUTE_AT_END_ONLY = 0,
-    E_DETAILED_ROUTE_FOR_EACH_ATOM,
-    E_DETAILED_ROUTE_INVALID
-};
-
-/* Linked list structure.  Stores one integer (iblk). */
-struct t_molecule_link {
-    t_pack_molecule* moleculeptr;
-    t_molecule_link* next;
-};
-
-struct t_molecule_stats {
-    int num_blocks = 0; //Number of blocks across all primitives in molecule
-
-    int num_pins = 0;        //Number of pins across all primitives in molecule
-    int num_input_pins = 0;  //Number of input pins across all primitives in molecule
-    int num_output_pins = 0; //Number of output pins across all primitives in molecule
-
-    int num_used_ext_pins = 0;    //Number of *used external* pins across all primitives in molecule
-    int num_used_ext_inputs = 0;  //Number of *used external* input pins across all primitives in molecule
-    int num_used_ext_outputs = 0; //Number of *used external* output pins across all primitives in molecule
-};
-
 /* Keeps a linked list of the unclustered blocks to speed up looking for *
  * unclustered blocks with a certain number of *external* inputs.        *
  * [0..lut_size].  Unclustered_list_head[i] points to the head of the    *
@@ -806,25 +760,9 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
     output_clustering(intra_lb_routing, packer_opts.global_clocks, is_clock, arch->architecture_id, packer_opts.output_file.c_str(), false);
 
     VTR_ASSERT(cluster_ctx.clb_nlist.blocks().size() == intra_lb_routing.size());
-    for (auto blk_id : cluster_ctx.clb_nlist.blocks())
-        free_intra_lb_nets(intra_lb_routing[blk_id]);
-
-    intra_lb_routing.clear();
-
-    if (packer_opts.hill_climbing_flag)
-        free(hill_climbing_inputs_avail);
-
-    free_cluster_placement_stats(cluster_placement_stats);
-
-    for (auto blk_id : cluster_ctx.clb_nlist.blocks())
-        cluster_ctx.clb_nlist.remove_block(blk_id);
-
-    cluster_ctx.clb_nlist = ClusteredNetlist();
-
-    free(unclustered_list_head);
-    free(memory_pool);
-
-    free(primitives_list);
+  
+    free_clustering_data(packer_opts, intra_lb_routing, hill_climbing_inputs_avail, cluster_placement_stats, 
+                      unclustered_list_head, memory_pool, primitives_list);
 
     return num_used_type_instances;
 }

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -167,13 +167,12 @@ void check_clustering() {
 }
 
 //calculate the initial timing at the start of packing stage
-void calc_init_packing_timing (const t_packer_opts& packer_opts, 
-							   const t_analysis_opts& analysis_opts,
-							   const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode, 
-							   std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc, 
-							   std::shared_ptr<SetupTimingInfo>& timing_info, 
-							   vtr::vector<AtomBlockId, float>& atom_criticality) {
-
+void calc_init_packing_timing(const t_packer_opts& packer_opts,
+                              const t_analysis_opts& analysis_opts,
+                              const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
+                              std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc,
+                              std::shared_ptr<SetupTimingInfo>& timing_info,
+                              vtr::vector<AtomBlockId, float>& atom_criticality) {
     auto& atom_ctx = g_vpr_ctx.atom();
 
     /*
@@ -218,19 +217,17 @@ void calc_init_packing_timing (const t_packer_opts& packer_opts,
             atom_criticality[blk] = std::max(atom_criticality[blk], crit);
         }
     }
-
 }
 
 //Free the clustering data structures
-void free_clustering_data(const t_packer_opts& packer_opts, 
-						  vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing, 
-						  int* hill_climbing_inputs_avail, 
-						  t_cluster_placement_stats* cluster_placement_stats, 
-						  t_molecule_link* unclustered_list_head, 
-						  t_molecule_link* memory_pool, 
-						  t_pb_graph_node** primitives_list) {
-
-	auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
+void free_clustering_data(const t_packer_opts& packer_opts,
+                          vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing,
+                          int* hill_climbing_inputs_avail,
+                          t_cluster_placement_stats* cluster_placement_stats,
+                          t_molecule_link* unclustered_list_head,
+                          t_molecule_link* memory_pool,
+                          t_pb_graph_node** primitives_list) {
+    auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
 
     for (auto blk_id : cluster_ctx.clb_nlist.blocks())
         free_intra_lb_nets(intra_lb_routing[blk_id]);
@@ -253,16 +250,15 @@ void free_clustering_data(const t_packer_opts& packer_opts,
     free(primitives_list);
 }
 
+//check the clustering and output it
+void check_and_output_clustering(const t_packer_opts& packer_opts,
+                                 const std::unordered_set<AtomNetId>& is_clock,
+                                 const t_arch* arch,
+                                 const int& num_clb,
+                                 const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing) {
+    auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
 
-void check_and_output_clustering(const t_packer_opts& packer_opts, 
-	  							 const std::unordered_set<AtomNetId>& is_clock, 
-	  							 const t_arch* arch, 
-	  							 const int& num_clb, 
-	  							 const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing) {
-
-	auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
-
-	VTR_ASSERT(num_clb == (int)cluster_ctx.clb_nlist.blocks().size());
+    VTR_ASSERT(num_clb == (int)cluster_ctx.clb_nlist.blocks().size());
     check_clustering();
 
     if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_CLUSTERS)) {

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -2,6 +2,169 @@
 
 #include "cluster_router.h"
 #include "cluster_placement.h"
+#include "output_clustering.h"
+
+/* TODO: May want to check that all atom blocks are actually reached */
+static void check_cluster_atom_blocks(t_pb* pb, std::unordered_set<AtomBlockId>& blocks_checked) {
+    int i, j;
+    const t_pb_type* pb_type;
+    bool has_child = false;
+    auto& atom_ctx = g_vpr_ctx.atom();
+
+    pb_type = pb->pb_graph_node->pb_type;
+    if (pb_type->num_modes == 0) {
+        /* primitive */
+        auto blk_id = atom_ctx.lookup.pb_atom(pb);
+        if (blk_id) {
+            if (blocks_checked.count(blk_id)) {
+                VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                                "pb %s contains atom block %s but atom block is already contained in another pb.\n",
+                                pb->name, atom_ctx.nlist.block_name(blk_id).c_str());
+            }
+            blocks_checked.insert(blk_id);
+            if (pb != atom_ctx.lookup.atom_pb(blk_id)) {
+                VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                                "pb %s contains atom block %s but atom block does not link to pb.\n",
+                                pb->name, atom_ctx.nlist.block_name(blk_id).c_str());
+            }
+        }
+    } else {
+        /* this is a container pb, all container pbs must contain children */
+        for (i = 0; i < pb_type->modes[pb->mode].num_pb_type_children; i++) {
+            for (j = 0; j < pb_type->modes[pb->mode].pb_type_children[i].num_pb; j++) {
+                if (pb->child_pbs[i] != nullptr) {
+                    if (pb->child_pbs[i][j].name != nullptr) {
+                        has_child = true;
+                        check_cluster_atom_blocks(&pb->child_pbs[i][j], blocks_checked);
+                    }
+                }
+            }
+        }
+        VTR_ASSERT(has_child);
+    }
+}
+
+/*Print the contents of each cluster to an echo file*/
+static void echo_clusters(char* filename) {
+    FILE* fp;
+    fp = vtr::fopen(filename, "w");
+
+    fprintf(fp, "--------------------------------------------------------------\n");
+    fprintf(fp, "Clusters\n");
+    fprintf(fp, "--------------------------------------------------------------\n");
+    fprintf(fp, "\n");
+
+    auto& atom_ctx = g_vpr_ctx.atom();
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    std::map<ClusterBlockId, std::vector<AtomBlockId>> cluster_atoms;
+
+    for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
+        cluster_atoms.insert({blk_id, std::vector<AtomBlockId>()});
+    }
+
+    for (auto atom_blk_id : atom_ctx.nlist.blocks()) {
+        ClusterBlockId clb_index = atom_ctx.lookup.atom_clb(atom_blk_id);
+
+        cluster_atoms[clb_index].push_back(atom_blk_id);
+    }
+
+    for (auto i = cluster_atoms.begin(); i != cluster_atoms.end(); i++) {
+        std::string cluster_name;
+        cluster_name = cluster_ctx.clb_nlist.block_name(i->first);
+        fprintf(fp, "Cluster %s Id: %zu \n", cluster_name.c_str(), size_t(i->first));
+        fprintf(fp, "\tAtoms in cluster: \n");
+
+        int num_atoms = i->second.size();
+
+        for (auto j = 0; j < num_atoms; j++) {
+            AtomBlockId atom_id = i->second[j];
+            fprintf(fp, "\t %s \n", atom_ctx.nlist.block_name(atom_id).c_str());
+        }
+    }
+
+    fprintf(fp, "\nCluster Floorplanning Constraints:\n");
+    auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
+
+    for (ClusterBlockId clb_id : cluster_ctx.clb_nlist.blocks()) {
+        std::vector<Region> reg = floorplanning_ctx.cluster_constraints[clb_id].get_partition_region();
+        if (reg.size() != 0) {
+            fprintf(fp, "\nRegions in Cluster %zu:\n", size_t(clb_id));
+            for (unsigned int i = 0; i < reg.size(); i++) {
+                print_region(fp, reg[i]);
+            }
+        }
+    }
+
+    fclose(fp);
+}
+
+/* TODO: Add more error checking! */
+void check_clustering() {
+    std::unordered_set<AtomBlockId> atoms_checked;
+    auto& atom_ctx = g_vpr_ctx.atom();
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    if (cluster_ctx.clb_nlist.blocks().size() == 0) {
+        VTR_LOG_WARN("Packing produced no clustered blocks");
+    }
+
+    /*
+     * Check that each atom block connects to one physical primitive and that the primitive links up to the parent clb
+     */
+    for (auto blk_id : atom_ctx.nlist.blocks()) {
+        //Each atom should be part of a pb
+        const t_pb* atom_pb = atom_ctx.lookup.atom_pb(blk_id);
+        if (!atom_pb) {
+            VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                            "Atom block %s is not mapped to a pb\n",
+                            atom_ctx.nlist.block_name(blk_id).c_str());
+        }
+
+        //Check the reverse mapping is consistent
+        if (atom_ctx.lookup.pb_atom(atom_pb) != blk_id) {
+            VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                            "pb %s does not contain atom block %s but atom block %s maps to pb.\n",
+                            atom_pb->name,
+                            atom_ctx.nlist.block_name(blk_id).c_str(),
+                            atom_ctx.nlist.block_name(blk_id).c_str());
+        }
+
+        VTR_ASSERT(atom_ctx.nlist.block_name(blk_id) == atom_pb->name);
+
+        const t_pb* cur_pb = atom_pb;
+        while (cur_pb->parent_pb) {
+            cur_pb = cur_pb->parent_pb;
+            VTR_ASSERT(cur_pb->name);
+        }
+
+        ClusterBlockId clb_index = atom_ctx.lookup.atom_clb(blk_id);
+        if (clb_index == ClusterBlockId::INVALID()) {
+            VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                            "Atom %s is not mapped to a CLB\n",
+                            atom_ctx.nlist.block_name(blk_id).c_str());
+        }
+
+        if (cur_pb != cluster_ctx.clb_nlist.block_pb(clb_index)) {
+            VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                            "CLB %s does not match CLB contained by pb %s.\n",
+                            cur_pb->name, atom_pb->name);
+        }
+    }
+
+    /* Check that I do not have spurious links in children pbs */
+    for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
+        check_cluster_atom_blocks(cluster_ctx.clb_nlist.block_pb(blk_id), atoms_checked);
+    }
+
+    for (auto blk_id : atom_ctx.nlist.blocks()) {
+        if (!atoms_checked.count(blk_id)) {
+            VPR_FATAL_ERROR(VPR_ERROR_PACK,
+                            "Atom block %s not found in any cluster.\n",
+                            atom_ctx.nlist.block_name(blk_id).c_str());
+        }
+    }
+}
 
 //calculate the initial timing at the start of packing stage
 void calc_init_packing_timing (const t_packer_opts& packer_opts, 
@@ -88,4 +251,25 @@ void free_clustering_data(const t_packer_opts& packer_opts,
     free(memory_pool);
 
     free(primitives_list);
+}
+
+
+void check_and_output_clustering(const t_packer_opts& packer_opts, 
+	  							 const std::unordered_set<AtomNetId>& is_clock, 
+	  							 const t_arch* arch, 
+	  							 const int& num_clb, 
+	  							 const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing) {
+
+	auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
+
+	VTR_ASSERT(num_clb == (int)cluster_ctx.clb_nlist.blocks().size());
+    check_clustering();
+
+    if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_CLUSTERS)) {
+        echo_clusters(getEchoFileName(E_ECHO_CLUSTERS));
+    }
+
+    output_clustering(intra_lb_routing, packer_opts.global_clocks, is_clock, arch->architecture_id, packer_opts.output_file.c_str(), false);
+
+    VTR_ASSERT(cluster_ctx.clb_nlist.blocks().size() == intra_lb_routing.size());
 }

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -1,0 +1,55 @@
+#include "cluster_util.h"
+
+void calc_init_packing_timing (const t_packer_opts& packer_opts, 
+							   const t_analysis_opts& analysis_opts,
+							   const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode, 
+							   std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc, 
+							   std::shared_ptr<SetupTimingInfo>& timing_info, 
+							   vtr::vector<AtomBlockId, float>& atom_criticality) {
+
+    auto& atom_ctx = g_vpr_ctx.atom();
+
+    /*
+     * Initialize the timing analyzer
+     */
+    clustering_delay_calc = std::make_shared<PreClusterDelayCalculator>(atom_ctx.nlist, atom_ctx.lookup, packer_opts.inter_cluster_net_delay, expected_lowest_cost_pb_gnode);
+    timing_info = make_setup_timing_info(clustering_delay_calc, packer_opts.timing_update_type);
+
+    //Calculate the initial timing
+    timing_info->update();
+
+    if (isEchoFileEnabled(E_ECHO_PRE_PACKING_TIMING_GRAPH)) {
+        auto& timing_ctx = g_vpr_ctx.timing();
+        tatum::write_echo(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH),
+                          *timing_ctx.graph, *timing_ctx.constraints, *clustering_delay_calc, timing_info->analyzer());
+
+        tatum::NodeId debug_tnode = id_or_pin_name_to_tnode(analysis_opts.echo_dot_timing_graph_node);
+        write_setup_timing_graph_dot(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH) + std::string(".dot"),
+                                     *timing_info, debug_tnode);
+    }
+
+    {
+        auto& timing_ctx = g_vpr_ctx.timing();
+        PreClusterTimingGraphResolver resolver(atom_ctx.nlist,
+                                               atom_ctx.lookup, *timing_ctx.graph, *clustering_delay_calc);
+        resolver.set_detail_level(analysis_opts.timing_report_detail);
+
+        tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph,
+                                              *timing_ctx.constraints);
+
+        timing_reporter.report_timing_setup(
+            "pre_pack.report_timing.setup.rpt",
+            *timing_info->setup_analyzer(),
+            analysis_opts.timing_report_npaths);
+    }
+
+    //Calculate true criticalities of each block
+    for (AtomBlockId blk : atom_ctx.nlist.blocks()) {
+        for (AtomPinId in_pin : atom_ctx.nlist.block_input_pins(blk)) {
+            //Max criticality over incoming nets
+            float crit = timing_info->setup_pin_criticality(in_pin);
+            atom_criticality[blk] = std::max(atom_criticality[blk], crit);
+        }
+    }
+
+}

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -55,6 +55,14 @@ struct t_molecule_stats {
     int num_used_ext_outputs = 0; //Number of *used external* output pins across all primitives in molecule
 };
 
+struct t_cluster_stats {
+    int num_molecules = 0;
+    int num_molecules_processed = 0;
+    int mols_since_last_print = 0;
+    int blocks_since_last_analysis = 0;
+    int num_unrelated_clustering_attempts = 0;
+};
+
 void check_clustering();
 
 //calculate the initial timing at the start of packing stage

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -58,24 +58,25 @@ struct t_molecule_stats {
 void check_clustering();
 
 //calculate the initial timing at the start of packing stage
-void calc_init_packing_timing (const t_packer_opts& packer_opts,
-							   const t_analysis_opts& analysis_opts,
-							   const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
-							   std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc,
-							   std::shared_ptr<SetupTimingInfo>& timing_info,
-							   vtr::vector<AtomBlockId, float>& atom_criticality);
+void calc_init_packing_timing(const t_packer_opts& packer_opts,
+                              const t_analysis_opts& analysis_opts,
+                              const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
+                              std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc,
+                              std::shared_ptr<SetupTimingInfo>& timing_info,
+                              vtr::vector<AtomBlockId, float>& atom_criticality);
 
-//Free the clustering data structures
+//free the clustering data structures
 void free_clustering_data(const t_packer_opts& packer_opts,
-						  vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing,
-						  int* hill_climbing_inputs_avail,
-						  t_cluster_placement_stats* cluster_placement_stats,
-						  t_molecule_link* unclustered_list_head,
-						  t_molecule_link* memory_pool,
-						  t_pb_graph_node** primitives_list);
+                          vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing,
+                          int* hill_climbing_inputs_avail,
+                          t_cluster_placement_stats* cluster_placement_stats,
+                          t_molecule_link* unclustered_list_head,
+                          t_molecule_link* memory_pool,
+                          t_pb_graph_node** primitives_list);
 
+//check ckustering legality and output it
 void check_and_output_clustering(const t_packer_opts& packer_opts,
-	  							 const std::unordered_set<AtomNetId>& is_clock,
-	  							 const t_arch* arch,
-	  							 const int& num_clb,
-	  							 const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing);
+                                 const std::unordered_set<AtomNetId>& is_clock,
+                                 const t_arch* arch,
+                                 const int& num_clb,
+                                 const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing);

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -1,0 +1,19 @@
+#include "globals.h"
+#include "atom_netlist.h"
+#include "pack_types.h"
+#include "echo_files.h"
+
+#include "timing_info.h"
+#include "PreClusterDelayCalculator.h"
+#include "PreClusterTimingGraphResolver.h"
+#include "tatum/echo_writer.hpp"
+#include "tatum/TimingReporter.hpp"
+
+//calculate the initial timing at the start of packing stage
+void calc_init_packing_timing (const t_packer_opts& packer_opts, 
+							   const t_analysis_opts& analysis_opts,
+							   const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode, 
+							   std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc, 
+							   std::shared_ptr<SetupTimingInfo>& timing_info, 
+							   vtr::vector<AtomBlockId, float>& atom_criticality);
+

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -9,6 +9,53 @@
 #include "tatum/echo_writer.hpp"
 #include "tatum/TimingReporter.hpp"
 
+enum e_gain_update {
+    GAIN,
+    NO_GAIN
+};
+enum e_feasibility {
+    FEASIBLE,
+    INFEASIBLE
+};
+enum e_gain_type {
+    HILL_CLIMBING,
+    NOT_HILL_CLIMBING
+};
+enum e_removal_policy {
+    REMOVE_CLUSTERED,
+    LEAVE_CLUSTERED
+};
+/* TODO: REMOVE_CLUSTERED no longer used, remove */
+enum e_net_relation_to_clustered_block {
+    INPUT,
+    OUTPUT
+};
+
+enum e_detailed_routing_stages {
+    E_DETAILED_ROUTE_AT_END_ONLY = 0,
+    E_DETAILED_ROUTE_FOR_EACH_ATOM,
+    E_DETAILED_ROUTE_INVALID
+};
+
+/* Linked list structure.  Stores one integer (iblk). */
+struct t_molecule_link {
+    t_pack_molecule* moleculeptr;
+    t_molecule_link* next;
+};
+
+struct t_molecule_stats {
+    int num_blocks = 0; //Number of blocks across all primitives in molecule
+
+    int num_pins = 0;        //Number of pins across all primitives in molecule
+    int num_input_pins = 0;  //Number of input pins across all primitives in molecule
+    int num_output_pins = 0; //Number of output pins across all primitives in molecule
+
+    int num_used_ext_pins = 0;    //Number of *used external* pins across all primitives in molecule
+    int num_used_ext_inputs = 0;  //Number of *used external* input pins across all primitives in molecule
+    int num_used_ext_outputs = 0; //Number of *used external* output pins across all primitives in molecule
+};
+
+
 //calculate the initial timing at the start of packing stage
 void calc_init_packing_timing (const t_packer_opts& packer_opts, 
 							   const t_analysis_opts& analysis_opts,
@@ -17,3 +64,11 @@ void calc_init_packing_timing (const t_packer_opts& packer_opts,
 							   std::shared_ptr<SetupTimingInfo>& timing_info, 
 							   vtr::vector<AtomBlockId, float>& atom_criticality);
 
+//Free the clustering data structures
+void free_clustering_data(const t_packer_opts& packer_opts, 
+						  vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing, 
+						  int* hill_climbing_inputs_avail, 
+						  t_cluster_placement_stats* cluster_placement_stats, 
+						  t_molecule_link* unclustered_list_head, 
+						  t_molecule_link* memory_pool, 
+						  t_pb_graph_node** primitives_list);

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -2,6 +2,7 @@
 #include "atom_netlist.h"
 #include "pack_types.h"
 #include "echo_files.h"
+#include "vpr_utils.h"
 
 #include "timing_info.h"
 #include "PreClusterDelayCalculator.h"
@@ -55,7 +56,7 @@ struct t_molecule_stats {
     int num_used_ext_outputs = 0; //Number of *used external* output pins across all primitives in molecule
 };
 
-struct t_cluster_stats {
+struct t_cluster_progress_stats {
     int num_molecules = 0;
     int num_molecules_processed = 0;
     int mols_since_last_print = 0;
@@ -88,3 +89,10 @@ void check_and_output_clustering(const t_packer_opts& packer_opts,
                                  const t_arch* arch,
                                  const int& num_clb,
                                  const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing);
+
+void get_max_cluster_size_and_pb_depth(int& max_cluster_size,
+                                       int& max_pb_depth);
+
+bool check_cluster_legality(const int& verbosity,
+                            const int& detailed_routing_stage,
+                            t_lb_router_data* router_data);

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -55,20 +55,27 @@ struct t_molecule_stats {
     int num_used_ext_outputs = 0; //Number of *used external* output pins across all primitives in molecule
 };
 
+void check_clustering();
 
 //calculate the initial timing at the start of packing stage
-void calc_init_packing_timing (const t_packer_opts& packer_opts, 
+void calc_init_packing_timing (const t_packer_opts& packer_opts,
 							   const t_analysis_opts& analysis_opts,
-							   const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode, 
-							   std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc, 
-							   std::shared_ptr<SetupTimingInfo>& timing_info, 
+							   const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
+							   std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc,
+							   std::shared_ptr<SetupTimingInfo>& timing_info,
 							   vtr::vector<AtomBlockId, float>& atom_criticality);
 
 //Free the clustering data structures
-void free_clustering_data(const t_packer_opts& packer_opts, 
-						  vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing, 
-						  int* hill_climbing_inputs_avail, 
-						  t_cluster_placement_stats* cluster_placement_stats, 
-						  t_molecule_link* unclustered_list_head, 
-						  t_molecule_link* memory_pool, 
+void free_clustering_data(const t_packer_opts& packer_opts,
+						  vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing,
+						  int* hill_climbing_inputs_avail,
+						  t_cluster_placement_stats* cluster_placement_stats,
+						  t_molecule_link* unclustered_list_head,
+						  t_molecule_link* memory_pool,
 						  t_pb_graph_node** primitives_list);
+
+void check_and_output_clustering(const t_packer_opts& packer_opts,
+	  							 const std::unordered_set<AtomNetId>& is_clock,
+	  							 const t_arch* arch,
+	  							 const int& num_clb,
+	  							 const vtr::vector<ClusterBlockId, std::vector<t_intra_lb_net>*>& intra_lb_routing);


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
The clustering code is doing most of the real packer functionality. It contains an extra-long function (do_clustring) that is more than 470 lines of code. In this PR, several helper functions are introduced to make the clustering code more readable.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The packer code needs a lot of refactoring to be more readable and easier to follow. While this PR didn't completely solve the issue, it is just the first step.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running vtr_reg_basic and vtr_reg_strong and getting exactly the same earlier results.
