### PR TITLE
gha: prevent from running large tests on forks

### DIFF
--- a/.github/workflows/large-tests.yml
+++ b/.github/workflows/large-tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
 
   Run-tests:
+    # Prevents from running on forks where no custom runners are available
+    if: ${{ github.repository_owner == 'verilog-to-routing' }}
+
     container: ubuntu:bionic
 
     runs-on: [self-hosted, Linux, X64]


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
With the new GH custom runners, CI for large tests cannot run on forks, as the custom runners are not deployed for usage outside of the scope of the `verilog-to-routing` org. This prevents the workflow from failing due to unavailable runners.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
