### PR TITLE
ci/test: run jobs on ubuntu-20.04, instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
 
   Build:
     name: 'B: Building VtR'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/setup-python@v2
@@ -86,7 +86,7 @@ jobs:
 
 
   Format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +109,7 @@ jobs:
 
   UniTests:
     name: 'U: C++ Unit Tests'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/setup-python@v2
@@ -126,7 +126,7 @@ jobs:
 
   Warnings:
     name: 'W: Check Compilation Warnings'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/setup-python@v2
@@ -148,7 +148,7 @@ jobs:
 
 
   Regression:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -218,7 +218,7 @@ jobs:
           vtr_flow/**/parse_results*.txt
 
   Sanitized:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -250,7 +250,7 @@ jobs:
 
   ODINII:
     name: 'ODIN-II Basic Test'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/setup-python@v2
@@ -273,7 +273,7 @@ jobs:
 
   VQM2BLIF:
     name: 'VQM2BLIF Basic Tests'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/setup-python@v2
@@ -294,7 +294,7 @@ jobs:
 
 
   YOSYSODINII:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -326,7 +326,7 @@ jobs:
 
 
   Compatibility:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -373,7 +373,7 @@ jobs:
       - VQM2BLIF
       - YOSYSODINII
       - Compatibility
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/setup-python@v2


### PR DESCRIPTION
#### Description

Since the base image of the Dockerfile is to be updated to ubuntu:focal (see #1970), this PR changes the environment used in the jobs of workflow 'test'.

#### Related Issue

- #1970

#### Motivation and Context

Ubuntu 18.04 is maintained until April 2023 (see https://endoflife.software/operating-systems/linux/ubuntu), however, Ubuntu 20.04 is also LTS. Hence, it is sensible to bump the environment, despite 18.04 not being EOL yet.

#### How Has This Been Tested?

It's CI, so self tested.

#### Types of changes

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
