### PR TITLE
Fixed small syntax errors in ODIN's Makefile test target.

### DIFF
--- a/ODIN_II/Makefile
+++ b/ODIN_II/Makefile
@@ -118,7 +118,7 @@ ifeq ($(_ELABORATOR), ODIN)
 	&& ./verify_odin.sh --no_report -j $(NB_OF_PROCESS) \
 			-t regression_test/benchmark/suite/light_suite \
 			-t regression_test/benchmark/suite/vtr_light_suite; \
-	&& $(MAKE) build \
+	$(MAKE) build \
 	&& ./verify_odin.sh --no_report --continue -j $(NB_OF_PROCESS) \
 		-t regression_test/benchmark/suite/heavy_suite; \
 	./verify_odin.sh --status_only
@@ -126,7 +126,7 @@ else ifeq ($(_ELABORATOR), YOSYS)
 	$(MAKE) sanitize ELABORATOR=YOSYS \
 	&& ./verify_odin.sh --no_report -j $(NB_OF_PROCESS) \
 			-t regression_test/benchmark/suite/yosys+odin/techmap_lightsuite; \
-	&& $(MAKE) build ELABORATOR=YOSYS \
+	$(MAKE) build ELABORATOR=YOSYS \
 	&& ./verify_odin.sh --no_report --continue -j $(NB_OF_PROCESS) \
 		-t regression_test/benchmark/suite/yosys+odin/techmap_heavysuite; \
 	./verify_odin.sh --status_only


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When trying to build the test target with the ODIN's Makefile, encountered a syntax error which I fixed.
#### Description
<!--- Describe your changes in detail -->
I have made the same edit on two lines of the Makefile.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It resoves the error when trying to make the test target.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The "make test" command now works and starts the benchmarks.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
