### PR TITLE
doc: update copyright year

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -92,7 +92,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Verilog-to-Routing"
-copyright = "2016, VTR Developers"
+copyright = "2012-2022, VTR Developers"
 author = "VTR Developers"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
#### Description

The year shown at the footer of the docs is `2016`. This PR updates it to `2012-2022`. @vaughnbetz what should be the proper starting year?

#### Related Issue

*None*

#### Motivation and Context

The docs have been updated since 2016...

#### How Has This Been Tested?

It's changing the content of a hardcoded string. There is no functionality change at all. It's tested in CI.

#### Types of changes

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:

- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
