### PR TITLE
ci: transition to GH custom runners for nightly builds

### DIFF
--- a/.github/scripts/hostsetup.sh
+++ b/.github/scripts/hostsetup.sh
@@ -39,6 +39,7 @@ apt install -y \
   gdb \
   git \
   gperf \
+  gzip \
   libcairo2-dev \
   libcapnp-dev \
   libgtk-3-dev \

--- a/.github/scripts/hostsetup.sh
+++ b/.github/scripts/hostsetup.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -e
+echo "========================================"
+echo "Host updating packages"
+echo "----------------------------------------"
+apt update
+echo "----------------------------------------"
+
+
+echo "========================================"
+echo "Add repositories"
+echo "----------------------------------------"
+apt install -y software-properties-common
+add-apt-repository ppa:ubuntu-toolchain-r/test
+echo "----------------------------------------"
+
+echo
+echo "========================================"
+echo "Host install packages"
+echo "----------------------------------------"
+
+apt install -y \
+  autoconf \
+  automake \
+  bash \
+  bison \
+  binutils \
+  binutils-gold \
+  build-essential \
+  capnproto \
+  clang \
+  cmake \
+  ctags \
+  curl \
+  doxygen \
+  flex \
+  fontconfig \
+  gdb \
+  git \
+  gperf \
+  libcairo2-dev \
+  libcapnp-dev \
+  libgtk-3-dev \
+  libevent-dev \
+  libfontconfig1-dev \
+  liblist-moreutils-perl \
+  libncurses5-dev \
+  libx11-dev \
+  libxft-dev \
+  libxml++2.6-dev \
+  libreadline-dev \
+  python \
+  python3 \
+  python3-dev \
+  python3-pip \
+  python3-virtualenv \
+  python3-yaml \
+  tcl-dev \
+  libffi-dev \
+  perl \
+  texinfo \
+  time \
+  valgrind \
+  zip \
+  qt5-default \
+  g++-9 \
+  gcc-9 \
+  wget
+  # Don't include libtbb-dev since it may increase memory usage
+  #libtbb-dev \
+
+export PATH="$PATH:/home/kbuilder/.local/bin"
+
+export CC=gcc-9
+export CXX=g++-9
+
+python3 -m pip install -r requirements.txt
+
+echo "----------------------------------------"

--- a/.github/scripts/run-vtr.sh
+++ b/.github/scripts/run-vtr.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+set -x
+set -e
+
+export VTR_DIR=$(pwd)
+source $SCRIPT_DIR/hostsetup.sh
+
+if ! { [ $VTR_TEST == "vtr_reg_strong" ] || [ $VTR_TEST == "odin_reg_strong" ] \
+|| [ $VTR_TEST == "odin_tech_strong" ] || [ $VTR_TEST == "vtr_reg_yosys_odin" ]; }; then
+	source $SCRIPT_DIR/vtr-full-setup.sh
+fi
+
+# Build VtR
+source $SCRIPT_DIR/vtr-build.sh
+# Run the reg test.
+source $SCRIPT_DIR/vtr-test.sh

--- a/.github/scripts/vtr-build.sh
+++ b/.github/scripts/vtr-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -z ${VTR_CMAKE_PARAMS+x} ]; then
+	echo "Missing $$VTR_CMAKE_PARAMS value"
+	exit 1
+fi
+
+export FAILURE=0
+make -k CMAKE_PARAMS="$VTR_CMAKE_PARAMS" -j$(nproc) || export FAILURE=1
+
+echo
+
+# When the build fails, produce the failure output in a clear way
+if [ $FAILURE -ne 0 ]; then
+        make CMAKE_PARAMS="$VTR_CMAKE_PARAMS" -j1
+        exit 1
+fi

--- a/.github/scripts/vtr-full-setup.sh
+++ b/.github/scripts/vtr-full-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+make get_titan_benchmarks
+make get_ispd_benchmarks
+
+dev/upgrade_vtr_archs.sh
+
+# Symbiflow archs do not require update
+make get_symbiflow_benchmarks

--- a/.github/scripts/vtr-test.sh
+++ b/.github/scripts/vtr-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+if [ -z ${VTR_TEST+x} ]; then
+	echo "Missing $$VTR_TEST value"
+	exit 1
+fi
+
+if [ -z ${VTR_TEST_OPTIONS+x} ]; then
+	echo "Missing $$VTR_TEST_OPTIONS value"
+	exit 1
+fi
+
+if [ -z $NUM_CORES ]; then
+	echo "Missing $$NUM_CORES value"
+	exit 1
+fi
+
+echo $PWD
+pwd
+pwd -L
+pwd -P
+cd $(realpath $(pwd))
+echo $PWD
+pwd
+pwd -L
+pwd -P
+
+(
+    while :
+    do
+        date
+        uptime
+        free -h
+        sleep 300
+    done
+) &
+MONITOR=$!
+
+echo "========================================"
+echo "VPR Build Info"
+echo "========================================"
+./vpr/vpr --version
+
+echo "========================================"
+echo "Running Tests"
+echo "========================================"
+export VPR_NUM_WORKERS=1
+
+set +e
+./run_reg_test.py $VTR_TEST $VTR_TEST_OPTIONS -j$NUM_CORES
+TEST_RESULT=$?
+set -e
+kill $MONITOR
+
+echo "========================================"
+echo "Cleaning benchmarks files"
+echo "========================================"
+# Removing Symbiflow archs and benchmarks
+find vtr_flow/arch/symbiflow/ -type f -not -name 'README.*' -delete
+find vtr_flow/benchmarks/symbiflow/ -type f -not -name 'README.*' -delete
+
+# Removing ISPD benchmarks
+find vtr_flow/benchmarks/ispd_blif/ -type f -not -name 'README.*' -delete
+
+# Removing Titan benchmarks
+find vtr_flow/benchmarks/titan_blif/ -type f -not -name 'README.*' -delete
+
+# Removing ISPD, Titan and Symbiflow tarballs
+find . -type f -regex ".*\.tar\.\(gz\|xz\)" -delete
+
+#Gzip output files from vtr_reg_nightly tests to lower working directory disk space
+find vtr_flow/tasks/regression_tests/vtr_reg_nightly_test1/ -type f -print0 | xargs -0 -P $(nproc) gzip
+find vtr_flow/tasks/regression_tests/vtr_reg_nightly_test2/ -type f -print0 | xargs -0 -P $(nproc) gzip
+find vtr_flow/tasks/regression_tests/vtr_reg_nightly_test3/ -type f -print0 | xargs -0 -P $(nproc) gzip
+find vtr_flow/tasks/regression_tests/vtr_reg_nightly_test4/ -type f -print0 | xargs -0 -P $(nproc) gzip
+
+# Make sure working directory doesn't exceed disk space limit!
+echo "Working directory size: $(du -sh)"
+if [[ $(du -s | cut -d $'\t' -f 1) -gt $(expr 1024 \* 1024 \* 90) ]]; then
+    echo "Working directory too large!"
+    exit 1
+fi
+
+exit $TEST_RESULT

--- a/.github/scripts/vtr-test.sh
+++ b/.github/scripts/vtr-test.sh
@@ -58,7 +58,7 @@ echo "========================================"
 echo "Packing benchmarks files"
 echo "========================================"
 
-results=qor_results.tar
+results=qor_results_$VTR_TEST.tar
 # Create archive with output files from the test
 find vtr_flow -type f \( -name "*.out" -o -name "*.log" -o -name "*.txt" -o -name "*.csv" \) -exec tar -rf $results {} \;
 gzip $results

--- a/.github/scripts/vtr-test.sh
+++ b/.github/scripts/vtr-test.sh
@@ -37,11 +37,6 @@ pwd -P
 ) &
 MONITOR=$!
 
-if [[ $VTR_CMAKE_PARAMS == *"-DVTR_ENABLE_SANITIZE=ON"*  ]]; then
-  echo "Setting LD_PRELOAD to /usr/lib/gcc/x86_64-linux-gnu/9/libasan.so"
-  export LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/9/libasan.so
-fi
-
 set +e
 
 echo "========================================"
@@ -65,7 +60,7 @@ echo "========================================"
 
 results=qor_results.tar
 # Create archive with output files from the test
-find vtr_flow -type f \( -name "*.txt" -o -name "*.log" -o -name "*.txt" -o -name "*.csv" \) -exec tar -rf $results {} \;
+find vtr_flow -type f \( -name "*.out" -o -name "*.log" -o -name "*.txt" -o -name "*.csv" \) -exec tar -rf $results {} \;
 gzip $results
 
 exit $TEST_RESULT

--- a/.github/workflows/large-tests.yml
+++ b/.github/workflows/large-tests.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {test: "vtr_reg_nightly_test1", options: "",           cmake: ""                                             }
-          - {test: "vtr_reg_nightly_test2", options: "",           cmake: ""                                             }
-          - {test: "vtr_reg_nightly_test3", options: "",           cmake: ""                                             }
-          - {test: "vtr_reg_nightly_test4", options: "",           cmake: ""                                             }
-          - {test: "vtr_reg_strong",        options: "",           cmake: "-DVTR_ASSERT_LEVEL=3"                         }
-          - {test: "vtr_reg_strong",        options: "-skip_qor",  cmake: "-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=ON"}
-          - {test: "vtr_reg_yosys",         options: "",           cmake: "-DWITH_YOSYS=ON"                              }
-          - {test: "vtr_reg_yosys_odin",    options: "",           cmake: "-DODIN_USE_YOSYS=ON"                          }
-          - {test: "odin_tech_strong",      options: "",           cmake: "-DODIN_USE_YOSYS=ON"                          }
-          - {test: "odin_reg_strong",       options: "",           cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test1", cores: "8",  options: "",          cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test2", cores: "16", options: "",          cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test3", cores: "16", options: "",          cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test4", cores: "16", options: "",          cmake: ""                                             }
+          - {test: "vtr_reg_strong",        cores: "16", options: "",          cmake: "-DVTR_ASSERT_LEVEL=3"                         }
+          - {test: "vtr_reg_strong",        cores: "16", options: "-skip_qor", cmake: "-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=ON"}
+          - {test: "vtr_reg_yosys",         cores: "16", options: "",          cmake: "-DWITH_YOSYS=ON"                              }
+          - {test: "vtr_reg_yosys_odin",    cores: "16", options: "",          cmake: "-DODIN_USE_YOSYS=ON"                          }
+          - {test: "odin_tech_strong",      cores: "16", options: "",          cmake: "-DODIN_USE_YOSYS=ON"                          }
+          - {test: "odin_reg_strong",       cores: "16", options: "",          cmake: ""                                             }
 
     env:
       DEBIAN_FRONTEND: "noninteractive"
@@ -44,7 +44,7 @@ jobs:
         VTR_TEST: ${{ matrix.test }}
         VTR_TEST_OPTIONS: ${{ matrix.options }}
         VTR_CMAKE_PARAMS: ${{ matrix.cmake }}
-        NUM_CORES: 16
+        NUM_CORES: ${{ matrix.cores }}
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -52,4 +52,4 @@ jobs:
         path: |
           **/results*.gz
           **/plot_*.svg
-          **/qor_results.tar.gz
+          **/qor_results*.tar.gz

--- a/.github/workflows/large-tests.yml
+++ b/.github/workflows/large-tests.yml
@@ -52,11 +52,4 @@ jobs:
         path: |
           **/results*.gz
           **/plot_*.svg
-          **/*.out.gz
-          **/vpr_stdout.log.gz
-          **/parse_results.txt.gz
-          **/qor_results.txt.gz
-          **/pack.log.gz
-          **/place.log.gz
-          **/route.log.gz
-          **/*_qor.csv.gz
+          **/qor_results.tar.gz

--- a/.github/workflows/large-tests.yml
+++ b/.github/workflows/large-tests.yml
@@ -1,0 +1,62 @@
+name: CI tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+
+  Run-tests:
+    container: ubuntu:bionic
+
+    runs-on: [self-hosted, Linux, X64]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {test: "vtr_reg_nightly_test1", options: "",           cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test2", options: "",           cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test3", options: "",           cmake: ""                                             }
+          - {test: "vtr_reg_nightly_test4", options: "",           cmake: ""                                             }
+          - {test: "vtr_reg_strong",        options: "",           cmake: "-DVTR_ASSERT_LEVEL=3"                         }
+          - {test: "vtr_reg_strong",        options: "-skip_qor",  cmake: "-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=ON"}
+          - {test: "vtr_reg_yosys",         options: "",           cmake: "-DWITH_YOSYS=ON"                              }
+          - {test: "vtr_reg_yosys_odin",    options: "",           cmake: "-DODIN_USE_YOSYS=ON"                          }
+          - {test: "odin_tech_strong",      options: "",           cmake: "-DODIN_USE_YOSYS=ON"                          }
+          - {test: "odin_reg_strong",       options: "",           cmake: ""                                             }
+
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Setup
+      run: stdbuf -i0 -i0 -e0 ./.github/scripts/hostsetup.sh
+
+    - name: Execute test script
+      run: stdbuf -i0 -o0 -e0 ./.github/scripts/run-vtr.sh
+      env:
+        VTR_TEST: ${{ matrix.test }}
+        VTR_TEST_OPTIONS: ${{ matrix.options }}
+        VTR_CMAKE_PARAMS: ${{ matrix.cmake }}
+        NUM_CORES: 16
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        path: |
+          **/results*.gz
+          **/plot_*.svg
+          **/*.out.gz
+          **/vpr_stdout.log.gz
+          **/parse_results.txt.gz
+          **/qor_results.txt.gz
+          **/pack.log.gz
+          **/place.log.gz
+          **/route.log.gz
+          **/*_qor.csv.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ set(SANITIZE_FLAGS "")
 if(VTR_ENABLE_SANITIZE)
     #Enable sanitizers
     # -fuse-ld=gold force the gold linker to be used (required for sanitizers, but not enabled by default on some systems)
-    set(SANITIZE_FLAGS "-g -fsanitize=address -fsanitize=leak -fsanitize=undefined -fuse-ld=gold")
+    set(SANITIZE_FLAGS "-g -fsanitize=address -fsanitize=leak -fsanitize=undefined -fuse-ld=gold -static-libasan")
     message(STATUS "SANITIZE_FLAGS: ${SANITIZE_FLAGS}")
 endif()
 

--- a/libs/librrgraph/CMakeLists.txt
+++ b/libs/librrgraph/CMakeLists.txt
@@ -7,9 +7,6 @@ file(GLOB_RECURSE LIB_SOURCES src/*/*.cpp)
 file(GLOB_RECURSE LIB_HEADERS src/*/*.h)
 files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
 
-#Remove test executable from library
-list(REMOVE_ITEM LIB_SOURCES ${EXEC_SOURCES})
-
 #Create the library
 add_library(librrgraph STATIC
     ${LIB_HEADERS}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR moves the infrastructure from Kokoro to GH actions to run large tests on GH custom runners

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1965

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
