### PR TITLE
removed deprecated gridlocations xml tag from arch tutorials

### DIFF
--- a/doc/src/tutorials/arch/classic_soft_logic.rst
+++ b/doc/src/tutorials/arch/classic_soft_logic.rst
@@ -104,7 +104,6 @@ The ratio of tracks that a particular input/output pin of the CLB connects to is
 In this example, a fc_in of 0.15 means that each input pin connects to 15% of the available routing tracks in the external-to-CLB routing channel adjacent to that pin.
 The pinlocations tag is used to associate pins on the CLB with which side of the logic block pins reside on where the pattern spread corresponds to evenly spreading out the pins on all sides of the CLB in a round-robin fashion.
 In this example, the CLB has a total of 33 pins (22 input pins, 10 output pins, 1 clock pin) so 8 pins are assigned to all sides of the CLB except one side which gets assigned 9 pins.
-The columns occupied by complex blocks of type CLB is defined by gridlocations where fill means that all columns should be type CLB unless that column is taken up by a block with higher priority (where a larger number means a higher priority).
 
 .. code-block:: xml
 
@@ -114,9 +113,7 @@ The columns occupied by complex blocks of type CLB is defined by gridlocations w
       <fc_out type="frac">0.125000</fc_out>
 
       <pinlocations pattern="spread"/>
-      <gridlocations>
-        <loc type="fill" priority="1"/>
-      </gridlocations>
+
     </pb_type>
 
 
@@ -171,8 +168,6 @@ Classic Soft Logic Block Complete Example
       <fc_out type="frac">0.125000</fc_out>
 
       <pinlocations pattern="spread"/>
-      <gridlocations>
-        <loc type="fill" priority="1"/>
-      </gridlocations>
+
     </pb_type>
 

--- a/doc/src/tutorials/arch/configurable_memory.rst
+++ b/doc/src/tutorials/arch/configurable_memory.rst
@@ -258,14 +258,11 @@ A memory block with a reconfigurable aspect ratio.
           </interconnect>
         </mode>
 
-
-
       <fc_in type="frac"> 0.15</fc_in>
       <fc_out type="frac"> 0.125</fc_out>
+
       <pinlocations pattern="spread"/>
-      <gridlocations>
-        <loc type="col" start="2" repeat="5" priority="2"/>
-      </gridlocations>
+
     </pb_type>
 
 

--- a/doc/src/tutorials/arch/configurable_memory_bus.rst
+++ b/doc/src/tutorials/arch/configurable_memory_bus.rst
@@ -138,7 +138,6 @@ A similar scheme is used at the outputs to ensure that either all outputs are re
 Finally, we model the relationship of the memory block with the general FPGA fabric.
 The ratio of tracks that a particular input/output pin of the CLB connects to is defined by fc_in/fc_out.
 The pinlocations describes which side of the logic block pins reside on where the pattern spread describes evenly spreading out the pins on all sides of the CLB in a round-robin fashion.
-The columns occupied by complex blocks of type CLB is defined by gridlocations where ``type="col" start="2" repeat="5"`` means that every fifth column starting from the second column type memory CLB unless that column is taken up by a block with higher priority (where a bigger number means a higher priority).
 
 .. code-block:: xml
 
@@ -148,9 +147,6 @@ The columns occupied by complex blocks of type CLB is defined by gridlocations w
       <fc_out type="frac">0.125000</fc_out>
 
       <pinlocations pattern="spread"/>
-      <gridlocations>
-        <loc type="col" start="2" repeat="5" priority="2"/>
-      </gridlocations>
 
 
 
@@ -248,6 +244,3 @@ Configurable Memory Bus-Based Complete Example
       <fc_out type="frac">0.125000</fc_out>
 
       <pinlocations pattern="spread"/>
-      <gridlocations>
-        <loc type="col" start="2" repeat="5" priority="2"/>
-      </gridlocations>

--- a/doc/src/tutorials/arch/fracturable_multiplier.rst
+++ b/doc/src/tutorials/arch/fracturable_multiplier.rst
@@ -166,15 +166,11 @@ A 36x36 multiplier fracturable into 18x18s and 9x9s
           </interconnect>
         </mode>
 
-
-
       <fc_in type="frac"> 0.15</fc_in>
       <fc_out type="frac"> 0.125</fc_out>
+
       <pinlocations pattern="spread"/>
 
-      <gridlocations>
-        <loc type="col" start="4" repeat="5" priority="2"/>
-      </gridlocations>
     </pb_type>
 
 

--- a/doc/src/tutorials/arch/fracturable_multiplier_bus.rst
+++ b/doc/src/tutorials/arch/fracturable_multiplier_bus.rst
@@ -373,8 +373,5 @@ Fracturable Multiplier Bus-Based Complete Example
         <loc side="right" offset="2">out[63:40]</loc>
       </pinlocations>
 
-      <gridlocations>
-        <loc type="col" start="4" repeat="5" priority="2"/>
-      </gridlocations>
     </pb_type>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Deleted "gridlocations" xml tags in pb_type xml examples throughout the architecture tutorials, as well as one sentence explaining the meaning of the gridlocations tag in the tutorial text.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The "gridlocations" xml tag is no longer supported and has already been removed from the documentation (other than these tutorials).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't been.  It is low risk since the change only impacts the documentation.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My change requires a change to the documentation
- [ x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
