### PR TITLE
Added Support for newer tbb lib versions

### DIFF
--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -184,7 +184,12 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(TBB_INCLUDE_DIRS)
-    file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    if(EXISTS "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h") #TBB_VERSION_FILE_PRE_2021
+      file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    elseif(EXISTS "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h") #TBB_VERSION_FILE_POST_2021
+      file(READ "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h" _tbb_version_file)
+    endif()
+
     string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
         TBB_VERSION_MAJOR "${_tbb_version_file}")
     string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"

--- a/libs/EXTERNAL/libtatum/cmake/modules/FindTBB.cmake
+++ b/libs/EXTERNAL/libtatum/cmake/modules/FindTBB.cmake
@@ -184,7 +184,12 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(TBB_INCLUDE_DIRS)
-    file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    if(EXISTS "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h") #TBB_VERSION_FILE_PRE_2021
+      file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    elseif(EXISTS "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h") #TBB_VERSION_FILE_POST_2021
+      file(READ "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h" _tbb_version_file)
+    endif()
+
     string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
         TBB_VERSION_MAJOR "${_tbb_version_file}")
     string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -230,6 +230,11 @@ endif()
 #Configure the build to use the selected engine
 if (VPR_USE_EXECUTION_ENGINE STREQUAL "tbb")
     target_compile_definitions(libvpr PRIVATE VPR_USE_TBB)
+    if(TBB_VERSION VERSION_LESS 2021.1)
+        target_compile_definitions(libvpr PRIVATE VPR_USE_TBB_PRE_2021)
+    else()
+        target_compile_definitions(libvpr PRIVATE VPR_USE_TBB_POST_2021)
+    endif()
     target_link_libraries(libvpr tbb)
     target_link_libraries(libvpr tbbmalloc_proxy) #Use the scalable memory allocator
     message(STATUS "VPR: will support parallel execution using '${VPR_USE_EXECUTION_ENGINE}'")


### PR DESCRIPTION
Intel updated their TBB library, changing the paths and deprecating some features. 
In order for VTR to continue working on more modern machines, some adaptation was required.

#### Description
Intel updated TBB. 
To support this, the required changes were:
- Fix the CMake files to detect either the `tbb_stddef.h` or `version.h` files of the library.
- Fix `vpr_api.c` due to `task_scheduler_init` being removed in newer versions
- Detect the version in CMake (in order to allow backward compatibility)

#### Related Issue
#1959

#### Motivation and Context
VTR will not compile on machines with TBB version greater than 2021.1

#### How Has This Been Tested?
Compiled on a machine with newer TBB version

#### Types of changes
- [ ] Bug fix (change which fixes an issue)

#### Checklist:
- [ ] All new and existing tests passed
