### PR TITLE
Fix `Global Routing` tech report link

### DIFF
--- a/doc/src/z_references.bib
+++ b/doc/src/z_references.bib
@@ -90,7 +90,7 @@
     type = {CSRI Technical Report},
     number = {358},
     year = {1996},
-    url = {http://www.eecg.toronto.edu/~vaughn/ papers/techrep.ps.Z},
+    url = {http://www.eecg.toronto.edu/~vaughn/papers/techrep.pdf},
 }
 
 @inproceedings{betz_automatic_generation_of_fpga_routing,


### PR DESCRIPTION
Points "On Biased and Non-Uniform Global Routing Architectures and CAD Tools for FPGAs" to https://www.eecg.utoronto.ca/~vaughn/papers/techrep.pdf -- a known working link of the paper referenced. Resolving https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1967

<!--- Provide a general summary of your changes in the Title above -->
#### Description
Fixing `z_references.bib` link.
<!--- Describe your changes in detail -->


#### Related Issue
<!--- Pull requests should be related to open issues -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1967

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken link. 
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a known-good link. No impact to code base. 

#### Types of changes
This is documentation bug fix. No checklist items below apply. 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
