### PR TITLE
doc/index: typo

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -15,7 +15,7 @@ Welcome to Verilog-to-Routing's documentation!
 .. image:: https://www.verilogtorouting.org/img/des90_routing_util.gif
     :width: 30%
 
-Form more information on the Verilog-to-Routing (VTR) project see :ref:`vtr` and :ref:`vtr_cad_flow`.
+For more information on the Verilog-to-Routing (VTR) project see :ref:`vtr` and :ref:`vtr_cad_flow`.
 
 For documentation and tutorials on the FPGA architecture description language see: :ref:`fpga_architecture_description`.
 


### PR DESCRIPTION
This is just a typo in the first sentence of the docs.