### PR TITLE
Fixed root Dockerfile for building vtr container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,29 @@
 FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 # set out workspace
 ENV WORKSPACE=/workspace
 RUN mkdir -p ${WORKSPACE}
-VOLUME ${WORKSPACE}
 WORKDIR ${WORKSPACE}
-# Set environment variables
-ARG GIT_SSL_NO_VERIFY=1
-ARG DEBIAN_FRONTEND=noninteractive
+COPY . ${WORKSPACE}
 # Install and cleanup is done in one command to minimize the build cache size
 RUN apt-get update -qq \
-    && apt-get -y install --no-install-recommends \
-# Additional packages not listed in install_apt_packages.sh
-    wget \
-    git \
-    ninja-build \
-    libeigen3-dev \
-    libtbb-dev \
-    python3-pip \
-# Clone VTR repo
-    && git clone https://github.com/verilog-to-routing/vtr-verilog-to-routing.git . \
 # Extract package names from install_apt_packages.sh
     && sed '/sudo/d' install_apt_packages.sh | sed '/#/d' | sed 's/ \\//g' | sed '/^$/d' | sed '/^[[:space:]]*$/d' \
 # Install packages
     | xargs apt-get -y install --no-install-recommends \
+# Additional packages not listed in install_apt_packages.sh
+    && apt-get -y install --no-install-recommends \
+    wget \
+    ninja-build \
+    libeigen3-dev \
+    libtbb-dev \
+    python3-pip \
+# Install python packages
+    && pip install -r requirements.txt \
 # Cleanup
     && apt-get autoclean && apt-get clean && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
-# Install python packages
-RUN pip install -r requirements.txt
 # Build VTR
-RUN make \
-&& make install
+RUN make && make install
 # Container's default launch command
-CMD [ "/bin/bash" ]
+SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,88 +1,35 @@
-FROM ubuntu:trusty as builder
-
-RUN apt-get update 
-RUN apt-get install -y \
-    software-properties-common
-
-# add auto gpg key other lauchpad ppa
-RUN add-apt-repository ppa:nilarimogard/webupd8
-RUN apt-get update && apt-get install -y \
-    launchpad-getkeys
-
-# add llvm PPA
-RUN printf "\n\
-deb http://ppa.launchpad.net/george-edison55/precise-backports/ubuntu precise main \n\
-deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main \n\
-deb https://apt.llvm.org/precise llvm-toolchain-precise-3.6 main \n\
-deb https://apt.llvm.org/trusty llvm-toolchain-trusty-6.0 main \n\
-deb https://apt.llvm.org/trusty llvm-toolchain-trusty-7 main \n\
-deb https://apt.llvm.org/trusty llvm-toolchain-trusty-8 main \n\
-" >> /etc/apt/sources.list
-
-# grab llvm keys
-RUN launchpad-getkeys
-
-RUN apt-get update
-RUN apt-get install -y \
-    ninja \
-    libssl-dev \
-    autoconf \
-    automake \
-    bash \
-    bison \
-    binutils \
-    binutils-gold \
-    build-essential \
-    ctags \
-    curl \
-    doxygen \
-    flex \
-    fontconfig \
-    gdb \
-    git \
-    gperf \
-    libcairo2-dev \
-    libgtk-3-dev \
-    libevent-dev \
-    libfontconfig1-dev \
-    liblist-moreutils-perl \
-    libncurses5-dev \
-    libx11-dev \
-    libxft-dev \
-    libxml++2.6-dev \
-    perl \
-    python \
-    python-lxml \
-    texinfo \
-    time \
-    valgrind \
-    zip \
-    qt5-default \
-    clang-format-7 \
-    g++-7 \
-    gcc-7 \
-    g++-8 \
-    gcc-8 \
-    g++-9 \
-    gcc-9 \
-    g++-10 \
-    gcc-10 \
-    g++-11 \
-    gcc-11 \
-    clang-6.0 \
-    clang-7 \
-    clang-10
-
-# install CMake
-WORKDIR /tmp
-ENV CMAKE=cmake-3.17.0
-RUN curl -s https://cmake.org/files/v3.17/${CMAKE}.tar.gz | tar xvzf -
-RUN cd ${CMAKE} && ./configure && make && make install
-
+FROM ubuntu:20.04
 # set out workspace
 ENV WORKSPACE=/workspace
 RUN mkdir -p ${WORKSPACE}
 VOLUME ${WORKSPACE}
 WORKDIR ${WORKSPACE}
-
+# Set environment variables
+ARG GIT_SSL_NO_VERIFY=1
+ARG DEBIAN_FRONTEND=noninteractive
+# Install and cleanup is done in one command to minimize the build cache size
+RUN apt-get update -qq \
+    && apt-get -y install --no-install-recommends \
+# Additional packages not listed in install_apt_packages.sh
+    wget \
+    git \
+    ninja-build \
+    libeigen3-dev \
+    libtbb-dev \
+    python3-pip \
+# Clone VTR repo
+    && git clone https://github.com/verilog-to-routing/vtr-verilog-to-routing.git . \
+# Extract package names from install_apt_packages.sh
+    && sed '/sudo/d' install_apt_packages.sh | sed '/#/d' | sed 's/ \\//g' | sed '/^$/d' | sed '/^[[:space:]]*$/d' \
+# Install packages
+    | xargs apt-get -y install --no-install-recommends \
+# Cleanup
+    && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+# Install python packages
+RUN pip install -r requirements.txt
+# Build VTR
+RUN make \
+&& make install
+# Container's default launch command
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed broken Dockerfile script located at the project root.

#### Description
<!--- Describe your changes in detail -->

- The target image is now based on Ubuntu 20:04 LTS
- Build packages are now extracted from install_apt_packages.sh & requirements.txt files in VTR root
- Image build process is now in accordance with the latest build instructions available in VTR documenation.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1756

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

As an option for building VTR, there is a docker container build script. VTR's fixed Dockerfile allows it to be built on different OSs and architectures effortlessly, by just running one command. This can especially be useful for building VTR on devices with Apple Silicon processors which currently lack native Linux support but support Linux-based docker containers.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The fixed Dockerfile script now builds VTR sucessfully.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
