### PR TITLE
WIP: Edge switch subsets

### DIFF
--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -2,11 +2,11 @@
 # https://github.com/duck2/uxsdcxx
 # Modify only if your build process doesn't involve regenerating this file.
 #
-# Cmdline: uxsdcxx/uxsdcap.py /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
-# Input file: /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
-# md5sum of input file: cd57d47fc9dfa62c7030397ca759217e
+# Cmdline: uxsdcxx/uxsdcap.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+# Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+# md5sum of input file: 5c529f385cc39043f69229d620e94c98
 
-@0xe4650d345d47589d;
+@0xcf38b97e680e90dd;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -202,15 +202,32 @@ struct RrNodes {
 	nodes @0 :List(Node);
 }
 
-struct Edge {
-	sinkNode @0 :UInt32;
-	srcNode @1 :UInt32;
-	switchId @2 :UInt32;
-	metadata @3 :Metadata;
+struct EPtn {
+	id @0 :UInt32;
 }
 
-struct RrEdges {
-	edges @0 :List(Edge);
+struct NodeEPtn {
+	dest @0 :UInt32;
+	id @1 :UInt32;
+	ePtns @2 :List(EPtn);
+}
+
+struct RrNodeEPtns {
+	nodeEPtns @0 :List(NodeEPtn);
+}
+
+struct Ddiff {
+	id @0 :UInt32;
+}
+
+struct EdgePtn {
+	id @0 :UInt32;
+	switchId @1 :UInt32;
+	ddiffs @2 :List(Ddiff);
+}
+
+struct RrEdgePtns {
+	edgePtns @0 :List(EdgePtn);
 }
 
 struct RrGraph {
@@ -223,5 +240,6 @@ struct RrGraph {
 	blockTypes @6 :BlockTypes;
 	grid @7 :GridLocs;
 	rrNodes @8 :RrNodes;
-	rrEdges @9 :RrEdges;
+	rrNodeEPtns @9 :RrNodeEPtns;
+	rrEdgePtns @10 :RrEdgePtns;
 }

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -4,9 +4,9 @@
 #
 # Cmdline: uxsdcxx/uxsdcap.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
 # Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
-# md5sum of input file: 5c529f385cc39043f69229d620e94c98
+# md5sum of input file: f70492b177e0daf17b52aa153b3fae93
 
-@0xcf38b97e680e90dd;
+@0xba70c56446959ad0;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -202,20 +202,6 @@ struct RrNodes {
 	nodes @0 :List(Node);
 }
 
-struct EPtn {
-	id @0 :UInt32;
-}
-
-struct NodeEPtn {
-	dest @0 :UInt32;
-	id @1 :UInt32;
-	ePtns @2 :List(EPtn);
-}
-
-struct RrNodeEPtns {
-	nodeEPtns @0 :List(NodeEPtn);
-}
-
 struct Ddiff {
 	id @0 :UInt32;
 }
@@ -230,6 +216,20 @@ struct RrEdgePtns {
 	edgePtns @0 :List(EdgePtn);
 }
 
+struct EPtn {
+	id @0 :UInt32;
+}
+
+struct NodeEPtn {
+	dest @0 :UInt32;
+	id @1 :UInt32;
+	ePtns @2 :List(EPtn);
+}
+
+struct RrNodeEPtns {
+	nodeEPtns @0 :List(NodeEPtn);
+}
+
 struct RrGraph {
 	toolComment @0 :Text;
 	toolName @1 :Text;
@@ -240,6 +240,6 @@ struct RrGraph {
 	blockTypes @6 :BlockTypes;
 	grid @7 :GridLocs;
 	rrNodes @8 :RrNodes;
-	rrNodeEPtns @9 :RrNodeEPtns;
-	rrEdgePtns @10 :RrEdgePtns;
+	rrEdgePtns @9 :RrEdgePtns;
+	rrNodeEPtns @10 :RrNodeEPtns;
 }

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -255,9 +255,12 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
         auto &device_ctx = g_vpr_ctx.mutable_device();
         const auto& rr_graph = device_ctx.rr_graph;
         for (const RRNodeId& inode : rr_graph.nodes()){
-            for(t_edge_size iedge = 0; iedge < rr_graph.num_edges(inode); ++iedge) {
-                auto sink_inode = size_t(rr_graph.edge_sink_node(inode, iedge));
-                auto switch_id = rr_graph.edge_switch(inode, iedge);
+
+            std::vector<t_dest_switch> rr_edges;
+            g_vpr_ctx.mutable_device().rr_graph.get_edges(inode, rr_edges);
+            for (auto edge : rr_edges) {                
+                auto sink_inode = size_t(edge.dest);
+                auto switch_id = edge.switch_id;
                 auto value = vtr::string_fmt("%d_%d_%zu",
                             (size_t)inode, sink_inode, switch_id);
 

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -513,12 +513,12 @@ static bool check_rr_graph_connectivity(RRNodeId prev_node, RRNodeId node) {
 
     for (RREdgeId edge : rr_graph.edge_range(prev_node)) {
         //If the sink node is reachable by previous node return true
-        if (rr_graph.edge_sink_node(edge) == node) {
+        if (rr_graph.edge_sink_node_abs(prev_node, edge) == node) {
             return true;
         }
 
         // If there are any non-configurable branches return true
-        short edge_switch = rr_graph.edge_switch(edge);
+        short edge_switch = rr_graph.edge_switch_abs(prev_node, edge);
         if (!(temp_rr_graph.rr_switch_inf(RRSwitchId(edge_switch)).configurable())) return true;
     }
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1482,6 +1482,12 @@ struct t_linked_f_pointer {
     float* fptr;
 };
 
+struct t_switch_edge_ptn {
+    short switch_id;
+    uint16_t edge_count; // up to 65,536 edges per pattern
+    int ptn_idx;
+};
+
 /**
  * @brief Type of a routing resource node.
  *

--- a/vpr/src/device/rr_graph_builder.cpp
+++ b/vpr/src/device/rr_graph_builder.cpp
@@ -92,7 +92,7 @@ void RRGraphBuilder::reorder_nodes(e_rr_node_reorder_algorithm reorder_rr_graph_
                 que.pop();
                 degree[u] += node_storage_.num_edges(u);
                 for (RREdgeId edge = node_storage_.first_edge(u); edge < node_storage_.last_edge(u); edge = RREdgeId(size_t(edge) + 1)) {
-                    RRNodeId v = node_storage_.edge_sink_node(edge);
+                    RRNodeId v = node_storage_.edge_sink_node_abs(u, edge);
                     degree[v]++;
                     if (bfs_idx[v]) continue;
                     bfs_idx[v] = cur_idx++;

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -128,6 +128,23 @@ class RRGraphBuilder {
     inline void set_node_direction(RRNodeId id, Direction new_direction) {
         node_storage_.set_node_direction(id, new_direction);
     }
+    
+    inline void add_node_first_dest(RRNodeId id, int dest){
+        node_storage_.add_node_first_dest(id, dest);
+    }
+    inline void add_edge_ddiff(int id){
+        node_storage_.add_edge_ddiff(id);
+    }
+    inline void add_edge_ptn(int switch_id){
+        node_storage_.add_edge_ptn(switch_id);
+    }
+    inline void add_node_to_edge_ptn(int edge_ptn_idx){
+        node_storage_.add_node_to_edge_ptn(edge_ptn_idx);
+    }
+
+
+
+
 
     /** @brief Reserve the lists of edges to be memory efficient.
      * This function is mainly used to reserve memory space inside RRGraph,

--- a/vpr/src/device/rr_graph_view.cpp
+++ b/vpr/src/device/rr_graph_view.cpp
@@ -2,7 +2,7 @@
 #include "rr_node.h"
 #include "physical_types.h"
 
-RRGraphView::RRGraphView(const t_rr_graph_storage& node_storage, const RRSpatialLookup& node_lookup, const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data, const vtr::vector<RRSegmentId, t_segment_inf>& rr_segments, const vtr::vector<RRSwitchId, t_rr_switch_inf>& rr_switch_inf)
+RRGraphView::RRGraphView(t_rr_graph_storage& node_storage, const RRSpatialLookup& node_lookup, const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data, const vtr::vector<RRSegmentId, t_segment_inf>& rr_segments, const vtr::vector<RRSwitchId, t_rr_switch_inf>& rr_switch_inf)
     : node_storage_(node_storage)
     , node_lookup_(node_lookup)
     , rr_indexed_data_(rr_indexed_data)

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -145,7 +145,7 @@ class RRGraphView {
         return node_storage_.node_yhigh(node);
     }
 
-    inline std::vector<int> node_to_edge_ptns(RRNodeId node) const {
+    inline std::vector<t_switch_edge_ptn> node_to_edge_ptns(RRNodeId node) const {
         return node_storage_.node_to_edge_ptns(node);
     }
 

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -145,9 +145,7 @@ class RRGraphView {
         return node_storage_.node_yhigh(node);
     }
 
-    inline std::vector<t_switch_edge_ptn> node_to_edge_ptns(RRNodeId node) const {
-        return node_storage_.node_to_edge_ptns(node);
-    }
+
     inline t_switch_edge_ptn edge_ptns(int node) const {
         return node_storage_.edge_ptns(node);
     }

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -148,6 +148,13 @@ class RRGraphView {
     inline std::vector<t_switch_edge_ptn> node_to_edge_ptns(RRNodeId node) const {
         return node_storage_.node_to_edge_ptns(node);
     }
+    inline t_switch_edge_ptn edge_ptns(int node) const {
+        return node_storage_.edge_ptns(node);
+    }
+
+    inline int node_to_edge_ptns_new(RRNodeId node) const {
+        return node_storage_.node_to_edge_ptns_new(node);
+    }
 
     inline t_switch_edge_ptn edge_ptn(int ptn) const {
         return node_storage_.edge_ptn(ptn);
@@ -156,6 +163,15 @@ class RRGraphView {
     inline int edge_ptn_data(int ptn) const {
         return node_storage_.edge_ptn_data(ptn);
     }
+
+    short edge_switch_abs(const RRNodeId& id, RREdgeId edge) const {
+        return node_storage_.edge_switch_abs(id, edge);
+    }
+
+    RRNodeId edge_sink_node_abs(const RRNodeId& id, RREdgeId edge) const {
+        return node_storage_.edge_sink_node_abs(id, edge);
+    }
+
       
 
     /** @brief Get the first out coming edge of resource node. This function is inlined for runtime optimization. */

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -35,7 +35,7 @@ class RRGraphView {
     /* -- Constructors -- */
   public:
     /* See detailed comments about the data structures in the internal data storage section of this file */
-    RRGraphView(const t_rr_graph_storage& node_storage,
+    RRGraphView(t_rr_graph_storage& node_storage,
                 const RRSpatialLookup& node_lookup,
                 const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
                 const vtr::vector<RRSegmentId, t_segment_inf>& rr_segments,
@@ -155,6 +155,18 @@ class RRGraphView {
     inline int node_to_edge_ptns_new(RRNodeId node) const {
         return node_storage_.node_to_edge_ptns_new(node);
     }
+    
+    inline int num_edge_ptns(const RRNodeId& id) const {
+        return node_storage_.num_edge_ptns(id);
+    }
+
+    inline void get_edges(RRNodeId id, std::vector<t_dest_switch> &edges)  {
+        node_storage_.get_edges(id, edges);
+    }
+    inline void get_non_configurable_edges(RRNodeId id, std::vector<t_dest_switch> &edges)  {
+        node_storage_.get_non_configurable_edges(id, edges);
+    }
+
 
     inline t_switch_edge_ptn edge_ptn(int ptn) const {
         return node_storage_.edge_ptn(ptn);
@@ -376,6 +388,10 @@ class RRGraphView {
         return node_storage_.num_edges(node);
     }
 
+    inline vtr::StrongIdRange<RREdgeId> int_range(const int id) const {
+        return node_storage_.int_range(id);
+    }
+
     /** @brief The ptc_num carries different meanings for different node types 
      * (true in VPR RRG that is currently supported, may not be true in customized RRG) 
      * CHANX or CHANY: the track id in routing channels 
@@ -446,7 +462,7 @@ class RRGraphView {
     /* Note: only read-only object or data structures are allowed!!! */
   private:
     /* node-level storage including edge storages */
-    const t_rr_graph_storage& node_storage_;
+    t_rr_graph_storage& node_storage_;
     /* Fast look-up for rr nodes */
     const RRSpatialLookup& node_lookup_;
 

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -150,8 +150,8 @@ class RRGraphView {
         return node_storage_.edge_ptns(node);
     }
 
-    inline int node_to_edge_ptns_new(RRNodeId node) const {
-        return node_storage_.node_to_edge_ptns_new(node);
+    inline int node_to_edge_ptns(RRNodeId node) const {
+        return node_storage_.node_to_edge_ptns(node);
     }
     
     inline int num_edge_ptns(const RRNodeId& id) const {

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -145,9 +145,25 @@ class RRGraphView {
         return node_storage_.node_yhigh(node);
     }
 
+    inline std::vector<int> node_to_edge_ptns(RRNodeId node) const {
+        return node_storage_.node_to_edge_ptns(node);
+    }
+
+    inline t_switch_edge_ptn edge_ptn(int ptn) const {
+        return node_storage_.edge_ptn(ptn);
+    }
+
+    inline int edge_ptn_data(int ptn) const {
+        return node_storage_.edge_ptn_data(ptn);
+    }
+      
+
     /** @brief Get the first out coming edge of resource node. This function is inlined for runtime optimization. */
     inline RREdgeId node_first_edge(RRNodeId node) const {
         return node_storage_.first_edge(node);
+    }
+    inline int node_first_dest(RRNodeId node) const {
+        return node_storage_.node_first_dest(node);
     }
 
     /** @brief Get the last out coming edge of resource node. This function is inlined for runtime optimization. */

--- a/vpr/src/device/rr_graph_view.h
+++ b/vpr/src/device/rr_graph_view.h
@@ -285,11 +285,18 @@ class RRGraphView {
     inline short edge_switch(RRNodeId id, t_edge_size iedge) const {
         return node_storage_.edge_switch(id, iedge);
     }
+    inline short edge_switch(RREdgeId iedge) const {
+        return node_storage_.edge_switch(iedge);
+    }
+
     /** @brief Get the destination node for the iedge'th edge from specified RRNodeId.
      *  This method should generally not be used, and instead first_edge and
      *  last_edge should be used.*/
     inline RRNodeId edge_sink_node(RRNodeId id, t_edge_size iedge) const {
         return node_storage_.edge_sink_node(id, iedge);
+    }
+    inline RRNodeId edge_sink_node(RREdgeId iedge) const {
+        return node_storage_.edge_sink_node(iedge);
     }
 
     /** @brief Get the number of configurable edges. This function is inlined for runtime optimization. */

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -1165,17 +1165,26 @@ bool directconnect_exists(int src_rr_node, int sink_rr_node) {
     VTR_ASSERT(rr_graph.node_type(RRNodeId(src_rr_node)) == SOURCE && rr_graph.node_type(RRNodeId(sink_rr_node)) == SINK);
 
     //TODO: This is a constant depth search, but still may be too slow
-    for (t_edge_size i_src_edge = 0; i_src_edge < rr_graph.num_edges(RRNodeId(src_rr_node)); ++i_src_edge) {
-        int opin_rr_node = size_t(rr_graph.edge_sink_node(RRNodeId(src_rr_node), i_src_edge));
+    std::vector<t_dest_switch> rr_edges;
+    g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(src_rr_node), rr_edges);
+    for (auto rr_edge : rr_edges) { 
+    // for (t_edge_size i_src_edge = 0; i_src_edge < rr_graph.num_edges(RRNodeId(src_rr_node)); ++i_src_edge) {
+        int opin_rr_node = size_t(rr_edge.dest);
 
         if (rr_graph.node_type(RRNodeId(opin_rr_node)) != OPIN) continue;
 
-        for (t_edge_size i_opin_edge = 0; i_opin_edge < rr_graph.num_edges(RRNodeId(opin_rr_node)); ++i_opin_edge) {
-            int ipin_rr_node = size_t(rr_graph.edge_sink_node(RRNodeId(opin_rr_node), i_opin_edge));
+        std::vector<t_dest_switch> rr_edges2;
+        g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(opin_rr_node), rr_edges2);
+        for (auto rr_edge2 : rr_edges2) {
+        // for (t_edge_size i_opin_edge = 0; i_opin_edge < rr_graph.num_edges(RRNodeId(opin_rr_node)); ++i_opin_edge) {
+            int ipin_rr_node = size_t(rr_edge2.dest);
             if (rr_graph.node_type(RRNodeId(ipin_rr_node)) != IPIN) continue;
 
-            for (t_edge_size i_ipin_edge = 0; i_ipin_edge < rr_graph.num_edges(RRNodeId(ipin_rr_node)); ++i_ipin_edge) {
-                if (size_t(sink_rr_node) == size_t(rr_graph.edge_sink_node(RRNodeId(ipin_rr_node), i_ipin_edge))) {
+            std::vector<t_dest_switch> rr_edges3;
+            g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(ipin_rr_node), rr_edges3);
+            for (auto rr_edge3 : rr_edges3) {
+            // for (t_edge_size i_ipin_edge = 0; i_ipin_edge < rr_graph.num_edges(RRNodeId(ipin_rr_node)); ++i_ipin_edge) {
+                if (size_t(sink_rr_node) == size_t(rr_edge3.dest)) {
                     return true;
                 }
             }

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -309,8 +309,11 @@ static bool check_adjacent(int from_node, int to_node) {
 
     reached = false;
 
-    for (t_edge_size iconn = 0; iconn < rr_graph.num_edges(RRNodeId(from_node)); iconn++) {
-        if (size_t(rr_graph.edge_sink_node(RRNodeId(from_node), iconn)) == size_t(to_node)) {
+    std::vector<t_dest_switch> rr_edges;
+    g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);
+    for (auto rr_edge : rr_edges) { 
+    // for (t_edge_size iconn = 0; iconn < rr_graph.num_edges(RRNodeId(from_node)); iconn++) {
+        if (size_t(rr_edge.dest) == size_t(to_node)) {
             reached = true;
             break;
         }

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -420,10 +420,10 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //     int switch_idx = rr_graph_->edge_switch(from_edge);
     //     VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
     // }
-    
+
     size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
     int first_dest = rr_graph_->node_first_dest(from_node);
-    int e_ptn_idx = rr_graph_->node_to_edge_ptns_new(from_node); 
+    int e_ptn_idx = rr_graph_->node_to_edge_ptns(from_node); 
     int edges_num = rr_graph_->num_edges(from_node);
     int edges_count = 0;
 

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -422,30 +422,87 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //     VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
     // }
 
-        int first_dest = rr_graph_->node_first_dest(from_node);
+        // int first_dest = rr_graph_->node_first_dest(from_node);
+        // size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
+        // int k = 0;
+        // int rel = 0;
+        // short cur_switch;
+        // for (const auto& p : rr_graph_->node_to_edge_ptns(from_node)){
+        //     // const auto& p = rr_graph_->edge_ptn(ptn);
+        //     cur_switch = p.switch_id;
+        //     while (k < p.edge_count){
+        //         RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
+        //         timing_driven_expand_neighbour(current,
+        //                                     from_node_int,
+        //                                     RREdgeId(first_edge+rel),
+        //                                     size_t(to_node),
+        //                                     cost_params,
+        //                                     bounding_box,
+        //                                     target_node,
+        //                                     target_bb,
+        //                                     cur_switch);
+        //         k++;
+        //         rel++;
+        //     }
+        //     k = 0;
+        // }
+
+
+
         size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
-        int k = 0;
-        int rel = 0;
-        short cur_switch;
-        for (const auto& p : rr_graph_->node_to_edge_ptns(from_node)){
-            // const auto& p = rr_graph_->edge_ptn(ptn);
-            cur_switch = p.switch_id;
+        int rel = 1;
+        int first_dest = rr_graph_->node_first_dest(from_node);
+        int edges_num = rr_graph_->num_edges(from_node);
+
+        // First Edge
+        int e_ptn_idx = rr_graph_->node_to_edge_ptns_new(from_node); 
+        int edges_added = 0;
+        t_switch_edge_ptn p;
+        while (edges_added < 1*(edges_num>0)){
+
+            
+            p = rr_graph_->edge_ptns(e_ptn_idx);
+
+            RRNodeId to_node = RRNodeId(first_dest);
+            timing_driven_expand_neighbour(current,
+                                        from_node_int,
+                                        RREdgeId(first_edge),
+                                        size_t(to_node),
+                                        cost_params,
+                                        bounding_box,
+                                        target_node,
+                                        target_bb,
+                                        p.switch_id);
+
+            edges_added++;
+        }
+
+        int k = 1; // skip the first edge
+        while (edges_added < edges_num) { // only for nodes with more than one edge
             while (k < p.edge_count){
+
                 RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
                 timing_driven_expand_neighbour(current,
-                                            from_node_int,
-                                            RREdgeId(first_edge+rel),
-                                            size_t(to_node),
-                                            cost_params,
-                                            bounding_box,
-                                            target_node,
-                                            target_bb,
-                                            cur_switch);
+                                        from_node_int,
+                                        RREdgeId(first_edge+rel),
+                                        size_t(to_node),
+                                        cost_params,
+                                        bounding_box,
+                                        target_node,
+                                        target_bb,
+                                        p.switch_id);
+
                 k++;
                 rel++;
+                edges_added++;
             }
             k = 0;
+            e_ptn_idx++;
+            p = rr_graph_->edge_ptns(e_ptn_idx);
         }
+
+
+
 
 
     // for (RREdgeId from_edge : edges) {

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -393,7 +393,6 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //For each node associated with the current heap element, expand all of it's neighbors
     int from_node_int = current->index;
     RRNodeId from_node(from_node_int);
-    // auto edges = rr_nodes_.edge_range(from_node);
 
     // This is a simple prefetch that prefetches:
     //  - RR node data reachable from this node
@@ -421,73 +420,40 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //     int switch_idx = rr_graph_->edge_switch(from_edge);
     //     VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
     // }
+    
+    size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
+    int first_dest = rr_graph_->node_first_dest(from_node);
+    int e_ptn_idx = rr_graph_->node_to_edge_ptns_new(from_node); 
+    int edges_num = rr_graph_->num_edges(from_node);
+    int edges_count = 0;
 
-        // int first_dest = rr_graph_->node_first_dest(from_node);
-        // size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
-        // int k = 0;
-        // int rel = 0;
-        // short cur_switch;
-        // for (const auto& p : rr_graph_->node_to_edge_ptns(from_node)){
-        //     // const auto& p = rr_graph_->edge_ptn(ptn);
-        //     cur_switch = p.switch_id;
-        //     while (k < p.edge_count){
-        //         RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
-        //         timing_driven_expand_neighbour(current,
-        //                                     from_node_int,
-        //                                     RREdgeId(first_edge+rel),
-        //                                     size_t(to_node),
-        //                                     cost_params,
-        //                                     bounding_box,
-        //                                     target_node,
-        //                                     target_bb,
-        //                                     cur_switch);
-        //         k++;
-        //         rel++;
-        //     }
-        //     k = 0;
-        // }
-
-
-
-        size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
-        int first_dest = rr_graph_->node_first_dest(from_node);
-        int e_ptn_idx = rr_graph_->node_to_edge_ptns_new(from_node); 
-        int edges_num = rr_graph_->num_edges(from_node);
-        int edges_count = 0;
-
-        t_switch_edge_ptn p = rr_graph_->edge_ptns(e_ptn_idx);
-        int k = 0;
-        // while (edges_count < edges_num){
-        int num_ptns = rr_graph_->num_edge_ptns(from_node);
-        for (int j=0; j<num_ptns; j++){
-            const int p_edge_count = p.edge_count;
-            for (int i=0; i<p_edge_count; i++){
-                RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
-                timing_driven_expand_neighbour(current,
-                                    from_node_int,
-                                    RREdgeId(first_edge+edges_count),
-                                    size_t(to_node),
-                                    cost_params,
-                                    bounding_box,
-                                    target_node,
-                                    target_bb,
-                                    p.switch_id);
-                edges_count += 1;
-                k++;
-            }
-            k = 0;
-            e_ptn_idx++;
-            p = rr_graph_->edge_ptns(e_ptn_idx);
+    t_switch_edge_ptn p = rr_graph_->edge_ptns(e_ptn_idx);
+    int k = 0;
+    int num_ptns = rr_graph_->num_edge_ptns(from_node);
+    for (int j=0; j<num_ptns; j++){
+        const int p_edge_count = p.edge_count;
+        for (int i=0; i<p_edge_count; i++){
+            RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
+            timing_driven_expand_neighbour(current,
+                                from_node_int,
+                                RREdgeId(first_edge+edges_count),
+                                size_t(to_node),
+                                cost_params,
+                                bounding_box,
+                                target_node,
+                                target_bb,
+                                p.switch_id);
+            edges_count += 1;
+            k++;
         }
+        k = 0;
+        e_ptn_idx++;
+        p = rr_graph_->edge_ptns(e_ptn_idx);
+    }
 
-// if (k == p.edge_count){
-//                 k = 0;
-//                 e_ptn_idx++;
-//                 p = rr_graph_->edge_ptns(e_ptn_idx);
-//             }
+    // --- Previous Method for accessing edges ---
 
-
-
+    // auto edges = rr_nodes_.edge_range(from_node);
     // for (RREdgeId from_edge : edges) {
     //     RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
     //     timing_driven_expand_neighbour(current,
@@ -499,6 +465,7 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //                                    target_node,
     //                                    target_bb);
     // }
+
 }
 
 //Conditionally adds to_node to the router heap (via path from from_node via from_edge).

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -393,7 +393,7 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //For each node associated with the current heap element, expand all of it's neighbors
     int from_node_int = current->index;
     RRNodeId from_node(from_node_int);
-    auto edges = rr_nodes_.edge_range(from_node);
+    // auto edges = rr_nodes_.edge_range(from_node);
 
     // This is a simple prefetch that prefetches:
     //  - RR node data reachable from this node
@@ -412,25 +412,53 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //  - directrf_stratixiv_arch_timing.blif
     //  - gsm_switch_stratixiv_arch_timing.blif
     //
-    for (RREdgeId from_edge : edges) {
-        RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
-        rr_nodes_.prefetch_node(to_node);
 
-        int switch_idx = rr_graph_->edge_switch(from_edge);
-        VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
-    }
+    // auto edges = rr_nodes_.edge_range(from_node);
+    // for (RREdgeId from_edge : edges) {
+    //     RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
+    //     rr_nodes_.prefetch_node(to_node);
 
-    for (RREdgeId from_edge : edges) {
-        RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
-        timing_driven_expand_neighbour(current,
-                                       from_node_int,
-                                       from_edge,
-                                       size_t(to_node),
-                                       cost_params,
-                                       bounding_box,
-                                       target_node,
-                                       target_bb);
-    }
+    //     int switch_idx = rr_graph_->edge_switch(from_edge);
+    //     VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
+    // }
+
+        int first_dest = rr_graph_->node_first_dest(from_node);
+        size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
+        int k = 0;
+        int rel = 0;
+        short cur_switch;
+        for (const auto& ptn : rr_graph_->node_to_edge_ptns(from_node)){
+            const auto& p = rr_graph_->edge_ptn(ptn);
+            cur_switch = p.switch_id;
+            while (k < p.edge_count){
+                RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
+                timing_driven_expand_neighbour(current,
+                                            from_node_int,
+                                            RREdgeId(first_edge+rel),
+                                            size_t(to_node),
+                                            cost_params,
+                                            bounding_box,
+                                            target_node,
+                                            target_bb,
+                                            cur_switch);
+                k++;
+                rel++;
+            }
+            k = 0;
+        }
+
+
+    // for (RREdgeId from_edge : edges) {
+    //     RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
+    //     timing_driven_expand_neighbour(current,
+    //                                    from_node_int,
+    //                                    from_edge,
+    //                                    size_t(to_node),
+    //                                    cost_params,
+    //                                    bounding_box,
+    //                                    target_node,
+    //                                    target_bb);
+    // }
 }
 
 //Conditionally adds to_node to the router heap (via path from from_node via from_edge).
@@ -444,7 +472,8 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbour(t_heap* current,
                                                             const t_conn_cost_params cost_params,
                                                             const t_bb bounding_box,
                                                             int target_node,
-                                                            const t_bb target_bb) {
+                                                            const t_bb target_bb,
+                                                            const short switch_id) {
     RRNodeId to_node(to_node_int);
     int to_xlow = rr_graph_->node_xlow(to_node);
     int to_ylow = rr_graph_->node_ylow(to_node);
@@ -511,7 +540,8 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbour(t_heap* current,
                                   from_node,
                                   to_node_int,
                                   from_edge,
-                                  target_node);
+                                  target_node,
+                                  switch_id);
     }
 }
 
@@ -522,7 +552,8 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params 
                                                        const int from_node,
                                                        const int to_node,
                                                        const RREdgeId from_edge,
-                                                       const int target_node) {
+                                                       const int target_node,
+                                                       const short switch_id) {
     t_heap next;
 
     // Initalize RCV data struct if needed, otherwise it's set to nullptr
@@ -547,7 +578,8 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params 
                                       from_node,
                                       to_node,
                                       from_edge,
-                                      target_node);
+                                      target_node,
+                                      switch_id);
 
     float best_total_cost = rr_node_route_inf_[to_node].path_cost;
     float best_back_cost = rr_node_route_inf_[to_node].backward_path_cost;
@@ -667,7 +699,8 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
                                                                const int from_node,
                                                                const int to_node,
                                                                const RREdgeId from_edge,
-                                                               const int target_node) {
+                                                               const int target_node,
+                                                               const short iswitch) {
     /* new_costs.backward_cost: is the "known" part of the cost to this node -- the
      * congestion cost of all the routing resources back to the existing route
      * plus the known delay of the total path back to the source.
@@ -678,7 +711,7 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
      */
 
     //Info for the switch connecting from_node to_node
-    int iswitch = rr_graph_->edge_switch(from_edge);
+    // int iswitch = rr_graph_->edge_switch(from_edge);
     bool switch_buffered = rr_switch_inf_[iswitch].buffered();
     bool reached_configurably = rr_switch_inf_[iswitch].configurable();
     float switch_R = rr_switch_inf_[iswitch].R;
@@ -774,7 +807,7 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
 
 template<typename Heap>
 void ConnectionRouter<Heap>::empty_heap_annotating_node_route_inf() {
-    //Pop any remaining nodes in the heap and annotate their costs
+    //Pop any remaining nodes in the heap and annotaFte their costs
     //
     //Useful for visualizing router expansion in graphics, as it shows
     //the cost of all nodes considered by the router (e.g. nodes never

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -427,8 +427,8 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
         int k = 0;
         int rel = 0;
         short cur_switch;
-        for (const auto& ptn : rr_graph_->node_to_edge_ptns(from_node)){
-            const auto& p = rr_graph_->edge_ptn(ptn);
+        for (const auto& p : rr_graph_->node_to_edge_ptns(from_node)){
+            // const auto& p = rr_graph_->edge_ptn(ptn);
             cur_switch = p.switch_id;
             while (k < p.edge_count){
                 RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -413,15 +413,15 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
     //  - gsm_switch_stratixiv_arch_timing.blif
     //
     for (RREdgeId from_edge : edges) {
-        RRNodeId to_node = rr_nodes_.edge_sink_node(from_edge);
+        RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
         rr_nodes_.prefetch_node(to_node);
 
-        int switch_idx = rr_nodes_.edge_switch(from_edge);
+        int switch_idx = rr_graph_->edge_switch(from_edge);
         VTR_PREFETCH(&rr_switch_inf_[switch_idx], 0, 0);
     }
 
     for (RREdgeId from_edge : edges) {
-        RRNodeId to_node = rr_nodes_.edge_sink_node(from_edge);
+        RRNodeId to_node = rr_graph_->edge_sink_node(from_edge);
         timing_driven_expand_neighbour(current,
                                        from_node_int,
                                        from_edge,
@@ -678,7 +678,7 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(t_heap* to,
      */
 
     //Info for the switch connecting from_node to_node
-    int iswitch = rr_nodes_.edge_switch(from_edge);
+    int iswitch = rr_graph_->edge_switch(from_edge);
     bool switch_buffered = rr_switch_inf_[iswitch].buffered();
     bool reached_configurably = rr_switch_inf_[iswitch].configurable();
     float switch_R = rr_switch_inf_[iswitch].R;

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -450,58 +450,41 @@ void ConnectionRouter<Heap>::timing_driven_expand_neighbours(t_heap* current,
 
 
         size_t first_edge = (size_t)rr_graph_->node_first_edge(from_node);
-        int rel = 1;
         int first_dest = rr_graph_->node_first_dest(from_node);
-        int edges_num = rr_graph_->num_edges(from_node);
-
-        // First Edge
         int e_ptn_idx = rr_graph_->node_to_edge_ptns_new(from_node); 
-        int edges_added = 0;
-        t_switch_edge_ptn p;
-        while (edges_added < 1*(edges_num>0)){
+        int edges_num = rr_graph_->num_edges(from_node);
+        int edges_count = 0;
 
-            
-            p = rr_graph_->edge_ptns(e_ptn_idx);
-
-            RRNodeId to_node = RRNodeId(first_dest);
-            timing_driven_expand_neighbour(current,
-                                        from_node_int,
-                                        RREdgeId(first_edge),
-                                        size_t(to_node),
-                                        cost_params,
-                                        bounding_box,
-                                        target_node,
-                                        target_bb,
-                                        p.switch_id);
-
-            edges_added++;
-        }
-
-        int k = 1; // skip the first edge
-        while (edges_added < edges_num) { // only for nodes with more than one edge
-            while (k < p.edge_count){
-
+        t_switch_edge_ptn p = rr_graph_->edge_ptns(e_ptn_idx);
+        int k = 0;
+        // while (edges_count < edges_num){
+        int num_ptns = rr_graph_->num_edge_ptns(from_node);
+        for (int j=0; j<num_ptns; j++){
+            const int p_edge_count = p.edge_count;
+            for (int i=0; i<p_edge_count; i++){
                 RRNodeId to_node = RRNodeId(first_dest+rr_graph_->edge_ptn_data(p.ptn_idx+k));
                 timing_driven_expand_neighbour(current,
-                                        from_node_int,
-                                        RREdgeId(first_edge+rel),
-                                        size_t(to_node),
-                                        cost_params,
-                                        bounding_box,
-                                        target_node,
-                                        target_bb,
-                                        p.switch_id);
-
+                                    from_node_int,
+                                    RREdgeId(first_edge+edges_count),
+                                    size_t(to_node),
+                                    cost_params,
+                                    bounding_box,
+                                    target_node,
+                                    target_bb,
+                                    p.switch_id);
+                edges_count += 1;
                 k++;
-                rel++;
-                edges_added++;
             }
             k = 0;
             e_ptn_idx++;
             p = rr_graph_->edge_ptns(e_ptn_idx);
         }
 
-
+// if (k == p.edge_count){
+//                 k = 0;
+//                 e_ptn_idx++;
+//                 p = rr_graph_->edge_ptns(e_ptn_idx);
+//             }
 
 
 

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -187,7 +187,8 @@ class ConnectionRouter : public ConnectionRouterInterface {
         const t_conn_cost_params cost_params,
         const t_bb bounding_box,
         int target_node,
-        const t_bb target_bb);
+        const t_bb target_bb,
+        const short from_switch_id);
 
     // Add to_node to the heap, and also add any nodes which are connected by
     // non-configurable edges
@@ -197,7 +198,8 @@ class ConnectionRouter : public ConnectionRouterInterface {
         const int from_node,
         const int to_node,
         const RREdgeId from_edge,
-        const int target_node);
+        const int target_node,
+        const short from_switch_id);
 
     // Calculates the cost of reaching to_node
     void evaluate_timing_driven_node_costs(
@@ -206,7 +208,8 @@ class ConnectionRouter : public ConnectionRouterInterface {
         const int from_node,
         const int to_node,
         const RREdgeId from_edge,
-        const int target_node);
+        const int target_node,
+        const short from_switch_id);
 
     // Find paths from current heap to all nodes in the RR graph
     std::vector<t_heap> timing_driven_find_all_shortest_paths_from_heap(

--- a/vpr/src/route/gen/rr_graph_uxsdcxx.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
  * Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
- * md5sum of input file: 5c529f385cc39043f69229d620e94c98
+ * md5sum of input file: f70492b177e0daf17b52aa153b3fae93
  */
 
 #include <functional>
@@ -104,14 +104,6 @@ inline void load_node_required_attributes(const pugi::xml_node &root, unsigned i
 template <class T, typename Context>
 inline void load_rr_nodes(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 template <class T, typename Context>
-inline void load_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
-inline void load_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char*)> * report_error);
-template <class T, typename Context>
-inline void load_node_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
-inline void load_node_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * dest, unsigned int * id, const std::function<void(const char*)> * report_error);
-template <class T, typename Context>
-inline void load_rr_node_e_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
-template <class T, typename Context>
 inline void load_ddiff(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 inline void load_ddiff_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char*)> * report_error);
 template <class T, typename Context>
@@ -119,6 +111,14 @@ inline void load_edge_ptn(const pugi::xml_node &root, T &out, Context &context, 
 inline void load_edge_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, unsigned int * switch_id, const std::function<void(const char*)> * report_error);
 template <class T, typename Context>
 inline void load_rr_edge_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_node_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_node_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * dest, unsigned int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_rr_node_e_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 template <class T, typename Context>
 inline void load_rr_graph(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 
@@ -152,13 +152,13 @@ inline void write_node(T &in, std::ostream &os, const void *data, void *iter);
 template <class T>
 inline void write_rr_nodes(T &in, std::ostream &os, const void *data, void *iter);
 template <class T>
-inline void write_node_e_ptn(T &in, std::ostream &os, const void *data, void *iter);
-template <class T>
-inline void write_rr_node_e_ptns(T &in, std::ostream &os, const void *data, void *iter);
-template <class T>
 inline void write_edge_ptn(T &in, std::ostream &os, const void *data, void *iter);
 template <class T>
 inline void write_rr_edge_ptns(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_node_e_ptn(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_rr_node_e_ptns(T &in, std::ostream &os, const void *data, void *iter);
 template <class T>
 inline void write_rr_graph(T &in, std::ostream &os, const void *data, void *iter);
 
@@ -315,17 +315,6 @@ constexpr const char *atok_lookup_t_node[] = {"capacity", "direction", "id", "ty
 enum class gtok_t_rr_nodes {NODE};
 constexpr const char *gtok_lookup_t_rr_nodes[] = {"node"};
 
-enum class atok_t_e_ptn {ID};
-constexpr const char *atok_lookup_t_e_ptn[] = {"id"};
-
-enum class gtok_t_node_e_ptn {E_PTN};
-constexpr const char *gtok_lookup_t_node_e_ptn[] = {"e_ptn"};
-enum class atok_t_node_e_ptn {DEST, ID};
-constexpr const char *atok_lookup_t_node_e_ptn[] = {"dest", "id"};
-
-enum class gtok_t_rr_node_e_ptns {NODE_E_PTN};
-constexpr const char *gtok_lookup_t_rr_node_e_ptns[] = {"node_e_ptn"};
-
 enum class atok_t_ddiff {ID};
 constexpr const char *atok_lookup_t_ddiff[] = {"id"};
 
@@ -336,8 +325,19 @@ constexpr const char *atok_lookup_t_edge_ptn[] = {"id", "switch_id"};
 
 enum class gtok_t_rr_edge_ptns {EDGE_PTN};
 constexpr const char *gtok_lookup_t_rr_edge_ptns[] = {"edge_ptn"};
-enum class gtok_t_rr_graph {CHANNELS, SWITCHES, SEGMENTS, BLOCK_TYPES, GRID, RR_NODES, RR_NODE_E_PTNS, RR_EDGE_PTNS};
-constexpr const char *gtok_lookup_t_rr_graph[] = {"channels", "switches", "segments", "block_types", "grid", "rr_nodes", "rr_node_e_ptns", "rr_edge_ptns"};
+
+enum class atok_t_e_ptn {ID};
+constexpr const char *atok_lookup_t_e_ptn[] = {"id"};
+
+enum class gtok_t_node_e_ptn {E_PTN};
+constexpr const char *gtok_lookup_t_node_e_ptn[] = {"e_ptn"};
+enum class atok_t_node_e_ptn {DEST, ID};
+constexpr const char *atok_lookup_t_node_e_ptn[] = {"dest", "id"};
+
+enum class gtok_t_rr_node_e_ptns {NODE_E_PTN};
+constexpr const char *gtok_lookup_t_rr_node_e_ptns[] = {"node_e_ptn"};
+enum class gtok_t_rr_graph {CHANNELS, SWITCHES, SEGMENTS, BLOCK_TYPES, GRID, RR_NODES, RR_EDGE_PTNS, RR_NODE_E_PTNS};
+constexpr const char *gtok_lookup_t_rr_graph[] = {"channels", "switches", "segments", "block_types", "grid", "rr_nodes", "rr_edge_ptns", "rr_node_e_ptns"};
 enum class atok_t_rr_graph {TOOL_COMMENT, TOOL_NAME, TOOL_VERSION};
 constexpr const char *atok_lookup_t_rr_graph[] = {"tool_comment", "tool_name", "tool_version"};
 
@@ -1388,6 +1388,97 @@ inline gtok_t_rr_nodes lex_node_t_rr_nodes(const char *in, const std::function<v
 	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_nodes>.").c_str());
 }
 
+inline atok_t_ddiff lex_attr_t_ddiff(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_ddiff::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <ddiff>.").c_str());
+}
+
+inline gtok_t_edge_ptn lex_node_t_edge_ptn(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('d', 0, 32) | onechar('d', 8, 32) | onechar('i', 16, 32) | onechar('f', 24, 32):
+			switch(in[4]){
+			case onechar('f', 0, 8):
+				return gtok_t_edge_ptn::DDIFF;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <edge_ptn>.").c_str());
+}
+inline atok_t_edge_ptn lex_attr_t_edge_ptn(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_edge_ptn::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('s', 0, 64) | onechar('w', 8, 64) | onechar('i', 16, 64) | onechar('t', 24, 64) | onechar('c', 32, 64) | onechar('h', 40, 64) | onechar('_', 48, 64) | onechar('i', 56, 64):
+			switch(in[8]){
+			case onechar('d', 0, 8):
+				return atok_t_edge_ptn::SWITCH_ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <edge_ptn>.").c_str());
+}
+
+inline gtok_t_rr_edge_ptns lex_node_t_rr_edge_ptns(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('e', 0, 64) | onechar('d', 8, 64) | onechar('g', 16, 64) | onechar('e', 24, 64) | onechar('_', 32, 64) | onechar('p', 40, 64) | onechar('t', 48, 64) | onechar('n', 56, 64):
+			return gtok_t_rr_edge_ptns::EDGE_PTN;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_edge_ptns>.").c_str());
+}
+
 inline atok_t_e_ptn lex_attr_t_e_ptn(const char *in, const std::function<void(const char *)> * report_error){
 	unsigned int len = strlen(in);
 	switch(len){
@@ -1482,97 +1573,6 @@ inline gtok_t_rr_node_e_ptns lex_node_t_rr_node_e_ptns(const char *in, const std
 	default: break;
 	}
 	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_node_e_ptns>.").c_str());
-}
-
-inline atok_t_ddiff lex_attr_t_ddiff(const char *in, const std::function<void(const char *)> * report_error){
-	unsigned int len = strlen(in);
-	switch(len){
-	case 2:
-		switch(in[0]){
-		case onechar('i', 0, 8):
-			switch(in[1]){
-			case onechar('d', 0, 8):
-				return atok_t_ddiff::ID;
-			break;
-			default: break;
-			}
-		break;
-		default: break;
-		}
-		break;
-	default: break;
-	}
-	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <ddiff>.").c_str());
-}
-
-inline gtok_t_edge_ptn lex_node_t_edge_ptn(const char *in, const std::function<void(const char *)> *report_error){
-	unsigned int len = strlen(in);
-	switch(len){
-	case 5:
-		switch(*((triehash_uu32*)&in[0])){
-		case onechar('d', 0, 32) | onechar('d', 8, 32) | onechar('i', 16, 32) | onechar('f', 24, 32):
-			switch(in[4]){
-			case onechar('f', 0, 8):
-				return gtok_t_edge_ptn::DDIFF;
-			break;
-			default: break;
-			}
-		break;
-		default: break;
-		}
-		break;
-	default: break;
-	}
-	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <edge_ptn>.").c_str());
-}
-inline atok_t_edge_ptn lex_attr_t_edge_ptn(const char *in, const std::function<void(const char *)> * report_error){
-	unsigned int len = strlen(in);
-	switch(len){
-	case 2:
-		switch(in[0]){
-		case onechar('i', 0, 8):
-			switch(in[1]){
-			case onechar('d', 0, 8):
-				return atok_t_edge_ptn::ID;
-			break;
-			default: break;
-			}
-		break;
-		default: break;
-		}
-		break;
-	case 9:
-		switch(*((triehash_uu64*)&in[0])){
-		case onechar('s', 0, 64) | onechar('w', 8, 64) | onechar('i', 16, 64) | onechar('t', 24, 64) | onechar('c', 32, 64) | onechar('h', 40, 64) | onechar('_', 48, 64) | onechar('i', 56, 64):
-			switch(in[8]){
-			case onechar('d', 0, 8):
-				return atok_t_edge_ptn::SWITCH_ID;
-			break;
-			default: break;
-			}
-		break;
-		default: break;
-		}
-		break;
-	default: break;
-	}
-	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <edge_ptn>.").c_str());
-}
-
-inline gtok_t_rr_edge_ptns lex_node_t_rr_edge_ptns(const char *in, const std::function<void(const char *)> *report_error){
-	unsigned int len = strlen(in);
-	switch(len){
-	case 8:
-		switch(*((triehash_uu64*)&in[0])){
-		case onechar('e', 0, 64) | onechar('d', 8, 64) | onechar('g', 16, 64) | onechar('e', 24, 64) | onechar('_', 32, 64) | onechar('p', 40, 64) | onechar('t', 48, 64) | onechar('n', 56, 64):
-			return gtok_t_rr_edge_ptns::EDGE_PTN;
-		break;
-		default: break;
-		}
-		break;
-	default: break;
-	}
-	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_edge_ptns>.").c_str());
 }
 
 inline gtok_t_rr_graph lex_node_t_rr_graph(const char *in, const std::function<void(const char *)> *report_error){
@@ -2591,43 +2591,6 @@ inline void load_node_required_attributes(const pugi::xml_node &root, unsigned i
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node, report_error);
 }
 
-inline void load_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char *)> * report_error){
-	std::bitset<1> astate = 0;
-	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
-		atok_t_e_ptn in = lex_attr_t_e_ptn(attr.name(), report_error);
-		if(astate[(int)in] == 0) astate[(int)in] = 1;
-		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <e_ptn>.").c_str());
-		switch(in){
-		case atok_t_e_ptn::ID:
-			*id = load_unsigned_int(attr.value(), report_error);
-			break;
-		default: break; /* Not possible. */
-		}
-	}
-	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
-	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_e_ptn, report_error);
-}
-
-inline void load_node_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * dest, unsigned int * id, const std::function<void(const char *)> * report_error){
-	std::bitset<2> astate = 0;
-	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
-		atok_t_node_e_ptn in = lex_attr_t_node_e_ptn(attr.name(), report_error);
-		if(astate[(int)in] == 0) astate[(int)in] = 1;
-		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_e_ptn>.").c_str());
-		switch(in){
-		case atok_t_node_e_ptn::DEST:
-			*dest = load_unsigned_int(attr.value(), report_error);
-			break;
-		case atok_t_node_e_ptn::ID:
-			*id = load_unsigned_int(attr.value(), report_error);
-			break;
-		default: break; /* Not possible. */
-		}
-	}
-	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
-	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_e_ptn, report_error);
-}
-
 inline void load_ddiff_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char *)> * report_error){
 	std::bitset<1> astate = 0;
 	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
@@ -2663,6 +2626,43 @@ inline void load_edge_ptn_required_attributes(const pugi::xml_node &root, unsign
 	}
 	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_edge_ptn, report_error);
+}
+
+inline void load_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<1> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_e_ptn in = lex_attr_t_e_ptn(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <e_ptn>.").c_str());
+		switch(in){
+		case atok_t_e_ptn::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_e_ptn, report_error);
+}
+
+inline void load_node_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * dest, unsigned int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node_e_ptn in = lex_attr_t_node_e_ptn(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_e_ptn>.").c_str());
+		switch(in){
+		case atok_t_node_e_ptn::DEST:
+			*dest = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_node_e_ptn::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_e_ptn, report_error);
 }
 template<class T, typename Context>
 inline void load_channel(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
@@ -3758,151 +3758,6 @@ inline void load_rr_nodes(const pugi::xml_node &root, T &out, Context &context, 
 }
 
 template<class T, typename Context>
-inline void load_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
-	(void)root;
-	(void)out;
-	(void)context;
-	(void)report_error;
-	// Update current file offset in case an error is encountered.
-	*offset_debug = root.offset_debug();
-
-
-	if(root.first_child().type() == pugi::node_element)
-		noreturn_report(report_error, "Unexpected child element in <e_ptn>.");
-
-}
-
-constexpr int NUM_T_NODE_E_PTN_STATES = 2;
-constexpr const int NUM_T_NODE_E_PTN_INPUTS = 1;
-constexpr int gstate_t_node_e_ptn[NUM_T_NODE_E_PTN_STATES][NUM_T_NODE_E_PTN_INPUTS] = {
-	{0},
-	{0},
-};
-template<class T, typename Context>
-inline void load_node_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
-	(void)root;
-	(void)out;
-	(void)context;
-	(void)report_error;
-	// Update current file offset in case an error is encountered.
-	*offset_debug = root.offset_debug();
-
-
-	// Preallocate arrays by counting child nodes (if any)
-	size_t e_ptn_count = 0;
-	{
-		int next, state=1;
-		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-			*offset_debug = node.offset_debug();
-			gtok_t_node_e_ptn in = lex_node_t_node_e_ptn(node.name(), report_error);
-			next = gstate_t_node_e_ptn[state][(int)in];
-			if(next == -1)
-				dfa_error(gtok_lookup_t_node_e_ptn[(int)in], gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
-			state = next;
-			switch(in) {
-			case gtok_t_node_e_ptn::E_PTN:
-				e_ptn_count += 1;
-				break;
-			default: break; /* Not possible. */
-			}
-		}
-		
-		out.preallocate_node_e_ptn_e_ptn(context, e_ptn_count);
-	}
-	int next, state=1;
-	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
-		*offset_debug = node.offset_debug();
-		gtok_t_node_e_ptn in = lex_node_t_node_e_ptn(node.name(), report_error);
-		next = gstate_t_node_e_ptn[state][(int)in];
-		if(next == -1)
-			dfa_error(gtok_lookup_t_node_e_ptn[(int)in], gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
-		state = next;
-		switch(in){
-		case gtok_t_node_e_ptn::E_PTN:
-			{
-				unsigned int e_ptn_id;
-				memset(&e_ptn_id, 0, sizeof(e_ptn_id));
-				load_e_ptn_required_attributes(node, &e_ptn_id, report_error);
-				auto child_context = out.add_node_e_ptn_e_ptn(context, e_ptn_id);
-				load_e_ptn(node, out, child_context, report_error, offset_debug);
-				out.finish_node_e_ptn_e_ptn(child_context);
-			}
-			break;
-		default: break; /* Not possible. */
-		}
-	}
-	if(state != 0) dfa_error("end of input", gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
-
-}
-
-constexpr int NUM_T_RR_NODE_E_PTNS_STATES = 2;
-constexpr const int NUM_T_RR_NODE_E_PTNS_INPUTS = 1;
-constexpr int gstate_t_rr_node_e_ptns[NUM_T_RR_NODE_E_PTNS_STATES][NUM_T_RR_NODE_E_PTNS_INPUTS] = {
-	{0},
-	{0},
-};
-template<class T, typename Context>
-inline void load_rr_node_e_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
-	(void)root;
-	(void)out;
-	(void)context;
-	(void)report_error;
-	// Update current file offset in case an error is encountered.
-	*offset_debug = root.offset_debug();
-
-	if(root.first_attribute())
-		noreturn_report(report_error, "Unexpected attribute in <rr_node_e_ptns>.");
-
-	// Preallocate arrays by counting child nodes (if any)
-	size_t node_e_ptn_count = 0;
-	{
-		int next, state=1;
-		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-			*offset_debug = node.offset_debug();
-			gtok_t_rr_node_e_ptns in = lex_node_t_rr_node_e_ptns(node.name(), report_error);
-			next = gstate_t_rr_node_e_ptns[state][(int)in];
-			if(next == -1)
-				dfa_error(gtok_lookup_t_rr_node_e_ptns[(int)in], gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
-			state = next;
-			switch(in) {
-			case gtok_t_rr_node_e_ptns::NODE_E_PTN:
-				node_e_ptn_count += 1;
-				break;
-			default: break; /* Not possible. */
-			}
-		}
-		
-		out.preallocate_rr_node_e_ptns_node_e_ptn(context, node_e_ptn_count);
-	}
-	int next, state=1;
-	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
-		*offset_debug = node.offset_debug();
-		gtok_t_rr_node_e_ptns in = lex_node_t_rr_node_e_ptns(node.name(), report_error);
-		next = gstate_t_rr_node_e_ptns[state][(int)in];
-		if(next == -1)
-			dfa_error(gtok_lookup_t_rr_node_e_ptns[(int)in], gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
-		state = next;
-		switch(in){
-		case gtok_t_rr_node_e_ptns::NODE_E_PTN:
-			{
-				unsigned int node_e_ptn_dest;
-				memset(&node_e_ptn_dest, 0, sizeof(node_e_ptn_dest));
-				unsigned int node_e_ptn_id;
-				memset(&node_e_ptn_id, 0, sizeof(node_e_ptn_id));
-				load_node_e_ptn_required_attributes(node, &node_e_ptn_dest, &node_e_ptn_id, report_error);
-				auto child_context = out.add_rr_node_e_ptns_node_e_ptn(context, node_e_ptn_dest, node_e_ptn_id);
-				load_node_e_ptn(node, out, child_context, report_error, offset_debug);
-				out.finish_rr_node_e_ptns_node_e_ptn(child_context);
-			}
-			break;
-		default: break; /* Not possible. */
-		}
-	}
-	if(state != 0) dfa_error("end of input", gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
-
-}
-
-template<class T, typename Context>
 inline void load_ddiff(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
 	(void)root;
 	(void)out;
@@ -4048,6 +3903,151 @@ inline void load_rr_edge_ptns(const pugi::xml_node &root, T &out, Context &conte
 }
 
 template<class T, typename Context>
+inline void load_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <e_ptn>.");
+
+}
+
+constexpr int NUM_T_NODE_E_PTN_STATES = 2;
+constexpr const int NUM_T_NODE_E_PTN_INPUTS = 1;
+constexpr int gstate_t_node_e_ptn[NUM_T_NODE_E_PTN_STATES][NUM_T_NODE_E_PTN_INPUTS] = {
+	{0},
+	{0},
+};
+template<class T, typename Context>
+inline void load_node_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+
+	// Preallocate arrays by counting child nodes (if any)
+	size_t e_ptn_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_node_e_ptn in = lex_node_t_node_e_ptn(node.name(), report_error);
+			next = gstate_t_node_e_ptn[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_node_e_ptn[(int)in], gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_node_e_ptn::E_PTN:
+				e_ptn_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_node_e_ptn_e_ptn(context, e_ptn_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_node_e_ptn in = lex_node_t_node_e_ptn(node.name(), report_error);
+		next = gstate_t_node_e_ptn[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_node_e_ptn[(int)in], gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_node_e_ptn::E_PTN:
+			{
+				unsigned int e_ptn_id;
+				memset(&e_ptn_id, 0, sizeof(e_ptn_id));
+				load_e_ptn_required_attributes(node, &e_ptn_id, report_error);
+				auto child_context = out.add_node_e_ptn_e_ptn(context, e_ptn_id);
+				load_e_ptn(node, out, child_context, report_error, offset_debug);
+				out.finish_node_e_ptn_e_ptn(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
+
+}
+
+constexpr int NUM_T_RR_NODE_E_PTNS_STATES = 2;
+constexpr const int NUM_T_RR_NODE_E_PTNS_INPUTS = 1;
+constexpr int gstate_t_rr_node_e_ptns[NUM_T_RR_NODE_E_PTNS_STATES][NUM_T_RR_NODE_E_PTNS_INPUTS] = {
+	{0},
+	{0},
+};
+template<class T, typename Context>
+inline void load_rr_node_e_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <rr_node_e_ptns>.");
+
+	// Preallocate arrays by counting child nodes (if any)
+	size_t node_e_ptn_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_rr_node_e_ptns in = lex_node_t_rr_node_e_ptns(node.name(), report_error);
+			next = gstate_t_rr_node_e_ptns[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_rr_node_e_ptns[(int)in], gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_rr_node_e_ptns::NODE_E_PTN:
+				node_e_ptn_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_rr_node_e_ptns_node_e_ptn(context, node_e_ptn_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_rr_node_e_ptns in = lex_node_t_rr_node_e_ptns(node.name(), report_error);
+		next = gstate_t_rr_node_e_ptns[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_rr_node_e_ptns[(int)in], gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_rr_node_e_ptns::NODE_E_PTN:
+			{
+				unsigned int node_e_ptn_dest;
+				memset(&node_e_ptn_dest, 0, sizeof(node_e_ptn_dest));
+				unsigned int node_e_ptn_id;
+				memset(&node_e_ptn_id, 0, sizeof(node_e_ptn_id));
+				load_node_e_ptn_required_attributes(node, &node_e_ptn_dest, &node_e_ptn_id, report_error);
+				auto child_context = out.add_rr_node_e_ptns_node_e_ptn(context, node_e_ptn_dest, node_e_ptn_id);
+				load_node_e_ptn(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_node_e_ptns_node_e_ptn(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
+
+}
+
+template<class T, typename Context>
 inline void load_rr_graph(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
 	(void)root;
 	(void)out;
@@ -4121,18 +4121,18 @@ inline void load_rr_graph(const pugi::xml_node &root, T &out, Context &context, 
 				out.finish_rr_graph_rr_nodes(child_context);
 			}
 			break;
-		case gtok_t_rr_graph::RR_NODE_E_PTNS:
-			{
-				auto child_context = out.init_rr_graph_rr_node_e_ptns(context);
-				load_rr_node_e_ptns(node, out, child_context, report_error, offset_debug);
-				out.finish_rr_graph_rr_node_e_ptns(child_context);
-			}
-			break;
 		case gtok_t_rr_graph::RR_EDGE_PTNS:
 			{
 				auto child_context = out.init_rr_graph_rr_edge_ptns(context);
 				load_rr_edge_ptns(node, out, child_context, report_error, offset_debug);
 				out.finish_rr_graph_rr_edge_ptns(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::RR_NODE_E_PTNS:
+			{
+				auto child_context = out.init_rr_graph_rr_node_e_ptns(context);
+				load_rr_node_e_ptns(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_rr_node_e_ptns(child_context);
 			}
 			break;
 		default: break; /* Not possible. */
@@ -4439,39 +4439,6 @@ inline void write_rr_nodes(T &in, std::ostream &os, Context &context){
 }
 
 template<class T, typename Context>
-inline void write_node_e_ptn(T &in, std::ostream &os, Context &context){
-	(void)in;
-	(void)os;
-	(void)context;
-	{
-		for(size_t i=0, n=in.num_node_e_ptn_e_ptn(context); i<n; i++){
-			auto child_context = in.get_node_e_ptn_e_ptn(i, context);
-			os << "<e_ptn";
-			os << " id=\"" << in.get_e_ptn_id(child_context) << "\"";
-			os << "/>\n";
-		}
-	}
-}
-
-template<class T, typename Context>
-inline void write_rr_node_e_ptns(T &in, std::ostream &os, Context &context){
-	(void)in;
-	(void)os;
-	(void)context;
-	{
-		for(size_t i=0, n=in.num_rr_node_e_ptns_node_e_ptn(context); i<n; i++){
-			auto child_context = in.get_rr_node_e_ptns_node_e_ptn(i, context);
-			os << "<node_e_ptn";
-			os << " dest=\"" << in.get_node_e_ptn_dest(child_context) << "\"";
-			os << " id=\"" << in.get_node_e_ptn_id(child_context) << "\"";
-			os << ">";
-			write_node_e_ptn(in, os, child_context);
-			os << "</node_e_ptn>\n";
-		}
-	}
-}
-
-template<class T, typename Context>
 inline void write_edge_ptn(T &in, std::ostream &os, Context &context){
 	(void)in;
 	(void)os;
@@ -4500,6 +4467,39 @@ inline void write_rr_edge_ptns(T &in, std::ostream &os, Context &context){
 			os << ">";
 			write_edge_ptn(in, os, child_context);
 			os << "</edge_ptn>\n";
+		}
+	}
+}
+
+template<class T, typename Context>
+inline void write_node_e_ptn(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_node_e_ptn_e_ptn(context); i<n; i++){
+			auto child_context = in.get_node_e_ptn_e_ptn(i, context);
+			os << "<e_ptn";
+			os << " id=\"" << in.get_e_ptn_id(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
+}
+
+template<class T, typename Context>
+inline void write_rr_node_e_ptns(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_rr_node_e_ptns_node_e_ptn(context); i<n; i++){
+			auto child_context = in.get_rr_node_e_ptns_node_e_ptn(i, context);
+			os << "<node_e_ptn";
+			os << " dest=\"" << in.get_node_e_ptn_dest(child_context) << "\"";
+			os << " id=\"" << in.get_node_e_ptn_id(child_context) << "\"";
+			os << ">";
+			write_node_e_ptn(in, os, child_context);
+			os << "</node_e_ptn>\n";
 		}
 	}
 }
@@ -4546,16 +4546,16 @@ inline void write_rr_graph(T &in, std::ostream &os, Context &context){
 		os << "</rr_nodes>\n";
 	}
 	{
-		auto child_context = in.get_rr_graph_rr_node_e_ptns(context);
-		os << "<rr_node_e_ptns>\n";
-		write_rr_node_e_ptns(in, os, child_context);
-		os << "</rr_node_e_ptns>\n";
-	}
-	{
 		auto child_context = in.get_rr_graph_rr_edge_ptns(context);
 		os << "<rr_edge_ptns>\n";
 		write_rr_edge_ptns(in, os, child_context);
 		os << "</rr_edge_ptns>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_rr_node_e_ptns(context);
+		os << "<rr_node_e_ptns>\n";
+		write_rr_node_e_ptns(in, os, child_context);
+		os << "</rr_node_e_ptns>\n";
 	}
 }
 

--- a/vpr/src/route/gen/rr_graph_uxsdcxx.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx.h
@@ -4,12 +4,13 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcxx.py /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
- * Input file: /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
- * md5sum of input file: cd57d47fc9dfa62c7030397ca759217e
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+ * Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+ * md5sum of input file: 5c529f385cc39043f69229d620e94c98
  */
 
 #include <functional>
+
 
 #include <bitset>
 #include <cassert>
@@ -32,4434 +33,4613 @@ namespace uxsd {
  * Internal function for getting line and column number from file based on
  * byte offset.
  */
-inline void get_line_number(const char* filename, std::ptrdiff_t offset, int* line, int* col);
+inline void get_line_number(const char *filename, std::ptrdiff_t offset, int * line, int * col);
 
-[[noreturn]] inline void noreturn_report(const std::function<void(const char*)>* report_error, const char* msg) {
+[[noreturn]] inline void noreturn_report(const std::function<void(const char *)> * report_error, const char *msg) {
     (*report_error)(msg);
     throw std::runtime_error("Unreachable!");
 }
 
 /* Declarations for internal load functions for the complex types. */
-template<class T, typename Context>
-inline void load_channel(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_channel_required_attributes(const pugi::xml_node& root, int* chan_width_max, int* x_max, int* x_min, int* y_max, int* y_min, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_x_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_x_list_required_attributes(const pugi::xml_node& root, unsigned int* index, int* info, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_y_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_y_list_required_attributes(const pugi::xml_node& root, unsigned int* index, int* info, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_channels(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_timing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_sizing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_sizing_required_attributes(const pugi::xml_node& root, float* buf_size, float* mux_trans_size, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_switch(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_switch_required_attributes(const pugi::xml_node& root, int* id, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_switches(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_segment_timing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_segment(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_segment_required_attributes(const pugi::xml_node& root, int* id, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_segments(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_pin(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_pin_required_attributes(const pugi::xml_node& root, int* ptc, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_pin_class(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_pin_class_required_attributes(const pugi::xml_node& root, enum_pin_type* type, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_block_type(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_block_type_required_attributes(const pugi::xml_node& root, int* height, int* id, int* width, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_block_types(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_grid_loc(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_grid_loc_required_attributes(const pugi::xml_node& root, int* block_type_id, int* height_offset, int* width_offset, int* x, int* y, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_grid_locs(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_node_loc(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_node_loc_required_attributes(const pugi::xml_node& root, int* ptc, int* xhigh, int* xlow, int* yhigh, int* ylow, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_node_timing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_node_timing_required_attributes(const pugi::xml_node& root, float* C, float* R, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_node_segment(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_node_segment_required_attributes(const pugi::xml_node& root, int* segment_id, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_meta(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_metadata(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_node(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_node_required_attributes(const pugi::xml_node& root, unsigned int* capacity, unsigned int* id, enum_node_type* type, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_rr_nodes(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_edge(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-inline void load_edge_required_attributes(const pugi::xml_node& root, unsigned int* sink_node, unsigned int* src_node, unsigned int* switch_id, const std::function<void(const char*)>* report_error);
-template<class T, typename Context>
-inline void load_rr_edges(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
-template<class T, typename Context>
-inline void load_rr_graph(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+template <class T, typename Context>
+inline void load_channel(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_channel_required_attributes(const pugi::xml_node &root, int * chan_width_max, int * x_max, int * x_min, int * y_max, int * y_min, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_x_list(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_x_list_required_attributes(const pugi::xml_node &root, unsigned int * index, int * info, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_y_list(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_y_list_required_attributes(const pugi::xml_node &root, unsigned int * index, int * info, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_channels(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_sizing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_sizing_required_attributes(const pugi::xml_node &root, float * buf_size, float * mux_trans_size, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_switch(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_switch_required_attributes(const pugi::xml_node &root, int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_switches(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_segment_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_segment(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_segment_required_attributes(const pugi::xml_node &root, int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_segments(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_pin(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_pin_required_attributes(const pugi::xml_node &root, int * ptc, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_pin_class(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_pin_class_required_attributes(const pugi::xml_node &root, enum_pin_type * type, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_block_type(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_block_type_required_attributes(const pugi::xml_node &root, int * height, int * id, int * width, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_block_types(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_grid_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_grid_locs(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_node_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_node_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_node_timing_required_attributes(const pugi::xml_node &root, float * C, float * R, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_node_segment(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_node_segment_required_attributes(const pugi::xml_node &root, int * segment_id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_meta(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_metadata(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_node(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_node_required_attributes(const pugi::xml_node &root, unsigned int * capacity, unsigned int * id, enum_node_type * type, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_rr_nodes(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_node_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_node_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * dest, unsigned int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_rr_node_e_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_ddiff(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_ddiff_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_edge_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+inline void load_edge_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, unsigned int * switch_id, const std::function<void(const char*)> * report_error);
+template <class T, typename Context>
+inline void load_rr_edge_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
+template <class T, typename Context>
+inline void load_rr_graph(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 
 /* Declarations for internal write functions for the complex types. */
-template<class T>
-inline void write_channels(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_switch(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_switches(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_segment(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_segments(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_pin(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_pin_class(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_block_type(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_block_types(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_grid_locs(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_meta(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_metadata(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_node(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_rr_nodes(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_edge(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_rr_edges(T& in, std::ostream& os, const void* data, void* iter);
-template<class T>
-inline void write_rr_graph(T& in, std::ostream& os, const void* data, void* iter);
+template <class T>
+inline void write_channels(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_switch(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_switches(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_segment(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_segments(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_pin(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_pin_class(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_block_type(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_block_types(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_grid_locs(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_meta(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_metadata(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_node(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_rr_nodes(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_node_e_ptn(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_rr_node_e_ptns(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_edge_ptn(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_rr_edge_ptns(T &in, std::ostream &os, const void *data, void *iter);
+template <class T>
+inline void write_rr_graph(T &in, std::ostream &os, const void *data, void *iter);
 
 /* Load function for the root element. */
-template<class T, typename Context>
-inline void load_rr_graph_xml(T& out, Context& context, const char* filename, std::istream& is) {
-    pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load(is);
-    if (!result) {
-        int line, col;
-        get_line_number(filename, result.offset, &line, &col);
-        std::stringstream msg;
-        msg << "Unable to load XML file '" << filename << "', ";
-        msg << result.description() << " (line: " << line;
-        msg << " col: " << col << ")";
-        out.error_encountered(filename, line, msg.str().c_str());
-    }
-    ptrdiff_t offset_debug = 0;
-    std::function<void(const char*)> report_error = [filename, &out, &offset_debug](const char* message) {
-        int line, col;
-        get_line_number(filename, offset_debug, &line, &col);
-        out.error_encountered(filename, line, message);
-        // If error_encountered didn't throw, throw now to unwind.
-        throw std::runtime_error(message);
-    };
-    out.start_load(&report_error);
-
-    for (pugi::xml_node node = doc.first_child(); node; node = node.next_sibling()) {
-        if (std::strcmp(node.name(), "rr_graph") == 0) {
-            /* If errno is set up to this point, it messes with strtol errno checking. */
-            errno = 0;
-            load_rr_graph(node, out, context, &report_error, &offset_debug);
-        } else {
-            offset_debug = node.offset_debug();
-            report_error(("Invalid root-level element " + std::string(node.name())).c_str());
-        }
-    }
-    out.finish_load();
+template <class T, typename Context>
+inline void load_rr_graph_xml(T &out, Context &context, const char * filename, std::istream &is){
+	pugi::xml_document doc;
+	pugi::xml_parse_result result = doc.load(is);
+	if(!result) {
+		int line, col;
+		get_line_number(filename, result.offset, &line, &col);
+		std::stringstream msg;
+		msg << "Unable to load XML file '" << filename << "', ";
+		msg << result.description() << " (line: " << line;
+		msg << " col: " << col << ")";		out.error_encountered(filename, line, msg.str().c_str());
+	}
+	ptrdiff_t offset_debug = 0;
+	std::function<void(const char *)> report_error = [filename, &out, &offset_debug](const char * message) {
+		int line, col;
+		get_line_number(filename, offset_debug, &line, &col);
+		out.error_encountered(filename, line, message);
+		// If error_encountered didn't throw, throw now to unwind.
+		throw std::runtime_error(message);
+	};
+	out.start_load(&report_error);
+	
+	for(pugi::xml_node node= doc.first_child(); node; node = node.next_sibling()){
+		if(std::strcmp(node.name(), "rr_graph") == 0){
+			/* If errno is set up to this point, it messes with strtol errno checking. */
+			errno = 0;
+			load_rr_graph(node, out, context, &report_error, &offset_debug);
+		} else {
+			offset_debug = node.offset_debug();
+			report_error(("Invalid root-level element " + std::string(node.name())).c_str());
+		}
+	}
+	out.finish_load();
 }
 
 /* Write function for the root element. */
-template<class T, typename Context>
-inline void write_rr_graph_xml(T& in, Context& context, std::ostream& os) {
-    in.start_write();
-    os << "<rr_graph";
-    if ((bool)in.get_rr_graph_tool_comment(context))
-        os << " tool_comment=\"" << in.get_rr_graph_tool_comment(context) << "\"";
-    if ((bool)in.get_rr_graph_tool_name(context))
-        os << " tool_name=\"" << in.get_rr_graph_tool_name(context) << "\"";
-    if ((bool)in.get_rr_graph_tool_version(context))
-        os << " tool_version=\"" << in.get_rr_graph_tool_version(context) << "\"";
-    os << ">\n";
-    write_rr_graph(in, os, context);
-    os << "</rr_graph>\n";
-    in.finish_write();
+template <class T, typename Context>
+inline void write_rr_graph_xml(T &in, Context &context, std::ostream &os){
+	in.start_write();
+	os << "<rr_graph";
+	if((bool)in.get_rr_graph_tool_comment(context))
+		os << " tool_comment=\"" << in.get_rr_graph_tool_comment(context) << "\"";
+	if((bool)in.get_rr_graph_tool_name(context))
+		os << " tool_name=\"" << in.get_rr_graph_tool_name(context) << "\"";
+	if((bool)in.get_rr_graph_tool_version(context))
+		os << " tool_version=\"" << in.get_rr_graph_tool_version(context) << "\"";
+	os << ">\n";
+	write_rr_graph(in, os, context);
+	os << "</rr_graph>\n";
+	in.finish_write();
 }
+
 
 typedef const uint32_t __attribute__((aligned(1))) triehash_uu32;
 typedef const uint64_t __attribute__((aligned(1))) triehash_uu64;
 static_assert(alignof(triehash_uu32) == 1, "Unaligned 32-bit access not found.");
 static_assert(alignof(triehash_uu64) == 1, "Unaligned 64-bit access not found.");
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#    define onechar(c, s, l) (((uint64_t)(c)) << (s))
+#define onechar(c, s, l) (((uint64_t)(c)) << (s))
 #else
-#    define onechar(c, s, l) (((uint64_t)(c)) << (l - 8 - s))
+#define onechar(c, s, l) (((uint64_t)(c)) << (l-8-s))
 #endif
 
 /* Tokens for attribute and node names. */
 
-enum class atok_t_channel { CHAN_WIDTH_MAX,
-                            X_MAX,
-                            X_MIN,
-                            Y_MAX,
-                            Y_MIN };
-constexpr const char* atok_lookup_t_channel[] = {"chan_width_max", "x_max", "x_min", "y_max", "y_min"};
+enum class atok_t_channel {CHAN_WIDTH_MAX, X_MAX, X_MIN, Y_MAX, Y_MIN};
+constexpr const char *atok_lookup_t_channel[] = {"chan_width_max", "x_max", "x_min", "y_max", "y_min"};
 
-enum class atok_t_x_list { INDEX,
-                           INFO };
-constexpr const char* atok_lookup_t_x_list[] = {"index", "info"};
 
-enum class atok_t_y_list { INDEX,
-                           INFO };
-constexpr const char* atok_lookup_t_y_list[] = {"index", "info"};
+enum class atok_t_x_list {INDEX, INFO};
+constexpr const char *atok_lookup_t_x_list[] = {"index", "info"};
 
-enum class gtok_t_channels { CHANNEL,
-                             X_LIST,
-                             Y_LIST };
-constexpr const char* gtok_lookup_t_channels[] = {"channel", "x_list", "y_list"};
 
-enum class atok_t_timing { CIN,
-                           CINTERNAL,
-                           COUT,
-                           R,
-                           TDEL };
-constexpr const char* atok_lookup_t_timing[] = {"Cin", "Cinternal", "Cout", "R", "Tdel"};
+enum class atok_t_y_list {INDEX, INFO};
+constexpr const char *atok_lookup_t_y_list[] = {"index", "info"};
 
-enum class atok_t_sizing { BUF_SIZE,
-                           MUX_TRANS_SIZE };
-constexpr const char* atok_lookup_t_sizing[] = {"buf_size", "mux_trans_size"};
+enum class gtok_t_channels {CHANNEL, X_LIST, Y_LIST};
+constexpr const char *gtok_lookup_t_channels[] = {"channel", "x_list", "y_list"};
 
-enum class gtok_t_switch { TIMING,
-                           SIZING };
-constexpr const char* gtok_lookup_t_switch[] = {"timing", "sizing"};
-enum class atok_t_switch { ID,
-                           NAME,
-                           TYPE };
-constexpr const char* atok_lookup_t_switch[] = {"id", "name", "type"};
+enum class atok_t_timing {CIN, CINTERNAL, COUT, R, TDEL};
+constexpr const char *atok_lookup_t_timing[] = {"Cin", "Cinternal", "Cout", "R", "Tdel"};
 
-enum class gtok_t_switches { SWITCH };
-constexpr const char* gtok_lookup_t_switches[] = {"switch"};
 
-enum class atok_t_segment_timing { C_PER_METER,
-                                   R_PER_METER };
-constexpr const char* atok_lookup_t_segment_timing[] = {"C_per_meter", "R_per_meter"};
+enum class atok_t_sizing {BUF_SIZE, MUX_TRANS_SIZE};
+constexpr const char *atok_lookup_t_sizing[] = {"buf_size", "mux_trans_size"};
 
-enum class gtok_t_segment { TIMING };
-constexpr const char* gtok_lookup_t_segment[] = {"timing"};
-enum class atok_t_segment { ID,
-                            NAME };
-constexpr const char* atok_lookup_t_segment[] = {"id", "name"};
+enum class gtok_t_switch {TIMING, SIZING};
+constexpr const char *gtok_lookup_t_switch[] = {"timing", "sizing"};
+enum class atok_t_switch {ID, NAME, TYPE};
+constexpr const char *atok_lookup_t_switch[] = {"id", "name", "type"};
 
-enum class gtok_t_segments { SEGMENT };
-constexpr const char* gtok_lookup_t_segments[] = {"segment"};
+enum class gtok_t_switches {SWITCH};
+constexpr const char *gtok_lookup_t_switches[] = {"switch"};
 
-enum class atok_t_pin { PTC };
-constexpr const char* atok_lookup_t_pin[] = {"ptc"};
+enum class atok_t_segment_timing {C_PER_METER, R_PER_METER};
+constexpr const char *atok_lookup_t_segment_timing[] = {"C_per_meter", "R_per_meter"};
 
-enum class gtok_t_pin_class { PIN };
-constexpr const char* gtok_lookup_t_pin_class[] = {"pin"};
-enum class atok_t_pin_class { TYPE };
-constexpr const char* atok_lookup_t_pin_class[] = {"type"};
+enum class gtok_t_segment {TIMING};
+constexpr const char *gtok_lookup_t_segment[] = {"timing"};
+enum class atok_t_segment {ID, NAME};
+constexpr const char *atok_lookup_t_segment[] = {"id", "name"};
 
-enum class gtok_t_block_type { PIN_CLASS };
-constexpr const char* gtok_lookup_t_block_type[] = {"pin_class"};
-enum class atok_t_block_type { HEIGHT,
-                               ID,
-                               NAME,
-                               WIDTH };
-constexpr const char* atok_lookup_t_block_type[] = {"height", "id", "name", "width"};
+enum class gtok_t_segments {SEGMENT};
+constexpr const char *gtok_lookup_t_segments[] = {"segment"};
 
-enum class gtok_t_block_types { BLOCK_TYPE };
-constexpr const char* gtok_lookup_t_block_types[] = {"block_type"};
+enum class atok_t_pin {PTC};
+constexpr const char *atok_lookup_t_pin[] = {"ptc"};
 
-enum class atok_t_grid_loc { BLOCK_TYPE_ID,
-                             HEIGHT_OFFSET,
-                             WIDTH_OFFSET,
-                             X,
-                             Y };
-constexpr const char* atok_lookup_t_grid_loc[] = {"block_type_id", "height_offset", "width_offset", "x", "y"};
+enum class gtok_t_pin_class {PIN};
+constexpr const char *gtok_lookup_t_pin_class[] = {"pin"};
+enum class atok_t_pin_class {TYPE};
+constexpr const char *atok_lookup_t_pin_class[] = {"type"};
 
-enum class gtok_t_grid_locs { GRID_LOC };
-constexpr const char* gtok_lookup_t_grid_locs[] = {"grid_loc"};
+enum class gtok_t_block_type {PIN_CLASS};
+constexpr const char *gtok_lookup_t_block_type[] = {"pin_class"};
+enum class atok_t_block_type {HEIGHT, ID, NAME, WIDTH};
+constexpr const char *atok_lookup_t_block_type[] = {"height", "id", "name", "width"};
 
-enum class atok_t_node_loc { PTC,
-                             SIDE,
-                             XHIGH,
-                             XLOW,
-                             YHIGH,
-                             YLOW };
-constexpr const char* atok_lookup_t_node_loc[] = {"ptc", "side", "xhigh", "xlow", "yhigh", "ylow"};
+enum class gtok_t_block_types {BLOCK_TYPE};
+constexpr const char *gtok_lookup_t_block_types[] = {"block_type"};
 
-enum class atok_t_node_timing { C,
-                                R };
-constexpr const char* atok_lookup_t_node_timing[] = {"C", "R"};
+enum class atok_t_grid_loc {BLOCK_TYPE_ID, HEIGHT_OFFSET, WIDTH_OFFSET, X, Y};
+constexpr const char *atok_lookup_t_grid_loc[] = {"block_type_id", "height_offset", "width_offset", "x", "y"};
 
-enum class atok_t_node_segment { SEGMENT_ID };
-constexpr const char* atok_lookup_t_node_segment[] = {"segment_id"};
+enum class gtok_t_grid_locs {GRID_LOC};
+constexpr const char *gtok_lookup_t_grid_locs[] = {"grid_loc"};
 
-enum class atok_t_meta { NAME };
-constexpr const char* atok_lookup_t_meta[] = {"name"};
+enum class atok_t_node_loc {PTC, SIDE, XHIGH, XLOW, YHIGH, YLOW};
+constexpr const char *atok_lookup_t_node_loc[] = {"ptc", "side", "xhigh", "xlow", "yhigh", "ylow"};
 
-enum class gtok_t_metadata { META };
-constexpr const char* gtok_lookup_t_metadata[] = {"meta"};
-enum class gtok_t_node { LOC,
-                         TIMING,
-                         SEGMENT,
-                         METADATA };
-constexpr const char* gtok_lookup_t_node[] = {"loc", "timing", "segment", "metadata"};
-enum class atok_t_node { CAPACITY,
-                         DIRECTION,
-                         ID,
-                         TYPE };
-constexpr const char* atok_lookup_t_node[] = {"capacity", "direction", "id", "type"};
 
-enum class gtok_t_rr_nodes { NODE };
-constexpr const char* gtok_lookup_t_rr_nodes[] = {"node"};
-enum class gtok_t_edge { METADATA };
-constexpr const char* gtok_lookup_t_edge[] = {"metadata"};
-enum class atok_t_edge { SINK_NODE,
-                         SRC_NODE,
-                         SWITCH_ID };
-constexpr const char* atok_lookup_t_edge[] = {"sink_node", "src_node", "switch_id"};
+enum class atok_t_node_timing {C, R};
+constexpr const char *atok_lookup_t_node_timing[] = {"C", "R"};
 
-enum class gtok_t_rr_edges { EDGE };
-constexpr const char* gtok_lookup_t_rr_edges[] = {"edge"};
-enum class gtok_t_rr_graph { CHANNELS,
-                             SWITCHES,
-                             SEGMENTS,
-                             BLOCK_TYPES,
-                             GRID,
-                             RR_NODES,
-                             RR_EDGES };
-constexpr const char* gtok_lookup_t_rr_graph[] = {"channels", "switches", "segments", "block_types", "grid", "rr_nodes", "rr_edges"};
-enum class atok_t_rr_graph { TOOL_COMMENT,
-                             TOOL_NAME,
-                             TOOL_VERSION };
-constexpr const char* atok_lookup_t_rr_graph[] = {"tool_comment", "tool_name", "tool_version"};
+
+enum class atok_t_node_segment {SEGMENT_ID};
+constexpr const char *atok_lookup_t_node_segment[] = {"segment_id"};
+
+
+enum class atok_t_meta {NAME};
+constexpr const char *atok_lookup_t_meta[] = {"name"};
+
+enum class gtok_t_metadata {META};
+constexpr const char *gtok_lookup_t_metadata[] = {"meta"};
+enum class gtok_t_node {LOC, TIMING, SEGMENT, METADATA};
+constexpr const char *gtok_lookup_t_node[] = {"loc", "timing", "segment", "metadata"};
+enum class atok_t_node {CAPACITY, DIRECTION, ID, TYPE};
+constexpr const char *atok_lookup_t_node[] = {"capacity", "direction", "id", "type"};
+
+enum class gtok_t_rr_nodes {NODE};
+constexpr const char *gtok_lookup_t_rr_nodes[] = {"node"};
+
+enum class atok_t_e_ptn {ID};
+constexpr const char *atok_lookup_t_e_ptn[] = {"id"};
+
+enum class gtok_t_node_e_ptn {E_PTN};
+constexpr const char *gtok_lookup_t_node_e_ptn[] = {"e_ptn"};
+enum class atok_t_node_e_ptn {DEST, ID};
+constexpr const char *atok_lookup_t_node_e_ptn[] = {"dest", "id"};
+
+enum class gtok_t_rr_node_e_ptns {NODE_E_PTN};
+constexpr const char *gtok_lookup_t_rr_node_e_ptns[] = {"node_e_ptn"};
+
+enum class atok_t_ddiff {ID};
+constexpr const char *atok_lookup_t_ddiff[] = {"id"};
+
+enum class gtok_t_edge_ptn {DDIFF};
+constexpr const char *gtok_lookup_t_edge_ptn[] = {"ddiff"};
+enum class atok_t_edge_ptn {ID, SWITCH_ID};
+constexpr const char *atok_lookup_t_edge_ptn[] = {"id", "switch_id"};
+
+enum class gtok_t_rr_edge_ptns {EDGE_PTN};
+constexpr const char *gtok_lookup_t_rr_edge_ptns[] = {"edge_ptn"};
+enum class gtok_t_rr_graph {CHANNELS, SWITCHES, SEGMENTS, BLOCK_TYPES, GRID, RR_NODES, RR_NODE_E_PTNS, RR_EDGE_PTNS};
+constexpr const char *gtok_lookup_t_rr_graph[] = {"channels", "switches", "segments", "block_types", "grid", "rr_nodes", "rr_node_e_ptns", "rr_edge_ptns"};
+enum class atok_t_rr_graph {TOOL_COMMENT, TOOL_NAME, TOOL_VERSION};
+constexpr const char *atok_lookup_t_rr_graph[] = {"tool_comment", "tool_name", "tool_version"};
+
 
 /* Internal lexers. These convert the PugiXML node names to input tokens. */
-inline atok_t_channel lex_attr_t_channel(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('x', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('a', 24, 32):
-                    switch (in[4]) {
-                        case onechar('x', 0, 8):
-                            return atok_t_channel::X_MAX;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('x', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            return atok_t_channel::X_MIN;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('y', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('a', 24, 32):
-                    switch (in[4]) {
-                        case onechar('x', 0, 8):
-                            return atok_t_channel::Y_MAX;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('y', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            return atok_t_channel::Y_MIN;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 14:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('c', 0, 64) | onechar('h', 8, 64) | onechar('a', 16, 64) | onechar('n', 24, 64) | onechar('_', 32, 64) | onechar('w', 40, 64) | onechar('i', 48, 64) | onechar('d', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('t', 0, 32) | onechar('h', 8, 32) | onechar('_', 16, 32) | onechar('m', 24, 32):
-                            switch (in[12]) {
-                                case onechar('a', 0, 8):
-                                    switch (in[13]) {
-                                        case onechar('x', 0, 8):
-                                            return atok_t_channel::CHAN_WIDTH_MAX;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <channel>.").c_str());
+inline atok_t_channel lex_attr_t_channel(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('x', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('a', 24, 32):
+			switch(in[4]){
+			case onechar('x', 0, 8):
+				return atok_t_channel::X_MAX;
+			break;
+			default: break;
+			}
+		break;
+		case onechar('x', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				return atok_t_channel::X_MIN;
+			break;
+			default: break;
+			}
+		break;
+		case onechar('y', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('a', 24, 32):
+			switch(in[4]){
+			case onechar('x', 0, 8):
+				return atok_t_channel::Y_MAX;
+			break;
+			default: break;
+			}
+		break;
+		case onechar('y', 0, 32) | onechar('_', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				return atok_t_channel::Y_MIN;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 14:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('c', 0, 64) | onechar('h', 8, 64) | onechar('a', 16, 64) | onechar('n', 24, 64) | onechar('_', 32, 64) | onechar('w', 40, 64) | onechar('i', 48, 64) | onechar('d', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('t', 0, 32) | onechar('h', 8, 32) | onechar('_', 16, 32) | onechar('m', 24, 32):
+				switch(in[12]){
+				case onechar('a', 0, 8):
+					switch(in[13]){
+					case onechar('x', 0, 8):
+						return atok_t_channel::CHAN_WIDTH_MAX;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <channel>.").c_str());
 }
 
-inline atok_t_x_list lex_attr_t_x_list(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('f', 16, 32) | onechar('o', 24, 32):
-                    return atok_t_x_list::INFO;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
-                    switch (in[4]) {
-                        case onechar('x', 0, 8):
-                            return atok_t_x_list::INDEX;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <x_list>.").c_str());
+inline atok_t_x_list lex_attr_t_x_list(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('f', 16, 32) | onechar('o', 24, 32):
+			return atok_t_x_list::INFO;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
+			switch(in[4]){
+			case onechar('x', 0, 8):
+				return atok_t_x_list::INDEX;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <x_list>.").c_str());
 }
 
-inline atok_t_y_list lex_attr_t_y_list(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('f', 16, 32) | onechar('o', 24, 32):
-                    return atok_t_y_list::INFO;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
-                    switch (in[4]) {
-                        case onechar('x', 0, 8):
-                            return atok_t_y_list::INDEX;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <y_list>.").c_str());
+inline atok_t_y_list lex_attr_t_y_list(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('f', 16, 32) | onechar('o', 24, 32):
+			return atok_t_y_list::INFO;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('i', 0, 32) | onechar('n', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
+			switch(in[4]){
+			case onechar('x', 0, 8):
+				return atok_t_y_list::INDEX;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <y_list>.").c_str());
 }
 
-inline gtok_t_channels lex_node_t_channels(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('x', 0, 32) | onechar('_', 8, 32) | onechar('l', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('s', 0, 8):
-                            switch (in[5]) {
-                                case onechar('t', 0, 8):
-                                    return gtok_t_channels::X_LIST;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('y', 0, 32) | onechar('_', 8, 32) | onechar('l', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('s', 0, 8):
-                            switch (in[5]) {
-                                case onechar('t', 0, 8):
-                                    return gtok_t_channels::Y_LIST;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 7:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('c', 0, 32) | onechar('h', 8, 32) | onechar('a', 16, 32) | onechar('n', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            switch (in[5]) {
-                                case onechar('e', 0, 8):
-                                    switch (in[6]) {
-                                        case onechar('l', 0, 8):
-                                            return gtok_t_channels::CHANNEL;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <channels>.").c_str());
+inline gtok_t_channels lex_node_t_channels(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('x', 0, 32) | onechar('_', 8, 32) | onechar('l', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('s', 0, 8):
+				switch(in[5]){
+				case onechar('t', 0, 8):
+					return gtok_t_channels::X_LIST;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		case onechar('y', 0, 32) | onechar('_', 8, 32) | onechar('l', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('s', 0, 8):
+				switch(in[5]){
+				case onechar('t', 0, 8):
+					return gtok_t_channels::Y_LIST;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 7:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('c', 0, 32) | onechar('h', 8, 32) | onechar('a', 16, 32) | onechar('n', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				switch(in[5]){
+				case onechar('e', 0, 8):
+					switch(in[6]){
+					case onechar('l', 0, 8):
+						return gtok_t_channels::CHANNEL;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <channels>.").c_str());
 }
 
-inline atok_t_timing lex_attr_t_timing(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 1:
-            switch (in[0]) {
-                case onechar('R', 0, 8):
-                    return atok_t_timing::R;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 3:
-            switch (in[0]) {
-                case onechar('C', 0, 8):
-                    switch (in[1]) {
-                        case onechar('i', 0, 8):
-                            switch (in[2]) {
-                                case onechar('n', 0, 8):
-                                    return atok_t_timing::CIN;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('C', 0, 32) | onechar('o', 8, 32) | onechar('u', 16, 32) | onechar('t', 24, 32):
-                    return atok_t_timing::COUT;
-                    break;
-                case onechar('T', 0, 32) | onechar('d', 8, 32) | onechar('e', 16, 32) | onechar('l', 24, 32):
-                    return atok_t_timing::TDEL;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('C', 0, 64) | onechar('i', 8, 64) | onechar('n', 16, 64) | onechar('t', 24, 64) | onechar('e', 32, 64) | onechar('r', 40, 64) | onechar('n', 48, 64) | onechar('a', 56, 64):
-                    switch (in[8]) {
-                        case onechar('l', 0, 8):
-                            return atok_t_timing::CINTERNAL;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <timing>.").c_str());
+inline atok_t_timing lex_attr_t_timing(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 1:
+		switch(in[0]){
+		case onechar('R', 0, 8):
+			return atok_t_timing::R;
+		break;
+		default: break;
+		}
+		break;
+	case 3:
+		switch(in[0]){
+		case onechar('C', 0, 8):
+			switch(in[1]){
+			case onechar('i', 0, 8):
+				switch(in[2]){
+				case onechar('n', 0, 8):
+					return atok_t_timing::CIN;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('C', 0, 32) | onechar('o', 8, 32) | onechar('u', 16, 32) | onechar('t', 24, 32):
+			return atok_t_timing::COUT;
+		break;
+		case onechar('T', 0, 32) | onechar('d', 8, 32) | onechar('e', 16, 32) | onechar('l', 24, 32):
+			return atok_t_timing::TDEL;
+		break;
+		default: break;
+		}
+		break;
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('C', 0, 64) | onechar('i', 8, 64) | onechar('n', 16, 64) | onechar('t', 24, 64) | onechar('e', 32, 64) | onechar('r', 40, 64) | onechar('n', 48, 64) | onechar('a', 56, 64):
+			switch(in[8]){
+			case onechar('l', 0, 8):
+				return atok_t_timing::CINTERNAL;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <timing>.").c_str());
 }
 
-inline atok_t_sizing lex_attr_t_sizing(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('b', 0, 64) | onechar('u', 8, 64) | onechar('f', 16, 64) | onechar('_', 24, 64) | onechar('s', 32, 64) | onechar('i', 40, 64) | onechar('z', 48, 64) | onechar('e', 56, 64):
-                    return atok_t_sizing::BUF_SIZE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 14:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('m', 0, 64) | onechar('u', 8, 64) | onechar('x', 16, 64) | onechar('_', 24, 64) | onechar('t', 32, 64) | onechar('r', 40, 64) | onechar('a', 48, 64) | onechar('n', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('s', 0, 32) | onechar('_', 8, 32) | onechar('s', 16, 32) | onechar('i', 24, 32):
-                            switch (in[12]) {
-                                case onechar('z', 0, 8):
-                                    switch (in[13]) {
-                                        case onechar('e', 0, 8):
-                                            return atok_t_sizing::MUX_TRANS_SIZE;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <sizing>.").c_str());
+inline atok_t_sizing lex_attr_t_sizing(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('b', 0, 64) | onechar('u', 8, 64) | onechar('f', 16, 64) | onechar('_', 24, 64) | onechar('s', 32, 64) | onechar('i', 40, 64) | onechar('z', 48, 64) | onechar('e', 56, 64):
+			return atok_t_sizing::BUF_SIZE;
+		break;
+		default: break;
+		}
+		break;
+	case 14:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('m', 0, 64) | onechar('u', 8, 64) | onechar('x', 16, 64) | onechar('_', 24, 64) | onechar('t', 32, 64) | onechar('r', 40, 64) | onechar('a', 48, 64) | onechar('n', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('s', 0, 32) | onechar('_', 8, 32) | onechar('s', 16, 32) | onechar('i', 24, 32):
+				switch(in[12]){
+				case onechar('z', 0, 8):
+					switch(in[13]){
+					case onechar('e', 0, 8):
+						return atok_t_sizing::MUX_TRANS_SIZE;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <sizing>.").c_str());
 }
 
-inline gtok_t_switch lex_node_t_switch(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('s', 0, 32) | onechar('i', 8, 32) | onechar('z', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            switch (in[5]) {
-                                case onechar('g', 0, 8):
-                                    return gtok_t_switch::SIZING;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('t', 0, 32) | onechar('i', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            switch (in[5]) {
-                                case onechar('g', 0, 8):
-                                    return gtok_t_switch::TIMING;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <switch>.").c_str());
+inline gtok_t_switch lex_node_t_switch(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('s', 0, 32) | onechar('i', 8, 32) | onechar('z', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				switch(in[5]){
+				case onechar('g', 0, 8):
+					return gtok_t_switch::SIZING;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		case onechar('t', 0, 32) | onechar('i', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				switch(in[5]){
+				case onechar('g', 0, 8):
+					return gtok_t_switch::TIMING;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <switch>.").c_str());
 }
-inline atok_t_switch lex_attr_t_switch(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 2:
-            switch (in[0]) {
-                case onechar('i', 0, 8):
-                    switch (in[1]) {
-                        case onechar('d', 0, 8):
-                            return atok_t_switch::ID;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_switch::NAME;
-                    break;
-                case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_switch::TYPE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <switch>.").c_str());
+inline atok_t_switch lex_attr_t_switch(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_switch::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
+			return atok_t_switch::NAME;
+		break;
+		case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
+			return atok_t_switch::TYPE;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <switch>.").c_str());
 }
 
-inline gtok_t_switches lex_node_t_switches(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('s', 0, 32) | onechar('w', 8, 32) | onechar('i', 16, 32) | onechar('t', 24, 32):
-                    switch (in[4]) {
-                        case onechar('c', 0, 8):
-                            switch (in[5]) {
-                                case onechar('h', 0, 8):
-                                    return gtok_t_switches::SWITCH;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <switches>.").c_str());
+inline gtok_t_switches lex_node_t_switches(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('s', 0, 32) | onechar('w', 8, 32) | onechar('i', 16, 32) | onechar('t', 24, 32):
+			switch(in[4]){
+			case onechar('c', 0, 8):
+				switch(in[5]){
+				case onechar('h', 0, 8):
+					return gtok_t_switches::SWITCH;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <switches>.").c_str());
 }
 
-inline atok_t_segment_timing lex_attr_t_segment_timing(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 11:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('C', 0, 64) | onechar('_', 8, 64) | onechar('p', 16, 64) | onechar('e', 24, 64) | onechar('r', 32, 64) | onechar('_', 40, 64) | onechar('m', 48, 64) | onechar('e', 56, 64):
-                    switch (in[8]) {
-                        case onechar('t', 0, 8):
-                            switch (in[9]) {
-                                case onechar('e', 0, 8):
-                                    switch (in[10]) {
-                                        case onechar('r', 0, 8):
-                                            return atok_t_segment_timing::C_PER_METER;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('R', 0, 64) | onechar('_', 8, 64) | onechar('p', 16, 64) | onechar('e', 24, 64) | onechar('r', 32, 64) | onechar('_', 40, 64) | onechar('m', 48, 64) | onechar('e', 56, 64):
-                    switch (in[8]) {
-                        case onechar('t', 0, 8):
-                            switch (in[9]) {
-                                case onechar('e', 0, 8):
-                                    switch (in[10]) {
-                                        case onechar('r', 0, 8):
-                                            return atok_t_segment_timing::R_PER_METER;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <segment_timing>.").c_str());
+inline atok_t_segment_timing lex_attr_t_segment_timing(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 11:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('C', 0, 64) | onechar('_', 8, 64) | onechar('p', 16, 64) | onechar('e', 24, 64) | onechar('r', 32, 64) | onechar('_', 40, 64) | onechar('m', 48, 64) | onechar('e', 56, 64):
+			switch(in[8]){
+			case onechar('t', 0, 8):
+				switch(in[9]){
+				case onechar('e', 0, 8):
+					switch(in[10]){
+					case onechar('r', 0, 8):
+						return atok_t_segment_timing::C_PER_METER;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		case onechar('R', 0, 64) | onechar('_', 8, 64) | onechar('p', 16, 64) | onechar('e', 24, 64) | onechar('r', 32, 64) | onechar('_', 40, 64) | onechar('m', 48, 64) | onechar('e', 56, 64):
+			switch(in[8]){
+			case onechar('t', 0, 8):
+				switch(in[9]){
+				case onechar('e', 0, 8):
+					switch(in[10]){
+					case onechar('r', 0, 8):
+						return atok_t_segment_timing::R_PER_METER;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <segment_timing>.").c_str());
 }
 
-inline gtok_t_segment lex_node_t_segment(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('t', 0, 32) | onechar('i', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            switch (in[5]) {
-                                case onechar('g', 0, 8):
-                                    return gtok_t_segment::TIMING;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <segment>.").c_str());
+inline gtok_t_segment lex_node_t_segment(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('t', 0, 32) | onechar('i', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				switch(in[5]){
+				case onechar('g', 0, 8):
+					return gtok_t_segment::TIMING;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <segment>.").c_str());
 }
-inline atok_t_segment lex_attr_t_segment(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 2:
-            switch (in[0]) {
-                case onechar('i', 0, 8):
-                    switch (in[1]) {
-                        case onechar('d', 0, 8):
-                            return atok_t_segment::ID;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_segment::NAME;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <segment>.").c_str());
+inline atok_t_segment lex_attr_t_segment(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_segment::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
+			return atok_t_segment::NAME;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <segment>.").c_str());
 }
 
-inline gtok_t_segments lex_node_t_segments(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 7:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('s', 0, 32) | onechar('e', 8, 32) | onechar('g', 16, 32) | onechar('m', 24, 32):
-                    switch (in[4]) {
-                        case onechar('e', 0, 8):
-                            switch (in[5]) {
-                                case onechar('n', 0, 8):
-                                    switch (in[6]) {
-                                        case onechar('t', 0, 8):
-                                            return gtok_t_segments::SEGMENT;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <segments>.").c_str());
+inline gtok_t_segments lex_node_t_segments(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 7:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('s', 0, 32) | onechar('e', 8, 32) | onechar('g', 16, 32) | onechar('m', 24, 32):
+			switch(in[4]){
+			case onechar('e', 0, 8):
+				switch(in[5]){
+				case onechar('n', 0, 8):
+					switch(in[6]){
+					case onechar('t', 0, 8):
+						return gtok_t_segments::SEGMENT;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <segments>.").c_str());
 }
 
-inline atok_t_pin lex_attr_t_pin(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 3:
-            switch (in[0]) {
-                case onechar('p', 0, 8):
-                    switch (in[1]) {
-                        case onechar('t', 0, 8):
-                            switch (in[2]) {
-                                case onechar('c', 0, 8):
-                                    return atok_t_pin::PTC;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <pin>.").c_str());
+inline atok_t_pin lex_attr_t_pin(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 3:
+		switch(in[0]){
+		case onechar('p', 0, 8):
+			switch(in[1]){
+			case onechar('t', 0, 8):
+				switch(in[2]){
+				case onechar('c', 0, 8):
+					return atok_t_pin::PTC;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <pin>.").c_str());
 }
 
-inline gtok_t_pin_class lex_node_t_pin_class(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 3:
-            switch (in[0]) {
-                case onechar('p', 0, 8):
-                    switch (in[1]) {
-                        case onechar('i', 0, 8):
-                            switch (in[2]) {
-                                case onechar('n', 0, 8):
-                                    return gtok_t_pin_class::PIN;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <pin_class>.").c_str());
+inline gtok_t_pin_class lex_node_t_pin_class(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 3:
+		switch(in[0]){
+		case onechar('p', 0, 8):
+			switch(in[1]){
+			case onechar('i', 0, 8):
+				switch(in[2]){
+				case onechar('n', 0, 8):
+					return gtok_t_pin_class::PIN;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <pin_class>.").c_str());
 }
-inline atok_t_pin_class lex_attr_t_pin_class(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_pin_class::TYPE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <pin_class>.").c_str());
+inline atok_t_pin_class lex_attr_t_pin_class(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
+			return atok_t_pin_class::TYPE;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <pin_class>.").c_str());
 }
 
-inline gtok_t_block_type lex_node_t_block_type(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('p', 0, 64) | onechar('i', 8, 64) | onechar('n', 16, 64) | onechar('_', 24, 64) | onechar('c', 32, 64) | onechar('l', 40, 64) | onechar('a', 48, 64) | onechar('s', 56, 64):
-                    switch (in[8]) {
-                        case onechar('s', 0, 8):
-                            return gtok_t_block_type::PIN_CLASS;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <block_type>.").c_str());
+inline gtok_t_block_type lex_node_t_block_type(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('p', 0, 64) | onechar('i', 8, 64) | onechar('n', 16, 64) | onechar('_', 24, 64) | onechar('c', 32, 64) | onechar('l', 40, 64) | onechar('a', 48, 64) | onechar('s', 56, 64):
+			switch(in[8]){
+			case onechar('s', 0, 8):
+				return gtok_t_block_type::PIN_CLASS;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <block_type>.").c_str());
 }
-inline atok_t_block_type lex_attr_t_block_type(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 2:
-            switch (in[0]) {
-                case onechar('i', 0, 8):
-                    switch (in[1]) {
-                        case onechar('d', 0, 8):
-                            return atok_t_block_type::ID;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_block_type::NAME;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('w', 0, 32) | onechar('i', 8, 32) | onechar('d', 16, 32) | onechar('t', 24, 32):
-                    switch (in[4]) {
-                        case onechar('h', 0, 8):
-                            return atok_t_block_type::WIDTH;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('h', 0, 32) | onechar('e', 8, 32) | onechar('i', 16, 32) | onechar('g', 24, 32):
-                    switch (in[4]) {
-                        case onechar('h', 0, 8):
-                            switch (in[5]) {
-                                case onechar('t', 0, 8):
-                                    return atok_t_block_type::HEIGHT;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <block_type>.").c_str());
+inline atok_t_block_type lex_attr_t_block_type(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_block_type::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
+			return atok_t_block_type::NAME;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('w', 0, 32) | onechar('i', 8, 32) | onechar('d', 16, 32) | onechar('t', 24, 32):
+			switch(in[4]){
+			case onechar('h', 0, 8):
+				return atok_t_block_type::WIDTH;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('h', 0, 32) | onechar('e', 8, 32) | onechar('i', 16, 32) | onechar('g', 24, 32):
+			switch(in[4]){
+			case onechar('h', 0, 8):
+				switch(in[5]){
+				case onechar('t', 0, 8):
+					return atok_t_block_type::HEIGHT;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <block_type>.").c_str());
 }
 
-inline gtok_t_block_types lex_node_t_block_types(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 10:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('b', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('c', 24, 64) | onechar('k', 32, 64) | onechar('_', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
-                    switch (in[8]) {
-                        case onechar('p', 0, 8):
-                            switch (in[9]) {
-                                case onechar('e', 0, 8):
-                                    return gtok_t_block_types::BLOCK_TYPE;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <block_types>.").c_str());
+inline gtok_t_block_types lex_node_t_block_types(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 10:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('b', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('c', 24, 64) | onechar('k', 32, 64) | onechar('_', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
+			switch(in[8]){
+			case onechar('p', 0, 8):
+				switch(in[9]){
+				case onechar('e', 0, 8):
+					return gtok_t_block_types::BLOCK_TYPE;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <block_types>.").c_str());
 }
 
-inline atok_t_grid_loc lex_attr_t_grid_loc(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 1:
-            switch (in[0]) {
-                case onechar('x', 0, 8):
-                    return atok_t_grid_loc::X;
-                    break;
-                case onechar('y', 0, 8):
-                    return atok_t_grid_loc::Y;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 12:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('w', 0, 64) | onechar('i', 8, 64) | onechar('d', 16, 64) | onechar('t', 24, 64) | onechar('h', 32, 64) | onechar('_', 40, 64) | onechar('o', 48, 64) | onechar('f', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('f', 0, 32) | onechar('s', 8, 32) | onechar('e', 16, 32) | onechar('t', 24, 32):
-                            return atok_t_grid_loc::WIDTH_OFFSET;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 13:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('b', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('c', 24, 64) | onechar('k', 32, 64) | onechar('_', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('p', 0, 32) | onechar('e', 8, 32) | onechar('_', 16, 32) | onechar('i', 24, 32):
-                            switch (in[12]) {
-                                case onechar('d', 0, 8):
-                                    return atok_t_grid_loc::BLOCK_TYPE_ID;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('h', 0, 64) | onechar('e', 8, 64) | onechar('i', 16, 64) | onechar('g', 24, 64) | onechar('h', 32, 64) | onechar('t', 40, 64) | onechar('_', 48, 64) | onechar('o', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('f', 0, 32) | onechar('f', 8, 32) | onechar('s', 16, 32) | onechar('e', 24, 32):
-                            switch (in[12]) {
-                                case onechar('t', 0, 8):
-                                    return atok_t_grid_loc::HEIGHT_OFFSET;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <grid_loc>.").c_str());
+inline atok_t_grid_loc lex_attr_t_grid_loc(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 1:
+		switch(in[0]){
+		case onechar('x', 0, 8):
+			return atok_t_grid_loc::X;
+		break;
+		case onechar('y', 0, 8):
+			return atok_t_grid_loc::Y;
+		break;
+		default: break;
+		}
+		break;
+	case 12:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('w', 0, 64) | onechar('i', 8, 64) | onechar('d', 16, 64) | onechar('t', 24, 64) | onechar('h', 32, 64) | onechar('_', 40, 64) | onechar('o', 48, 64) | onechar('f', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('f', 0, 32) | onechar('s', 8, 32) | onechar('e', 16, 32) | onechar('t', 24, 32):
+				return atok_t_grid_loc::WIDTH_OFFSET;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 13:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('b', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('c', 24, 64) | onechar('k', 32, 64) | onechar('_', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('p', 0, 32) | onechar('e', 8, 32) | onechar('_', 16, 32) | onechar('i', 24, 32):
+				switch(in[12]){
+				case onechar('d', 0, 8):
+					return atok_t_grid_loc::BLOCK_TYPE_ID;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		case onechar('h', 0, 64) | onechar('e', 8, 64) | onechar('i', 16, 64) | onechar('g', 24, 64) | onechar('h', 32, 64) | onechar('t', 40, 64) | onechar('_', 48, 64) | onechar('o', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('f', 0, 32) | onechar('f', 8, 32) | onechar('s', 16, 32) | onechar('e', 24, 32):
+				switch(in[12]){
+				case onechar('t', 0, 8):
+					return atok_t_grid_loc::HEIGHT_OFFSET;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <grid_loc>.").c_str());
 }
 
-inline gtok_t_grid_locs lex_node_t_grid_locs(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('g', 0, 64) | onechar('r', 8, 64) | onechar('i', 16, 64) | onechar('d', 24, 64) | onechar('_', 32, 64) | onechar('l', 40, 64) | onechar('o', 48, 64) | onechar('c', 56, 64):
-                    return gtok_t_grid_locs::GRID_LOC;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <grid_locs>.").c_str());
+inline gtok_t_grid_locs lex_node_t_grid_locs(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('g', 0, 64) | onechar('r', 8, 64) | onechar('i', 16, 64) | onechar('d', 24, 64) | onechar('_', 32, 64) | onechar('l', 40, 64) | onechar('o', 48, 64) | onechar('c', 56, 64):
+			return gtok_t_grid_locs::GRID_LOC;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <grid_locs>.").c_str());
 }
 
-inline atok_t_node_loc lex_attr_t_node_loc(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 3:
-            switch (in[0]) {
-                case onechar('p', 0, 8):
-                    switch (in[1]) {
-                        case onechar('t', 0, 8):
-                            switch (in[2]) {
-                                case onechar('c', 0, 8):
-                                    return atok_t_node_loc::PTC;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('s', 0, 32) | onechar('i', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_node_loc::SIDE;
-                    break;
-                case onechar('x', 0, 32) | onechar('l', 8, 32) | onechar('o', 16, 32) | onechar('w', 24, 32):
-                    return atok_t_node_loc::XLOW;
-                    break;
-                case onechar('y', 0, 32) | onechar('l', 8, 32) | onechar('o', 16, 32) | onechar('w', 24, 32):
-                    return atok_t_node_loc::YLOW;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('x', 0, 32) | onechar('h', 8, 32) | onechar('i', 16, 32) | onechar('g', 24, 32):
-                    switch (in[4]) {
-                        case onechar('h', 0, 8):
-                            return atok_t_node_loc::XHIGH;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('y', 0, 32) | onechar('h', 8, 32) | onechar('i', 16, 32) | onechar('g', 24, 32):
-                    switch (in[4]) {
-                        case onechar('h', 0, 8):
-                            return atok_t_node_loc::YHIGH;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_loc>.").c_str());
+inline atok_t_node_loc lex_attr_t_node_loc(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 3:
+		switch(in[0]){
+		case onechar('p', 0, 8):
+			switch(in[1]){
+			case onechar('t', 0, 8):
+				switch(in[2]){
+				case onechar('c', 0, 8):
+					return atok_t_node_loc::PTC;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('s', 0, 32) | onechar('i', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
+			return atok_t_node_loc::SIDE;
+		break;
+		case onechar('x', 0, 32) | onechar('l', 8, 32) | onechar('o', 16, 32) | onechar('w', 24, 32):
+			return atok_t_node_loc::XLOW;
+		break;
+		case onechar('y', 0, 32) | onechar('l', 8, 32) | onechar('o', 16, 32) | onechar('w', 24, 32):
+			return atok_t_node_loc::YLOW;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('x', 0, 32) | onechar('h', 8, 32) | onechar('i', 16, 32) | onechar('g', 24, 32):
+			switch(in[4]){
+			case onechar('h', 0, 8):
+				return atok_t_node_loc::XHIGH;
+			break;
+			default: break;
+			}
+		break;
+		case onechar('y', 0, 32) | onechar('h', 8, 32) | onechar('i', 16, 32) | onechar('g', 24, 32):
+			switch(in[4]){
+			case onechar('h', 0, 8):
+				return atok_t_node_loc::YHIGH;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_loc>.").c_str());
 }
 
-inline atok_t_node_timing lex_attr_t_node_timing(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 1:
-            switch (in[0]) {
-                case onechar('C', 0, 8):
-                    return atok_t_node_timing::C;
-                    break;
-                case onechar('R', 0, 8):
-                    return atok_t_node_timing::R;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_timing>.").c_str());
+inline atok_t_node_timing lex_attr_t_node_timing(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 1:
+		switch(in[0]){
+		case onechar('C', 0, 8):
+			return atok_t_node_timing::C;
+		break;
+		case onechar('R', 0, 8):
+			return atok_t_node_timing::R;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_timing>.").c_str());
 }
 
-inline atok_t_node_segment lex_attr_t_node_segment(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 10:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('s', 0, 64) | onechar('e', 8, 64) | onechar('g', 16, 64) | onechar('m', 24, 64) | onechar('e', 32, 64) | onechar('n', 40, 64) | onechar('t', 48, 64) | onechar('_', 56, 64):
-                    switch (in[8]) {
-                        case onechar('i', 0, 8):
-                            switch (in[9]) {
-                                case onechar('d', 0, 8):
-                                    return atok_t_node_segment::SEGMENT_ID;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_segment>.").c_str());
+inline atok_t_node_segment lex_attr_t_node_segment(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 10:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('s', 0, 64) | onechar('e', 8, 64) | onechar('g', 16, 64) | onechar('m', 24, 64) | onechar('e', 32, 64) | onechar('n', 40, 64) | onechar('t', 48, 64) | onechar('_', 56, 64):
+			switch(in[8]){
+			case onechar('i', 0, 8):
+				switch(in[9]){
+				case onechar('d', 0, 8):
+					return atok_t_node_segment::SEGMENT_ID;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_segment>.").c_str());
 }
 
-inline atok_t_meta lex_attr_t_meta(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_meta::NAME;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <meta>.").c_str());
+inline atok_t_meta lex_attr_t_meta(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
+			return atok_t_meta::NAME;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <meta>.").c_str());
 }
 
-inline gtok_t_metadata lex_node_t_metadata(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('m', 0, 32) | onechar('e', 8, 32) | onechar('t', 16, 32) | onechar('a', 24, 32):
-                    return gtok_t_metadata::META;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <metadata>.").c_str());
+inline gtok_t_metadata lex_node_t_metadata(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('m', 0, 32) | onechar('e', 8, 32) | onechar('t', 16, 32) | onechar('a', 24, 32):
+			return gtok_t_metadata::META;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <metadata>.").c_str());
 }
 
-inline gtok_t_node lex_node_t_node(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 3:
-            switch (in[0]) {
-                case onechar('l', 0, 8):
-                    switch (in[1]) {
-                        case onechar('o', 0, 8):
-                            switch (in[2]) {
-                                case onechar('c', 0, 8):
-                                    return gtok_t_node::LOC;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('t', 0, 32) | onechar('i', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
-                    switch (in[4]) {
-                        case onechar('n', 0, 8):
-                            switch (in[5]) {
-                                case onechar('g', 0, 8):
-                                    return gtok_t_node::TIMING;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 7:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('s', 0, 32) | onechar('e', 8, 32) | onechar('g', 16, 32) | onechar('m', 24, 32):
-                    switch (in[4]) {
-                        case onechar('e', 0, 8):
-                            switch (in[5]) {
-                                case onechar('n', 0, 8):
-                                    switch (in[6]) {
-                                        case onechar('t', 0, 8):
-                                            return gtok_t_node::SEGMENT;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('m', 0, 64) | onechar('e', 8, 64) | onechar('t', 16, 64) | onechar('a', 24, 64) | onechar('d', 32, 64) | onechar('a', 40, 64) | onechar('t', 48, 64) | onechar('a', 56, 64):
-                    return gtok_t_node::METADATA;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <node>.").c_str());
+inline gtok_t_node lex_node_t_node(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 3:
+		switch(in[0]){
+		case onechar('l', 0, 8):
+			switch(in[1]){
+			case onechar('o', 0, 8):
+				switch(in[2]){
+				case onechar('c', 0, 8):
+					return gtok_t_node::LOC;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('t', 0, 32) | onechar('i', 8, 32) | onechar('m', 16, 32) | onechar('i', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				switch(in[5]){
+				case onechar('g', 0, 8):
+					return gtok_t_node::TIMING;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 7:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('s', 0, 32) | onechar('e', 8, 32) | onechar('g', 16, 32) | onechar('m', 24, 32):
+			switch(in[4]){
+			case onechar('e', 0, 8):
+				switch(in[5]){
+				case onechar('n', 0, 8):
+					switch(in[6]){
+					case onechar('t', 0, 8):
+						return gtok_t_node::SEGMENT;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('m', 0, 64) | onechar('e', 8, 64) | onechar('t', 16, 64) | onechar('a', 24, 64) | onechar('d', 32, 64) | onechar('a', 40, 64) | onechar('t', 48, 64) | onechar('a', 56, 64):
+			return gtok_t_node::METADATA;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <node>.").c_str());
 }
-inline atok_t_node lex_attr_t_node(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 2:
-            switch (in[0]) {
-                case onechar('i', 0, 8):
-                    switch (in[1]) {
-                        case onechar('d', 0, 8):
-                            return atok_t_node::ID;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
-                    return atok_t_node::TYPE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('c', 0, 64) | onechar('a', 8, 64) | onechar('p', 16, 64) | onechar('a', 24, 64) | onechar('c', 32, 64) | onechar('i', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
-                    return atok_t_node::CAPACITY;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('d', 0, 64) | onechar('i', 8, 64) | onechar('r', 16, 64) | onechar('e', 24, 64) | onechar('c', 32, 64) | onechar('t', 40, 64) | onechar('i', 48, 64) | onechar('o', 56, 64):
-                    switch (in[8]) {
-                        case onechar('n', 0, 8):
-                            return atok_t_node::DIRECTION;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node>.").c_str());
+inline atok_t_node lex_attr_t_node(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_node::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
+			return atok_t_node::TYPE;
+		break;
+		default: break;
+		}
+		break;
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('c', 0, 64) | onechar('a', 8, 64) | onechar('p', 16, 64) | onechar('a', 24, 64) | onechar('c', 32, 64) | onechar('i', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
+			return atok_t_node::CAPACITY;
+		break;
+		default: break;
+		}
+		break;
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('d', 0, 64) | onechar('i', 8, 64) | onechar('r', 16, 64) | onechar('e', 24, 64) | onechar('c', 32, 64) | onechar('t', 40, 64) | onechar('i', 48, 64) | onechar('o', 56, 64):
+			switch(in[8]){
+			case onechar('n', 0, 8):
+				return atok_t_node::DIRECTION;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node>.").c_str());
 }
 
-inline gtok_t_rr_nodes lex_node_t_rr_nodes(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('n', 0, 32) | onechar('o', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
-                    return gtok_t_rr_nodes::NODE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_nodes>.").c_str());
+inline gtok_t_rr_nodes lex_node_t_rr_nodes(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('n', 0, 32) | onechar('o', 8, 32) | onechar('d', 16, 32) | onechar('e', 24, 32):
+			return gtok_t_rr_nodes::NODE;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_nodes>.").c_str());
 }
 
-inline gtok_t_edge lex_node_t_edge(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('m', 0, 64) | onechar('e', 8, 64) | onechar('t', 16, 64) | onechar('a', 24, 64) | onechar('d', 32, 64) | onechar('a', 40, 64) | onechar('t', 48, 64) | onechar('a', 56, 64):
-                    return gtok_t_edge::METADATA;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <edge>.").c_str());
-}
-inline atok_t_edge lex_attr_t_edge(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('s', 0, 64) | onechar('r', 8, 64) | onechar('c', 16, 64) | onechar('_', 24, 64) | onechar('n', 32, 64) | onechar('o', 40, 64) | onechar('d', 48, 64) | onechar('e', 56, 64):
-                    return atok_t_edge::SRC_NODE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('s', 0, 64) | onechar('i', 8, 64) | onechar('n', 16, 64) | onechar('k', 24, 64) | onechar('_', 32, 64) | onechar('n', 40, 64) | onechar('o', 48, 64) | onechar('d', 56, 64):
-                    switch (in[8]) {
-                        case onechar('e', 0, 8):
-                            return atok_t_edge::SINK_NODE;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('s', 0, 64) | onechar('w', 8, 64) | onechar('i', 16, 64) | onechar('t', 24, 64) | onechar('c', 32, 64) | onechar('h', 40, 64) | onechar('_', 48, 64) | onechar('i', 56, 64):
-                    switch (in[8]) {
-                        case onechar('d', 0, 8):
-                            return atok_t_edge::SWITCH_ID;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <edge>.").c_str());
+inline atok_t_e_ptn lex_attr_t_e_ptn(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_e_ptn::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <e_ptn>.").c_str());
 }
 
-inline gtok_t_rr_edges lex_node_t_rr_edges(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('e', 0, 32) | onechar('d', 8, 32) | onechar('g', 16, 32) | onechar('e', 24, 32):
-                    return gtok_t_rr_edges::EDGE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_edges>.").c_str());
+inline gtok_t_node_e_ptn lex_node_t_node_e_ptn(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('e', 0, 32) | onechar('_', 8, 32) | onechar('p', 16, 32) | onechar('t', 24, 32):
+			switch(in[4]){
+			case onechar('n', 0, 8):
+				return gtok_t_node_e_ptn::E_PTN;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <node_e_ptn>.").c_str());
+}
+inline atok_t_node_e_ptn lex_attr_t_node_e_ptn(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_node_e_ptn::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('d', 0, 32) | onechar('e', 8, 32) | onechar('s', 16, 32) | onechar('t', 24, 32):
+			return atok_t_node_e_ptn::DEST;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <node_e_ptn>.").c_str());
 }
 
-inline gtok_t_rr_graph lex_node_t_rr_graph(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('g', 0, 32) | onechar('r', 8, 32) | onechar('i', 16, 32) | onechar('d', 24, 32):
-                    return gtok_t_rr_graph::GRID;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('c', 0, 64) | onechar('h', 8, 64) | onechar('a', 16, 64) | onechar('n', 24, 64) | onechar('n', 32, 64) | onechar('e', 40, 64) | onechar('l', 48, 64) | onechar('s', 56, 64):
-                    return gtok_t_rr_graph::CHANNELS;
-                    break;
-                case onechar('r', 0, 64) | onechar('r', 8, 64) | onechar('_', 16, 64) | onechar('e', 24, 64) | onechar('d', 32, 64) | onechar('g', 40, 64) | onechar('e', 48, 64) | onechar('s', 56, 64):
-                    return gtok_t_rr_graph::RR_EDGES;
-                    break;
-                case onechar('r', 0, 64) | onechar('r', 8, 64) | onechar('_', 16, 64) | onechar('n', 24, 64) | onechar('o', 32, 64) | onechar('d', 40, 64) | onechar('e', 48, 64) | onechar('s', 56, 64):
-                    return gtok_t_rr_graph::RR_NODES;
-                    break;
-                case onechar('s', 0, 64) | onechar('e', 8, 64) | onechar('g', 16, 64) | onechar('m', 24, 64) | onechar('e', 32, 64) | onechar('n', 40, 64) | onechar('t', 48, 64) | onechar('s', 56, 64):
-                    return gtok_t_rr_graph::SEGMENTS;
-                    break;
-                case onechar('s', 0, 64) | onechar('w', 8, 64) | onechar('i', 16, 64) | onechar('t', 24, 64) | onechar('c', 32, 64) | onechar('h', 40, 64) | onechar('e', 48, 64) | onechar('s', 56, 64):
-                    return gtok_t_rr_graph::SWITCHES;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 11:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('b', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('c', 24, 64) | onechar('k', 32, 64) | onechar('_', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
-                    switch (in[8]) {
-                        case onechar('p', 0, 8):
-                            switch (in[9]) {
-                                case onechar('e', 0, 8):
-                                    switch (in[10]) {
-                                        case onechar('s', 0, 8):
-                                            return gtok_t_rr_graph::BLOCK_TYPES;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_graph>.").c_str());
+inline gtok_t_rr_node_e_ptns lex_node_t_rr_node_e_ptns(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 10:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('n', 0, 64) | onechar('o', 8, 64) | onechar('d', 16, 64) | onechar('e', 24, 64) | onechar('_', 32, 64) | onechar('e', 40, 64) | onechar('_', 48, 64) | onechar('p', 56, 64):
+			switch(in[8]){
+			case onechar('t', 0, 8):
+				switch(in[9]){
+				case onechar('n', 0, 8):
+					return gtok_t_rr_node_e_ptns::NODE_E_PTN;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_node_e_ptns>.").c_str());
 }
-inline atok_t_rr_graph lex_attr_t_rr_graph(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('t', 0, 64) | onechar('o', 8, 64) | onechar('o', 16, 64) | onechar('l', 24, 64) | onechar('_', 32, 64) | onechar('n', 40, 64) | onechar('a', 48, 64) | onechar('m', 56, 64):
-                    switch (in[8]) {
-                        case onechar('e', 0, 8):
-                            return atok_t_rr_graph::TOOL_NAME;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 12:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('t', 0, 64) | onechar('o', 8, 64) | onechar('o', 16, 64) | onechar('l', 24, 64) | onechar('_', 32, 64) | onechar('c', 40, 64) | onechar('o', 48, 64) | onechar('m', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('m', 0, 32) | onechar('e', 8, 32) | onechar('n', 16, 32) | onechar('t', 24, 32):
-                            return atok_t_rr_graph::TOOL_COMMENT;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('t', 0, 64) | onechar('o', 8, 64) | onechar('o', 16, 64) | onechar('l', 24, 64) | onechar('_', 32, 64) | onechar('v', 40, 64) | onechar('e', 48, 64) | onechar('r', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('s', 0, 32) | onechar('i', 8, 32) | onechar('o', 16, 32) | onechar('n', 24, 32):
-                            return atok_t_rr_graph::TOOL_VERSION;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <rr_graph>.").c_str());
+
+inline atok_t_ddiff lex_attr_t_ddiff(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_ddiff::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <ddiff>.").c_str());
+}
+
+inline gtok_t_edge_ptn lex_node_t_edge_ptn(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('d', 0, 32) | onechar('d', 8, 32) | onechar('i', 16, 32) | onechar('f', 24, 32):
+			switch(in[4]){
+			case onechar('f', 0, 8):
+				return gtok_t_edge_ptn::DDIFF;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <edge_ptn>.").c_str());
+}
+inline atok_t_edge_ptn lex_attr_t_edge_ptn(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 2:
+		switch(in[0]){
+		case onechar('i', 0, 8):
+			switch(in[1]){
+			case onechar('d', 0, 8):
+				return atok_t_edge_ptn::ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('s', 0, 64) | onechar('w', 8, 64) | onechar('i', 16, 64) | onechar('t', 24, 64) | onechar('c', 32, 64) | onechar('h', 40, 64) | onechar('_', 48, 64) | onechar('i', 56, 64):
+			switch(in[8]){
+			case onechar('d', 0, 8):
+				return atok_t_edge_ptn::SWITCH_ID;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <edge_ptn>.").c_str());
+}
+
+inline gtok_t_rr_edge_ptns lex_node_t_rr_edge_ptns(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('e', 0, 64) | onechar('d', 8, 64) | onechar('g', 16, 64) | onechar('e', 24, 64) | onechar('_', 32, 64) | onechar('p', 40, 64) | onechar('t', 48, 64) | onechar('n', 56, 64):
+			return gtok_t_rr_edge_ptns::EDGE_PTN;
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_edge_ptns>.").c_str());
+}
+
+inline gtok_t_rr_graph lex_node_t_rr_graph(const char *in, const std::function<void(const char *)> *report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('g', 0, 32) | onechar('r', 8, 32) | onechar('i', 16, 32) | onechar('d', 24, 32):
+			return gtok_t_rr_graph::GRID;
+		break;
+		default: break;
+		}
+		break;
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('c', 0, 64) | onechar('h', 8, 64) | onechar('a', 16, 64) | onechar('n', 24, 64) | onechar('n', 32, 64) | onechar('e', 40, 64) | onechar('l', 48, 64) | onechar('s', 56, 64):
+			return gtok_t_rr_graph::CHANNELS;
+		break;
+		case onechar('r', 0, 64) | onechar('r', 8, 64) | onechar('_', 16, 64) | onechar('n', 24, 64) | onechar('o', 32, 64) | onechar('d', 40, 64) | onechar('e', 48, 64) | onechar('s', 56, 64):
+			return gtok_t_rr_graph::RR_NODES;
+		break;
+		case onechar('s', 0, 64) | onechar('e', 8, 64) | onechar('g', 16, 64) | onechar('m', 24, 64) | onechar('e', 32, 64) | onechar('n', 40, 64) | onechar('t', 48, 64) | onechar('s', 56, 64):
+			return gtok_t_rr_graph::SEGMENTS;
+		break;
+		case onechar('s', 0, 64) | onechar('w', 8, 64) | onechar('i', 16, 64) | onechar('t', 24, 64) | onechar('c', 32, 64) | onechar('h', 40, 64) | onechar('e', 48, 64) | onechar('s', 56, 64):
+			return gtok_t_rr_graph::SWITCHES;
+		break;
+		default: break;
+		}
+		break;
+	case 11:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('b', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('c', 24, 64) | onechar('k', 32, 64) | onechar('_', 40, 64) | onechar('t', 48, 64) | onechar('y', 56, 64):
+			switch(in[8]){
+			case onechar('p', 0, 8):
+				switch(in[9]){
+				case onechar('e', 0, 8):
+					switch(in[10]){
+					case onechar('s', 0, 8):
+						return gtok_t_rr_graph::BLOCK_TYPES;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 12:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('r', 0, 64) | onechar('r', 8, 64) | onechar('_', 16, 64) | onechar('e', 24, 64) | onechar('d', 32, 64) | onechar('g', 40, 64) | onechar('e', 48, 64) | onechar('_', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('p', 0, 32) | onechar('t', 8, 32) | onechar('n', 16, 32) | onechar('s', 24, 32):
+				return gtok_t_rr_graph::RR_EDGE_PTNS;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 14:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('r', 0, 64) | onechar('r', 8, 64) | onechar('_', 16, 64) | onechar('n', 24, 64) | onechar('o', 32, 64) | onechar('d', 40, 64) | onechar('e', 48, 64) | onechar('_', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('e', 0, 32) | onechar('_', 8, 32) | onechar('p', 16, 32) | onechar('t', 24, 32):
+				switch(in[12]){
+				case onechar('n', 0, 8):
+					switch(in[13]){
+					case onechar('s', 0, 8):
+						return gtok_t_rr_graph::RR_NODE_E_PTNS;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <rr_graph>.").c_str());
+}
+inline atok_t_rr_graph lex_attr_t_rr_graph(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('t', 0, 64) | onechar('o', 8, 64) | onechar('o', 16, 64) | onechar('l', 24, 64) | onechar('_', 32, 64) | onechar('n', 40, 64) | onechar('a', 48, 64) | onechar('m', 56, 64):
+			switch(in[8]){
+			case onechar('e', 0, 8):
+				return atok_t_rr_graph::TOOL_NAME;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 12:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('t', 0, 64) | onechar('o', 8, 64) | onechar('o', 16, 64) | onechar('l', 24, 64) | onechar('_', 32, 64) | onechar('c', 40, 64) | onechar('o', 48, 64) | onechar('m', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('m', 0, 32) | onechar('e', 8, 32) | onechar('n', 16, 32) | onechar('t', 24, 32):
+				return atok_t_rr_graph::TOOL_COMMENT;
+			break;
+			default: break;
+			}
+		break;
+		case onechar('t', 0, 64) | onechar('o', 8, 64) | onechar('o', 16, 64) | onechar('l', 24, 64) | onechar('_', 32, 64) | onechar('v', 40, 64) | onechar('e', 48, 64) | onechar('r', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('s', 0, 32) | onechar('i', 8, 32) | onechar('o', 16, 32) | onechar('n', 24, 32):
+				return atok_t_rr_graph::TOOL_VERSION;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <rr_graph>.").c_str());
 }
 
 /**
  * Internal error function for xs:choice and xs:sequence validators.
  */
-[[noreturn]] inline void dfa_error(const char* wrong, const int* states, const char* const* lookup, int len, const std::function<void(const char*)>* report_error);
+[[noreturn]] inline void dfa_error(const char *wrong, const int *states, const char * const *lookup, int len, const std::function<void(const char *)> * report_error);
 
 /**
  * Internal error function for xs:all validators.
  */
 template<std::size_t N>
-[[noreturn]] inline void all_error(std::bitset<N> gstate, const char* const* lookup, const std::function<void(const char*)>* report_error);
+[[noreturn]] inline void all_error(std::bitset<N> gstate, const char * const *lookup, const std::function<void(const char *)> * report_error);
 
 /**
  * Internal error function for attribute validators.
  */
 template<std::size_t N>
-[[noreturn]] inline void attr_error(std::bitset<N> astate, const char* const* lookup, const std::function<void(const char*)>* report_error);
+[[noreturn]] inline void attr_error(std::bitset<N> astate, const char * const *lookup, const std::function<void(const char *)> * report_error);
+
 
 /* Lookup tables for enums. */
-constexpr const char* lookup_switch_type[] = {"UXSD_INVALID", "mux", "tristate", "pass_gate", "short", "buffer"};
-constexpr const char* lookup_pin_type[] = {"UXSD_INVALID", "OPEN", "OUTPUT", "INPUT"};
-constexpr const char* lookup_node_type[] = {"UXSD_INVALID", "CHANX", "CHANY", "SOURCE", "SINK", "OPIN", "IPIN"};
-constexpr const char* lookup_node_direction[] = {"UXSD_INVALID", "INC_DIR", "DEC_DIR", "BI_DIR"};
-constexpr const char* lookup_loc_side[] = {"UXSD_INVALID", "LEFT", "RIGHT", "TOP", "BOTTOM", "RIGHT_LEFT", "RIGHT_BOTTOM", "RIGHT_BOTTOM_LEFT", "TOP_RIGHT", "TOP_BOTTOM", "TOP_LEFT", "TOP_RIGHT_BOTTOM", "TOP_RIGHT_LEFT", "TOP_BOTTOM_LEFT", "TOP_RIGHT_BOTTOM_LEFT", "BOTTOM_LEFT"};
+constexpr const char *lookup_switch_type[] = {"UXSD_INVALID", "mux", "tristate", "pass_gate", "short", "buffer"};
+constexpr const char *lookup_pin_type[] = {"UXSD_INVALID", "OPEN", "OUTPUT", "INPUT"};
+constexpr const char *lookup_node_type[] = {"UXSD_INVALID", "CHANX", "CHANY", "SOURCE", "SINK", "OPIN", "IPIN"};
+constexpr const char *lookup_node_direction[] = {"UXSD_INVALID", "INC_DIR", "DEC_DIR", "BI_DIR"};
+constexpr const char *lookup_loc_side[] = {"UXSD_INVALID", "LEFT", "RIGHT", "TOP", "BOTTOM", "RIGHT_LEFT", "RIGHT_BOTTOM", "RIGHT_BOTTOM_LEFT", "TOP_RIGHT", "TOP_BOTTOM", "TOP_LEFT", "TOP_RIGHT_BOTTOM", "TOP_RIGHT_LEFT", "TOP_BOTTOM_LEFT", "TOP_RIGHT_BOTTOM_LEFT", "BOTTOM_LEFT"};
 
 /* Lexers(string->token functions) for enums. */
-inline enum_switch_type lex_enum_switch_type(const char* in, bool throw_on_invalid, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 3:
-            switch (in[0]) {
-                case onechar('m', 0, 8):
-                    switch (in[1]) {
-                        case onechar('u', 0, 8):
-                            switch (in[2]) {
-                                case onechar('x', 0, 8):
-                                    return enum_switch_type::MUX;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('s', 0, 32) | onechar('h', 8, 32) | onechar('o', 16, 32) | onechar('r', 24, 32):
-                    switch (in[4]) {
-                        case onechar('t', 0, 8):
-                            return enum_switch_type::SHORT;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('b', 0, 32) | onechar('u', 8, 32) | onechar('f', 16, 32) | onechar('f', 24, 32):
-                    switch (in[4]) {
-                        case onechar('e', 0, 8):
-                            switch (in[5]) {
-                                case onechar('r', 0, 8):
-                                    return enum_switch_type::BUFFER;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('t', 0, 64) | onechar('r', 8, 64) | onechar('i', 16, 64) | onechar('s', 24, 64) | onechar('t', 32, 64) | onechar('a', 40, 64) | onechar('t', 48, 64) | onechar('e', 56, 64):
-                    return enum_switch_type::TRISTATE;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('p', 0, 64) | onechar('a', 8, 64) | onechar('s', 16, 64) | onechar('s', 24, 64) | onechar('_', 32, 64) | onechar('g', 40, 64) | onechar('a', 48, 64) | onechar('t', 56, 64):
-                    switch (in[8]) {
-                        case onechar('e', 0, 8):
-                            return enum_switch_type::PASS_GATE;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    if (throw_on_invalid)
-        noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_switch_type.").c_str());
-    return enum_switch_type::UXSD_INVALID;
+inline enum_switch_type lex_enum_switch_type(const char *in, bool throw_on_invalid, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 3:
+		switch(in[0]){
+		case onechar('m', 0, 8):
+			switch(in[1]){
+			case onechar('u', 0, 8):
+				switch(in[2]){
+				case onechar('x', 0, 8):
+					return enum_switch_type::MUX;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('s', 0, 32) | onechar('h', 8, 32) | onechar('o', 16, 32) | onechar('r', 24, 32):
+			switch(in[4]){
+			case onechar('t', 0, 8):
+				return enum_switch_type::SHORT;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('b', 0, 32) | onechar('u', 8, 32) | onechar('f', 16, 32) | onechar('f', 24, 32):
+			switch(in[4]){
+			case onechar('e', 0, 8):
+				switch(in[5]){
+				case onechar('r', 0, 8):
+					return enum_switch_type::BUFFER;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('t', 0, 64) | onechar('r', 8, 64) | onechar('i', 16, 64) | onechar('s', 24, 64) | onechar('t', 32, 64) | onechar('a', 40, 64) | onechar('t', 48, 64) | onechar('e', 56, 64):
+			return enum_switch_type::TRISTATE;
+		break;
+		default: break;
+		}
+		break;
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('p', 0, 64) | onechar('a', 8, 64) | onechar('s', 16, 64) | onechar('s', 24, 64) | onechar('_', 32, 64) | onechar('g', 40, 64) | onechar('a', 48, 64) | onechar('t', 56, 64):
+			switch(in[8]){
+			case onechar('e', 0, 8):
+				return enum_switch_type::PASS_GATE;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	if(throw_on_invalid)
+		noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_switch_type.").c_str());
+	return enum_switch_type::UXSD_INVALID;
 }
 
-inline enum_pin_type lex_enum_pin_type(const char* in, bool throw_on_invalid, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('O', 0, 32) | onechar('P', 8, 32) | onechar('E', 16, 32) | onechar('N', 24, 32):
-                    return enum_pin_type::OPEN;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('I', 0, 32) | onechar('N', 8, 32) | onechar('P', 16, 32) | onechar('U', 24, 32):
-                    switch (in[4]) {
-                        case onechar('T', 0, 8):
-                            return enum_pin_type::INPUT;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('O', 0, 32) | onechar('U', 8, 32) | onechar('T', 16, 32) | onechar('P', 24, 32):
-                    switch (in[4]) {
-                        case onechar('U', 0, 8):
-                            switch (in[5]) {
-                                case onechar('T', 0, 8):
-                                    return enum_pin_type::OUTPUT;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    if (throw_on_invalid)
-        noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_pin_type.").c_str());
-    return enum_pin_type::UXSD_INVALID;
+inline enum_pin_type lex_enum_pin_type(const char *in, bool throw_on_invalid, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('O', 0, 32) | onechar('P', 8, 32) | onechar('E', 16, 32) | onechar('N', 24, 32):
+			return enum_pin_type::OPEN;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('I', 0, 32) | onechar('N', 8, 32) | onechar('P', 16, 32) | onechar('U', 24, 32):
+			switch(in[4]){
+			case onechar('T', 0, 8):
+				return enum_pin_type::INPUT;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('O', 0, 32) | onechar('U', 8, 32) | onechar('T', 16, 32) | onechar('P', 24, 32):
+			switch(in[4]){
+			case onechar('U', 0, 8):
+				switch(in[5]){
+				case onechar('T', 0, 8):
+					return enum_pin_type::OUTPUT;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	if(throw_on_invalid)
+		noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_pin_type.").c_str());
+	return enum_pin_type::UXSD_INVALID;
 }
 
-inline enum_node_type lex_enum_node_type(const char* in, bool throw_on_invalid, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('I', 0, 32) | onechar('P', 8, 32) | onechar('I', 16, 32) | onechar('N', 24, 32):
-                    return enum_node_type::IPIN;
-                    break;
-                case onechar('O', 0, 32) | onechar('P', 8, 32) | onechar('I', 16, 32) | onechar('N', 24, 32):
-                    return enum_node_type::OPIN;
-                    break;
-                case onechar('S', 0, 32) | onechar('I', 8, 32) | onechar('N', 16, 32) | onechar('K', 24, 32):
-                    return enum_node_type::SINK;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('C', 0, 32) | onechar('H', 8, 32) | onechar('A', 16, 32) | onechar('N', 24, 32):
-                    switch (in[4]) {
-                        case onechar('X', 0, 8):
-                            return enum_node_type::CHANX;
-                            break;
-                        case onechar('Y', 0, 8):
-                            return enum_node_type::CHANY;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('S', 0, 32) | onechar('O', 8, 32) | onechar('U', 16, 32) | onechar('R', 24, 32):
-                    switch (in[4]) {
-                        case onechar('C', 0, 8):
-                            switch (in[5]) {
-                                case onechar('E', 0, 8):
-                                    return enum_node_type::SOURCE;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    if (throw_on_invalid)
-        noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_node_type.").c_str());
-    return enum_node_type::UXSD_INVALID;
+inline enum_node_type lex_enum_node_type(const char *in, bool throw_on_invalid, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('I', 0, 32) | onechar('P', 8, 32) | onechar('I', 16, 32) | onechar('N', 24, 32):
+			return enum_node_type::IPIN;
+		break;
+		case onechar('O', 0, 32) | onechar('P', 8, 32) | onechar('I', 16, 32) | onechar('N', 24, 32):
+			return enum_node_type::OPIN;
+		break;
+		case onechar('S', 0, 32) | onechar('I', 8, 32) | onechar('N', 16, 32) | onechar('K', 24, 32):
+			return enum_node_type::SINK;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('C', 0, 32) | onechar('H', 8, 32) | onechar('A', 16, 32) | onechar('N', 24, 32):
+			switch(in[4]){
+			case onechar('X', 0, 8):
+				return enum_node_type::CHANX;
+			break;
+			case onechar('Y', 0, 8):
+				return enum_node_type::CHANY;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('S', 0, 32) | onechar('O', 8, 32) | onechar('U', 16, 32) | onechar('R', 24, 32):
+			switch(in[4]){
+			case onechar('C', 0, 8):
+				switch(in[5]){
+				case onechar('E', 0, 8):
+					return enum_node_type::SOURCE;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	if(throw_on_invalid)
+		noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_node_type.").c_str());
+	return enum_node_type::UXSD_INVALID;
 }
 
-inline enum_node_direction lex_enum_node_direction(const char* in, bool throw_on_invalid, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('B', 0, 32) | onechar('I', 8, 32) | onechar('_', 16, 32) | onechar('D', 24, 32):
-                    switch (in[4]) {
-                        case onechar('I', 0, 8):
-                            switch (in[5]) {
-                                case onechar('R', 0, 8):
-                                    return enum_node_direction::BI_DIR;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 7:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('D', 0, 32) | onechar('E', 8, 32) | onechar('C', 16, 32) | onechar('_', 24, 32):
-                    switch (in[4]) {
-                        case onechar('D', 0, 8):
-                            switch (in[5]) {
-                                case onechar('I', 0, 8):
-                                    switch (in[6]) {
-                                        case onechar('R', 0, 8):
-                                            return enum_node_direction::DEC_DIR;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('I', 0, 32) | onechar('N', 8, 32) | onechar('C', 16, 32) | onechar('_', 24, 32):
-                    switch (in[4]) {
-                        case onechar('D', 0, 8):
-                            switch (in[5]) {
-                                case onechar('I', 0, 8):
-                                    switch (in[6]) {
-                                        case onechar('R', 0, 8):
-                                            return enum_node_direction::INC_DIR;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    if (throw_on_invalid)
-        noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_node_direction.").c_str());
-    return enum_node_direction::UXSD_INVALID;
+inline enum_node_direction lex_enum_node_direction(const char *in, bool throw_on_invalid, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('B', 0, 32) | onechar('I', 8, 32) | onechar('_', 16, 32) | onechar('D', 24, 32):
+			switch(in[4]){
+			case onechar('I', 0, 8):
+				switch(in[5]){
+				case onechar('R', 0, 8):
+					return enum_node_direction::BI_DIR;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 7:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('D', 0, 32) | onechar('E', 8, 32) | onechar('C', 16, 32) | onechar('_', 24, 32):
+			switch(in[4]){
+			case onechar('D', 0, 8):
+				switch(in[5]){
+				case onechar('I', 0, 8):
+					switch(in[6]){
+					case onechar('R', 0, 8):
+						return enum_node_direction::DEC_DIR;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		case onechar('I', 0, 32) | onechar('N', 8, 32) | onechar('C', 16, 32) | onechar('_', 24, 32):
+			switch(in[4]){
+			case onechar('D', 0, 8):
+				switch(in[5]){
+				case onechar('I', 0, 8):
+					switch(in[6]){
+					case onechar('R', 0, 8):
+						return enum_node_direction::INC_DIR;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	if(throw_on_invalid)
+		noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_node_direction.").c_str());
+	return enum_node_direction::UXSD_INVALID;
 }
 
-inline enum_loc_side lex_enum_loc_side(const char* in, bool throw_on_invalid, const std::function<void(const char*)>* report_error) {
-    unsigned int len = strlen(in);
-    switch (len) {
-        case 3:
-            switch (in[0]) {
-                case onechar('T', 0, 8):
-                    switch (in[1]) {
-                        case onechar('O', 0, 8):
-                            switch (in[2]) {
-                                case onechar('P', 0, 8):
-                                    return enum_loc_side::TOP;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 4:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('L', 0, 32) | onechar('E', 8, 32) | onechar('F', 16, 32) | onechar('T', 24, 32):
-                    return enum_loc_side::LEFT;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 5:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('R', 0, 32) | onechar('I', 8, 32) | onechar('G', 16, 32) | onechar('H', 24, 32):
-                    switch (in[4]) {
-                        case onechar('T', 0, 8):
-                            return enum_loc_side::RIGHT;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 6:
-            switch (*((triehash_uu32*)&in[0])) {
-                case onechar('B', 0, 32) | onechar('O', 8, 32) | onechar('T', 16, 32) | onechar('T', 24, 32):
-                    switch (in[4]) {
-                        case onechar('O', 0, 8):
-                            switch (in[5]) {
-                                case onechar('M', 0, 8):
-                                    return enum_loc_side::BOTTOM;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 8:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('L', 32, 64) | onechar('E', 40, 64) | onechar('F', 48, 64) | onechar('T', 56, 64):
-                    return enum_loc_side::TOP_LEFT;
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 9:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
-                    switch (in[8]) {
-                        case onechar('T', 0, 8):
-                            return enum_loc_side::TOP_RIGHT;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 10:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('R', 0, 64) | onechar('I', 8, 64) | onechar('G', 16, 64) | onechar('H', 24, 64) | onechar('T', 32, 64) | onechar('_', 40, 64) | onechar('L', 48, 64) | onechar('E', 56, 64):
-                    switch (in[8]) {
-                        case onechar('F', 0, 8):
-                            switch (in[9]) {
-                                case onechar('T', 0, 8):
-                                    return enum_loc_side::RIGHT_LEFT;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('B', 32, 64) | onechar('O', 40, 64) | onechar('T', 48, 64) | onechar('T', 56, 64):
-                    switch (in[8]) {
-                        case onechar('O', 0, 8):
-                            switch (in[9]) {
-                                case onechar('M', 0, 8):
-                                    return enum_loc_side::TOP_BOTTOM;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 11:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('B', 0, 64) | onechar('O', 8, 64) | onechar('T', 16, 64) | onechar('T', 24, 64) | onechar('O', 32, 64) | onechar('M', 40, 64) | onechar('_', 48, 64) | onechar('L', 56, 64):
-                    switch (in[8]) {
-                        case onechar('E', 0, 8):
-                            switch (in[9]) {
-                                case onechar('F', 0, 8):
-                                    switch (in[10]) {
-                                        case onechar('T', 0, 8):
-                                            return enum_loc_side::BOTTOM_LEFT;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 12:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('R', 0, 64) | onechar('I', 8, 64) | onechar('G', 16, 64) | onechar('H', 24, 64) | onechar('T', 32, 64) | onechar('_', 40, 64) | onechar('B', 48, 64) | onechar('O', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('T', 0, 32) | onechar('T', 8, 32) | onechar('O', 16, 32) | onechar('M', 24, 32):
-                            return enum_loc_side::RIGHT_BOTTOM;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 14:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('T', 0, 32) | onechar('_', 8, 32) | onechar('L', 16, 32) | onechar('E', 24, 32):
-                            switch (in[12]) {
-                                case onechar('F', 0, 8):
-                                    switch (in[13]) {
-                                        case onechar('T', 0, 8):
-                                            return enum_loc_side::TOP_RIGHT_LEFT;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 15:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('B', 32, 64) | onechar('O', 40, 64) | onechar('T', 48, 64) | onechar('T', 56, 64):
-                    switch (*((triehash_uu32*)&in[8])) {
-                        case onechar('O', 0, 32) | onechar('M', 8, 32) | onechar('_', 16, 32) | onechar('L', 24, 32):
-                            switch (in[12]) {
-                                case onechar('E', 0, 8):
-                                    switch (in[13]) {
-                                        case onechar('F', 0, 8):
-                                            switch (in[14]) {
-                                                case onechar('T', 0, 8):
-                                                    return enum_loc_side::TOP_BOTTOM_LEFT;
-                                                    break;
-                                                default:
-                                                    break;
-                                            }
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 16:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
-                    switch (*((triehash_uu64*)&in[8])) {
-                        case onechar('T', 0, 64) | onechar('_', 8, 64) | onechar('B', 16, 64) | onechar('O', 24, 64) | onechar('T', 32, 64) | onechar('T', 40, 64) | onechar('O', 48, 64) | onechar('M', 56, 64):
-                            return enum_loc_side::TOP_RIGHT_BOTTOM;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 17:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('R', 0, 64) | onechar('I', 8, 64) | onechar('G', 16, 64) | onechar('H', 24, 64) | onechar('T', 32, 64) | onechar('_', 40, 64) | onechar('B', 48, 64) | onechar('O', 56, 64):
-                    switch (*((triehash_uu64*)&in[8])) {
-                        case onechar('T', 0, 64) | onechar('T', 8, 64) | onechar('O', 16, 64) | onechar('M', 24, 64) | onechar('_', 32, 64) | onechar('L', 40, 64) | onechar('E', 48, 64) | onechar('F', 56, 64):
-                            switch (in[16]) {
-                                case onechar('T', 0, 8):
-                                    return enum_loc_side::RIGHT_BOTTOM_LEFT;
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case 21:
-            switch (*((triehash_uu64*)&in[0])) {
-                case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
-                    switch (*((triehash_uu64*)&in[8])) {
-                        case onechar('T', 0, 64) | onechar('_', 8, 64) | onechar('B', 16, 64) | onechar('O', 24, 64) | onechar('T', 32, 64) | onechar('T', 40, 64) | onechar('O', 48, 64) | onechar('M', 56, 64):
-                            switch (*((triehash_uu32*)&in[16])) {
-                                case onechar('_', 0, 32) | onechar('L', 8, 32) | onechar('E', 16, 32) | onechar('F', 24, 32):
-                                    switch (in[20]) {
-                                        case onechar('T', 0, 8):
-                                            return enum_loc_side::TOP_RIGHT_BOTTOM_LEFT;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
-    }
-    if (throw_on_invalid)
-        noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_loc_side.").c_str());
-    return enum_loc_side::UXSD_INVALID;
+inline enum_loc_side lex_enum_loc_side(const char *in, bool throw_on_invalid, const std::function<void(const char *)> * report_error){
+	unsigned int len = strlen(in);
+	switch(len){
+	case 3:
+		switch(in[0]){
+		case onechar('T', 0, 8):
+			switch(in[1]){
+			case onechar('O', 0, 8):
+				switch(in[2]){
+				case onechar('P', 0, 8):
+					return enum_loc_side::TOP;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 4:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('L', 0, 32) | onechar('E', 8, 32) | onechar('F', 16, 32) | onechar('T', 24, 32):
+			return enum_loc_side::LEFT;
+		break;
+		default: break;
+		}
+		break;
+	case 5:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('R', 0, 32) | onechar('I', 8, 32) | onechar('G', 16, 32) | onechar('H', 24, 32):
+			switch(in[4]){
+			case onechar('T', 0, 8):
+				return enum_loc_side::RIGHT;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('B', 0, 32) | onechar('O', 8, 32) | onechar('T', 16, 32) | onechar('T', 24, 32):
+			switch(in[4]){
+			case onechar('O', 0, 8):
+				switch(in[5]){
+				case onechar('M', 0, 8):
+					return enum_loc_side::BOTTOM;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 8:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('L', 32, 64) | onechar('E', 40, 64) | onechar('F', 48, 64) | onechar('T', 56, 64):
+			return enum_loc_side::TOP_LEFT;
+		break;
+		default: break;
+		}
+		break;
+	case 9:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
+			switch(in[8]){
+			case onechar('T', 0, 8):
+				return enum_loc_side::TOP_RIGHT;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 10:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('R', 0, 64) | onechar('I', 8, 64) | onechar('G', 16, 64) | onechar('H', 24, 64) | onechar('T', 32, 64) | onechar('_', 40, 64) | onechar('L', 48, 64) | onechar('E', 56, 64):
+			switch(in[8]){
+			case onechar('F', 0, 8):
+				switch(in[9]){
+				case onechar('T', 0, 8):
+					return enum_loc_side::RIGHT_LEFT;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('B', 32, 64) | onechar('O', 40, 64) | onechar('T', 48, 64) | onechar('T', 56, 64):
+			switch(in[8]){
+			case onechar('O', 0, 8):
+				switch(in[9]){
+				case onechar('M', 0, 8):
+					return enum_loc_side::TOP_BOTTOM;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 11:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('B', 0, 64) | onechar('O', 8, 64) | onechar('T', 16, 64) | onechar('T', 24, 64) | onechar('O', 32, 64) | onechar('M', 40, 64) | onechar('_', 48, 64) | onechar('L', 56, 64):
+			switch(in[8]){
+			case onechar('E', 0, 8):
+				switch(in[9]){
+				case onechar('F', 0, 8):
+					switch(in[10]){
+					case onechar('T', 0, 8):
+						return enum_loc_side::BOTTOM_LEFT;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 12:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('R', 0, 64) | onechar('I', 8, 64) | onechar('G', 16, 64) | onechar('H', 24, 64) | onechar('T', 32, 64) | onechar('_', 40, 64) | onechar('B', 48, 64) | onechar('O', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('T', 0, 32) | onechar('T', 8, 32) | onechar('O', 16, 32) | onechar('M', 24, 32):
+				return enum_loc_side::RIGHT_BOTTOM;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 14:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('T', 0, 32) | onechar('_', 8, 32) | onechar('L', 16, 32) | onechar('E', 24, 32):
+				switch(in[12]){
+				case onechar('F', 0, 8):
+					switch(in[13]){
+					case onechar('T', 0, 8):
+						return enum_loc_side::TOP_RIGHT_LEFT;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 15:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('B', 32, 64) | onechar('O', 40, 64) | onechar('T', 48, 64) | onechar('T', 56, 64):
+			switch(*((triehash_uu32*)&in[8])){
+			case onechar('O', 0, 32) | onechar('M', 8, 32) | onechar('_', 16, 32) | onechar('L', 24, 32):
+				switch(in[12]){
+				case onechar('E', 0, 8):
+					switch(in[13]){
+					case onechar('F', 0, 8):
+						switch(in[14]){
+						case onechar('T', 0, 8):
+							return enum_loc_side::TOP_BOTTOM_LEFT;
+						break;
+						default: break;
+						}
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 16:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
+			switch(*((triehash_uu64*)&in[8])){
+			case onechar('T', 0, 64) | onechar('_', 8, 64) | onechar('B', 16, 64) | onechar('O', 24, 64) | onechar('T', 32, 64) | onechar('T', 40, 64) | onechar('O', 48, 64) | onechar('M', 56, 64):
+				return enum_loc_side::TOP_RIGHT_BOTTOM;
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 17:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('R', 0, 64) | onechar('I', 8, 64) | onechar('G', 16, 64) | onechar('H', 24, 64) | onechar('T', 32, 64) | onechar('_', 40, 64) | onechar('B', 48, 64) | onechar('O', 56, 64):
+			switch(*((triehash_uu64*)&in[8])){
+			case onechar('T', 0, 64) | onechar('T', 8, 64) | onechar('O', 16, 64) | onechar('M', 24, 64) | onechar('_', 32, 64) | onechar('L', 40, 64) | onechar('E', 48, 64) | onechar('F', 56, 64):
+				switch(in[16]){
+				case onechar('T', 0, 8):
+					return enum_loc_side::RIGHT_BOTTOM_LEFT;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	case 21:
+		switch(*((triehash_uu64*)&in[0])){
+		case onechar('T', 0, 64) | onechar('O', 8, 64) | onechar('P', 16, 64) | onechar('_', 24, 64) | onechar('R', 32, 64) | onechar('I', 40, 64) | onechar('G', 48, 64) | onechar('H', 56, 64):
+			switch(*((triehash_uu64*)&in[8])){
+			case onechar('T', 0, 64) | onechar('_', 8, 64) | onechar('B', 16, 64) | onechar('O', 24, 64) | onechar('T', 32, 64) | onechar('T', 40, 64) | onechar('O', 48, 64) | onechar('M', 56, 64):
+				switch(*((triehash_uu32*)&in[16])){
+				case onechar('_', 0, 32) | onechar('L', 8, 32) | onechar('E', 16, 32) | onechar('F', 24, 32):
+					switch(in[20]){
+					case onechar('T', 0, 8):
+						return enum_loc_side::TOP_RIGHT_BOTTOM_LEFT;
+					break;
+					default: break;
+					}
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
+		break;
+		default: break;
+		}
+		break;
+	default: break;
+	}
+	if(throw_on_invalid)
+		noreturn_report(report_error, ("Found unrecognized enum value " + std::string(in) + " of enum_loc_side.").c_str());
+	return enum_loc_side::UXSD_INVALID;
 }
+
 
 /* Internal loading functions, which validate and load a PugiXML DOM tree into memory. */
-inline int load_int(const char* in, const std::function<void(const char*)>* report_error) {
-    int out;
-    out = std::strtol(in, NULL, 10);
-    if (errno != 0)
-        noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a int.").c_str());
-    return out;
+inline int load_int(const char *in, const std::function<void(const char *)> * report_error){
+	int out;
+	out = std::strtol(in, NULL, 10);
+	if(errno != 0)
+		noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a int.").c_str());
+	return out;
 }
 
-inline unsigned int load_unsigned_int(const char* in, const std::function<void(const char*)>* report_error) {
-    unsigned int out;
-    out = std::strtoul(in, NULL, 10);
-    if (errno != 0)
-        noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a unsigned int.").c_str());
-    return out;
+inline unsigned int load_unsigned_int(const char *in, const std::function<void(const char *)> * report_error){
+	unsigned int out;
+	out = std::strtoul(in, NULL, 10);
+	if(errno != 0)
+		noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a unsigned int.").c_str());
+	return out;
 }
 
-inline float load_float(const char* in, const std::function<void(const char*)>* report_error) {
-    float out;
-    out = std::strtof(in, NULL);
-    if (errno != 0)
-        noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a float.").c_str());
-    return out;
+inline float load_float(const char *in, const std::function<void(const char *)> * report_error){
+	float out;
+	out = std::strtof(in, NULL);
+	if(errno != 0)
+		noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a float.").c_str());
+	return out;
 }
-inline void load_channel_required_attributes(const pugi::xml_node& root, int* chan_width_max, int* x_max, int* x_min, int* y_max, int* y_min, const std::function<void(const char*)>* report_error) {
-    std::bitset<5> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_channel in = lex_attr_t_channel(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <channel>.").c_str());
-        switch (in) {
-            case atok_t_channel::CHAN_WIDTH_MAX:
-                *chan_width_max = load_int(attr.value(), report_error);
-                break;
-            case atok_t_channel::X_MAX:
-                *x_max = load_int(attr.value(), report_error);
-                break;
-            case atok_t_channel::X_MIN:
-                *x_min = load_int(attr.value(), report_error);
-                break;
-            case atok_t_channel::Y_MAX:
-                *y_max = load_int(attr.value(), report_error);
-                break;
-            case atok_t_channel::Y_MIN:
-                *y_min = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<5> test_astate = astate | std::bitset<5>(0b00000);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_channel, report_error);
+inline void load_channel_required_attributes(const pugi::xml_node &root, int * chan_width_max, int * x_max, int * x_min, int * y_max, int * y_min, const std::function<void(const char *)> * report_error){
+	std::bitset<5> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_channel in = lex_attr_t_channel(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <channel>.").c_str());
+		switch(in){
+		case atok_t_channel::CHAN_WIDTH_MAX:
+			*chan_width_max = load_int(attr.value(), report_error);
+			break;
+		case atok_t_channel::X_MAX:
+			*x_max = load_int(attr.value(), report_error);
+			break;
+		case atok_t_channel::X_MIN:
+			*x_min = load_int(attr.value(), report_error);
+			break;
+		case atok_t_channel::Y_MAX:
+			*y_max = load_int(attr.value(), report_error);
+			break;
+		case atok_t_channel::Y_MIN:
+			*y_min = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<5> test_astate = astate | std::bitset<5>(0b00000);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_channel, report_error);
 }
 
-inline void load_x_list_required_attributes(const pugi::xml_node& root, unsigned int* index, int* info, const std::function<void(const char*)>* report_error) {
-    std::bitset<2> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_x_list in = lex_attr_t_x_list(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <x_list>.").c_str());
-        switch (in) {
-            case atok_t_x_list::INDEX:
-                *index = load_unsigned_int(attr.value(), report_error);
-                break;
-            case atok_t_x_list::INFO:
-                *info = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_x_list, report_error);
+inline void load_x_list_required_attributes(const pugi::xml_node &root, unsigned int * index, int * info, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_x_list in = lex_attr_t_x_list(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <x_list>.").c_str());
+		switch(in){
+		case atok_t_x_list::INDEX:
+			*index = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_x_list::INFO:
+			*info = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_x_list, report_error);
 }
 
-inline void load_y_list_required_attributes(const pugi::xml_node& root, unsigned int* index, int* info, const std::function<void(const char*)>* report_error) {
-    std::bitset<2> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_y_list in = lex_attr_t_y_list(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <y_list>.").c_str());
-        switch (in) {
-            case atok_t_y_list::INDEX:
-                *index = load_unsigned_int(attr.value(), report_error);
-                break;
-            case atok_t_y_list::INFO:
-                *info = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_y_list, report_error);
+inline void load_y_list_required_attributes(const pugi::xml_node &root, unsigned int * index, int * info, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_y_list in = lex_attr_t_y_list(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <y_list>.").c_str());
+		switch(in){
+		case atok_t_y_list::INDEX:
+			*index = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_y_list::INFO:
+			*info = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_y_list, report_error);
 }
 
-inline void load_sizing_required_attributes(const pugi::xml_node& root, float* buf_size, float* mux_trans_size, const std::function<void(const char*)>* report_error) {
-    std::bitset<2> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_sizing in = lex_attr_t_sizing(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <sizing>.").c_str());
-        switch (in) {
-            case atok_t_sizing::BUF_SIZE:
-                *buf_size = load_float(attr.value(), report_error);
-                break;
-            case atok_t_sizing::MUX_TRANS_SIZE:
-                *mux_trans_size = load_float(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_sizing, report_error);
+inline void load_sizing_required_attributes(const pugi::xml_node &root, float * buf_size, float * mux_trans_size, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_sizing in = lex_attr_t_sizing(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <sizing>.").c_str());
+		switch(in){
+		case atok_t_sizing::BUF_SIZE:
+			*buf_size = load_float(attr.value(), report_error);
+			break;
+		case atok_t_sizing::MUX_TRANS_SIZE:
+			*mux_trans_size = load_float(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_sizing, report_error);
 }
 
-inline void load_switch_required_attributes(const pugi::xml_node& root, int* id, const std::function<void(const char*)>* report_error) {
-    std::bitset<3> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_switch in = lex_attr_t_switch(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <switch>.").c_str());
-        switch (in) {
-            case atok_t_switch::ID:
-                *id = load_int(attr.value(), report_error);
-                break;
-            case atok_t_switch::NAME:
-                /* Attribute name set after element init */
-                break;
-            case atok_t_switch::TYPE:
-                /* Attribute type set after element init */
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<3> test_astate = astate | std::bitset<3>(0b100);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_switch, report_error);
+inline void load_switch_required_attributes(const pugi::xml_node &root, int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<3> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_switch in = lex_attr_t_switch(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <switch>.").c_str());
+		switch(in){
+		case atok_t_switch::ID:
+			*id = load_int(attr.value(), report_error);
+			break;
+		case atok_t_switch::NAME:
+			/* Attribute name set after element init */
+			break;
+		case atok_t_switch::TYPE:
+			/* Attribute type set after element init */
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<3> test_astate = astate | std::bitset<3>(0b100);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_switch, report_error);
 }
 
-inline void load_segment_required_attributes(const pugi::xml_node& root, int* id, const std::function<void(const char*)>* report_error) {
-    std::bitset<2> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_segment in = lex_attr_t_segment(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <segment>.").c_str());
-        switch (in) {
-            case atok_t_segment::ID:
-                *id = load_int(attr.value(), report_error);
-                break;
-            case atok_t_segment::NAME:
-                /* Attribute name set after element init */
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_segment, report_error);
+inline void load_segment_required_attributes(const pugi::xml_node &root, int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_segment in = lex_attr_t_segment(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <segment>.").c_str());
+		switch(in){
+		case atok_t_segment::ID:
+			*id = load_int(attr.value(), report_error);
+			break;
+		case atok_t_segment::NAME:
+			/* Attribute name set after element init */
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_segment, report_error);
 }
 
-inline void load_pin_required_attributes(const pugi::xml_node& root, int* ptc, const std::function<void(const char*)>* report_error) {
-    std::bitset<1> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_pin in = lex_attr_t_pin(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <pin>.").c_str());
-        switch (in) {
-            case atok_t_pin::PTC:
-                *ptc = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_pin, report_error);
+inline void load_pin_required_attributes(const pugi::xml_node &root, int * ptc, const std::function<void(const char *)> * report_error){
+	std::bitset<1> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_pin in = lex_attr_t_pin(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <pin>.").c_str());
+		switch(in){
+		case atok_t_pin::PTC:
+			*ptc = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_pin, report_error);
 }
 
-inline void load_pin_class_required_attributes(const pugi::xml_node& root, enum_pin_type* type, const std::function<void(const char*)>* report_error) {
-    std::bitset<1> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_pin_class in = lex_attr_t_pin_class(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <pin_class>.").c_str());
-        switch (in) {
-            case atok_t_pin_class::TYPE:
-                *type = lex_enum_pin_type(attr.value(), true, report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_pin_class, report_error);
+inline void load_pin_class_required_attributes(const pugi::xml_node &root, enum_pin_type * type, const std::function<void(const char *)> * report_error){
+	std::bitset<1> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_pin_class in = lex_attr_t_pin_class(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <pin_class>.").c_str());
+		switch(in){
+		case atok_t_pin_class::TYPE:
+			*type = lex_enum_pin_type(attr.value(), true, report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_pin_class, report_error);
 }
 
-inline void load_block_type_required_attributes(const pugi::xml_node& root, int* height, int* id, int* width, const std::function<void(const char*)>* report_error) {
-    std::bitset<4> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_block_type in = lex_attr_t_block_type(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <block_type>.").c_str());
-        switch (in) {
-            case atok_t_block_type::HEIGHT:
-                *height = load_int(attr.value(), report_error);
-                break;
-            case atok_t_block_type::ID:
-                *id = load_int(attr.value(), report_error);
-                break;
-            case atok_t_block_type::NAME:
-                /* Attribute name set after element init */
-                break;
-            case atok_t_block_type::WIDTH:
-                *width = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<4> test_astate = astate | std::bitset<4>(0b0000);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_block_type, report_error);
+inline void load_block_type_required_attributes(const pugi::xml_node &root, int * height, int * id, int * width, const std::function<void(const char *)> * report_error){
+	std::bitset<4> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_block_type in = lex_attr_t_block_type(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <block_type>.").c_str());
+		switch(in){
+		case atok_t_block_type::HEIGHT:
+			*height = load_int(attr.value(), report_error);
+			break;
+		case atok_t_block_type::ID:
+			*id = load_int(attr.value(), report_error);
+			break;
+		case atok_t_block_type::NAME:
+			/* Attribute name set after element init */
+			break;
+		case atok_t_block_type::WIDTH:
+			*width = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<4> test_astate = astate | std::bitset<4>(0b0000);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_block_type, report_error);
 }
 
-inline void load_grid_loc_required_attributes(const pugi::xml_node& root, int* block_type_id, int* height_offset, int* width_offset, int* x, int* y, const std::function<void(const char*)>* report_error) {
-    std::bitset<5> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_grid_loc in = lex_attr_t_grid_loc(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <grid_loc>.").c_str());
-        switch (in) {
-            case atok_t_grid_loc::BLOCK_TYPE_ID:
-                *block_type_id = load_int(attr.value(), report_error);
-                break;
-            case atok_t_grid_loc::HEIGHT_OFFSET:
-                *height_offset = load_int(attr.value(), report_error);
-                break;
-            case atok_t_grid_loc::WIDTH_OFFSET:
-                *width_offset = load_int(attr.value(), report_error);
-                break;
-            case atok_t_grid_loc::X:
-                *x = load_int(attr.value(), report_error);
-                break;
-            case atok_t_grid_loc::Y:
-                *y = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<5> test_astate = astate | std::bitset<5>(0b00000);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_grid_loc, report_error);
+inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, const std::function<void(const char *)> * report_error){
+	std::bitset<5> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_grid_loc in = lex_attr_t_grid_loc(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <grid_loc>.").c_str());
+		switch(in){
+		case atok_t_grid_loc::BLOCK_TYPE_ID:
+			*block_type_id = load_int(attr.value(), report_error);
+			break;
+		case atok_t_grid_loc::HEIGHT_OFFSET:
+			*height_offset = load_int(attr.value(), report_error);
+			break;
+		case atok_t_grid_loc::WIDTH_OFFSET:
+			*width_offset = load_int(attr.value(), report_error);
+			break;
+		case atok_t_grid_loc::X:
+			*x = load_int(attr.value(), report_error);
+			break;
+		case atok_t_grid_loc::Y:
+			*y = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<5> test_astate = astate | std::bitset<5>(0b00000);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_grid_loc, report_error);
 }
 
-inline void load_node_loc_required_attributes(const pugi::xml_node& root, int* ptc, int* xhigh, int* xlow, int* yhigh, int* ylow, const std::function<void(const char*)>* report_error) {
-    std::bitset<6> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_loc>.").c_str());
-        switch (in) {
-            case atok_t_node_loc::PTC:
-                *ptc = load_int(attr.value(), report_error);
-                break;
-            case atok_t_node_loc::SIDE:
-                /* Attribute side set after element init */
-                break;
-            case atok_t_node_loc::XHIGH:
-                *xhigh = load_int(attr.value(), report_error);
-                break;
-            case atok_t_node_loc::XLOW:
-                *xlow = load_int(attr.value(), report_error);
-                break;
-            case atok_t_node_loc::YHIGH:
-                *yhigh = load_int(attr.value(), report_error);
-                break;
-            case atok_t_node_loc::YLOW:
-                *ylow = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<6> test_astate = astate | std::bitset<6>(0b000010);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_loc, report_error);
+inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char *)> * report_error){
+	std::bitset<6> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_loc>.").c_str());
+		switch(in){
+		case atok_t_node_loc::PTC:
+			*ptc = load_int(attr.value(), report_error);
+			break;
+		case atok_t_node_loc::SIDE:
+			/* Attribute side set after element init */
+			break;
+		case atok_t_node_loc::XHIGH:
+			*xhigh = load_int(attr.value(), report_error);
+			break;
+		case atok_t_node_loc::XLOW:
+			*xlow = load_int(attr.value(), report_error);
+			break;
+		case atok_t_node_loc::YHIGH:
+			*yhigh = load_int(attr.value(), report_error);
+			break;
+		case atok_t_node_loc::YLOW:
+			*ylow = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<6> test_astate = astate | std::bitset<6>(0b000010);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_loc, report_error);
 }
 
-inline void load_node_timing_required_attributes(const pugi::xml_node& root, float* C, float* R, const std::function<void(const char*)>* report_error) {
-    std::bitset<2> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_node_timing in = lex_attr_t_node_timing(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_timing>.").c_str());
-        switch (in) {
-            case atok_t_node_timing::C:
-                *C = load_float(attr.value(), report_error);
-                break;
-            case atok_t_node_timing::R:
-                *R = load_float(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_timing, report_error);
+inline void load_node_timing_required_attributes(const pugi::xml_node &root, float * C, float * R, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node_timing in = lex_attr_t_node_timing(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_timing>.").c_str());
+		switch(in){
+		case atok_t_node_timing::C:
+			*C = load_float(attr.value(), report_error);
+			break;
+		case atok_t_node_timing::R:
+			*R = load_float(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_timing, report_error);
 }
 
-inline void load_node_segment_required_attributes(const pugi::xml_node& root, int* segment_id, const std::function<void(const char*)>* report_error) {
-    std::bitset<1> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_node_segment in = lex_attr_t_node_segment(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_segment>.").c_str());
-        switch (in) {
-            case atok_t_node_segment::SEGMENT_ID:
-                *segment_id = load_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_segment, report_error);
+inline void load_node_segment_required_attributes(const pugi::xml_node &root, int * segment_id, const std::function<void(const char *)> * report_error){
+	std::bitset<1> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node_segment in = lex_attr_t_node_segment(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_segment>.").c_str());
+		switch(in){
+		case atok_t_node_segment::SEGMENT_ID:
+			*segment_id = load_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_segment, report_error);
 }
 
-inline void load_node_required_attributes(const pugi::xml_node& root, unsigned int* capacity, unsigned int* id, enum_node_type* type, const std::function<void(const char*)>* report_error) {
-    std::bitset<4> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_node in = lex_attr_t_node(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node>.").c_str());
-        switch (in) {
-            case atok_t_node::CAPACITY:
-                *capacity = load_unsigned_int(attr.value(), report_error);
-                break;
-            case atok_t_node::DIRECTION:
-                /* Attribute direction set after element init */
-                break;
-            case atok_t_node::ID:
-                *id = load_unsigned_int(attr.value(), report_error);
-                break;
-            case atok_t_node::TYPE:
-                *type = lex_enum_node_type(attr.value(), true, report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<4> test_astate = astate | std::bitset<4>(0b0010);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_node, report_error);
+inline void load_node_required_attributes(const pugi::xml_node &root, unsigned int * capacity, unsigned int * id, enum_node_type * type, const std::function<void(const char *)> * report_error){
+	std::bitset<4> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node in = lex_attr_t_node(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node>.").c_str());
+		switch(in){
+		case atok_t_node::CAPACITY:
+			*capacity = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_node::DIRECTION:
+			/* Attribute direction set after element init */
+			break;
+		case atok_t_node::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_node::TYPE:
+			*type = lex_enum_node_type(attr.value(), true, report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<4> test_astate = astate | std::bitset<4>(0b0010);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node, report_error);
 }
 
-inline void load_edge_required_attributes(const pugi::xml_node& root, unsigned int* sink_node, unsigned int* src_node, unsigned int* switch_id, const std::function<void(const char*)>* report_error) {
-    std::bitset<3> astate = 0;
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_edge in = lex_attr_t_edge(attr.name(), report_error);
-        if (astate[(int)in] == 0)
-            astate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <edge>.").c_str());
-        switch (in) {
-            case atok_t_edge::SINK_NODE:
-                *sink_node = load_unsigned_int(attr.value(), report_error);
-                break;
-            case atok_t_edge::SRC_NODE:
-                *src_node = load_unsigned_int(attr.value(), report_error);
-                break;
-            case atok_t_edge::SWITCH_ID:
-                *switch_id = load_unsigned_int(attr.value(), report_error);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<3> test_astate = astate | std::bitset<3>(0b000);
-    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_edge, report_error);
+inline void load_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<1> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_e_ptn in = lex_attr_t_e_ptn(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <e_ptn>.").c_str());
+		switch(in){
+		case atok_t_e_ptn::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_e_ptn, report_error);
+}
+
+inline void load_node_e_ptn_required_attributes(const pugi::xml_node &root, unsigned int * dest, unsigned int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node_e_ptn in = lex_attr_t_node_e_ptn(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_e_ptn>.").c_str());
+		switch(in){
+		case atok_t_node_e_ptn::DEST:
+			*dest = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_node_e_ptn::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_e_ptn, report_error);
+}
+
+inline void load_ddiff_required_attributes(const pugi::xml_node &root, unsigned int * id, const std::function<void(const char *)> * report_error){
+	std::bitset<1> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_ddiff in = lex_attr_t_ddiff(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <ddiff>.").c_str());
+		switch(in){
+		case atok_t_ddiff::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_astate = astate | std::bitset<1>(0b0);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_ddiff, report_error);
+}
+
+inline void load_edge_ptn_required_attributes(const pugi::xml_node &root, unsigned int * id, unsigned int * switch_id, const std::function<void(const char *)> * report_error){
+	std::bitset<2> astate = 0;
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_edge_ptn in = lex_attr_t_edge_ptn(attr.name(), report_error);
+		if(astate[(int)in] == 0) astate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <edge_ptn>.").c_str());
+		switch(in){
+		case atok_t_edge_ptn::ID:
+			*id = load_unsigned_int(attr.value(), report_error);
+			break;
+		case atok_t_edge_ptn::SWITCH_ID:
+			*switch_id = load_unsigned_int(attr.value(), report_error);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_astate = astate | std::bitset<2>(0b00);
+	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_edge_ptn, report_error);
 }
 template<class T, typename Context>
-inline void load_channel(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_channel(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <channel>.");
-}
 
-template<class T, typename Context>
-inline void load_x_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <channel>.");
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <x_list>.");
 }
 
 template<class T, typename Context>
-inline void load_y_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_x_list(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <y_list>.");
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <x_list>.");
+
+}
+
+template<class T, typename Context>
+inline void load_y_list(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <y_list>.");
+
 }
 
 constexpr int NUM_T_CHANNELS_STATES = 4;
 constexpr const int NUM_T_CHANNELS_INPUTS = 3;
 constexpr int gstate_t_channels[NUM_T_CHANNELS_STATES][NUM_T_CHANNELS_INPUTS] = {
-    {-1, -1, 0},
-    {-1, 1, 0},
-    {-1, 1, -1},
-    {2, -1, -1},
+	{-1, -1, 0},
+	{-1, 1, 0},
+	{-1, 1, -1},
+	{2, -1, -1},
 };
 template<class T, typename Context>
-inline void load_channels(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_channels(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <channels>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <channels>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t x_list_count = 0;
-    size_t y_list_count = 0;
-    {
-        int next, state = 3;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_channels in = lex_node_t_channels(node.name(), report_error);
-            next = gstate_t_channels[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_channels[(int)in], gstate_t_channels[state], gtok_lookup_t_channels, 3, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_channels::CHANNEL:
-                    break;
-                case gtok_t_channels::X_LIST:
-                    x_list_count += 1;
-                    break;
-                case gtok_t_channels::Y_LIST:
-                    y_list_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t x_list_count = 0;
+	size_t y_list_count = 0;
+	{
+		int next, state=3;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_channels in = lex_node_t_channels(node.name(), report_error);
+			next = gstate_t_channels[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_channels[(int)in], gstate_t_channels[state], gtok_lookup_t_channels, 3, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_channels::CHANNEL:
+				break;
+			case gtok_t_channels::X_LIST:
+				x_list_count += 1;
+				break;
+			case gtok_t_channels::Y_LIST:
+				y_list_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_channels_x_list(context, x_list_count);
+		out.preallocate_channels_y_list(context, y_list_count);
+	}
+	int next, state=3;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_channels in = lex_node_t_channels(node.name(), report_error);
+		next = gstate_t_channels[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_channels[(int)in], gstate_t_channels[state], gtok_lookup_t_channels, 3, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_channels::CHANNEL:
+			{
+				int channel_chan_width_max;
+				memset(&channel_chan_width_max, 0, sizeof(channel_chan_width_max));
+				int channel_x_max;
+				memset(&channel_x_max, 0, sizeof(channel_x_max));
+				int channel_x_min;
+				memset(&channel_x_min, 0, sizeof(channel_x_min));
+				int channel_y_max;
+				memset(&channel_y_max, 0, sizeof(channel_y_max));
+				int channel_y_min;
+				memset(&channel_y_min, 0, sizeof(channel_y_min));
+				load_channel_required_attributes(node, &channel_chan_width_max, &channel_x_max, &channel_x_min, &channel_y_max, &channel_y_min, report_error);
+				auto child_context = out.init_channels_channel(context, channel_chan_width_max, channel_x_max, channel_x_min, channel_y_max, channel_y_min);
+				load_channel(node, out, child_context, report_error, offset_debug);
+				out.finish_channels_channel(child_context);
+			}
+			break;
+		case gtok_t_channels::X_LIST:
+			{
+				unsigned int x_list_index;
+				memset(&x_list_index, 0, sizeof(x_list_index));
+				int x_list_info;
+				memset(&x_list_info, 0, sizeof(x_list_info));
+				load_x_list_required_attributes(node, &x_list_index, &x_list_info, report_error);
+				auto child_context = out.add_channels_x_list(context, x_list_index, x_list_info);
+				load_x_list(node, out, child_context, report_error, offset_debug);
+				out.finish_channels_x_list(child_context);
+			}
+			break;
+		case gtok_t_channels::Y_LIST:
+			{
+				unsigned int y_list_index;
+				memset(&y_list_index, 0, sizeof(y_list_index));
+				int y_list_info;
+				memset(&y_list_info, 0, sizeof(y_list_info));
+				load_y_list_required_attributes(node, &y_list_index, &y_list_info, report_error);
+				auto child_context = out.add_channels_y_list(context, y_list_index, y_list_info);
+				load_y_list(node, out, child_context, report_error, offset_debug);
+				out.finish_channels_y_list(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_channels[state], gtok_lookup_t_channels, 3, report_error);
 
-        out.preallocate_channels_x_list(context, x_list_count);
-        out.preallocate_channels_y_list(context, y_list_count);
-    }
-    int next, state = 3;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_channels in = lex_node_t_channels(node.name(), report_error);
-        next = gstate_t_channels[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_channels[(int)in], gstate_t_channels[state], gtok_lookup_t_channels, 3, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_channels::CHANNEL: {
-                int channel_chan_width_max;
-                memset(&channel_chan_width_max, 0, sizeof(channel_chan_width_max));
-                int channel_x_max;
-                memset(&channel_x_max, 0, sizeof(channel_x_max));
-                int channel_x_min;
-                memset(&channel_x_min, 0, sizeof(channel_x_min));
-                int channel_y_max;
-                memset(&channel_y_max, 0, sizeof(channel_y_max));
-                int channel_y_min;
-                memset(&channel_y_min, 0, sizeof(channel_y_min));
-                load_channel_required_attributes(node, &channel_chan_width_max, &channel_x_max, &channel_x_min, &channel_y_max, &channel_y_min, report_error);
-                auto child_context = out.init_channels_channel(context, channel_chan_width_max, channel_x_max, channel_x_min, channel_y_max, channel_y_min);
-                load_channel(node, out, child_context, report_error, offset_debug);
-                out.finish_channels_channel(child_context);
-            } break;
-            case gtok_t_channels::X_LIST: {
-                unsigned int x_list_index;
-                memset(&x_list_index, 0, sizeof(x_list_index));
-                int x_list_info;
-                memset(&x_list_info, 0, sizeof(x_list_info));
-                load_x_list_required_attributes(node, &x_list_index, &x_list_info, report_error);
-                auto child_context = out.add_channels_x_list(context, x_list_index, x_list_info);
-                load_x_list(node, out, child_context, report_error, offset_debug);
-                out.finish_channels_x_list(child_context);
-            } break;
-            case gtok_t_channels::Y_LIST: {
-                unsigned int y_list_index;
-                memset(&y_list_index, 0, sizeof(y_list_index));
-                int y_list_info;
-                memset(&y_list_info, 0, sizeof(y_list_info));
-                load_y_list_required_attributes(node, &y_list_index, &y_list_info, report_error);
-                auto child_context = out.add_channels_y_list(context, y_list_index, y_list_info);
-                load_y_list(node, out, child_context, report_error, offset_debug);
-                out.finish_channels_y_list(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_channels[state], gtok_lookup_t_channels, 3, report_error);
 }
 
 template<class T, typename Context>
-inline void load_timing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_timing in = lex_attr_t_timing(attr.name(), report_error);
-        switch (in) {
-            case atok_t_timing::CIN:
-                out.set_timing_Cin(load_float(attr.value(), report_error), context);
-                break;
-            case atok_t_timing::CINTERNAL:
-                out.set_timing_Cinternal(load_float(attr.value(), report_error), context);
-                break;
-            case atok_t_timing::COUT:
-                out.set_timing_Cout(load_float(attr.value(), report_error), context);
-                break;
-            case atok_t_timing::R:
-                out.set_timing_R(load_float(attr.value(), report_error), context);
-                break;
-            case atok_t_timing::TDEL:
-                out.set_timing_Tdel(load_float(attr.value(), report_error), context);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_timing in = lex_attr_t_timing(attr.name(), report_error);
+		switch(in){
+		case atok_t_timing::CIN:
+			out.set_timing_Cin(load_float(attr.value(), report_error), context);
+			break;
+		case atok_t_timing::CINTERNAL:
+			out.set_timing_Cinternal(load_float(attr.value(), report_error), context);
+			break;
+		case atok_t_timing::COUT:
+			out.set_timing_Cout(load_float(attr.value(), report_error), context);
+			break;
+		case atok_t_timing::R:
+			out.set_timing_R(load_float(attr.value(), report_error), context);
+			break;
+		case atok_t_timing::TDEL:
+			out.set_timing_Tdel(load_float(attr.value(), report_error), context);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <timing>.");
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <timing>.");
+
 }
 
 template<class T, typename Context>
-inline void load_sizing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_sizing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <sizing>.");
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <sizing>.");
+
 }
 
 template<class T, typename Context>
-inline void load_switch(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_switch(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_switch in = lex_attr_t_switch(attr.name(), report_error);
-        switch (in) {
-            case atok_t_switch::ID:
-                /* Attribute id is already set */
-                break;
-            case atok_t_switch::NAME:
-                out.set_switch_name(attr.value(), context);
-                break;
-            case atok_t_switch::TYPE:
-                out.set_switch_type(lex_enum_switch_type(attr.value(), true, report_error), context);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_switch in = lex_attr_t_switch(attr.name(), report_error);
+		switch(in){
+		case atok_t_switch::ID:
+			/* Attribute id is already set */
+			break;
+		case atok_t_switch::NAME:
+			out.set_switch_name(attr.value(), context);
+			break;
+		case atok_t_switch::TYPE:
+			out.set_switch_type(lex_enum_switch_type(attr.value(), true, report_error), context);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    std::bitset<2> gstate = 0;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_switch in = lex_node_t_switch(node.name(), report_error);
-        if (gstate[(int)in] == 0)
-            gstate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <switch>.").c_str());
-        switch (in) {
-            case gtok_t_switch::TIMING: {
-                auto child_context = out.init_switch_timing(context);
-                load_timing(node, out, child_context, report_error, offset_debug);
-                out.finish_switch_timing(child_context);
-            } break;
-            case gtok_t_switch::SIZING: {
-                float sizing_buf_size;
-                memset(&sizing_buf_size, 0, sizeof(sizing_buf_size));
-                float sizing_mux_trans_size;
-                memset(&sizing_mux_trans_size, 0, sizeof(sizing_mux_trans_size));
-                load_sizing_required_attributes(node, &sizing_buf_size, &sizing_mux_trans_size, report_error);
-                auto child_context = out.init_switch_sizing(context, sizing_buf_size, sizing_mux_trans_size);
-                load_sizing(node, out, child_context, report_error, offset_debug);
-                out.finish_switch_sizing(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<2> test_gstate = gstate | std::bitset<2>(0b01);
-    if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_switch, report_error);
+	std::bitset<2> gstate = 0;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_switch in = lex_node_t_switch(node.name(), report_error);
+		if(gstate[(int)in] == 0) gstate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <switch>.").c_str());
+		switch(in){
+		case gtok_t_switch::TIMING:
+			{
+				auto child_context = out.init_switch_timing(context);
+				load_timing(node, out, child_context, report_error, offset_debug);
+				out.finish_switch_timing(child_context);
+			}
+			break;
+		case gtok_t_switch::SIZING:
+			{
+				float sizing_buf_size;
+				memset(&sizing_buf_size, 0, sizeof(sizing_buf_size));
+				float sizing_mux_trans_size;
+				memset(&sizing_mux_trans_size, 0, sizeof(sizing_mux_trans_size));
+				load_sizing_required_attributes(node, &sizing_buf_size, &sizing_mux_trans_size, report_error);
+				auto child_context = out.init_switch_sizing(context, sizing_buf_size, sizing_mux_trans_size);
+				load_sizing(node, out, child_context, report_error, offset_debug);
+				out.finish_switch_sizing(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<2> test_gstate = gstate | std::bitset<2>(0b01);
+	if(!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_switch, report_error);
+
 }
 
 constexpr int NUM_T_SWITCHES_STATES = 2;
 constexpr const int NUM_T_SWITCHES_INPUTS = 1;
 constexpr int gstate_t_switches[NUM_T_SWITCHES_STATES][NUM_T_SWITCHES_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_switches(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_switches(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <switches>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <switches>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t switch_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_switches in = lex_node_t_switches(node.name(), report_error);
-            next = gstate_t_switches[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_switches[(int)in], gstate_t_switches[state], gtok_lookup_t_switches, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_switches::SWITCH:
-                    switch_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t switch_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_switches in = lex_node_t_switches(node.name(), report_error);
+			next = gstate_t_switches[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_switches[(int)in], gstate_t_switches[state], gtok_lookup_t_switches, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_switches::SWITCH:
+				switch_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_switches_switch(context, switch_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_switches in = lex_node_t_switches(node.name(), report_error);
+		next = gstate_t_switches[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_switches[(int)in], gstate_t_switches[state], gtok_lookup_t_switches, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_switches::SWITCH:
+			{
+				int switch_id;
+				memset(&switch_id, 0, sizeof(switch_id));
+				load_switch_required_attributes(node, &switch_id, report_error);
+				auto child_context = out.add_switches_switch(context, switch_id);
+				load_switch(node, out, child_context, report_error, offset_debug);
+				out.finish_switches_switch(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_switches[state], gtok_lookup_t_switches, 1, report_error);
 
-        out.preallocate_switches_switch(context, switch_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_switches in = lex_node_t_switches(node.name(), report_error);
-        next = gstate_t_switches[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_switches[(int)in], gstate_t_switches[state], gtok_lookup_t_switches, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_switches::SWITCH: {
-                int switch_id;
-                memset(&switch_id, 0, sizeof(switch_id));
-                load_switch_required_attributes(node, &switch_id, report_error);
-                auto child_context = out.add_switches_switch(context, switch_id);
-                load_switch(node, out, child_context, report_error, offset_debug);
-                out.finish_switches_switch(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_switches[state], gtok_lookup_t_switches, 1, report_error);
 }
 
 template<class T, typename Context>
-inline void load_segment_timing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_segment_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_segment_timing in = lex_attr_t_segment_timing(attr.name(), report_error);
-        switch (in) {
-            case atok_t_segment_timing::C_PER_METER:
-                out.set_segment_timing_C_per_meter(load_float(attr.value(), report_error), context);
-                break;
-            case atok_t_segment_timing::R_PER_METER:
-                out.set_segment_timing_R_per_meter(load_float(attr.value(), report_error), context);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_segment_timing in = lex_attr_t_segment_timing(attr.name(), report_error);
+		switch(in){
+		case atok_t_segment_timing::C_PER_METER:
+			out.set_segment_timing_C_per_meter(load_float(attr.value(), report_error), context);
+			break;
+		case atok_t_segment_timing::R_PER_METER:
+			out.set_segment_timing_R_per_meter(load_float(attr.value(), report_error), context);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <segment_timing>.");
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <segment_timing>.");
+
 }
 
 template<class T, typename Context>
-inline void load_segment(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_segment(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_segment in = lex_attr_t_segment(attr.name(), report_error);
-        switch (in) {
-            case atok_t_segment::ID:
-                /* Attribute id is already set */
-                break;
-            case atok_t_segment::NAME:
-                out.set_segment_name(attr.value(), context);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_segment in = lex_attr_t_segment(attr.name(), report_error);
+		switch(in){
+		case atok_t_segment::ID:
+			/* Attribute id is already set */
+			break;
+		case atok_t_segment::NAME:
+			out.set_segment_name(attr.value(), context);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    std::bitset<1> gstate = 0;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_segment in = lex_node_t_segment(node.name(), report_error);
-        if (gstate[(int)in] == 0)
-            gstate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <segment>.").c_str());
-        switch (in) {
-            case gtok_t_segment::TIMING: {
-                auto child_context = out.init_segment_timing(context);
-                load_segment_timing(node, out, child_context, report_error, offset_debug);
-                out.finish_segment_timing(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<1> test_gstate = gstate | std::bitset<1>(0b1);
-    if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_segment, report_error);
+	std::bitset<1> gstate = 0;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_segment in = lex_node_t_segment(node.name(), report_error);
+		if(gstate[(int)in] == 0) gstate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <segment>.").c_str());
+		switch(in){
+		case gtok_t_segment::TIMING:
+			{
+				auto child_context = out.init_segment_timing(context);
+				load_segment_timing(node, out, child_context, report_error, offset_debug);
+				out.finish_segment_timing(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<1> test_gstate = gstate | std::bitset<1>(0b1);
+	if(!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_segment, report_error);
+
 }
 
 constexpr int NUM_T_SEGMENTS_STATES = 2;
 constexpr const int NUM_T_SEGMENTS_INPUTS = 1;
 constexpr int gstate_t_segments[NUM_T_SEGMENTS_STATES][NUM_T_SEGMENTS_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_segments(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_segments(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <segments>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <segments>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t segment_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_segments in = lex_node_t_segments(node.name(), report_error);
-            next = gstate_t_segments[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_segments[(int)in], gstate_t_segments[state], gtok_lookup_t_segments, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_segments::SEGMENT:
-                    segment_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t segment_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_segments in = lex_node_t_segments(node.name(), report_error);
+			next = gstate_t_segments[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_segments[(int)in], gstate_t_segments[state], gtok_lookup_t_segments, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_segments::SEGMENT:
+				segment_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_segments_segment(context, segment_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_segments in = lex_node_t_segments(node.name(), report_error);
+		next = gstate_t_segments[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_segments[(int)in], gstate_t_segments[state], gtok_lookup_t_segments, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_segments::SEGMENT:
+			{
+				int segment_id;
+				memset(&segment_id, 0, sizeof(segment_id));
+				load_segment_required_attributes(node, &segment_id, report_error);
+				auto child_context = out.add_segments_segment(context, segment_id);
+				load_segment(node, out, child_context, report_error, offset_debug);
+				out.finish_segments_segment(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_segments[state], gtok_lookup_t_segments, 1, report_error);
 
-        out.preallocate_segments_segment(context, segment_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_segments in = lex_node_t_segments(node.name(), report_error);
-        next = gstate_t_segments[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_segments[(int)in], gstate_t_segments[state], gtok_lookup_t_segments, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_segments::SEGMENT: {
-                int segment_id;
-                memset(&segment_id, 0, sizeof(segment_id));
-                load_segment_required_attributes(node, &segment_id, report_error);
-                auto child_context = out.add_segments_segment(context, segment_id);
-                load_segment(node, out, child_context, report_error, offset_debug);
-                out.finish_segments_segment(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_segments[state], gtok_lookup_t_segments, 1, report_error);
 }
 
 template<class T, typename Context>
-inline void load_pin(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_pin(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    out.set_pin_value(root.child_value(), context);
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <pin>.");
+
+	out.set_pin_value(root.child_value(), context);
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <pin>.");
+
 }
 
 constexpr int NUM_T_PIN_CLASS_STATES = 2;
 constexpr const int NUM_T_PIN_CLASS_INPUTS = 1;
 constexpr int gstate_t_pin_class[NUM_T_PIN_CLASS_STATES][NUM_T_PIN_CLASS_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_pin_class(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_pin_class(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t pin_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_pin_class in = lex_node_t_pin_class(node.name(), report_error);
-            next = gstate_t_pin_class[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_pin_class[(int)in], gstate_t_pin_class[state], gtok_lookup_t_pin_class, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_pin_class::PIN:
-                    pin_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
 
-        out.preallocate_pin_class_pin(context, pin_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_pin_class in = lex_node_t_pin_class(node.name(), report_error);
-        next = gstate_t_pin_class[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_pin_class[(int)in], gstate_t_pin_class[state], gtok_lookup_t_pin_class, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_pin_class::PIN: {
-                int pin_ptc;
-                memset(&pin_ptc, 0, sizeof(pin_ptc));
-                load_pin_required_attributes(node, &pin_ptc, report_error);
-                auto child_context = out.add_pin_class_pin(context, pin_ptc);
-                load_pin(node, out, child_context, report_error, offset_debug);
-                out.finish_pin_class_pin(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_pin_class[state], gtok_lookup_t_pin_class, 1, report_error);
+	// Preallocate arrays by counting child nodes (if any)
+	size_t pin_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_pin_class in = lex_node_t_pin_class(node.name(), report_error);
+			next = gstate_t_pin_class[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_pin_class[(int)in], gstate_t_pin_class[state], gtok_lookup_t_pin_class, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_pin_class::PIN:
+				pin_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_pin_class_pin(context, pin_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_pin_class in = lex_node_t_pin_class(node.name(), report_error);
+		next = gstate_t_pin_class[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_pin_class[(int)in], gstate_t_pin_class[state], gtok_lookup_t_pin_class, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_pin_class::PIN:
+			{
+				int pin_ptc;
+				memset(&pin_ptc, 0, sizeof(pin_ptc));
+				load_pin_required_attributes(node, &pin_ptc, report_error);
+				auto child_context = out.add_pin_class_pin(context, pin_ptc);
+				load_pin(node, out, child_context, report_error, offset_debug);
+				out.finish_pin_class_pin(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_pin_class[state], gtok_lookup_t_pin_class, 1, report_error);
+
 }
 
 constexpr int NUM_T_BLOCK_TYPE_STATES = 1;
 constexpr const int NUM_T_BLOCK_TYPE_INPUTS = 1;
 constexpr int gstate_t_block_type[NUM_T_BLOCK_TYPE_STATES][NUM_T_BLOCK_TYPE_INPUTS] = {
-    {0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_block_type(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_block_type(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_block_type in = lex_attr_t_block_type(attr.name(), report_error);
-        switch (in) {
-            case atok_t_block_type::HEIGHT:
-                /* Attribute height is already set */
-                break;
-            case atok_t_block_type::ID:
-                /* Attribute id is already set */
-                break;
-            case atok_t_block_type::NAME:
-                out.set_block_type_name(attr.value(), context);
-                break;
-            case atok_t_block_type::WIDTH:
-                /* Attribute width is already set */
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_block_type in = lex_attr_t_block_type(attr.name(), report_error);
+		switch(in){
+		case atok_t_block_type::HEIGHT:
+			/* Attribute height is already set */
+			break;
+		case atok_t_block_type::ID:
+			/* Attribute id is already set */
+			break;
+		case atok_t_block_type::NAME:
+			out.set_block_type_name(attr.value(), context);
+			break;
+		case atok_t_block_type::WIDTH:
+			/* Attribute width is already set */
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t pin_class_count = 0;
-    {
-        int next, state = 0;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_block_type in = lex_node_t_block_type(node.name(), report_error);
-            next = gstate_t_block_type[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_block_type[(int)in], gstate_t_block_type[state], gtok_lookup_t_block_type, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_block_type::PIN_CLASS:
-                    pin_class_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t pin_class_count = 0;
+	{
+		int next, state=0;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_block_type in = lex_node_t_block_type(node.name(), report_error);
+			next = gstate_t_block_type[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_block_type[(int)in], gstate_t_block_type[state], gtok_lookup_t_block_type, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_block_type::PIN_CLASS:
+				pin_class_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_block_type_pin_class(context, pin_class_count);
+	}
+	int next, state=0;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_block_type in = lex_node_t_block_type(node.name(), report_error);
+		next = gstate_t_block_type[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_block_type[(int)in], gstate_t_block_type[state], gtok_lookup_t_block_type, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_block_type::PIN_CLASS:
+			{
+				enum_pin_type pin_class_type;
+				memset(&pin_class_type, 0, sizeof(pin_class_type));
+				load_pin_class_required_attributes(node, &pin_class_type, report_error);
+				auto child_context = out.add_block_type_pin_class(context, pin_class_type);
+				load_pin_class(node, out, child_context, report_error, offset_debug);
+				out.finish_block_type_pin_class(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_block_type[state], gtok_lookup_t_block_type, 1, report_error);
 
-        out.preallocate_block_type_pin_class(context, pin_class_count);
-    }
-    int next, state = 0;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_block_type in = lex_node_t_block_type(node.name(), report_error);
-        next = gstate_t_block_type[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_block_type[(int)in], gstate_t_block_type[state], gtok_lookup_t_block_type, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_block_type::PIN_CLASS: {
-                enum_pin_type pin_class_type;
-                memset(&pin_class_type, 0, sizeof(pin_class_type));
-                load_pin_class_required_attributes(node, &pin_class_type, report_error);
-                auto child_context = out.add_block_type_pin_class(context, pin_class_type);
-                load_pin_class(node, out, child_context, report_error, offset_debug);
-                out.finish_block_type_pin_class(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_block_type[state], gtok_lookup_t_block_type, 1, report_error);
 }
 
 constexpr int NUM_T_BLOCK_TYPES_STATES = 2;
 constexpr const int NUM_T_BLOCK_TYPES_INPUTS = 1;
 constexpr int gstate_t_block_types[NUM_T_BLOCK_TYPES_STATES][NUM_T_BLOCK_TYPES_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_block_types(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_block_types(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <block_types>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <block_types>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t block_type_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_block_types in = lex_node_t_block_types(node.name(), report_error);
-            next = gstate_t_block_types[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_block_types[(int)in], gstate_t_block_types[state], gtok_lookup_t_block_types, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_block_types::BLOCK_TYPE:
-                    block_type_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t block_type_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_block_types in = lex_node_t_block_types(node.name(), report_error);
+			next = gstate_t_block_types[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_block_types[(int)in], gstate_t_block_types[state], gtok_lookup_t_block_types, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_block_types::BLOCK_TYPE:
+				block_type_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_block_types_block_type(context, block_type_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_block_types in = lex_node_t_block_types(node.name(), report_error);
+		next = gstate_t_block_types[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_block_types[(int)in], gstate_t_block_types[state], gtok_lookup_t_block_types, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_block_types::BLOCK_TYPE:
+			{
+				int block_type_height;
+				memset(&block_type_height, 0, sizeof(block_type_height));
+				int block_type_id;
+				memset(&block_type_id, 0, sizeof(block_type_id));
+				int block_type_width;
+				memset(&block_type_width, 0, sizeof(block_type_width));
+				load_block_type_required_attributes(node, &block_type_height, &block_type_id, &block_type_width, report_error);
+				auto child_context = out.add_block_types_block_type(context, block_type_height, block_type_id, block_type_width);
+				load_block_type(node, out, child_context, report_error, offset_debug);
+				out.finish_block_types_block_type(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_block_types[state], gtok_lookup_t_block_types, 1, report_error);
 
-        out.preallocate_block_types_block_type(context, block_type_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_block_types in = lex_node_t_block_types(node.name(), report_error);
-        next = gstate_t_block_types[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_block_types[(int)in], gstate_t_block_types[state], gtok_lookup_t_block_types, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_block_types::BLOCK_TYPE: {
-                int block_type_height;
-                memset(&block_type_height, 0, sizeof(block_type_height));
-                int block_type_id;
-                memset(&block_type_id, 0, sizeof(block_type_id));
-                int block_type_width;
-                memset(&block_type_width, 0, sizeof(block_type_width));
-                load_block_type_required_attributes(node, &block_type_height, &block_type_id, &block_type_width, report_error);
-                auto child_context = out.add_block_types_block_type(context, block_type_height, block_type_id, block_type_width);
-                load_block_type(node, out, child_context, report_error, offset_debug);
-                out.finish_block_types_block_type(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_block_types[state], gtok_lookup_t_block_types, 1, report_error);
 }
 
 template<class T, typename Context>
-inline void load_grid_loc(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_grid_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <grid_loc>.");
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <grid_loc>.");
+
 }
 
 constexpr int NUM_T_GRID_LOCS_STATES = 2;
 constexpr const int NUM_T_GRID_LOCS_INPUTS = 1;
 constexpr int gstate_t_grid_locs[NUM_T_GRID_LOCS_STATES][NUM_T_GRID_LOCS_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_grid_locs(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_grid_locs(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <grid_locs>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <grid_locs>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t grid_loc_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_grid_locs in = lex_node_t_grid_locs(node.name(), report_error);
-            next = gstate_t_grid_locs[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_grid_locs[(int)in], gstate_t_grid_locs[state], gtok_lookup_t_grid_locs, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_grid_locs::GRID_LOC:
-                    grid_loc_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t grid_loc_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_grid_locs in = lex_node_t_grid_locs(node.name(), report_error);
+			next = gstate_t_grid_locs[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_grid_locs[(int)in], gstate_t_grid_locs[state], gtok_lookup_t_grid_locs, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_grid_locs::GRID_LOC:
+				grid_loc_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_grid_locs_grid_loc(context, grid_loc_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_grid_locs in = lex_node_t_grid_locs(node.name(), report_error);
+		next = gstate_t_grid_locs[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_grid_locs[(int)in], gstate_t_grid_locs[state], gtok_lookup_t_grid_locs, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_grid_locs::GRID_LOC:
+			{
+				int grid_loc_block_type_id;
+				memset(&grid_loc_block_type_id, 0, sizeof(grid_loc_block_type_id));
+				int grid_loc_height_offset;
+				memset(&grid_loc_height_offset, 0, sizeof(grid_loc_height_offset));
+				int grid_loc_width_offset;
+				memset(&grid_loc_width_offset, 0, sizeof(grid_loc_width_offset));
+				int grid_loc_x;
+				memset(&grid_loc_x, 0, sizeof(grid_loc_x));
+				int grid_loc_y;
+				memset(&grid_loc_y, 0, sizeof(grid_loc_y));
+				load_grid_loc_required_attributes(node, &grid_loc_block_type_id, &grid_loc_height_offset, &grid_loc_width_offset, &grid_loc_x, &grid_loc_y, report_error);
+				auto child_context = out.add_grid_locs_grid_loc(context, grid_loc_block_type_id, grid_loc_height_offset, grid_loc_width_offset, grid_loc_x, grid_loc_y);
+				load_grid_loc(node, out, child_context, report_error, offset_debug);
+				out.finish_grid_locs_grid_loc(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_grid_locs[state], gtok_lookup_t_grid_locs, 1, report_error);
 
-        out.preallocate_grid_locs_grid_loc(context, grid_loc_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_grid_locs in = lex_node_t_grid_locs(node.name(), report_error);
-        next = gstate_t_grid_locs[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_grid_locs[(int)in], gstate_t_grid_locs[state], gtok_lookup_t_grid_locs, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_grid_locs::GRID_LOC: {
-                int grid_loc_block_type_id;
-                memset(&grid_loc_block_type_id, 0, sizeof(grid_loc_block_type_id));
-                int grid_loc_height_offset;
-                memset(&grid_loc_height_offset, 0, sizeof(grid_loc_height_offset));
-                int grid_loc_width_offset;
-                memset(&grid_loc_width_offset, 0, sizeof(grid_loc_width_offset));
-                int grid_loc_x;
-                memset(&grid_loc_x, 0, sizeof(grid_loc_x));
-                int grid_loc_y;
-                memset(&grid_loc_y, 0, sizeof(grid_loc_y));
-                load_grid_loc_required_attributes(node, &grid_loc_block_type_id, &grid_loc_height_offset, &grid_loc_width_offset, &grid_loc_x, &grid_loc_y, report_error);
-                auto child_context = out.add_grid_locs_grid_loc(context, grid_loc_block_type_id, grid_loc_height_offset, grid_loc_width_offset, grid_loc_x, grid_loc_y);
-                load_grid_loc(node, out, child_context, report_error, offset_debug);
-                out.finish_grid_locs_grid_loc(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_grid_locs[state], gtok_lookup_t_grid_locs, 1, report_error);
 }
 
 template<class T, typename Context>
-inline void load_node_loc(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_node_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
-        switch (in) {
-            case atok_t_node_loc::PTC:
-                /* Attribute ptc is already set */
-                break;
-            case atok_t_node_loc::SIDE:
-                out.set_node_loc_side(lex_enum_loc_side(attr.value(), true, report_error), context);
-                break;
-            case atok_t_node_loc::XHIGH:
-                /* Attribute xhigh is already set */
-                break;
-            case atok_t_node_loc::XLOW:
-                /* Attribute xlow is already set */
-                break;
-            case atok_t_node_loc::YHIGH:
-                /* Attribute yhigh is already set */
-                break;
-            case atok_t_node_loc::YLOW:
-                /* Attribute ylow is already set */
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
+		switch(in){
+		case atok_t_node_loc::PTC:
+			/* Attribute ptc is already set */
+			break;
+		case atok_t_node_loc::SIDE:
+			out.set_node_loc_side(lex_enum_loc_side(attr.value(), true, report_error), context);
+			break;
+		case atok_t_node_loc::XHIGH:
+			/* Attribute xhigh is already set */
+			break;
+		case atok_t_node_loc::XLOW:
+			/* Attribute xlow is already set */
+			break;
+		case atok_t_node_loc::YHIGH:
+			/* Attribute yhigh is already set */
+			break;
+		case atok_t_node_loc::YLOW:
+			/* Attribute ylow is already set */
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <node_loc>.");
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <node_loc>.");
+
 }
 
 template<class T, typename Context>
-inline void load_node_timing(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_node_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <node_timing>.");
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <node_timing>.");
+
 }
 
 template<class T, typename Context>
-inline void load_node_segment(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_node_segment(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <node_segment>.");
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <node_segment>.");
+
 }
 
 template<class T, typename Context>
-inline void load_meta(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_meta(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_meta in = lex_attr_t_meta(attr.name(), report_error);
-        switch (in) {
-            case atok_t_meta::NAME:
-                out.set_meta_name(attr.value(), context);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_meta in = lex_attr_t_meta(attr.name(), report_error);
+		switch(in){
+		case atok_t_meta::NAME:
+			out.set_meta_name(attr.value(), context);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    out.set_meta_value(root.child_value(), context);
-    if (root.first_child().type() == pugi::node_element)
-        noreturn_report(report_error, "Unexpected child element in <meta>.");
+	out.set_meta_value(root.child_value(), context);
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <meta>.");
+
 }
 
 constexpr int NUM_T_METADATA_STATES = 2;
 constexpr const int NUM_T_METADATA_INPUTS = 1;
 constexpr int gstate_t_metadata[NUM_T_METADATA_STATES][NUM_T_METADATA_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_metadata(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_metadata(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <metadata>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <metadata>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t meta_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_metadata in = lex_node_t_metadata(node.name(), report_error);
-            next = gstate_t_metadata[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_metadata[(int)in], gstate_t_metadata[state], gtok_lookup_t_metadata, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_metadata::META:
-                    meta_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t meta_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_metadata in = lex_node_t_metadata(node.name(), report_error);
+			next = gstate_t_metadata[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_metadata[(int)in], gstate_t_metadata[state], gtok_lookup_t_metadata, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_metadata::META:
+				meta_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_metadata_meta(context, meta_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_metadata in = lex_node_t_metadata(node.name(), report_error);
+		next = gstate_t_metadata[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_metadata[(int)in], gstate_t_metadata[state], gtok_lookup_t_metadata, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_metadata::META:
+			{
+				auto child_context = out.add_metadata_meta(context);
+				load_meta(node, out, child_context, report_error, offset_debug);
+				out.finish_metadata_meta(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_metadata[state], gtok_lookup_t_metadata, 1, report_error);
 
-        out.preallocate_metadata_meta(context, meta_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_metadata in = lex_node_t_metadata(node.name(), report_error);
-        next = gstate_t_metadata[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_metadata[(int)in], gstate_t_metadata[state], gtok_lookup_t_metadata, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_metadata::META: {
-                auto child_context = out.add_metadata_meta(context);
-                load_meta(node, out, child_context, report_error, offset_debug);
-                out.finish_metadata_meta(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_metadata[state], gtok_lookup_t_metadata, 1, report_error);
 }
 
 template<class T, typename Context>
-inline void load_node(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_node(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_node in = lex_attr_t_node(attr.name(), report_error);
-        switch (in) {
-            case atok_t_node::CAPACITY:
-                /* Attribute capacity is already set */
-                break;
-            case atok_t_node::DIRECTION:
-                out.set_node_direction(lex_enum_node_direction(attr.value(), true, report_error), context);
-                break;
-            case atok_t_node::ID:
-                /* Attribute id is already set */
-                break;
-            case atok_t_node::TYPE:
-                /* Attribute type is already set */
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_node in = lex_attr_t_node(attr.name(), report_error);
+		switch(in){
+		case atok_t_node::CAPACITY:
+			/* Attribute capacity is already set */
+			break;
+		case atok_t_node::DIRECTION:
+			out.set_node_direction(lex_enum_node_direction(attr.value(), true, report_error), context);
+			break;
+		case atok_t_node::ID:
+			/* Attribute id is already set */
+			break;
+		case atok_t_node::TYPE:
+			/* Attribute type is already set */
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
-    std::bitset<4> gstate = 0;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_node in = lex_node_t_node(node.name(), report_error);
-        if (gstate[(int)in] == 0)
-            gstate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <node>.").c_str());
-        switch (in) {
-            case gtok_t_node::LOC: {
-                int node_loc_ptc;
-                memset(&node_loc_ptc, 0, sizeof(node_loc_ptc));
-                int node_loc_xhigh;
-                memset(&node_loc_xhigh, 0, sizeof(node_loc_xhigh));
-                int node_loc_xlow;
-                memset(&node_loc_xlow, 0, sizeof(node_loc_xlow));
-                int node_loc_yhigh;
-                memset(&node_loc_yhigh, 0, sizeof(node_loc_yhigh));
-                int node_loc_ylow;
-                memset(&node_loc_ylow, 0, sizeof(node_loc_ylow));
-                load_node_loc_required_attributes(node, &node_loc_ptc, &node_loc_xhigh, &node_loc_xlow, &node_loc_yhigh, &node_loc_ylow, report_error);
-                auto child_context = out.init_node_loc(context, node_loc_ptc, node_loc_xhigh, node_loc_xlow, node_loc_yhigh, node_loc_ylow);
-                load_node_loc(node, out, child_context, report_error, offset_debug);
-                out.finish_node_loc(child_context);
-            } break;
-            case gtok_t_node::TIMING: {
-                float node_timing_C;
-                memset(&node_timing_C, 0, sizeof(node_timing_C));
-                float node_timing_R;
-                memset(&node_timing_R, 0, sizeof(node_timing_R));
-                load_node_timing_required_attributes(node, &node_timing_C, &node_timing_R, report_error);
-                auto child_context = out.init_node_timing(context, node_timing_C, node_timing_R);
-                load_node_timing(node, out, child_context, report_error, offset_debug);
-                out.finish_node_timing(child_context);
-            } break;
-            case gtok_t_node::SEGMENT: {
-                int node_segment_segment_id;
-                memset(&node_segment_segment_id, 0, sizeof(node_segment_segment_id));
-                load_node_segment_required_attributes(node, &node_segment_segment_id, report_error);
-                auto child_context = out.init_node_segment(context, node_segment_segment_id);
-                load_node_segment(node, out, child_context, report_error, offset_debug);
-                out.finish_node_segment(child_context);
-            } break;
-            case gtok_t_node::METADATA: {
-                auto child_context = out.init_node_metadata(context);
-                load_metadata(node, out, child_context, report_error, offset_debug);
-                out.finish_node_metadata(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<4> test_gstate = gstate | std::bitset<4>(0b1110);
-    if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_node, report_error);
+	std::bitset<4> gstate = 0;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_node in = lex_node_t_node(node.name(), report_error);
+		if(gstate[(int)in] == 0) gstate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <node>.").c_str());
+		switch(in){
+		case gtok_t_node::LOC:
+			{
+				int node_loc_ptc;
+				memset(&node_loc_ptc, 0, sizeof(node_loc_ptc));
+				int node_loc_xhigh;
+				memset(&node_loc_xhigh, 0, sizeof(node_loc_xhigh));
+				int node_loc_xlow;
+				memset(&node_loc_xlow, 0, sizeof(node_loc_xlow));
+				int node_loc_yhigh;
+				memset(&node_loc_yhigh, 0, sizeof(node_loc_yhigh));
+				int node_loc_ylow;
+				memset(&node_loc_ylow, 0, sizeof(node_loc_ylow));
+				load_node_loc_required_attributes(node, &node_loc_ptc, &node_loc_xhigh, &node_loc_xlow, &node_loc_yhigh, &node_loc_ylow, report_error);
+				auto child_context = out.init_node_loc(context, node_loc_ptc, node_loc_xhigh, node_loc_xlow, node_loc_yhigh, node_loc_ylow);
+				load_node_loc(node, out, child_context, report_error, offset_debug);
+				out.finish_node_loc(child_context);
+			}
+			break;
+		case gtok_t_node::TIMING:
+			{
+				float node_timing_C;
+				memset(&node_timing_C, 0, sizeof(node_timing_C));
+				float node_timing_R;
+				memset(&node_timing_R, 0, sizeof(node_timing_R));
+				load_node_timing_required_attributes(node, &node_timing_C, &node_timing_R, report_error);
+				auto child_context = out.init_node_timing(context, node_timing_C, node_timing_R);
+				load_node_timing(node, out, child_context, report_error, offset_debug);
+				out.finish_node_timing(child_context);
+			}
+			break;
+		case gtok_t_node::SEGMENT:
+			{
+				int node_segment_segment_id;
+				memset(&node_segment_segment_id, 0, sizeof(node_segment_segment_id));
+				load_node_segment_required_attributes(node, &node_segment_segment_id, report_error);
+				auto child_context = out.init_node_segment(context, node_segment_segment_id);
+				load_node_segment(node, out, child_context, report_error, offset_debug);
+				out.finish_node_segment(child_context);
+			}
+			break;
+		case gtok_t_node::METADATA:
+			{
+				auto child_context = out.init_node_metadata(context);
+				load_metadata(node, out, child_context, report_error, offset_debug);
+				out.finish_node_metadata(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<4> test_gstate = gstate | std::bitset<4>(0b1110);
+	if(!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_node, report_error);
+
 }
 
 constexpr int NUM_T_RR_NODES_STATES = 2;
 constexpr const int NUM_T_RR_NODES_INPUTS = 1;
 constexpr int gstate_t_rr_nodes[NUM_T_RR_NODES_STATES][NUM_T_RR_NODES_INPUTS] = {
-    {0},
-    {0},
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_rr_nodes(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_rr_nodes(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <rr_nodes>.");
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <rr_nodes>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t node_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_rr_nodes in = lex_node_t_rr_nodes(node.name(), report_error);
-            next = gstate_t_rr_nodes[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_rr_nodes[(int)in], gstate_t_rr_nodes[state], gtok_lookup_t_rr_nodes, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_rr_nodes::NODE:
-                    node_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t node_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_rr_nodes in = lex_node_t_rr_nodes(node.name(), report_error);
+			next = gstate_t_rr_nodes[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_rr_nodes[(int)in], gstate_t_rr_nodes[state], gtok_lookup_t_rr_nodes, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_rr_nodes::NODE:
+				node_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_rr_nodes_node(context, node_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_rr_nodes in = lex_node_t_rr_nodes(node.name(), report_error);
+		next = gstate_t_rr_nodes[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_rr_nodes[(int)in], gstate_t_rr_nodes[state], gtok_lookup_t_rr_nodes, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_rr_nodes::NODE:
+			{
+				unsigned int node_capacity;
+				memset(&node_capacity, 0, sizeof(node_capacity));
+				unsigned int node_id;
+				memset(&node_id, 0, sizeof(node_id));
+				enum_node_type node_type;
+				memset(&node_type, 0, sizeof(node_type));
+				load_node_required_attributes(node, &node_capacity, &node_id, &node_type, report_error);
+				auto child_context = out.add_rr_nodes_node(context, node_capacity, node_id, node_type);
+				load_node(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_nodes_node(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_rr_nodes[state], gtok_lookup_t_rr_nodes, 1, report_error);
 
-        out.preallocate_rr_nodes_node(context, node_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_rr_nodes in = lex_node_t_rr_nodes(node.name(), report_error);
-        next = gstate_t_rr_nodes[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_rr_nodes[(int)in], gstate_t_rr_nodes[state], gtok_lookup_t_rr_nodes, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_rr_nodes::NODE: {
-                unsigned int node_capacity;
-                memset(&node_capacity, 0, sizeof(node_capacity));
-                unsigned int node_id;
-                memset(&node_id, 0, sizeof(node_id));
-                enum_node_type node_type;
-                memset(&node_type, 0, sizeof(node_type));
-                load_node_required_attributes(node, &node_capacity, &node_id, &node_type, report_error);
-                auto child_context = out.add_rr_nodes_node(context, node_capacity, node_id, node_type);
-                load_node(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_nodes_node(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_rr_nodes[state], gtok_lookup_t_rr_nodes, 1, report_error);
 }
 
 template<class T, typename Context>
-inline void load_edge(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    std::bitset<1> gstate = 0;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_edge in = lex_node_t_edge(node.name(), report_error);
-        if (gstate[(int)in] == 0)
-            gstate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <edge>.").c_str());
-        switch (in) {
-            case gtok_t_edge::METADATA: {
-                auto child_context = out.init_edge_metadata(context);
-                load_metadata(node, out, child_context, report_error, offset_debug);
-                out.finish_edge_metadata(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<1> test_gstate = gstate | std::bitset<1>(0b1);
-    if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_edge, report_error);
+
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <e_ptn>.");
+
 }
 
-constexpr int NUM_T_RR_EDGES_STATES = 2;
-constexpr const int NUM_T_RR_EDGES_INPUTS = 1;
-constexpr int gstate_t_rr_edges[NUM_T_RR_EDGES_STATES][NUM_T_RR_EDGES_INPUTS] = {
-    {0},
-    {0},
+constexpr int NUM_T_NODE_E_PTN_STATES = 2;
+constexpr const int NUM_T_NODE_E_PTN_INPUTS = 1;
+constexpr int gstate_t_node_e_ptn[NUM_T_NODE_E_PTN_STATES][NUM_T_NODE_E_PTN_INPUTS] = {
+	{0},
+	{0},
 };
 template<class T, typename Context>
-inline void load_rr_edges(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_node_e_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    if (root.first_attribute())
-        noreturn_report(report_error, "Unexpected attribute in <rr_edges>.");
 
-    // Preallocate arrays by counting child nodes (if any)
-    size_t edge_count = 0;
-    {
-        int next, state = 1;
-        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-            *offset_debug = node.offset_debug();
-            gtok_t_rr_edges in = lex_node_t_rr_edges(node.name(), report_error);
-            next = gstate_t_rr_edges[state][(int)in];
-            if (next == -1)
-                dfa_error(gtok_lookup_t_rr_edges[(int)in], gstate_t_rr_edges[state], gtok_lookup_t_rr_edges, 1, report_error);
-            state = next;
-            switch (in) {
-                case gtok_t_rr_edges::EDGE:
-                    edge_count += 1;
-                    break;
-                default:
-                    break; /* Not possible. */
-            }
-        }
+	// Preallocate arrays by counting child nodes (if any)
+	size_t e_ptn_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_node_e_ptn in = lex_node_t_node_e_ptn(node.name(), report_error);
+			next = gstate_t_node_e_ptn[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_node_e_ptn[(int)in], gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_node_e_ptn::E_PTN:
+				e_ptn_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_node_e_ptn_e_ptn(context, e_ptn_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_node_e_ptn in = lex_node_t_node_e_ptn(node.name(), report_error);
+		next = gstate_t_node_e_ptn[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_node_e_ptn[(int)in], gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_node_e_ptn::E_PTN:
+			{
+				unsigned int e_ptn_id;
+				memset(&e_ptn_id, 0, sizeof(e_ptn_id));
+				load_e_ptn_required_attributes(node, &e_ptn_id, report_error);
+				auto child_context = out.add_node_e_ptn_e_ptn(context, e_ptn_id);
+				load_e_ptn(node, out, child_context, report_error, offset_debug);
+				out.finish_node_e_ptn_e_ptn(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_node_e_ptn[state], gtok_lookup_t_node_e_ptn, 1, report_error);
 
-        out.preallocate_rr_edges_edge(context, edge_count);
-    }
-    int next, state = 1;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_rr_edges in = lex_node_t_rr_edges(node.name(), report_error);
-        next = gstate_t_rr_edges[state][(int)in];
-        if (next == -1)
-            dfa_error(gtok_lookup_t_rr_edges[(int)in], gstate_t_rr_edges[state], gtok_lookup_t_rr_edges, 1, report_error);
-        state = next;
-        switch (in) {
-            case gtok_t_rr_edges::EDGE: {
-                unsigned int edge_sink_node;
-                memset(&edge_sink_node, 0, sizeof(edge_sink_node));
-                unsigned int edge_src_node;
-                memset(&edge_src_node, 0, sizeof(edge_src_node));
-                unsigned int edge_switch_id;
-                memset(&edge_switch_id, 0, sizeof(edge_switch_id));
-                load_edge_required_attributes(node, &edge_sink_node, &edge_src_node, &edge_switch_id, report_error);
-                auto child_context = out.add_rr_edges_edge(context, edge_sink_node, edge_src_node, edge_switch_id);
-                load_edge(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_edges_edge(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    if (state != 0) dfa_error("end of input", gstate_t_rr_edges[state], gtok_lookup_t_rr_edges, 1, report_error);
+}
+
+constexpr int NUM_T_RR_NODE_E_PTNS_STATES = 2;
+constexpr const int NUM_T_RR_NODE_E_PTNS_INPUTS = 1;
+constexpr int gstate_t_rr_node_e_ptns[NUM_T_RR_NODE_E_PTNS_STATES][NUM_T_RR_NODE_E_PTNS_INPUTS] = {
+	{0},
+	{0},
+};
+template<class T, typename Context>
+inline void load_rr_node_e_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <rr_node_e_ptns>.");
+
+	// Preallocate arrays by counting child nodes (if any)
+	size_t node_e_ptn_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_rr_node_e_ptns in = lex_node_t_rr_node_e_ptns(node.name(), report_error);
+			next = gstate_t_rr_node_e_ptns[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_rr_node_e_ptns[(int)in], gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_rr_node_e_ptns::NODE_E_PTN:
+				node_e_ptn_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_rr_node_e_ptns_node_e_ptn(context, node_e_ptn_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_rr_node_e_ptns in = lex_node_t_rr_node_e_ptns(node.name(), report_error);
+		next = gstate_t_rr_node_e_ptns[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_rr_node_e_ptns[(int)in], gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_rr_node_e_ptns::NODE_E_PTN:
+			{
+				unsigned int node_e_ptn_dest;
+				memset(&node_e_ptn_dest, 0, sizeof(node_e_ptn_dest));
+				unsigned int node_e_ptn_id;
+				memset(&node_e_ptn_id, 0, sizeof(node_e_ptn_id));
+				load_node_e_ptn_required_attributes(node, &node_e_ptn_dest, &node_e_ptn_id, report_error);
+				auto child_context = out.add_rr_node_e_ptns_node_e_ptn(context, node_e_ptn_dest, node_e_ptn_id);
+				load_node_e_ptn(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_node_e_ptns_node_e_ptn(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_rr_node_e_ptns[state], gtok_lookup_t_rr_node_e_ptns, 1, report_error);
+
 }
 
 template<class T, typename Context>
-inline void load_rr_graph(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    // Update current file offset in case an error is encountered.
-    *offset_debug = root.offset_debug();
+inline void load_ddiff(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
 
-    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
-        atok_t_rr_graph in = lex_attr_t_rr_graph(attr.name(), report_error);
-        switch (in) {
-            case atok_t_rr_graph::TOOL_COMMENT:
-                out.set_rr_graph_tool_comment(attr.value(), context);
-                break;
-            case atok_t_rr_graph::TOOL_NAME:
-                out.set_rr_graph_tool_name(attr.value(), context);
-                break;
-            case atok_t_rr_graph::TOOL_VERSION:
-                out.set_rr_graph_tool_version(attr.value(), context);
-                break;
-            default:
-                break; /* Not possible. */
-        }
-    }
 
-    std::bitset<7> gstate = 0;
-    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
-        *offset_debug = node.offset_debug();
-        gtok_t_rr_graph in = lex_node_t_rr_graph(node.name(), report_error);
-        if (gstate[(int)in] == 0)
-            gstate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <rr_graph>.").c_str());
-        switch (in) {
-            case gtok_t_rr_graph::CHANNELS: {
-                auto child_context = out.init_rr_graph_channels(context);
-                load_channels(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_channels(child_context);
-            } break;
-            case gtok_t_rr_graph::SWITCHES: {
-                auto child_context = out.init_rr_graph_switches(context);
-                load_switches(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_switches(child_context);
-            } break;
-            case gtok_t_rr_graph::SEGMENTS: {
-                auto child_context = out.init_rr_graph_segments(context);
-                load_segments(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_segments(child_context);
-            } break;
-            case gtok_t_rr_graph::BLOCK_TYPES: {
-                auto child_context = out.init_rr_graph_block_types(context);
-                load_block_types(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_block_types(child_context);
-            } break;
-            case gtok_t_rr_graph::GRID: {
-                auto child_context = out.init_rr_graph_grid(context);
-                load_grid_locs(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_grid(child_context);
-            } break;
-            case gtok_t_rr_graph::RR_NODES: {
-                auto child_context = out.init_rr_graph_rr_nodes(context);
-                load_rr_nodes(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_rr_nodes(child_context);
-            } break;
-            case gtok_t_rr_graph::RR_EDGES: {
-                auto child_context = out.init_rr_graph_rr_edges(context);
-                load_rr_edges(node, out, child_context, report_error, offset_debug);
-                out.finish_rr_graph_rr_edges(child_context);
-            } break;
-            default:
-                break; /* Not possible. */
-        }
-    }
-    std::bitset<7> test_gstate = gstate | std::bitset<7>(0b0000000);
-    if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_rr_graph, report_error);
+	if(root.first_child().type() == pugi::node_element)
+		noreturn_report(report_error, "Unexpected child element in <ddiff>.");
+
 }
+
+constexpr int NUM_T_EDGE_PTN_STATES = 2;
+constexpr const int NUM_T_EDGE_PTN_INPUTS = 1;
+constexpr int gstate_t_edge_ptn[NUM_T_EDGE_PTN_STATES][NUM_T_EDGE_PTN_INPUTS] = {
+	{0},
+	{0},
+};
+template<class T, typename Context>
+inline void load_edge_ptn(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+
+	// Preallocate arrays by counting child nodes (if any)
+	size_t ddiff_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_edge_ptn in = lex_node_t_edge_ptn(node.name(), report_error);
+			next = gstate_t_edge_ptn[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_edge_ptn[(int)in], gstate_t_edge_ptn[state], gtok_lookup_t_edge_ptn, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_edge_ptn::DDIFF:
+				ddiff_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_edge_ptn_ddiff(context, ddiff_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_edge_ptn in = lex_node_t_edge_ptn(node.name(), report_error);
+		next = gstate_t_edge_ptn[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_edge_ptn[(int)in], gstate_t_edge_ptn[state], gtok_lookup_t_edge_ptn, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_edge_ptn::DDIFF:
+			{
+				unsigned int ddiff_id;
+				memset(&ddiff_id, 0, sizeof(ddiff_id));
+				load_ddiff_required_attributes(node, &ddiff_id, report_error);
+				auto child_context = out.add_edge_ptn_ddiff(context, ddiff_id);
+				load_ddiff(node, out, child_context, report_error, offset_debug);
+				out.finish_edge_ptn_ddiff(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_edge_ptn[state], gtok_lookup_t_edge_ptn, 1, report_error);
+
+}
+
+constexpr int NUM_T_RR_EDGE_PTNS_STATES = 2;
+constexpr const int NUM_T_RR_EDGE_PTNS_INPUTS = 1;
+constexpr int gstate_t_rr_edge_ptns[NUM_T_RR_EDGE_PTNS_STATES][NUM_T_RR_EDGE_PTNS_INPUTS] = {
+	{0},
+	{0},
+};
+template<class T, typename Context>
+inline void load_rr_edge_ptns(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+	if(root.first_attribute())
+		noreturn_report(report_error, "Unexpected attribute in <rr_edge_ptns>.");
+
+	// Preallocate arrays by counting child nodes (if any)
+	size_t edge_ptn_count = 0;
+	{
+		int next, state=1;
+		for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+			*offset_debug = node.offset_debug();
+			gtok_t_rr_edge_ptns in = lex_node_t_rr_edge_ptns(node.name(), report_error);
+			next = gstate_t_rr_edge_ptns[state][(int)in];
+			if(next == -1)
+				dfa_error(gtok_lookup_t_rr_edge_ptns[(int)in], gstate_t_rr_edge_ptns[state], gtok_lookup_t_rr_edge_ptns, 1, report_error);
+			state = next;
+			switch(in) {
+			case gtok_t_rr_edge_ptns::EDGE_PTN:
+				edge_ptn_count += 1;
+				break;
+			default: break; /* Not possible. */
+			}
+		}
+		
+		out.preallocate_rr_edge_ptns_edge_ptn(context, edge_ptn_count);
+	}
+	int next, state=1;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_rr_edge_ptns in = lex_node_t_rr_edge_ptns(node.name(), report_error);
+		next = gstate_t_rr_edge_ptns[state][(int)in];
+		if(next == -1)
+			dfa_error(gtok_lookup_t_rr_edge_ptns[(int)in], gstate_t_rr_edge_ptns[state], gtok_lookup_t_rr_edge_ptns, 1, report_error);
+		state = next;
+		switch(in){
+		case gtok_t_rr_edge_ptns::EDGE_PTN:
+			{
+				unsigned int edge_ptn_id;
+				memset(&edge_ptn_id, 0, sizeof(edge_ptn_id));
+				unsigned int edge_ptn_switch_id;
+				memset(&edge_ptn_switch_id, 0, sizeof(edge_ptn_switch_id));
+				load_edge_ptn_required_attributes(node, &edge_ptn_id, &edge_ptn_switch_id, report_error);
+				auto child_context = out.add_rr_edge_ptns_edge_ptn(context, edge_ptn_id, edge_ptn_switch_id);
+				load_edge_ptn(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_edge_ptns_edge_ptn(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	if(state != 0) dfa_error("end of input", gstate_t_rr_edge_ptns[state], gtok_lookup_t_rr_edge_ptns, 1, report_error);
+
+}
+
+template<class T, typename Context>
+inline void load_rr_graph(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	// Update current file offset in case an error is encountered.
+	*offset_debug = root.offset_debug();
+
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_rr_graph in = lex_attr_t_rr_graph(attr.name(), report_error);
+		switch(in){
+		case atok_t_rr_graph::TOOL_COMMENT:
+			out.set_rr_graph_tool_comment(attr.value(), context);
+			break;
+		case atok_t_rr_graph::TOOL_NAME:
+			out.set_rr_graph_tool_name(attr.value(), context);
+			break;
+		case atok_t_rr_graph::TOOL_VERSION:
+			out.set_rr_graph_tool_version(attr.value(), context);
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+
+	std::bitset<8> gstate = 0;
+	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling()){
+		*offset_debug = node.offset_debug();
+		gtok_t_rr_graph in = lex_node_t_rr_graph(node.name(), report_error);
+		if(gstate[(int)in] == 0) gstate[(int)in] = 1;
+		else noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <rr_graph>.").c_str());
+		switch(in){
+		case gtok_t_rr_graph::CHANNELS:
+			{
+				auto child_context = out.init_rr_graph_channels(context);
+				load_channels(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_channels(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::SWITCHES:
+			{
+				auto child_context = out.init_rr_graph_switches(context);
+				load_switches(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_switches(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::SEGMENTS:
+			{
+				auto child_context = out.init_rr_graph_segments(context);
+				load_segments(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_segments(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::BLOCK_TYPES:
+			{
+				auto child_context = out.init_rr_graph_block_types(context);
+				load_block_types(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_block_types(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::GRID:
+			{
+				auto child_context = out.init_rr_graph_grid(context);
+				load_grid_locs(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_grid(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::RR_NODES:
+			{
+				auto child_context = out.init_rr_graph_rr_nodes(context);
+				load_rr_nodes(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_rr_nodes(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::RR_NODE_E_PTNS:
+			{
+				auto child_context = out.init_rr_graph_rr_node_e_ptns(context);
+				load_rr_node_e_ptns(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_rr_node_e_ptns(child_context);
+			}
+			break;
+		case gtok_t_rr_graph::RR_EDGE_PTNS:
+			{
+				auto child_context = out.init_rr_graph_rr_edge_ptns(context);
+				load_rr_edge_ptns(node, out, child_context, report_error, offset_debug);
+				out.finish_rr_graph_rr_edge_ptns(child_context);
+			}
+			break;
+		default: break; /* Not possible. */
+		}
+	}
+	std::bitset<8> test_gstate = gstate | std::bitset<8>(0b00000000);
+	if(!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_rr_graph, report_error);
+
+}
+
 
 /* Internal writing functions, which uxsdcxx uses to write out a class. */
 template<class T, typename Context>
-inline void write_channels(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        auto child_context = in.get_channels_channel(context);
-        os << "<channel";
-        os << " chan_width_max=\"" << in.get_channel_chan_width_max(child_context) << "\"";
-        os << " x_max=\"" << in.get_channel_x_max(child_context) << "\"";
-        os << " x_min=\"" << in.get_channel_x_min(child_context) << "\"";
-        os << " y_max=\"" << in.get_channel_y_max(child_context) << "\"";
-        os << " y_min=\"" << in.get_channel_y_min(child_context) << "\"";
-        os << "/>\n";
-    }
-    {
-        for (size_t i = 0, n = in.num_channels_x_list(context); i < n; i++) {
-            auto child_context = in.get_channels_x_list(i, context);
-            os << "<x_list";
-            os << " index=\"" << in.get_x_list_index(child_context) << "\"";
-            os << " info=\"" << in.get_x_list_info(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
-    {
-        for (size_t i = 0, n = in.num_channels_y_list(context); i < n; i++) {
-            auto child_context = in.get_channels_y_list(i, context);
-            os << "<y_list";
-            os << " index=\"" << in.get_y_list_index(child_context) << "\"";
-            os << " info=\"" << in.get_y_list_info(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
+inline void write_channels(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		auto child_context = in.get_channels_channel(context);
+		os << "<channel";
+		os << " chan_width_max=\"" << in.get_channel_chan_width_max(child_context) << "\"";
+		os << " x_max=\"" << in.get_channel_x_max(child_context) << "\"";
+		os << " x_min=\"" << in.get_channel_x_min(child_context) << "\"";
+		os << " y_max=\"" << in.get_channel_y_max(child_context) << "\"";
+		os << " y_min=\"" << in.get_channel_y_min(child_context) << "\"";
+		os << "/>\n";
+	}
+	{
+		for(size_t i=0, n=in.num_channels_x_list(context); i<n; i++){
+			auto child_context = in.get_channels_x_list(i, context);
+			os << "<x_list";
+			os << " index=\"" << in.get_x_list_index(child_context) << "\"";
+			os << " info=\"" << in.get_x_list_info(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
+	{
+		for(size_t i=0, n=in.num_channels_y_list(context); i<n; i++){
+			auto child_context = in.get_channels_y_list(i, context);
+			os << "<y_list";
+			os << " index=\"" << in.get_y_list_index(child_context) << "\"";
+			os << " info=\"" << in.get_y_list_info(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_switch(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        if (in.has_switch_timing(context)) {
-            auto child_context = in.get_switch_timing(context);
-            os << "<timing";
-            if ((bool)in.get_timing_Cin(child_context))
-                os << " Cin=\"" << in.get_timing_Cin(child_context) << "\"";
-            if ((bool)in.get_timing_Cinternal(child_context))
-                os << " Cinternal=\"" << in.get_timing_Cinternal(child_context) << "\"";
-            if ((bool)in.get_timing_Cout(child_context))
-                os << " Cout=\"" << in.get_timing_Cout(child_context) << "\"";
-            if ((bool)in.get_timing_R(child_context))
-                os << " R=\"" << in.get_timing_R(child_context) << "\"";
-            if ((bool)in.get_timing_Tdel(child_context))
-                os << " Tdel=\"" << in.get_timing_Tdel(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
-    {
-        auto child_context = in.get_switch_sizing(context);
-        os << "<sizing";
-        os << " buf_size=\"" << in.get_sizing_buf_size(child_context) << "\"";
-        os << " mux_trans_size=\"" << in.get_sizing_mux_trans_size(child_context) << "\"";
-        os << "/>\n";
-    }
+inline void write_switch(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		if(in.has_switch_timing(context)){
+			auto child_context = in.get_switch_timing(context);
+			os << "<timing";
+			if((bool)in.get_timing_Cin(child_context))
+				os << " Cin=\"" << in.get_timing_Cin(child_context) << "\"";
+			if((bool)in.get_timing_Cinternal(child_context))
+				os << " Cinternal=\"" << in.get_timing_Cinternal(child_context) << "\"";
+			if((bool)in.get_timing_Cout(child_context))
+				os << " Cout=\"" << in.get_timing_Cout(child_context) << "\"";
+			if((bool)in.get_timing_R(child_context))
+				os << " R=\"" << in.get_timing_R(child_context) << "\"";
+			if((bool)in.get_timing_Tdel(child_context))
+				os << " Tdel=\"" << in.get_timing_Tdel(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
+	{
+		auto child_context = in.get_switch_sizing(context);
+		os << "<sizing";
+		os << " buf_size=\"" << in.get_sizing_buf_size(child_context) << "\"";
+		os << " mux_trans_size=\"" << in.get_sizing_mux_trans_size(child_context) << "\"";
+		os << "/>\n";
+	}
 }
 
 template<class T, typename Context>
-inline void write_switches(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_switches_switch(context); i < n; i++) {
-            auto child_context = in.get_switches_switch(i, context);
-            os << "<switch";
-            os << " id=\"" << in.get_switch_id(child_context) << "\"";
-            os << " name=\"" << in.get_switch_name(child_context) << "\"";
-            if ((bool)in.get_switch_type(child_context))
-                os << " type=\"" << lookup_switch_type[(int)in.get_switch_type(child_context)] << "\"";
-            os << ">";
-            write_switch(in, os, child_context);
-            os << "</switch>\n";
-        }
-    }
+inline void write_switches(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_switches_switch(context); i<n; i++){
+			auto child_context = in.get_switches_switch(i, context);
+			os << "<switch";
+			os << " id=\"" << in.get_switch_id(child_context) << "\"";
+			os << " name=\"" << in.get_switch_name(child_context) << "\"";
+			if((bool)in.get_switch_type(child_context))
+				os << " type=\"" << lookup_switch_type[(int)in.get_switch_type(child_context)] << "\"";
+			os << ">";
+			write_switch(in, os, child_context);
+			os << "</switch>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_segment(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        if (in.has_segment_timing(context)) {
-            auto child_context = in.get_segment_timing(context);
-            os << "<timing";
-            if ((bool)in.get_segment_timing_C_per_meter(child_context))
-                os << " C_per_meter=\"" << in.get_segment_timing_C_per_meter(child_context) << "\"";
-            if ((bool)in.get_segment_timing_R_per_meter(child_context))
-                os << " R_per_meter=\"" << in.get_segment_timing_R_per_meter(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
+inline void write_segment(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		if(in.has_segment_timing(context)){
+			auto child_context = in.get_segment_timing(context);
+			os << "<timing";
+			if((bool)in.get_segment_timing_C_per_meter(child_context))
+				os << " C_per_meter=\"" << in.get_segment_timing_C_per_meter(child_context) << "\"";
+			if((bool)in.get_segment_timing_R_per_meter(child_context))
+				os << " R_per_meter=\"" << in.get_segment_timing_R_per_meter(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_segments(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_segments_segment(context); i < n; i++) {
-            auto child_context = in.get_segments_segment(i, context);
-            os << "<segment";
-            os << " id=\"" << in.get_segment_id(child_context) << "\"";
-            os << " name=\"" << in.get_segment_name(child_context) << "\"";
-            os << ">";
-            write_segment(in, os, child_context);
-            os << "</segment>\n";
-        }
-    }
+inline void write_segments(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_segments_segment(context); i<n; i++){
+			auto child_context = in.get_segments_segment(i, context);
+			os << "<segment";
+			os << " id=\"" << in.get_segment_id(child_context) << "\"";
+			os << " name=\"" << in.get_segment_name(child_context) << "\"";
+			os << ">";
+			write_segment(in, os, child_context);
+			os << "</segment>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_pin(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    os << in.get_pin_value(context);
+inline void write_pin(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	os << in.get_pin_value(context);
 }
 
 template<class T, typename Context>
-inline void write_pin_class(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_pin_class_pin(context); i < n; i++) {
-            auto child_context = in.get_pin_class_pin(i, context);
-            os << "<pin";
-            os << " ptc=\"" << in.get_pin_ptc(child_context) << "\"";
-            os << ">";
-            write_pin(in, os, child_context);
-            os << "</pin>\n";
-        }
-    }
+inline void write_pin_class(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_pin_class_pin(context); i<n; i++){
+			auto child_context = in.get_pin_class_pin(i, context);
+			os << "<pin";
+			os << " ptc=\"" << in.get_pin_ptc(child_context) << "\"";
+			os << ">";
+			write_pin(in, os, child_context);
+			os << "</pin>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_block_type(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_block_type_pin_class(context); i < n; i++) {
-            auto child_context = in.get_block_type_pin_class(i, context);
-            os << "<pin_class";
-            os << " type=\"" << lookup_pin_type[(int)in.get_pin_class_type(child_context)] << "\"";
-            os << ">";
-            write_pin_class(in, os, child_context);
-            os << "</pin_class>\n";
-        }
-    }
+inline void write_block_type(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_block_type_pin_class(context); i<n; i++){
+			auto child_context = in.get_block_type_pin_class(i, context);
+			os << "<pin_class";
+			os << " type=\"" << lookup_pin_type[(int)in.get_pin_class_type(child_context)] << "\"";
+			os << ">";
+			write_pin_class(in, os, child_context);
+			os << "</pin_class>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_block_types(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_block_types_block_type(context); i < n; i++) {
-            auto child_context = in.get_block_types_block_type(i, context);
-            os << "<block_type";
-            os << " height=\"" << in.get_block_type_height(child_context) << "\"";
-            os << " id=\"" << in.get_block_type_id(child_context) << "\"";
-            os << " name=\"" << in.get_block_type_name(child_context) << "\"";
-            os << " width=\"" << in.get_block_type_width(child_context) << "\"";
-            os << ">";
-            write_block_type(in, os, child_context);
-            os << "</block_type>\n";
-        }
-    }
+inline void write_block_types(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_block_types_block_type(context); i<n; i++){
+			auto child_context = in.get_block_types_block_type(i, context);
+			os << "<block_type";
+			os << " height=\"" << in.get_block_type_height(child_context) << "\"";
+			os << " id=\"" << in.get_block_type_id(child_context) << "\"";
+			os << " name=\"" << in.get_block_type_name(child_context) << "\"";
+			os << " width=\"" << in.get_block_type_width(child_context) << "\"";
+			os << ">";
+			write_block_type(in, os, child_context);
+			os << "</block_type>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_grid_locs(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_grid_locs_grid_loc(context); i < n; i++) {
-            auto child_context = in.get_grid_locs_grid_loc(i, context);
-            os << "<grid_loc";
-            os << " block_type_id=\"" << in.get_grid_loc_block_type_id(child_context) << "\"";
-            os << " height_offset=\"" << in.get_grid_loc_height_offset(child_context) << "\"";
-            os << " width_offset=\"" << in.get_grid_loc_width_offset(child_context) << "\"";
-            os << " x=\"" << in.get_grid_loc_x(child_context) << "\"";
-            os << " y=\"" << in.get_grid_loc_y(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
+inline void write_grid_locs(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_grid_locs_grid_loc(context); i<n; i++){
+			auto child_context = in.get_grid_locs_grid_loc(i, context);
+			os << "<grid_loc";
+			os << " block_type_id=\"" << in.get_grid_loc_block_type_id(child_context) << "\"";
+			os << " height_offset=\"" << in.get_grid_loc_height_offset(child_context) << "\"";
+			os << " width_offset=\"" << in.get_grid_loc_width_offset(child_context) << "\"";
+			os << " x=\"" << in.get_grid_loc_x(child_context) << "\"";
+			os << " y=\"" << in.get_grid_loc_y(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_meta(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    os << in.get_meta_value(context);
+inline void write_meta(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	os << in.get_meta_value(context);
 }
 
 template<class T, typename Context>
-inline void write_metadata(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_metadata_meta(context); i < n; i++) {
-            auto child_context = in.get_metadata_meta(i, context);
-            os << "<meta";
-            os << " name=\"" << in.get_meta_name(child_context) << "\"";
-            os << ">";
-            write_meta(in, os, child_context);
-            os << "</meta>\n";
-        }
-    }
+inline void write_metadata(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_metadata_meta(context); i<n; i++){
+			auto child_context = in.get_metadata_meta(i, context);
+			os << "<meta";
+			os << " name=\"" << in.get_meta_name(child_context) << "\"";
+			os << ">";
+			write_meta(in, os, child_context);
+			os << "</meta>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_node(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        auto child_context = in.get_node_loc(context);
-        os << "<loc";
-        os << " ptc=\"" << in.get_node_loc_ptc(child_context) << "\"";
-        if ((bool)in.get_node_loc_side(child_context))
-            os << " side=\"" << lookup_loc_side[(int)in.get_node_loc_side(child_context)] << "\"";
-        os << " xhigh=\"" << in.get_node_loc_xhigh(child_context) << "\"";
-        os << " xlow=\"" << in.get_node_loc_xlow(child_context) << "\"";
-        os << " yhigh=\"" << in.get_node_loc_yhigh(child_context) << "\"";
-        os << " ylow=\"" << in.get_node_loc_ylow(child_context) << "\"";
-        os << "/>\n";
-    }
-    {
-        if (in.has_node_timing(context)) {
-            auto child_context = in.get_node_timing(context);
-            os << "<timing";
-            os << " C=\"" << in.get_node_timing_C(child_context) << "\"";
-            os << " R=\"" << in.get_node_timing_R(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
-    {
-        if (in.has_node_segment(context)) {
-            auto child_context = in.get_node_segment(context);
-            os << "<segment";
-            os << " segment_id=\"" << in.get_node_segment_segment_id(child_context) << "\"";
-            os << "/>\n";
-        }
-    }
-    {
-        if (in.has_node_metadata(context)) {
-            auto child_context = in.get_node_metadata(context);
-            os << "<metadata>\n";
-            write_metadata(in, os, child_context);
-            os << "</metadata>\n";
-        }
-    }
+inline void write_node(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		auto child_context = in.get_node_loc(context);
+		os << "<loc";
+		os << " ptc=\"" << in.get_node_loc_ptc(child_context) << "\"";
+		if((bool)in.get_node_loc_side(child_context))
+			os << " side=\"" << lookup_loc_side[(int)in.get_node_loc_side(child_context)] << "\"";
+		os << " xhigh=\"" << in.get_node_loc_xhigh(child_context) << "\"";
+		os << " xlow=\"" << in.get_node_loc_xlow(child_context) << "\"";
+		os << " yhigh=\"" << in.get_node_loc_yhigh(child_context) << "\"";
+		os << " ylow=\"" << in.get_node_loc_ylow(child_context) << "\"";
+		os << "/>\n";
+	}
+	{
+		if(in.has_node_timing(context)){
+			auto child_context = in.get_node_timing(context);
+			os << "<timing";
+			os << " C=\"" << in.get_node_timing_C(child_context) << "\"";
+			os << " R=\"" << in.get_node_timing_R(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
+	{
+		if(in.has_node_segment(context)){
+			auto child_context = in.get_node_segment(context);
+			os << "<segment";
+			os << " segment_id=\"" << in.get_node_segment_segment_id(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
+	{
+		if(in.has_node_metadata(context)){
+			auto child_context = in.get_node_metadata(context);
+			os << "<metadata>\n";
+			write_metadata(in, os, child_context);
+			os << "</metadata>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_rr_nodes(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_rr_nodes_node(context); i < n; i++) {
-            auto child_context = in.get_rr_nodes_node(i, context);
-            os << "<node";
-            os << " capacity=\"" << in.get_node_capacity(child_context) << "\"";
-            if ((bool)in.get_node_direction(child_context))
-                os << " direction=\"" << lookup_node_direction[(int)in.get_node_direction(child_context)] << "\"";
-            os << " id=\"" << in.get_node_id(child_context) << "\"";
-            os << " type=\"" << lookup_node_type[(int)in.get_node_type(child_context)] << "\"";
-            os << ">";
-            write_node(in, os, child_context);
-            os << "</node>\n";
-        }
-    }
+inline void write_rr_nodes(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_rr_nodes_node(context); i<n; i++){
+			auto child_context = in.get_rr_nodes_node(i, context);
+			os << "<node";
+			os << " capacity=\"" << in.get_node_capacity(child_context) << "\"";
+			if((bool)in.get_node_direction(child_context))
+				os << " direction=\"" << lookup_node_direction[(int)in.get_node_direction(child_context)] << "\"";
+			os << " id=\"" << in.get_node_id(child_context) << "\"";
+			os << " type=\"" << lookup_node_type[(int)in.get_node_type(child_context)] << "\"";
+			os << ">";
+			write_node(in, os, child_context);
+			os << "</node>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_edge(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        if (in.has_edge_metadata(context)) {
-            auto child_context = in.get_edge_metadata(context);
-            os << "<metadata>\n";
-            write_metadata(in, os, child_context);
-            os << "</metadata>\n";
-        }
-    }
+inline void write_node_e_ptn(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_node_e_ptn_e_ptn(context); i<n; i++){
+			auto child_context = in.get_node_e_ptn_e_ptn(i, context);
+			os << "<e_ptn";
+			os << " id=\"" << in.get_e_ptn_id(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_rr_edges(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        for (size_t i = 0, n = in.num_rr_edges_edge(context); i < n; i++) {
-            auto child_context = in.get_rr_edges_edge(i, context);
-            os << "<edge";
-            os << " sink_node=\"" << in.get_edge_sink_node(child_context) << "\"";
-            os << " src_node=\"" << in.get_edge_src_node(child_context) << "\"";
-            os << " switch_id=\"" << in.get_edge_switch_id(child_context) << "\"";
-            os << ">";
-            write_edge(in, os, child_context);
-            os << "</edge>\n";
-        }
-    }
+inline void write_rr_node_e_ptns(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_rr_node_e_ptns_node_e_ptn(context); i<n; i++){
+			auto child_context = in.get_rr_node_e_ptns_node_e_ptn(i, context);
+			os << "<node_e_ptn";
+			os << " dest=\"" << in.get_node_e_ptn_dest(child_context) << "\"";
+			os << " id=\"" << in.get_node_e_ptn_id(child_context) << "\"";
+			os << ">";
+			write_node_e_ptn(in, os, child_context);
+			os << "</node_e_ptn>\n";
+		}
+	}
 }
 
 template<class T, typename Context>
-inline void write_rr_graph(T& in, std::ostream& os, Context& context) {
-    (void)in;
-    (void)os;
-    (void)context;
-    {
-        auto child_context = in.get_rr_graph_channels(context);
-        os << "<channels>\n";
-        write_channels(in, os, child_context);
-        os << "</channels>\n";
-    }
-    {
-        auto child_context = in.get_rr_graph_switches(context);
-        os << "<switches>\n";
-        write_switches(in, os, child_context);
-        os << "</switches>\n";
-    }
-    {
-        auto child_context = in.get_rr_graph_segments(context);
-        os << "<segments>\n";
-        write_segments(in, os, child_context);
-        os << "</segments>\n";
-    }
-    {
-        auto child_context = in.get_rr_graph_block_types(context);
-        os << "<block_types>\n";
-        write_block_types(in, os, child_context);
-        os << "</block_types>\n";
-    }
-    {
-        auto child_context = in.get_rr_graph_grid(context);
-        os << "<grid>\n";
-        write_grid_locs(in, os, child_context);
-        os << "</grid>\n";
-    }
-    {
-        auto child_context = in.get_rr_graph_rr_nodes(context);
-        os << "<rr_nodes>\n";
-        write_rr_nodes(in, os, child_context);
-        os << "</rr_nodes>\n";
-    }
-    {
-        auto child_context = in.get_rr_graph_rr_edges(context);
-        os << "<rr_edges>\n";
-        write_rr_edges(in, os, child_context);
-        os << "</rr_edges>\n";
-    }
+inline void write_edge_ptn(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_edge_ptn_ddiff(context); i<n; i++){
+			auto child_context = in.get_edge_ptn_ddiff(i, context);
+			os << "<ddiff";
+			os << " id=\"" << in.get_ddiff_id(child_context) << "\"";
+			os << "/>\n";
+		}
+	}
 }
 
-inline void dfa_error(const char* wrong, const int* states, const char* const* lookup, int len, const std::function<void(const char*)>* report_error) {
-    std::vector<std::string> expected;
-    for (int i = 0; i < len; i++) {
-        if (states[i] != -1) expected.push_back(lookup[i]);
-    }
+template<class T, typename Context>
+inline void write_rr_edge_ptns(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		for(size_t i=0, n=in.num_rr_edge_ptns_edge_ptn(context); i<n; i++){
+			auto child_context = in.get_rr_edge_ptns_edge_ptn(i, context);
+			os << "<edge_ptn";
+			os << " id=\"" << in.get_edge_ptn_id(child_context) << "\"";
+			os << " switch_id=\"" << in.get_edge_ptn_switch_id(child_context) << "\"";
+			os << ">";
+			write_edge_ptn(in, os, child_context);
+			os << "</edge_ptn>\n";
+		}
+	}
+}
 
-    std::string expected_or = expected[0];
-    for (unsigned int i = 1; i < expected.size(); i++)
-        expected_or += std::string(" or ") + expected[i];
+template<class T, typename Context>
+inline void write_rr_graph(T &in, std::ostream &os, Context &context){
+	(void)in;
+	(void)os;
+	(void)context;
+	{
+		auto child_context = in.get_rr_graph_channels(context);
+		os << "<channels>\n";
+		write_channels(in, os, child_context);
+		os << "</channels>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_switches(context);
+		os << "<switches>\n";
+		write_switches(in, os, child_context);
+		os << "</switches>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_segments(context);
+		os << "<segments>\n";
+		write_segments(in, os, child_context);
+		os << "</segments>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_block_types(context);
+		os << "<block_types>\n";
+		write_block_types(in, os, child_context);
+		os << "</block_types>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_grid(context);
+		os << "<grid>\n";
+		write_grid_locs(in, os, child_context);
+		os << "</grid>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_rr_nodes(context);
+		os << "<rr_nodes>\n";
+		write_rr_nodes(in, os, child_context);
+		os << "</rr_nodes>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_rr_node_e_ptns(context);
+		os << "<rr_node_e_ptns>\n";
+		write_rr_node_e_ptns(in, os, child_context);
+		os << "</rr_node_e_ptns>\n";
+	}
+	{
+		auto child_context = in.get_rr_graph_rr_edge_ptns(context);
+		os << "<rr_edge_ptns>\n";
+		write_rr_edge_ptns(in, os, child_context);
+		os << "</rr_edge_ptns>\n";
+	}
+}
 
-    noreturn_report(report_error, ("Expected " + expected_or + ", found " + std::string(wrong)).c_str());
+inline void dfa_error(const char *wrong, const int *states, const char * const *lookup, int len, const std::function<void(const char *)> * report_error){
+	std::vector<std::string> expected;
+	for(int i=0; i<len; i++){
+		if(states[i] != -1) expected.push_back(lookup[i]);
+	}
+
+	std::string expected_or = expected[0];
+	for(unsigned int i=1; i<expected.size(); i++)
+		expected_or += std::string(" or ") + expected[i];
+
+	noreturn_report(report_error, ("Expected " + expected_or + ", found " + std::string(wrong)).c_str());
 }
 
 template<std::size_t N>
-inline void all_error(std::bitset<N> gstate, const char* const* lookup, const std::function<void(const char*)>* report_error) {
-    std::vector<std::string> missing;
-    for (unsigned int i = 0; i < N; i++) {
-        if (gstate[i] == 0) missing.push_back(lookup[i]);
-    }
+inline void all_error(std::bitset<N> gstate, const char * const *lookup, const std::function<void(const char *)> * report_error){
+	std::vector<std::string> missing;
+	for(unsigned int i=0; i<N; i++){
+		if(gstate[i] == 0) missing.push_back(lookup[i]);
+	}
 
-    std::string missing_and = missing[0];
-    for (unsigned int i = 1; i < missing.size(); i++)
-        missing_and += std::string(", ") + missing[i];
+	std::string missing_and = missing[0];
+	for(unsigned int i=1; i<missing.size(); i++)
+		missing_and += std::string(", ") + missing[i];
 
-    noreturn_report(report_error, ("Didn't find required elements " + missing_and + ".").c_str());
+	noreturn_report(report_error, ("Didn't find required elements " + missing_and + ".").c_str());
 }
 
 template<std::size_t N>
-inline void attr_error(std::bitset<N> astate, const char* const* lookup, const std::function<void(const char*)>* report_error) {
-    std::vector<std::string> missing;
-    for (unsigned int i = 0; i < N; i++) {
-        if (astate[i] == 0) missing.push_back(lookup[i]);
-    }
+inline void attr_error(std::bitset<N> astate, const char * const *lookup, const std::function<void(const char *)> * report_error){
+	std::vector<std::string> missing;
+	for(unsigned int i=0; i<N; i++){
+		if(astate[i] == 0) missing.push_back(lookup[i]);
+	}
 
-    std::string missing_and = missing[0];
-    for (unsigned int i = 1; i < missing.size(); i++)
-        missing_and += std::string(", ") + missing[i];
+	std::string missing_and = missing[0];
+	for(unsigned int i=1; i<missing.size(); i++)
+		missing_and += std::string(", ") + missing[i];
 
-    noreturn_report(report_error, ("Didn't find required attributes " + missing_and + ".").c_str());
+	noreturn_report(report_error, ("Didn't find required attributes " + missing_and + ".").c_str());
 }
 
-inline void get_line_number(const char* filename, std::ptrdiff_t target_offset, int* line, int* col) {
-    std::unique_ptr<FILE, decltype(&fclose)> f(fopen(filename, "rb"), fclose);
+inline void get_line_number(const char *filename, std::ptrdiff_t target_offset, int * line, int * col) {
+	std::unique_ptr<FILE,decltype(&fclose)> f(fopen(filename, "rb"), fclose);
 
-    if (!f) {
-        throw std::runtime_error(std::string("Failed to open file") + filename);
-    }
+	if (!f) {
+		throw std::runtime_error(std::string("Failed to open file") + filename);
+	}
 
-    int current_line = 1;
-    std::ptrdiff_t offset = 0;
-    std::ptrdiff_t last_line_offset = 0;
-    std::ptrdiff_t current_line_offset = 0;
+	int current_line = 1;
+	std::ptrdiff_t offset = 0;
+	std::ptrdiff_t last_line_offset = 0;
+	std::ptrdiff_t current_line_offset = 0;
 
-    char buffer[1024];
-    std::size_t size;
+	char buffer[1024];
+	std::size_t size;
 
-    while ((size = fread(buffer, 1, sizeof(buffer), f.get())) > 0) {
-        for (std::size_t i = 0; i < size; ++i) {
-            if (buffer[i] == '\n') {
-                current_line += 1;
-                last_line_offset = current_line_offset;
-                current_line_offset = offset + i;
+	while ((size = fread(buffer, 1, sizeof(buffer), f.get())) > 0) {
+		for (std::size_t i = 0; i < size; ++i) {
+			if (buffer[i] == '\n') {
+				current_line += 1;
+				last_line_offset = current_line_offset;
+				current_line_offset = offset + i;
 
-                if (target_offset < current_line_offset) {
-                    if (target_offset < last_line_offset) {
-                        throw std::runtime_error("Assertion violation");
-                    }
+				if(target_offset < current_line_offset) {
+					if(target_offset < last_line_offset) {
+						throw std::runtime_error("Assertion violation");
+					}
 
-                    *line = current_line - 1;
-                    *col = target_offset - last_line_offset;
-                    return;
-                }
-            }
-        }
+					*line = current_line - 1;
+					*col = target_offset - last_line_offset;
+					return;
+				}
+			}
+		}
 
-        offset += size;
-    }
+		offset += size;
+	}
 
-    *line = current_line;
-    *col = target_offset - current_line_offset;
+	*line = current_line;
+	*col = target_offset - current_line_offset;
 }
+
 
 } /* namespace uxsd */

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcap.py /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
- * Input file: /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
- * md5sum of input file: cd57d47fc9dfa62c7030397ca759217e
+ * Cmdline: uxsdcxx/uxsdcap.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+ * Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+ * md5sum of input file: 5c529f385cc39043f69229d620e94c98
  */
 
 #include <functional>
@@ -23,1249 +23,1385 @@
 /* All uxsdcxx functions and structs live in this namespace. */
 namespace uxsd {
 /* Declarations for internal load functions for the complex types. */
-template<class T, typename Context>
-void load_channel_capnp_type(const ucap::Channel::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_x_list_capnp_type(const ucap::XList::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_y_list_capnp_type(const ucap::YList::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_channels_capnp_type(const ucap::Channels::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_timing_capnp_type(const ucap::Timing::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_sizing_capnp_type(const ucap::Sizing::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_switch_capnp_type(const ucap::Switch::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_switches_capnp_type(const ucap::Switches::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_segment_timing_capnp_type(const ucap::SegmentTiming::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_segment_capnp_type(const ucap::Segment::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_segments_capnp_type(const ucap::Segments::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_pin_capnp_type(const ucap::Pin::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_pin_class_capnp_type(const ucap::PinClass::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_block_type_capnp_type(const ucap::BlockType::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_block_types_capnp_type(const ucap::BlockTypes::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_grid_loc_capnp_type(const ucap::GridLoc::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_grid_locs_capnp_type(const ucap::GridLocs::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_node_loc_capnp_type(const ucap::NodeLoc::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_node_timing_capnp_type(const ucap::NodeTiming::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_node_segment_capnp_type(const ucap::NodeSegment::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_meta_capnp_type(const ucap::Meta::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_metadata_capnp_type(const ucap::Metadata::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_node_capnp_type(const ucap::Node::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_rr_nodes_capnp_type(const ucap::RrNodes::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_edge_capnp_type(const ucap::Edge::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_rr_edges_capnp_type(const ucap::RrEdges::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
-template<class T, typename Context>
-void load_rr_graph_capnp_type(const ucap::RrGraph::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack);
+template <class T, typename Context>
+void load_channel_capnp_type(const ucap::Channel::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_x_list_capnp_type(const ucap::XList::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_y_list_capnp_type(const ucap::YList::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_channels_capnp_type(const ucap::Channels::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_timing_capnp_type(const ucap::Timing::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_sizing_capnp_type(const ucap::Sizing::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_switch_capnp_type(const ucap::Switch::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_switches_capnp_type(const ucap::Switches::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_segment_timing_capnp_type(const ucap::SegmentTiming::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_segment_capnp_type(const ucap::Segment::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_segments_capnp_type(const ucap::Segments::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_pin_capnp_type(const ucap::Pin::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_pin_class_capnp_type(const ucap::PinClass::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_block_type_capnp_type(const ucap::BlockType::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_block_types_capnp_type(const ucap::BlockTypes::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_grid_loc_capnp_type(const ucap::GridLoc::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_grid_locs_capnp_type(const ucap::GridLocs::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_node_loc_capnp_type(const ucap::NodeLoc::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_node_timing_capnp_type(const ucap::NodeTiming::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_node_segment_capnp_type(const ucap::NodeSegment::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_meta_capnp_type(const ucap::Meta::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_metadata_capnp_type(const ucap::Metadata::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_node_capnp_type(const ucap::Node::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_rr_nodes_capnp_type(const ucap::RrNodes::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_e_ptn_capnp_type(const ucap::EPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_node_e_ptn_capnp_type(const ucap::NodeEPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_rr_node_e_ptns_capnp_type(const ucap::RrNodeEPtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_ddiff_capnp_type(const ucap::Ddiff::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_edge_ptn_capnp_type(const ucap::EdgePtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_rr_edge_ptns_capnp_type(const ucap::RrEdgePtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_rr_graph_capnp_type(const ucap::RrGraph::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
 
 /* Declarations for internal write functions for the complex types. */
-template<class T, typename Context>
-inline void write_channels_capnp_type(T& in, ucap::Channels::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_switch_capnp_type(T& in, ucap::Switch::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_switches_capnp_type(T& in, ucap::Switches::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_segment_capnp_type(T& in, ucap::Segment::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_segments_capnp_type(T& in, ucap::Segments::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_pin_capnp_type(T& in, ucap::Pin::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_pin_class_capnp_type(T& in, ucap::PinClass::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_block_type_capnp_type(T& in, ucap::BlockType::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_block_types_capnp_type(T& in, ucap::BlockTypes::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_grid_locs_capnp_type(T& in, ucap::GridLocs::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_meta_capnp_type(T& in, ucap::Meta::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_metadata_capnp_type(T& in, ucap::Metadata::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_node_capnp_type(T& in, ucap::Node::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_rr_nodes_capnp_type(T& in, ucap::RrNodes::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_edge_capnp_type(T& in, ucap::Edge::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_rr_edges_capnp_type(T& in, ucap::RrEdges::Builder& root, Context& context);
-template<class T, typename Context>
-inline void write_rr_graph_capnp_type(T& in, ucap::RrGraph::Builder& root, Context& context);
+template <class T, typename Context>
+inline void write_channels_capnp_type(T &in, ucap::Channels::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_switch_capnp_type(T &in, ucap::Switch::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_switches_capnp_type(T &in, ucap::Switches::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_segment_capnp_type(T &in, ucap::Segment::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_segments_capnp_type(T &in, ucap::Segments::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_pin_capnp_type(T &in, ucap::Pin::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_pin_class_capnp_type(T &in, ucap::PinClass::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_block_type_capnp_type(T &in, ucap::BlockType::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_block_types_capnp_type(T &in, ucap::BlockTypes::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_grid_locs_capnp_type(T &in, ucap::GridLocs::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_meta_capnp_type(T &in, ucap::Meta::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_metadata_capnp_type(T &in, ucap::Metadata::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_node_capnp_type(T &in, ucap::Node::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_rr_nodes_capnp_type(T &in, ucap::RrNodes::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_node_e_ptn_capnp_type(T &in, ucap::NodeEPtn::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_rr_node_e_ptns_capnp_type(T &in, ucap::RrNodeEPtns::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_edge_ptn_capnp_type(T &in, ucap::EdgePtn::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_rr_edge_ptns_capnp_type(T &in, ucap::RrEdgePtns::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_rr_graph_capnp_type(T &in, ucap::RrGraph::Builder &root, Context &context);
 
 /* Enum conversions from uxsd to ucap */
-inline enum_switch_type conv_enum_switch_type(ucap::SwitchType e, const std::function<void(const char*)>* report_error) {
-    switch (e) {
-        case ucap::SwitchType::UXSD_INVALID:
-            return enum_switch_type::UXSD_INVALID;
-        case ucap::SwitchType::MUX:
-            return enum_switch_type::MUX;
-        case ucap::SwitchType::TRISTATE:
-            return enum_switch_type::TRISTATE;
-        case ucap::SwitchType::PASS_GATE:
-            return enum_switch_type::PASS_GATE;
-        case ucap::SwitchType::SHORT:
-            return enum_switch_type::SHORT;
-        case ucap::SwitchType::BUFFER:
-            return enum_switch_type::BUFFER;
-        default:
-            (*report_error)("Unknown enum_switch_type");
-            throw std::runtime_error("Unreachable!");
-    }
+inline enum_switch_type conv_enum_switch_type(ucap::SwitchType e, const std::function<void(const char *)> * report_error) {
+	switch(e) {
+	case ucap::SwitchType::UXSD_INVALID:
+		return enum_switch_type::UXSD_INVALID;
+	case ucap::SwitchType::MUX:
+		return enum_switch_type::MUX;
+	case ucap::SwitchType::TRISTATE:
+		return enum_switch_type::TRISTATE;
+	case ucap::SwitchType::PASS_GATE:
+		return enum_switch_type::PASS_GATE;
+	case ucap::SwitchType::SHORT:
+		return enum_switch_type::SHORT;
+	case ucap::SwitchType::BUFFER:
+		return enum_switch_type::BUFFER;
+	default:
+		(*report_error)("Unknown enum_switch_type");
+		throw std::runtime_error("Unreachable!");
+	}
 }
 
 inline ucap::SwitchType conv_to_enum_switch_type(enum_switch_type e) {
-    switch (e) {
-        case enum_switch_type::UXSD_INVALID:
-            return ucap::SwitchType::UXSD_INVALID;
-        case enum_switch_type::MUX:
-            return ucap::SwitchType::MUX;
-        case enum_switch_type::TRISTATE:
-            return ucap::SwitchType::TRISTATE;
-        case enum_switch_type::PASS_GATE:
-            return ucap::SwitchType::PASS_GATE;
-        case enum_switch_type::SHORT:
-            return ucap::SwitchType::SHORT;
-        case enum_switch_type::BUFFER:
-            return ucap::SwitchType::BUFFER;
-        default:
-            throw std::runtime_error("Unknown enum_switch_type");
-    }
+	switch(e) {
+	case enum_switch_type::UXSD_INVALID:
+		return ucap::SwitchType::UXSD_INVALID;
+	case enum_switch_type::MUX:
+		return ucap::SwitchType::MUX;
+	case enum_switch_type::TRISTATE:
+		return ucap::SwitchType::TRISTATE;
+	case enum_switch_type::PASS_GATE:
+		return ucap::SwitchType::PASS_GATE;
+	case enum_switch_type::SHORT:
+		return ucap::SwitchType::SHORT;
+	case enum_switch_type::BUFFER:
+		return ucap::SwitchType::BUFFER;
+	default:
+		throw std::runtime_error("Unknown enum_switch_type");
+	}
 }
 
-inline enum_pin_type conv_enum_pin_type(ucap::PinType e, const std::function<void(const char*)>* report_error) {
-    switch (e) {
-        case ucap::PinType::UXSD_INVALID:
-            return enum_pin_type::UXSD_INVALID;
-        case ucap::PinType::OPEN:
-            return enum_pin_type::OPEN;
-        case ucap::PinType::OUTPUT:
-            return enum_pin_type::OUTPUT;
-        case ucap::PinType::INPUT:
-            return enum_pin_type::INPUT;
-        default:
-            (*report_error)("Unknown enum_pin_type");
-            throw std::runtime_error("Unreachable!");
-    }
+inline enum_pin_type conv_enum_pin_type(ucap::PinType e, const std::function<void(const char *)> * report_error) {
+	switch(e) {
+	case ucap::PinType::UXSD_INVALID:
+		return enum_pin_type::UXSD_INVALID;
+	case ucap::PinType::OPEN:
+		return enum_pin_type::OPEN;
+	case ucap::PinType::OUTPUT:
+		return enum_pin_type::OUTPUT;
+	case ucap::PinType::INPUT:
+		return enum_pin_type::INPUT;
+	default:
+		(*report_error)("Unknown enum_pin_type");
+		throw std::runtime_error("Unreachable!");
+	}
 }
 
 inline ucap::PinType conv_to_enum_pin_type(enum_pin_type e) {
-    switch (e) {
-        case enum_pin_type::UXSD_INVALID:
-            return ucap::PinType::UXSD_INVALID;
-        case enum_pin_type::OPEN:
-            return ucap::PinType::OPEN;
-        case enum_pin_type::OUTPUT:
-            return ucap::PinType::OUTPUT;
-        case enum_pin_type::INPUT:
-            return ucap::PinType::INPUT;
-        default:
-            throw std::runtime_error("Unknown enum_pin_type");
-    }
+	switch(e) {
+	case enum_pin_type::UXSD_INVALID:
+		return ucap::PinType::UXSD_INVALID;
+	case enum_pin_type::OPEN:
+		return ucap::PinType::OPEN;
+	case enum_pin_type::OUTPUT:
+		return ucap::PinType::OUTPUT;
+	case enum_pin_type::INPUT:
+		return ucap::PinType::INPUT;
+	default:
+		throw std::runtime_error("Unknown enum_pin_type");
+	}
 }
 
-inline enum_node_type conv_enum_node_type(ucap::NodeType e, const std::function<void(const char*)>* report_error) {
-    switch (e) {
-        case ucap::NodeType::UXSD_INVALID:
-            return enum_node_type::UXSD_INVALID;
-        case ucap::NodeType::CHANX:
-            return enum_node_type::CHANX;
-        case ucap::NodeType::CHANY:
-            return enum_node_type::CHANY;
-        case ucap::NodeType::SOURCE:
-            return enum_node_type::SOURCE;
-        case ucap::NodeType::SINK:
-            return enum_node_type::SINK;
-        case ucap::NodeType::OPIN:
-            return enum_node_type::OPIN;
-        case ucap::NodeType::IPIN:
-            return enum_node_type::IPIN;
-        default:
-            (*report_error)("Unknown enum_node_type");
-            throw std::runtime_error("Unreachable!");
-    }
+inline enum_node_type conv_enum_node_type(ucap::NodeType e, const std::function<void(const char *)> * report_error) {
+	switch(e) {
+	case ucap::NodeType::UXSD_INVALID:
+		return enum_node_type::UXSD_INVALID;
+	case ucap::NodeType::CHANX:
+		return enum_node_type::CHANX;
+	case ucap::NodeType::CHANY:
+		return enum_node_type::CHANY;
+	case ucap::NodeType::SOURCE:
+		return enum_node_type::SOURCE;
+	case ucap::NodeType::SINK:
+		return enum_node_type::SINK;
+	case ucap::NodeType::OPIN:
+		return enum_node_type::OPIN;
+	case ucap::NodeType::IPIN:
+		return enum_node_type::IPIN;
+	default:
+		(*report_error)("Unknown enum_node_type");
+		throw std::runtime_error("Unreachable!");
+	}
 }
 
 inline ucap::NodeType conv_to_enum_node_type(enum_node_type e) {
-    switch (e) {
-        case enum_node_type::UXSD_INVALID:
-            return ucap::NodeType::UXSD_INVALID;
-        case enum_node_type::CHANX:
-            return ucap::NodeType::CHANX;
-        case enum_node_type::CHANY:
-            return ucap::NodeType::CHANY;
-        case enum_node_type::SOURCE:
-            return ucap::NodeType::SOURCE;
-        case enum_node_type::SINK:
-            return ucap::NodeType::SINK;
-        case enum_node_type::OPIN:
-            return ucap::NodeType::OPIN;
-        case enum_node_type::IPIN:
-            return ucap::NodeType::IPIN;
-        default:
-            throw std::runtime_error("Unknown enum_node_type");
-    }
+	switch(e) {
+	case enum_node_type::UXSD_INVALID:
+		return ucap::NodeType::UXSD_INVALID;
+	case enum_node_type::CHANX:
+		return ucap::NodeType::CHANX;
+	case enum_node_type::CHANY:
+		return ucap::NodeType::CHANY;
+	case enum_node_type::SOURCE:
+		return ucap::NodeType::SOURCE;
+	case enum_node_type::SINK:
+		return ucap::NodeType::SINK;
+	case enum_node_type::OPIN:
+		return ucap::NodeType::OPIN;
+	case enum_node_type::IPIN:
+		return ucap::NodeType::IPIN;
+	default:
+		throw std::runtime_error("Unknown enum_node_type");
+	}
 }
 
-inline enum_node_direction conv_enum_node_direction(ucap::NodeDirection e, const std::function<void(const char*)>* report_error) {
-    switch (e) {
-        case ucap::NodeDirection::UXSD_INVALID:
-            return enum_node_direction::UXSD_INVALID;
-        case ucap::NodeDirection::INC_DIR:
-            return enum_node_direction::INC_DIR;
-        case ucap::NodeDirection::DEC_DIR:
-            return enum_node_direction::DEC_DIR;
-        case ucap::NodeDirection::BI_DIR:
-            return enum_node_direction::BI_DIR;
-        default:
-            (*report_error)("Unknown enum_node_direction");
-            throw std::runtime_error("Unreachable!");
-    }
+inline enum_node_direction conv_enum_node_direction(ucap::NodeDirection e, const std::function<void(const char *)> * report_error) {
+	switch(e) {
+	case ucap::NodeDirection::UXSD_INVALID:
+		return enum_node_direction::UXSD_INVALID;
+	case ucap::NodeDirection::INC_DIR:
+		return enum_node_direction::INC_DIR;
+	case ucap::NodeDirection::DEC_DIR:
+		return enum_node_direction::DEC_DIR;
+	case ucap::NodeDirection::BI_DIR:
+		return enum_node_direction::BI_DIR;
+	default:
+		(*report_error)("Unknown enum_node_direction");
+		throw std::runtime_error("Unreachable!");
+	}
 }
 
 inline ucap::NodeDirection conv_to_enum_node_direction(enum_node_direction e) {
-    switch (e) {
-        case enum_node_direction::UXSD_INVALID:
-            return ucap::NodeDirection::UXSD_INVALID;
-        case enum_node_direction::INC_DIR:
-            return ucap::NodeDirection::INC_DIR;
-        case enum_node_direction::DEC_DIR:
-            return ucap::NodeDirection::DEC_DIR;
-        case enum_node_direction::BI_DIR:
-            return ucap::NodeDirection::BI_DIR;
-        default:
-            throw std::runtime_error("Unknown enum_node_direction");
-    }
+	switch(e) {
+	case enum_node_direction::UXSD_INVALID:
+		return ucap::NodeDirection::UXSD_INVALID;
+	case enum_node_direction::INC_DIR:
+		return ucap::NodeDirection::INC_DIR;
+	case enum_node_direction::DEC_DIR:
+		return ucap::NodeDirection::DEC_DIR;
+	case enum_node_direction::BI_DIR:
+		return ucap::NodeDirection::BI_DIR;
+	default:
+		throw std::runtime_error("Unknown enum_node_direction");
+	}
 }
 
-inline enum_loc_side conv_enum_loc_side(ucap::LocSide e, const std::function<void(const char*)>* report_error) {
-    switch (e) {
-        case ucap::LocSide::UXSD_INVALID:
-            return enum_loc_side::UXSD_INVALID;
-        case ucap::LocSide::LEFT:
-            return enum_loc_side::LEFT;
-        case ucap::LocSide::RIGHT:
-            return enum_loc_side::RIGHT;
-        case ucap::LocSide::TOP:
-            return enum_loc_side::TOP;
-        case ucap::LocSide::BOTTOM:
-            return enum_loc_side::BOTTOM;
-        case ucap::LocSide::RIGHT_LEFT:
-            return enum_loc_side::RIGHT_LEFT;
-        case ucap::LocSide::RIGHT_BOTTOM:
-            return enum_loc_side::RIGHT_BOTTOM;
-        case ucap::LocSide::RIGHT_BOTTOM_LEFT:
-            return enum_loc_side::RIGHT_BOTTOM_LEFT;
-        case ucap::LocSide::TOP_RIGHT:
-            return enum_loc_side::TOP_RIGHT;
-        case ucap::LocSide::TOP_BOTTOM:
-            return enum_loc_side::TOP_BOTTOM;
-        case ucap::LocSide::TOP_LEFT:
-            return enum_loc_side::TOP_LEFT;
-        case ucap::LocSide::TOP_RIGHT_BOTTOM:
-            return enum_loc_side::TOP_RIGHT_BOTTOM;
-        case ucap::LocSide::TOP_RIGHT_LEFT:
-            return enum_loc_side::TOP_RIGHT_LEFT;
-        case ucap::LocSide::TOP_BOTTOM_LEFT:
-            return enum_loc_side::TOP_BOTTOM_LEFT;
-        case ucap::LocSide::TOP_RIGHT_BOTTOM_LEFT:
-            return enum_loc_side::TOP_RIGHT_BOTTOM_LEFT;
-        case ucap::LocSide::BOTTOM_LEFT:
-            return enum_loc_side::BOTTOM_LEFT;
-        default:
-            (*report_error)("Unknown enum_loc_side");
-            throw std::runtime_error("Unreachable!");
-    }
+inline enum_loc_side conv_enum_loc_side(ucap::LocSide e, const std::function<void(const char *)> * report_error) {
+	switch(e) {
+	case ucap::LocSide::UXSD_INVALID:
+		return enum_loc_side::UXSD_INVALID;
+	case ucap::LocSide::LEFT:
+		return enum_loc_side::LEFT;
+	case ucap::LocSide::RIGHT:
+		return enum_loc_side::RIGHT;
+	case ucap::LocSide::TOP:
+		return enum_loc_side::TOP;
+	case ucap::LocSide::BOTTOM:
+		return enum_loc_side::BOTTOM;
+	case ucap::LocSide::RIGHT_LEFT:
+		return enum_loc_side::RIGHT_LEFT;
+	case ucap::LocSide::RIGHT_BOTTOM:
+		return enum_loc_side::RIGHT_BOTTOM;
+	case ucap::LocSide::RIGHT_BOTTOM_LEFT:
+		return enum_loc_side::RIGHT_BOTTOM_LEFT;
+	case ucap::LocSide::TOP_RIGHT:
+		return enum_loc_side::TOP_RIGHT;
+	case ucap::LocSide::TOP_BOTTOM:
+		return enum_loc_side::TOP_BOTTOM;
+	case ucap::LocSide::TOP_LEFT:
+		return enum_loc_side::TOP_LEFT;
+	case ucap::LocSide::TOP_RIGHT_BOTTOM:
+		return enum_loc_side::TOP_RIGHT_BOTTOM;
+	case ucap::LocSide::TOP_RIGHT_LEFT:
+		return enum_loc_side::TOP_RIGHT_LEFT;
+	case ucap::LocSide::TOP_BOTTOM_LEFT:
+		return enum_loc_side::TOP_BOTTOM_LEFT;
+	case ucap::LocSide::TOP_RIGHT_BOTTOM_LEFT:
+		return enum_loc_side::TOP_RIGHT_BOTTOM_LEFT;
+	case ucap::LocSide::BOTTOM_LEFT:
+		return enum_loc_side::BOTTOM_LEFT;
+	default:
+		(*report_error)("Unknown enum_loc_side");
+		throw std::runtime_error("Unreachable!");
+	}
 }
 
 inline ucap::LocSide conv_to_enum_loc_side(enum_loc_side e) {
-    switch (e) {
-        case enum_loc_side::UXSD_INVALID:
-            return ucap::LocSide::UXSD_INVALID;
-        case enum_loc_side::LEFT:
-            return ucap::LocSide::LEFT;
-        case enum_loc_side::RIGHT:
-            return ucap::LocSide::RIGHT;
-        case enum_loc_side::TOP:
-            return ucap::LocSide::TOP;
-        case enum_loc_side::BOTTOM:
-            return ucap::LocSide::BOTTOM;
-        case enum_loc_side::RIGHT_LEFT:
-            return ucap::LocSide::RIGHT_LEFT;
-        case enum_loc_side::RIGHT_BOTTOM:
-            return ucap::LocSide::RIGHT_BOTTOM;
-        case enum_loc_side::RIGHT_BOTTOM_LEFT:
-            return ucap::LocSide::RIGHT_BOTTOM_LEFT;
-        case enum_loc_side::TOP_RIGHT:
-            return ucap::LocSide::TOP_RIGHT;
-        case enum_loc_side::TOP_BOTTOM:
-            return ucap::LocSide::TOP_BOTTOM;
-        case enum_loc_side::TOP_LEFT:
-            return ucap::LocSide::TOP_LEFT;
-        case enum_loc_side::TOP_RIGHT_BOTTOM:
-            return ucap::LocSide::TOP_RIGHT_BOTTOM;
-        case enum_loc_side::TOP_RIGHT_LEFT:
-            return ucap::LocSide::TOP_RIGHT_LEFT;
-        case enum_loc_side::TOP_BOTTOM_LEFT:
-            return ucap::LocSide::TOP_BOTTOM_LEFT;
-        case enum_loc_side::TOP_RIGHT_BOTTOM_LEFT:
-            return ucap::LocSide::TOP_RIGHT_BOTTOM_LEFT;
-        case enum_loc_side::BOTTOM_LEFT:
-            return ucap::LocSide::BOTTOM_LEFT;
-        default:
-            throw std::runtime_error("Unknown enum_loc_side");
-    }
+	switch(e) {
+	case enum_loc_side::UXSD_INVALID:
+		return ucap::LocSide::UXSD_INVALID;
+	case enum_loc_side::LEFT:
+		return ucap::LocSide::LEFT;
+	case enum_loc_side::RIGHT:
+		return ucap::LocSide::RIGHT;
+	case enum_loc_side::TOP:
+		return ucap::LocSide::TOP;
+	case enum_loc_side::BOTTOM:
+		return ucap::LocSide::BOTTOM;
+	case enum_loc_side::RIGHT_LEFT:
+		return ucap::LocSide::RIGHT_LEFT;
+	case enum_loc_side::RIGHT_BOTTOM:
+		return ucap::LocSide::RIGHT_BOTTOM;
+	case enum_loc_side::RIGHT_BOTTOM_LEFT:
+		return ucap::LocSide::RIGHT_BOTTOM_LEFT;
+	case enum_loc_side::TOP_RIGHT:
+		return ucap::LocSide::TOP_RIGHT;
+	case enum_loc_side::TOP_BOTTOM:
+		return ucap::LocSide::TOP_BOTTOM;
+	case enum_loc_side::TOP_LEFT:
+		return ucap::LocSide::TOP_LEFT;
+	case enum_loc_side::TOP_RIGHT_BOTTOM:
+		return ucap::LocSide::TOP_RIGHT_BOTTOM;
+	case enum_loc_side::TOP_RIGHT_LEFT:
+		return ucap::LocSide::TOP_RIGHT_LEFT;
+	case enum_loc_side::TOP_BOTTOM_LEFT:
+		return ucap::LocSide::TOP_BOTTOM_LEFT;
+	case enum_loc_side::TOP_RIGHT_BOTTOM_LEFT:
+		return ucap::LocSide::TOP_RIGHT_BOTTOM_LEFT;
+	case enum_loc_side::BOTTOM_LEFT:
+		return ucap::LocSide::BOTTOM_LEFT;
+	default:
+		throw std::runtime_error("Unknown enum_loc_side");
+	}
 }
 
-/* Load function for the root element. */
-template<class T, typename Context>
-inline void load_rr_graph_capnp(T& out, kj::ArrayPtr<const ::capnp::word> data, Context& context, const char* filename) {
-    /* Remove traversal limits. */
-    ::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
-    opts.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
-    ::capnp::FlatArrayMessageReader reader(data, opts);
-    auto root = reader.getRoot<ucap::RrGraph>();
-    std::vector<std::pair<const char*, size_t>> stack;
-    stack.reserve(20);
-    stack.push_back(std::make_pair("root", 0));
 
-    std::function<void(const char*)> report_error = [filename, &out, &stack](const char* message) {
-        std::stringstream msg;
-        msg << message << std::endl;
-        msg << "Error occured at ";
-        for (size_t i = 0; i < stack.size(); ++i) {
-            msg << stack[i].first << "[" << stack[i].second << "]";
-            if (i + 1 < stack.size()) {
-                msg << " . ";
-            }
-        }
-        out.error_encountered(filename, -1, msg.str().c_str());
-    };
-    out.start_load(&report_error);
-    load_rr_graph_capnp_type(root, out, context, &report_error, &stack);
-    out.finish_load();
+/* Load function for the root element. */
+template <class T, typename Context>
+inline void load_rr_graph_capnp(T &out, kj::ArrayPtr<const ::capnp::word> data, Context &context, const char * filename){
+	/* Remove traversal limits. */
+	::capnp::ReaderOptions opts = ::capnp::ReaderOptions();
+	opts.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
+	::capnp::FlatArrayMessageReader reader(data, opts);
+	auto root = reader.getRoot<ucap::RrGraph>();
+	std::vector<std::pair<const char*, size_t>> stack;
+	stack.reserve(20);
+	stack.push_back(std::make_pair("root", 0));
+
+	std::function<void(const char *)> report_error = [filename, &out, &stack](const char *message){
+		std::stringstream msg;
+		msg << message << std::endl;
+		msg << "Error occured at ";
+		for(size_t i = 0; i < stack.size(); ++i) {
+			msg << stack[i].first << "[" << stack[i].second << "]";
+			if(i+1 < stack.size()) {
+				msg << " . ";
+			}
+		}
+		out.error_encountered(filename, -1, msg.str().c_str());
+	};
+	out.start_load(&report_error);
+	load_rr_graph_capnp_type(root, out, context, &report_error, &stack);
+	out.finish_load();
 }
 
 /* Write function for the root element. */
-template<class T, typename Context>
-inline void write_rr_graph_capnp(T& in, Context& context, ucap::RrGraph::Builder& root) {
-    in.start_write();
-    if ((bool)in.get_rr_graph_tool_comment(context))
-        root.setToolComment(in.get_rr_graph_tool_comment(context));
-    if ((bool)in.get_rr_graph_tool_name(context))
-        root.setToolName(in.get_rr_graph_tool_name(context));
-    if ((bool)in.get_rr_graph_tool_version(context))
-        root.setToolVersion(in.get_rr_graph_tool_version(context));
-    write_rr_graph_capnp_type(in, root, context);
-    in.finish_write();
+template <class T, typename Context>
+inline void write_rr_graph_capnp(T &in, Context &context, ucap::RrGraph::Builder &root) {
+	in.start_write();
+	if((bool)in.get_rr_graph_tool_comment(context))
+		root.setToolComment(in.get_rr_graph_tool_comment(context));
+	if((bool)in.get_rr_graph_tool_name(context))
+		root.setToolName(in.get_rr_graph_tool_name(context));
+	if((bool)in.get_rr_graph_tool_version(context))
+		root.setToolVersion(in.get_rr_graph_tool_version(context));
+	write_rr_graph_capnp_type(in, root, context);
+	in.finish_write();
 }
+
 
 /* Internal loading functions, which validate and load a PugiXML DOM tree into memory. */
 template<class T, typename Context>
-inline void load_channel_capnp_type(const ucap::Channel::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_channel_capnp_type(const ucap::Channel::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_x_list_capnp_type(const ucap::XList::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_x_list_capnp_type(const ucap::XList::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_y_list_capnp_type(const ucap::YList::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_y_list_capnp_type(const ucap::YList::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_channels_capnp_type(const ucap::Channels::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_channels_capnp_type(const ucap::Channels::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getChannel", 0));
-    if (root.hasChannel()) {
-        auto child_el = root.getChannel();
-        auto child_context = out.init_channels_channel(context, child_el.getChanWidthMax(), child_el.getXMax(), child_el.getXMin(), child_el.getYMax(), child_el.getYMin());
-        load_channel_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_channels_channel(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getXList", 0));
-    {
-        auto data = root.getXLists();
-        out.preallocate_channels_x_list(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_channels_x_list(context, el.getIndex(), el.getInfo());
-            load_x_list_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_channels_x_list(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getYList", 0));
-    {
-        auto data = root.getYLists();
-        out.preallocate_channels_y_list(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_channels_y_list(context, el.getIndex(), el.getInfo());
-            load_y_list_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_channels_y_list(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getChannel", 0));
+	if (root.hasChannel()) {
+		auto child_el = root.getChannel();
+		auto child_context = out.init_channels_channel(context, child_el.getChanWidthMax(), child_el.getXMax(), child_el.getXMin(), child_el.getYMax(), child_el.getYMin());
+		load_channel_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_channels_channel(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getXList", 0));
+	{
+		auto data = root.getXLists();
+		out.preallocate_channels_x_list(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_channels_x_list(context, el.getIndex(), el.getInfo());
+			load_x_list_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_channels_x_list(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getYList", 0));
+	{
+		auto data = root.getYLists();
+		out.preallocate_channels_y_list(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_channels_y_list(context, el.getIndex(), el.getInfo());
+			load_y_list_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_channels_y_list(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_timing_capnp_type(const ucap::Timing::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_timing_capnp_type(const ucap::Timing::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_timing_Cin(root.getCin(), context);
-    out.set_timing_Cinternal(root.getCinternal(), context);
-    out.set_timing_Cout(root.getCout(), context);
-    out.set_timing_R(root.getR(), context);
-    out.set_timing_Tdel(root.getTdel(), context);
+	out.set_timing_Cin(root.getCin(), context);
+	out.set_timing_Cinternal(root.getCinternal(), context);
+	out.set_timing_Cout(root.getCout(), context);
+	out.set_timing_R(root.getR(), context);
+	out.set_timing_Tdel(root.getTdel(), context);
 }
 
 template<class T, typename Context>
-inline void load_sizing_capnp_type(const ucap::Sizing::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_sizing_capnp_type(const ucap::Sizing::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_switch_capnp_type(const ucap::Switch::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_switch_capnp_type(const ucap::Switch::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_switch_name(root.getName().cStr(), context);
-    out.set_switch_type(conv_enum_switch_type(root.getType(), report_error), context);
-    stack->push_back(std::make_pair("getTiming", 0));
-    if (root.hasTiming()) {
-        auto child_el = root.getTiming();
-        auto child_context = out.init_switch_timing(context);
-        load_timing_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_switch_timing(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getSizing", 0));
-    if (root.hasSizing()) {
-        auto child_el = root.getSizing();
-        auto child_context = out.init_switch_sizing(context, child_el.getBufSize(), child_el.getMuxTransSize());
-        load_sizing_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_switch_sizing(child_context);
-    }
-    stack->pop_back();
+	out.set_switch_name(root.getName().cStr(), context);
+	out.set_switch_type(conv_enum_switch_type(root.getType(), report_error), context);
+	stack->push_back(std::make_pair("getTiming", 0));
+	if (root.hasTiming()) {
+		auto child_el = root.getTiming();
+		auto child_context = out.init_switch_timing(context);
+		load_timing_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_switch_timing(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getSizing", 0));
+	if (root.hasSizing()) {
+		auto child_el = root.getSizing();
+		auto child_context = out.init_switch_sizing(context, child_el.getBufSize(), child_el.getMuxTransSize());
+		load_sizing_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_switch_sizing(child_context);
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_switches_capnp_type(const ucap::Switches::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_switches_capnp_type(const ucap::Switches::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getSwitch", 0));
-    {
-        auto data = root.getSwitches();
-        out.preallocate_switches_switch(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_switches_switch(context, el.getId());
-            load_switch_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_switches_switch(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getSwitch", 0));
+	{
+		auto data = root.getSwitches();
+		out.preallocate_switches_switch(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_switches_switch(context, el.getId());
+			load_switch_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_switches_switch(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_segment_timing_capnp_type(const ucap::SegmentTiming::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_segment_timing_capnp_type(const ucap::SegmentTiming::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_segment_timing_C_per_meter(root.getCPerMeter(), context);
-    out.set_segment_timing_R_per_meter(root.getRPerMeter(), context);
+	out.set_segment_timing_C_per_meter(root.getCPerMeter(), context);
+	out.set_segment_timing_R_per_meter(root.getRPerMeter(), context);
 }
 
 template<class T, typename Context>
-inline void load_segment_capnp_type(const ucap::Segment::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_segment_capnp_type(const ucap::Segment::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_segment_name(root.getName().cStr(), context);
-    stack->push_back(std::make_pair("getTiming", 0));
-    if (root.hasTiming()) {
-        auto child_el = root.getTiming();
-        auto child_context = out.init_segment_timing(context);
-        load_segment_timing_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_segment_timing(child_context);
-    }
-    stack->pop_back();
+	out.set_segment_name(root.getName().cStr(), context);
+	stack->push_back(std::make_pair("getTiming", 0));
+	if (root.hasTiming()) {
+		auto child_el = root.getTiming();
+		auto child_context = out.init_segment_timing(context);
+		load_segment_timing_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_segment_timing(child_context);
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_segments_capnp_type(const ucap::Segments::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_segments_capnp_type(const ucap::Segments::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getSegment", 0));
-    {
-        auto data = root.getSegments();
-        out.preallocate_segments_segment(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_segments_segment(context, el.getId());
-            load_segment_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_segments_segment(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getSegment", 0));
+	{
+		auto data = root.getSegments();
+		out.preallocate_segments_segment(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_segments_segment(context, el.getId());
+			load_segment_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_segments_segment(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_pin_capnp_type(const ucap::Pin::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_pin_capnp_type(const ucap::Pin::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getValue", 0));
-    out.set_pin_value(root.getValue().cStr(), context);
-    stack->pop_back();
+	stack->push_back(std::make_pair("getValue", 0));
+	out.set_pin_value(root.getValue().cStr(), context);
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_pin_class_capnp_type(const ucap::PinClass::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_pin_class_capnp_type(const ucap::PinClass::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getPin", 0));
-    {
-        auto data = root.getPins();
-        out.preallocate_pin_class_pin(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_pin_class_pin(context, el.getPtc());
-            load_pin_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_pin_class_pin(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getPin", 0));
+	{
+		auto data = root.getPins();
+		out.preallocate_pin_class_pin(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_pin_class_pin(context, el.getPtc());
+			load_pin_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_pin_class_pin(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_block_type_capnp_type(const ucap::BlockType::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_block_type_capnp_type(const ucap::BlockType::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_block_type_name(root.getName().cStr(), context);
-    stack->push_back(std::make_pair("getPinClass", 0));
-    {
-        auto data = root.getPinClasses();
-        out.preallocate_block_type_pin_class(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_block_type_pin_class(context, conv_enum_pin_type(el.getType(), report_error));
-            load_pin_class_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_block_type_pin_class(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	out.set_block_type_name(root.getName().cStr(), context);
+	stack->push_back(std::make_pair("getPinClass", 0));
+	{
+		auto data = root.getPinClasses();
+		out.preallocate_block_type_pin_class(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_block_type_pin_class(context, conv_enum_pin_type(el.getType(), report_error));
+			load_pin_class_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_block_type_pin_class(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_block_types_capnp_type(const ucap::BlockTypes::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_block_types_capnp_type(const ucap::BlockTypes::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getBlockType", 0));
-    {
-        auto data = root.getBlockTypes();
-        out.preallocate_block_types_block_type(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_block_types_block_type(context, el.getHeight(), el.getId(), el.getWidth());
-            load_block_type_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_block_types_block_type(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getBlockType", 0));
+	{
+		auto data = root.getBlockTypes();
+		out.preallocate_block_types_block_type(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_block_types_block_type(context, el.getHeight(), el.getId(), el.getWidth());
+			load_block_type_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_block_types_block_type(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_grid_loc_capnp_type(const ucap::GridLoc::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_grid_loc_capnp_type(const ucap::GridLoc::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_grid_locs_capnp_type(const ucap::GridLocs::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_grid_locs_capnp_type(const ucap::GridLocs::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getGridLoc", 0));
-    {
-        auto data = root.getGridLocs();
-        out.preallocate_grid_locs_grid_loc(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_grid_locs_grid_loc(context, el.getBlockTypeId(), el.getHeightOffset(), el.getWidthOffset(), el.getX(), el.getY());
-            load_grid_loc_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_grid_locs_grid_loc(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getGridLoc", 0));
+	{
+		auto data = root.getGridLocs();
+		out.preallocate_grid_locs_grid_loc(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_grid_locs_grid_loc(context, el.getBlockTypeId(), el.getHeightOffset(), el.getWidthOffset(), el.getX(), el.getY());
+			load_grid_loc_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_grid_locs_grid_loc(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_node_loc_capnp_type(const ucap::NodeLoc::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_node_loc_capnp_type(const ucap::NodeLoc::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_node_loc_side(conv_enum_loc_side(root.getSide(), report_error), context);
+	out.set_node_loc_side(conv_enum_loc_side(root.getSide(), report_error), context);
 }
 
 template<class T, typename Context>
-inline void load_node_timing_capnp_type(const ucap::NodeTiming::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_node_timing_capnp_type(const ucap::NodeTiming::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_node_segment_capnp_type(const ucap::NodeSegment::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_node_segment_capnp_type(const ucap::NodeSegment::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
 }
 
 template<class T, typename Context>
-inline void load_meta_capnp_type(const ucap::Meta::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_meta_capnp_type(const ucap::Meta::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_meta_name(root.getName().cStr(), context);
-    stack->push_back(std::make_pair("getValue", 0));
-    out.set_meta_value(root.getValue().cStr(), context);
-    stack->pop_back();
+	out.set_meta_name(root.getName().cStr(), context);
+	stack->push_back(std::make_pair("getValue", 0));
+	out.set_meta_value(root.getValue().cStr(), context);
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_metadata_capnp_type(const ucap::Metadata::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_metadata_capnp_type(const ucap::Metadata::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getMeta", 0));
-    {
-        auto data = root.getMetas();
-        out.preallocate_metadata_meta(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_metadata_meta(context);
-            load_meta_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_metadata_meta(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getMeta", 0));
+	{
+		auto data = root.getMetas();
+		out.preallocate_metadata_meta(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_metadata_meta(context);
+			load_meta_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_metadata_meta(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_node_capnp_type(const ucap::Node::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_node_capnp_type(const ucap::Node::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_node_direction(conv_enum_node_direction(root.getDirection(), report_error), context);
-    stack->push_back(std::make_pair("getLoc", 0));
-    if (root.hasLoc()) {
-        auto child_el = root.getLoc();
-        auto child_context = out.init_node_loc(context, child_el.getPtc(), child_el.getXhigh(), child_el.getXlow(), child_el.getYhigh(), child_el.getYlow());
-        load_node_loc_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_node_loc(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getTiming", 0));
-    if (root.hasTiming()) {
-        auto child_el = root.getTiming();
-        auto child_context = out.init_node_timing(context, child_el.getC(), child_el.getR());
-        load_node_timing_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_node_timing(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getSegment", 0));
-    if (root.hasSegment()) {
-        auto child_el = root.getSegment();
-        auto child_context = out.init_node_segment(context, child_el.getSegmentId());
-        load_node_segment_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_node_segment(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getMetadata", 0));
-    if (root.hasMetadata()) {
-        auto child_el = root.getMetadata();
-        auto child_context = out.init_node_metadata(context);
-        load_metadata_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_node_metadata(child_context);
-    }
-    stack->pop_back();
+	out.set_node_direction(conv_enum_node_direction(root.getDirection(), report_error), context);
+	stack->push_back(std::make_pair("getLoc", 0));
+	if (root.hasLoc()) {
+		auto child_el = root.getLoc();
+		auto child_context = out.init_node_loc(context, child_el.getPtc(), child_el.getXhigh(), child_el.getXlow(), child_el.getYhigh(), child_el.getYlow());
+		load_node_loc_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_node_loc(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getTiming", 0));
+	if (root.hasTiming()) {
+		auto child_el = root.getTiming();
+		auto child_context = out.init_node_timing(context, child_el.getC(), child_el.getR());
+		load_node_timing_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_node_timing(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getSegment", 0));
+	if (root.hasSegment()) {
+		auto child_el = root.getSegment();
+		auto child_context = out.init_node_segment(context, child_el.getSegmentId());
+		load_node_segment_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_node_segment(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getMetadata", 0));
+	if (root.hasMetadata()) {
+		auto child_el = root.getMetadata();
+		auto child_context = out.init_node_metadata(context);
+		load_metadata_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_node_metadata(child_context);
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_rr_nodes_capnp_type(const ucap::RrNodes::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_rr_nodes_capnp_type(const ucap::RrNodes::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getNode", 0));
-    {
-        auto data = root.getNodes();
-        out.preallocate_rr_nodes_node(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_rr_nodes_node(context, el.getCapacity(), el.getId(), conv_enum_node_type(el.getType(), report_error));
-            load_node_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_rr_nodes_node(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getNode", 0));
+	{
+		auto data = root.getNodes();
+		out.preallocate_rr_nodes_node(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_rr_nodes_node(context, el.getCapacity(), el.getId(), conv_enum_node_type(el.getType(), report_error));
+			load_node_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_rr_nodes_node(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_edge_capnp_type(const ucap::Edge::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_e_ptn_capnp_type(const ucap::EPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getMetadata", 0));
-    if (root.hasMetadata()) {
-        auto child_el = root.getMetadata();
-        auto child_context = out.init_edge_metadata(context);
-        load_metadata_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_edge_metadata(child_context);
-    }
-    stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_rr_edges_capnp_type(const ucap::RrEdges::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_node_e_ptn_capnp_type(const ucap::NodeEPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    stack->push_back(std::make_pair("getEdge", 0));
-    {
-        auto data = root.getEdges();
-        out.preallocate_rr_edges_edge(context, data.size());
-        for (const auto& el : data) {
-            auto child_context = out.add_rr_edges_edge(context, el.getSinkNode(), el.getSrcNode(), el.getSwitchId());
-            load_edge_capnp_type(el, out, child_context, report_error, stack);
-            out.finish_rr_edges_edge(child_context);
-            stack->back().second += 1;
-        }
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getEPtn", 0));
+	{
+		auto data = root.getEPtns();
+		out.preallocate_node_e_ptn_e_ptn(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_node_e_ptn_e_ptn(context, el.getId());
+			load_e_ptn_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_node_e_ptn_e_ptn(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
 
 template<class T, typename Context>
-inline void load_rr_graph_capnp_type(const ucap::RrGraph::Reader& root, T& out, Context& context, const std::function<void(const char*)>* report_error, std::vector<std::pair<const char*, size_t>>* stack) {
-    (void)root;
-    (void)out;
-    (void)context;
-    (void)report_error;
-    (void)stack;
+inline void load_rr_node_e_ptns_capnp_type(const ucap::RrNodeEPtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
 
-    out.set_rr_graph_tool_comment(root.getToolComment().cStr(), context);
-    out.set_rr_graph_tool_name(root.getToolName().cStr(), context);
-    out.set_rr_graph_tool_version(root.getToolVersion().cStr(), context);
-    stack->push_back(std::make_pair("getChannels", 0));
-    if (root.hasChannels()) {
-        auto child_el = root.getChannels();
-        auto child_context = out.init_rr_graph_channels(context);
-        load_channels_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_channels(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getSwitches", 0));
-    if (root.hasSwitches()) {
-        auto child_el = root.getSwitches();
-        auto child_context = out.init_rr_graph_switches(context);
-        load_switches_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_switches(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getSegments", 0));
-    if (root.hasSegments()) {
-        auto child_el = root.getSegments();
-        auto child_context = out.init_rr_graph_segments(context);
-        load_segments_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_segments(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getBlockTypes", 0));
-    if (root.hasBlockTypes()) {
-        auto child_el = root.getBlockTypes();
-        auto child_context = out.init_rr_graph_block_types(context);
-        load_block_types_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_block_types(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getGrid", 0));
-    if (root.hasGrid()) {
-        auto child_el = root.getGrid();
-        auto child_context = out.init_rr_graph_grid(context);
-        load_grid_locs_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_grid(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getRrNodes", 0));
-    if (root.hasRrNodes()) {
-        auto child_el = root.getRrNodes();
-        auto child_context = out.init_rr_graph_rr_nodes(context);
-        load_rr_nodes_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_rr_nodes(child_context);
-    }
-    stack->pop_back();
-    stack->push_back(std::make_pair("getRrEdges", 0));
-    if (root.hasRrEdges()) {
-        auto child_el = root.getRrEdges();
-        auto child_context = out.init_rr_graph_rr_edges(context);
-        load_rr_edges_capnp_type(child_el, out, child_context, report_error, stack);
-        out.finish_rr_graph_rr_edges(child_context);
-    }
-    stack->pop_back();
+	stack->push_back(std::make_pair("getNodeEPtn", 0));
+	{
+		auto data = root.getNodeEPtns();
+		out.preallocate_rr_node_e_ptns_node_e_ptn(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_rr_node_e_ptns_node_e_ptn(context, el.getDest(), el.getId());
+			load_node_e_ptn_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_rr_node_e_ptns_node_e_ptn(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
 }
+
+template<class T, typename Context>
+inline void load_ddiff_capnp_type(const ucap::Ddiff::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+}
+
+template<class T, typename Context>
+inline void load_edge_ptn_capnp_type(const ucap::EdgePtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+	stack->push_back(std::make_pair("getDdiff", 0));
+	{
+		auto data = root.getDdiffs();
+		out.preallocate_edge_ptn_ddiff(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_edge_ptn_ddiff(context, el.getId());
+			load_ddiff_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_edge_ptn_ddiff(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
+}
+
+template<class T, typename Context>
+inline void load_rr_edge_ptns_capnp_type(const ucap::RrEdgePtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+	stack->push_back(std::make_pair("getEdgePtn", 0));
+	{
+		auto data = root.getEdgePtns();
+		out.preallocate_rr_edge_ptns_edge_ptn(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_rr_edge_ptns_edge_ptn(context, el.getId(), el.getSwitchId());
+			load_edge_ptn_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_rr_edge_ptns_edge_ptn(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
+}
+
+template<class T, typename Context>
+inline void load_rr_graph_capnp_type(const ucap::RrGraph::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+	out.set_rr_graph_tool_comment(root.getToolComment().cStr(), context);
+	out.set_rr_graph_tool_name(root.getToolName().cStr(), context);
+	out.set_rr_graph_tool_version(root.getToolVersion().cStr(), context);
+	stack->push_back(std::make_pair("getChannels", 0));
+	if (root.hasChannels()) {
+		auto child_el = root.getChannels();
+		auto child_context = out.init_rr_graph_channels(context);
+		load_channels_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_channels(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getSwitches", 0));
+	if (root.hasSwitches()) {
+		auto child_el = root.getSwitches();
+		auto child_context = out.init_rr_graph_switches(context);
+		load_switches_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_switches(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getSegments", 0));
+	if (root.hasSegments()) {
+		auto child_el = root.getSegments();
+		auto child_context = out.init_rr_graph_segments(context);
+		load_segments_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_segments(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getBlockTypes", 0));
+	if (root.hasBlockTypes()) {
+		auto child_el = root.getBlockTypes();
+		auto child_context = out.init_rr_graph_block_types(context);
+		load_block_types_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_block_types(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getGrid", 0));
+	if (root.hasGrid()) {
+		auto child_el = root.getGrid();
+		auto child_context = out.init_rr_graph_grid(context);
+		load_grid_locs_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_grid(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getRrNodes", 0));
+	if (root.hasRrNodes()) {
+		auto child_el = root.getRrNodes();
+		auto child_context = out.init_rr_graph_rr_nodes(context);
+		load_rr_nodes_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_rr_nodes(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getRrNodeEPtns", 0));
+	if (root.hasRrNodeEPtns()) {
+		auto child_el = root.getRrNodeEPtns();
+		auto child_context = out.init_rr_graph_rr_node_e_ptns(context);
+		load_rr_node_e_ptns_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_rr_node_e_ptns(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getRrEdgePtns", 0));
+	if (root.hasRrEdgePtns()) {
+		auto child_el = root.getRrEdgePtns();
+		auto child_context = out.init_rr_graph_rr_edge_ptns(context);
+		load_rr_edge_ptns_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_rr_edge_ptns(child_context);
+	}
+	stack->pop_back();
+}
+
 
 /* Internal writing functions, which uxsdcxx uses to write out a class. */
 template<class T, typename Context>
-inline void write_channels_capnp_type(T& in, ucap::Channels::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_channels_capnp_type(T &in, ucap::Channels::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    {
-        auto child_context = in.get_channels_channel(context);
-        auto channels_channel = root.initChannel();
-        channels_channel.setChanWidthMax(in.get_channel_chan_width_max(child_context));
-        channels_channel.setXMax(in.get_channel_x_max(child_context));
-        channels_channel.setXMin(in.get_channel_x_min(child_context));
-        channels_channel.setYMax(in.get_channel_y_max(child_context));
-        channels_channel.setYMin(in.get_channel_y_min(child_context));
-    }
+	{
+		auto child_context = in.get_channels_channel(context);
+		auto channels_channel = root.initChannel();
+		channels_channel.setChanWidthMax(in.get_channel_chan_width_max(child_context));
+		channels_channel.setXMax(in.get_channel_x_max(child_context));
+		channels_channel.setXMin(in.get_channel_x_min(child_context));
+		channels_channel.setYMax(in.get_channel_y_max(child_context));
+		channels_channel.setYMin(in.get_channel_y_min(child_context));
+	}
 
-    size_t num_channels_x_lists = in.num_channels_x_list(context);
-    auto channels_x_lists = root.initXLists(num_channels_x_lists);
-    for (size_t i = 0; i < num_channels_x_lists; i++) {
-        auto channels_x_list = channels_x_lists[i];
-        auto child_context = in.get_channels_x_list(i, context);
-        channels_x_list.setIndex(in.get_x_list_index(child_context));
-        channels_x_list.setInfo(in.get_x_list_info(child_context));
-    }
+	size_t num_channels_x_lists = in.num_channels_x_list(context);
+	auto channels_x_lists = root.initXLists(num_channels_x_lists);
+	for(size_t i = 0; i < num_channels_x_lists; i++) {
+		auto channels_x_list = channels_x_lists[i];
+		auto child_context = in.get_channels_x_list(i, context);
+		channels_x_list.setIndex(in.get_x_list_index(child_context));
+		channels_x_list.setInfo(in.get_x_list_info(child_context));
+	}
 
-    size_t num_channels_y_lists = in.num_channels_y_list(context);
-    auto channels_y_lists = root.initYLists(num_channels_y_lists);
-    for (size_t i = 0; i < num_channels_y_lists; i++) {
-        auto channels_y_list = channels_y_lists[i];
-        auto child_context = in.get_channels_y_list(i, context);
-        channels_y_list.setIndex(in.get_y_list_index(child_context));
-        channels_y_list.setInfo(in.get_y_list_info(child_context));
-    }
+	size_t num_channels_y_lists = in.num_channels_y_list(context);
+	auto channels_y_lists = root.initYLists(num_channels_y_lists);
+	for(size_t i = 0; i < num_channels_y_lists; i++) {
+		auto channels_y_list = channels_y_lists[i];
+		auto child_context = in.get_channels_y_list(i, context);
+		channels_y_list.setIndex(in.get_y_list_index(child_context));
+		channels_y_list.setInfo(in.get_y_list_info(child_context));
+	}
 }
 
 template<class T, typename Context>
-inline void write_switch_capnp_type(T& in, ucap::Switch::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_switch_capnp_type(T &in, ucap::Switch::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    if (in.has_switch_timing(context)) {
-        auto switch_timing = root.initTiming();
-        auto child_context = in.get_switch_timing(context);
-        if ((bool)in.get_timing_Cin(child_context))
-            switch_timing.setCin(in.get_timing_Cin(child_context));
-        if ((bool)in.get_timing_Cinternal(child_context))
-            switch_timing.setCinternal(in.get_timing_Cinternal(child_context));
-        if ((bool)in.get_timing_Cout(child_context))
-            switch_timing.setCout(in.get_timing_Cout(child_context));
-        if ((bool)in.get_timing_R(child_context))
-            switch_timing.setR(in.get_timing_R(child_context));
-        if ((bool)in.get_timing_Tdel(child_context))
-            switch_timing.setTdel(in.get_timing_Tdel(child_context));
-    }
+	if(in.has_switch_timing(context)){
+		auto switch_timing = root.initTiming();
+		auto child_context = in.get_switch_timing(context);
+		if((bool)in.get_timing_Cin(child_context))
+			switch_timing.setCin(in.get_timing_Cin(child_context));
+		if((bool)in.get_timing_Cinternal(child_context))
+			switch_timing.setCinternal(in.get_timing_Cinternal(child_context));
+		if((bool)in.get_timing_Cout(child_context))
+			switch_timing.setCout(in.get_timing_Cout(child_context));
+		if((bool)in.get_timing_R(child_context))
+			switch_timing.setR(in.get_timing_R(child_context));
+		if((bool)in.get_timing_Tdel(child_context))
+			switch_timing.setTdel(in.get_timing_Tdel(child_context));
+	}
 
-    {
-        auto child_context = in.get_switch_sizing(context);
-        auto switch_sizing = root.initSizing();
-        switch_sizing.setBufSize(in.get_sizing_buf_size(child_context));
-        switch_sizing.setMuxTransSize(in.get_sizing_mux_trans_size(child_context));
-    }
+	{
+		auto child_context = in.get_switch_sizing(context);
+		auto switch_sizing = root.initSizing();
+		switch_sizing.setBufSize(in.get_sizing_buf_size(child_context));
+		switch_sizing.setMuxTransSize(in.get_sizing_mux_trans_size(child_context));
+	}
 }
 
 template<class T, typename Context>
-inline void write_switches_capnp_type(T& in, ucap::Switches::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_switches_capnp_type(T &in, ucap::Switches::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_switches_switches = in.num_switches_switch(context);
-    auto switches_switches = root.initSwitches(num_switches_switches);
-    for (size_t i = 0; i < num_switches_switches; i++) {
-        auto switches_switch = switches_switches[i];
-        auto child_context = in.get_switches_switch(i, context);
-        switches_switch.setId(in.get_switch_id(child_context));
-        switches_switch.setName(in.get_switch_name(child_context));
-        if ((bool)in.get_switch_type(child_context))
-            switches_switch.setType(conv_to_enum_switch_type(in.get_switch_type(child_context)));
-        write_switch_capnp_type(in, switches_switch, child_context);
-    }
+	size_t num_switches_switches = in.num_switches_switch(context);
+	auto switches_switches = root.initSwitches(num_switches_switches);
+	for(size_t i = 0; i < num_switches_switches; i++) {
+		auto switches_switch = switches_switches[i];
+		auto child_context = in.get_switches_switch(i, context);
+		switches_switch.setId(in.get_switch_id(child_context));
+		switches_switch.setName(in.get_switch_name(child_context));
+		if((bool)in.get_switch_type(child_context))
+			switches_switch.setType(conv_to_enum_switch_type(in.get_switch_type(child_context)));
+		write_switch_capnp_type(in, switches_switch, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_segment_capnp_type(T& in, ucap::Segment::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_segment_capnp_type(T &in, ucap::Segment::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    if (in.has_segment_timing(context)) {
-        auto segment_timing = root.initTiming();
-        auto child_context = in.get_segment_timing(context);
-        if ((bool)in.get_segment_timing_C_per_meter(child_context))
-            segment_timing.setCPerMeter(in.get_segment_timing_C_per_meter(child_context));
-        if ((bool)in.get_segment_timing_R_per_meter(child_context))
-            segment_timing.setRPerMeter(in.get_segment_timing_R_per_meter(child_context));
-    }
+	if(in.has_segment_timing(context)){
+		auto segment_timing = root.initTiming();
+		auto child_context = in.get_segment_timing(context);
+		if((bool)in.get_segment_timing_C_per_meter(child_context))
+			segment_timing.setCPerMeter(in.get_segment_timing_C_per_meter(child_context));
+		if((bool)in.get_segment_timing_R_per_meter(child_context))
+			segment_timing.setRPerMeter(in.get_segment_timing_R_per_meter(child_context));
+	}
 }
 
 template<class T, typename Context>
-inline void write_segments_capnp_type(T& in, ucap::Segments::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_segments_capnp_type(T &in, ucap::Segments::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_segments_segments = in.num_segments_segment(context);
-    auto segments_segments = root.initSegments(num_segments_segments);
-    for (size_t i = 0; i < num_segments_segments; i++) {
-        auto segments_segment = segments_segments[i];
-        auto child_context = in.get_segments_segment(i, context);
-        segments_segment.setId(in.get_segment_id(child_context));
-        segments_segment.setName(in.get_segment_name(child_context));
-        write_segment_capnp_type(in, segments_segment, child_context);
-    }
+	size_t num_segments_segments = in.num_segments_segment(context);
+	auto segments_segments = root.initSegments(num_segments_segments);
+	for(size_t i = 0; i < num_segments_segments; i++) {
+		auto segments_segment = segments_segments[i];
+		auto child_context = in.get_segments_segment(i, context);
+		segments_segment.setId(in.get_segment_id(child_context));
+		segments_segment.setName(in.get_segment_name(child_context));
+		write_segment_capnp_type(in, segments_segment, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_pin_capnp_type(T& in, ucap::Pin::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
-    root.setValue(in.get_pin_value(context));
+inline void write_pin_capnp_type(T &in, ucap::Pin::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
+	root.setValue(in.get_pin_value(context));
 }
 
 template<class T, typename Context>
-inline void write_pin_class_capnp_type(T& in, ucap::PinClass::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_pin_class_capnp_type(T &in, ucap::PinClass::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_pin_class_pins = in.num_pin_class_pin(context);
-    auto pin_class_pins = root.initPins(num_pin_class_pins);
-    for (size_t i = 0; i < num_pin_class_pins; i++) {
-        auto pin_class_pin = pin_class_pins[i];
-        auto child_context = in.get_pin_class_pin(i, context);
-        pin_class_pin.setPtc(in.get_pin_ptc(child_context));
-        write_pin_capnp_type(in, pin_class_pin, child_context);
-    }
+	size_t num_pin_class_pins = in.num_pin_class_pin(context);
+	auto pin_class_pins = root.initPins(num_pin_class_pins);
+	for(size_t i = 0; i < num_pin_class_pins; i++) {
+		auto pin_class_pin = pin_class_pins[i];
+		auto child_context = in.get_pin_class_pin(i, context);
+		pin_class_pin.setPtc(in.get_pin_ptc(child_context));
+		write_pin_capnp_type(in, pin_class_pin, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_block_type_capnp_type(T& in, ucap::BlockType::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_block_type_capnp_type(T &in, ucap::BlockType::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_block_type_pin_classes = in.num_block_type_pin_class(context);
-    auto block_type_pin_classes = root.initPinClasses(num_block_type_pin_classes);
-    for (size_t i = 0; i < num_block_type_pin_classes; i++) {
-        auto block_type_pin_class = block_type_pin_classes[i];
-        auto child_context = in.get_block_type_pin_class(i, context);
-        block_type_pin_class.setType(conv_to_enum_pin_type(in.get_pin_class_type(child_context)));
-        write_pin_class_capnp_type(in, block_type_pin_class, child_context);
-    }
+	size_t num_block_type_pin_classes = in.num_block_type_pin_class(context);
+	auto block_type_pin_classes = root.initPinClasses(num_block_type_pin_classes);
+	for(size_t i = 0; i < num_block_type_pin_classes; i++) {
+		auto block_type_pin_class = block_type_pin_classes[i];
+		auto child_context = in.get_block_type_pin_class(i, context);
+		block_type_pin_class.setType(conv_to_enum_pin_type(in.get_pin_class_type(child_context)));
+		write_pin_class_capnp_type(in, block_type_pin_class, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_block_types_capnp_type(T& in, ucap::BlockTypes::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_block_types_capnp_type(T &in, ucap::BlockTypes::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_block_types_block_types = in.num_block_types_block_type(context);
-    auto block_types_block_types = root.initBlockTypes(num_block_types_block_types);
-    for (size_t i = 0; i < num_block_types_block_types; i++) {
-        auto block_types_block_type = block_types_block_types[i];
-        auto child_context = in.get_block_types_block_type(i, context);
-        block_types_block_type.setHeight(in.get_block_type_height(child_context));
-        block_types_block_type.setId(in.get_block_type_id(child_context));
-        block_types_block_type.setName(in.get_block_type_name(child_context));
-        block_types_block_type.setWidth(in.get_block_type_width(child_context));
-        write_block_type_capnp_type(in, block_types_block_type, child_context);
-    }
+	size_t num_block_types_block_types = in.num_block_types_block_type(context);
+	auto block_types_block_types = root.initBlockTypes(num_block_types_block_types);
+	for(size_t i = 0; i < num_block_types_block_types; i++) {
+		auto block_types_block_type = block_types_block_types[i];
+		auto child_context = in.get_block_types_block_type(i, context);
+		block_types_block_type.setHeight(in.get_block_type_height(child_context));
+		block_types_block_type.setId(in.get_block_type_id(child_context));
+		block_types_block_type.setName(in.get_block_type_name(child_context));
+		block_types_block_type.setWidth(in.get_block_type_width(child_context));
+		write_block_type_capnp_type(in, block_types_block_type, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_grid_locs_capnp_type(T& in, ucap::GridLocs::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_grid_locs_capnp_type(T &in, ucap::GridLocs::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_grid_locs_grid_locs = in.num_grid_locs_grid_loc(context);
-    auto grid_locs_grid_locs = root.initGridLocs(num_grid_locs_grid_locs);
-    for (size_t i = 0; i < num_grid_locs_grid_locs; i++) {
-        auto grid_locs_grid_loc = grid_locs_grid_locs[i];
-        auto child_context = in.get_grid_locs_grid_loc(i, context);
-        grid_locs_grid_loc.setBlockTypeId(in.get_grid_loc_block_type_id(child_context));
-        grid_locs_grid_loc.setHeightOffset(in.get_grid_loc_height_offset(child_context));
-        grid_locs_grid_loc.setWidthOffset(in.get_grid_loc_width_offset(child_context));
-        grid_locs_grid_loc.setX(in.get_grid_loc_x(child_context));
-        grid_locs_grid_loc.setY(in.get_grid_loc_y(child_context));
-    }
+	size_t num_grid_locs_grid_locs = in.num_grid_locs_grid_loc(context);
+	auto grid_locs_grid_locs = root.initGridLocs(num_grid_locs_grid_locs);
+	for(size_t i = 0; i < num_grid_locs_grid_locs; i++) {
+		auto grid_locs_grid_loc = grid_locs_grid_locs[i];
+		auto child_context = in.get_grid_locs_grid_loc(i, context);
+		grid_locs_grid_loc.setBlockTypeId(in.get_grid_loc_block_type_id(child_context));
+		grid_locs_grid_loc.setHeightOffset(in.get_grid_loc_height_offset(child_context));
+		grid_locs_grid_loc.setWidthOffset(in.get_grid_loc_width_offset(child_context));
+		grid_locs_grid_loc.setX(in.get_grid_loc_x(child_context));
+		grid_locs_grid_loc.setY(in.get_grid_loc_y(child_context));
+	}
 }
 
 template<class T, typename Context>
-inline void write_meta_capnp_type(T& in, ucap::Meta::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
-    root.setValue(in.get_meta_value(context));
+inline void write_meta_capnp_type(T &in, ucap::Meta::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
+	root.setValue(in.get_meta_value(context));
 }
 
 template<class T, typename Context>
-inline void write_metadata_capnp_type(T& in, ucap::Metadata::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_metadata_capnp_type(T &in, ucap::Metadata::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_metadata_metas = in.num_metadata_meta(context);
-    auto metadata_metas = root.initMetas(num_metadata_metas);
-    for (size_t i = 0; i < num_metadata_metas; i++) {
-        auto metadata_meta = metadata_metas[i];
-        auto child_context = in.get_metadata_meta(i, context);
-        metadata_meta.setName(in.get_meta_name(child_context));
-        write_meta_capnp_type(in, metadata_meta, child_context);
-    }
+	size_t num_metadata_metas = in.num_metadata_meta(context);
+	auto metadata_metas = root.initMetas(num_metadata_metas);
+	for(size_t i = 0; i < num_metadata_metas; i++) {
+		auto metadata_meta = metadata_metas[i];
+		auto child_context = in.get_metadata_meta(i, context);
+		metadata_meta.setName(in.get_meta_name(child_context));
+		write_meta_capnp_type(in, metadata_meta, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_node_capnp_type(T& in, ucap::Node::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_node_capnp_type(T &in, ucap::Node::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    {
-        auto child_context = in.get_node_loc(context);
-        auto node_loc = root.initLoc();
-        node_loc.setPtc(in.get_node_loc_ptc(child_context));
-        if ((bool)in.get_node_loc_side(child_context))
-            node_loc.setSide(conv_to_enum_loc_side(in.get_node_loc_side(child_context)));
-        node_loc.setXhigh(in.get_node_loc_xhigh(child_context));
-        node_loc.setXlow(in.get_node_loc_xlow(child_context));
-        node_loc.setYhigh(in.get_node_loc_yhigh(child_context));
-        node_loc.setYlow(in.get_node_loc_ylow(child_context));
-    }
+	{
+		auto child_context = in.get_node_loc(context);
+		auto node_loc = root.initLoc();
+		node_loc.setPtc(in.get_node_loc_ptc(child_context));
+		if((bool)in.get_node_loc_side(child_context))
+			node_loc.setSide(conv_to_enum_loc_side(in.get_node_loc_side(child_context)));
+		node_loc.setXhigh(in.get_node_loc_xhigh(child_context));
+		node_loc.setXlow(in.get_node_loc_xlow(child_context));
+		node_loc.setYhigh(in.get_node_loc_yhigh(child_context));
+		node_loc.setYlow(in.get_node_loc_ylow(child_context));
+	}
 
-    if (in.has_node_timing(context)) {
-        auto node_timing = root.initTiming();
-        auto child_context = in.get_node_timing(context);
-        node_timing.setC(in.get_node_timing_C(child_context));
-        node_timing.setR(in.get_node_timing_R(child_context));
-    }
+	if(in.has_node_timing(context)){
+		auto node_timing = root.initTiming();
+		auto child_context = in.get_node_timing(context);
+		node_timing.setC(in.get_node_timing_C(child_context));
+		node_timing.setR(in.get_node_timing_R(child_context));
+	}
 
-    if (in.has_node_segment(context)) {
-        auto node_segment = root.initSegment();
-        auto child_context = in.get_node_segment(context);
-        node_segment.setSegmentId(in.get_node_segment_segment_id(child_context));
-    }
+	if(in.has_node_segment(context)){
+		auto node_segment = root.initSegment();
+		auto child_context = in.get_node_segment(context);
+		node_segment.setSegmentId(in.get_node_segment_segment_id(child_context));
+	}
 
-    if (in.has_node_metadata(context)) {
-        auto node_metadata = root.initMetadata();
-        auto child_context = in.get_node_metadata(context);
-        write_metadata_capnp_type(in, node_metadata, child_context);
-    }
+	if(in.has_node_metadata(context)){
+		auto node_metadata = root.initMetadata();
+		auto child_context = in.get_node_metadata(context);
+		write_metadata_capnp_type(in, node_metadata, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_rr_nodes_capnp_type(T& in, ucap::RrNodes::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_rr_nodes_capnp_type(T &in, ucap::RrNodes::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_rr_nodes_nodes = in.num_rr_nodes_node(context);
-    auto rr_nodes_nodes = root.initNodes(num_rr_nodes_nodes);
-    for (size_t i = 0; i < num_rr_nodes_nodes; i++) {
-        auto rr_nodes_node = rr_nodes_nodes[i];
-        auto child_context = in.get_rr_nodes_node(i, context);
-        rr_nodes_node.setCapacity(in.get_node_capacity(child_context));
-        if ((bool)in.get_node_direction(child_context))
-            rr_nodes_node.setDirection(conv_to_enum_node_direction(in.get_node_direction(child_context)));
-        rr_nodes_node.setId(in.get_node_id(child_context));
-        rr_nodes_node.setType(conv_to_enum_node_type(in.get_node_type(child_context)));
-        write_node_capnp_type(in, rr_nodes_node, child_context);
-    }
+	size_t num_rr_nodes_nodes = in.num_rr_nodes_node(context);
+	auto rr_nodes_nodes = root.initNodes(num_rr_nodes_nodes);
+	for(size_t i = 0; i < num_rr_nodes_nodes; i++) {
+		auto rr_nodes_node = rr_nodes_nodes[i];
+		auto child_context = in.get_rr_nodes_node(i, context);
+		rr_nodes_node.setCapacity(in.get_node_capacity(child_context));
+		if((bool)in.get_node_direction(child_context))
+			rr_nodes_node.setDirection(conv_to_enum_node_direction(in.get_node_direction(child_context)));
+		rr_nodes_node.setId(in.get_node_id(child_context));
+		rr_nodes_node.setType(conv_to_enum_node_type(in.get_node_type(child_context)));
+		write_node_capnp_type(in, rr_nodes_node, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_edge_capnp_type(T& in, ucap::Edge::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_node_e_ptn_capnp_type(T &in, ucap::NodeEPtn::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    if (in.has_edge_metadata(context)) {
-        auto edge_metadata = root.initMetadata();
-        auto child_context = in.get_edge_metadata(context);
-        write_metadata_capnp_type(in, edge_metadata, child_context);
-    }
+	size_t num_node_e_ptn_e_ptns = in.num_node_e_ptn_e_ptn(context);
+	auto node_e_ptn_e_ptns = root.initEPtns(num_node_e_ptn_e_ptns);
+	for(size_t i = 0; i < num_node_e_ptn_e_ptns; i++) {
+		auto node_e_ptn_e_ptn = node_e_ptn_e_ptns[i];
+		auto child_context = in.get_node_e_ptn_e_ptn(i, context);
+		node_e_ptn_e_ptn.setId(in.get_e_ptn_id(child_context));
+	}
 }
 
 template<class T, typename Context>
-inline void write_rr_edges_capnp_type(T& in, ucap::RrEdges::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_rr_node_e_ptns_capnp_type(T &in, ucap::RrNodeEPtns::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    size_t num_rr_edges_edges = in.num_rr_edges_edge(context);
-    auto rr_edges_edges = root.initEdges(num_rr_edges_edges);
-    for (size_t i = 0; i < num_rr_edges_edges; i++) {
-        auto rr_edges_edge = rr_edges_edges[i];
-        auto child_context = in.get_rr_edges_edge(i, context);
-        rr_edges_edge.setSinkNode(in.get_edge_sink_node(child_context));
-        rr_edges_edge.setSrcNode(in.get_edge_src_node(child_context));
-        rr_edges_edge.setSwitchId(in.get_edge_switch_id(child_context));
-        write_edge_capnp_type(in, rr_edges_edge, child_context);
-    }
+	size_t num_rr_node_e_ptns_node_e_ptns = in.num_rr_node_e_ptns_node_e_ptn(context);
+	auto rr_node_e_ptns_node_e_ptns = root.initNodeEPtns(num_rr_node_e_ptns_node_e_ptns);
+	for(size_t i = 0; i < num_rr_node_e_ptns_node_e_ptns; i++) {
+		auto rr_node_e_ptns_node_e_ptn = rr_node_e_ptns_node_e_ptns[i];
+		auto child_context = in.get_rr_node_e_ptns_node_e_ptn(i, context);
+		rr_node_e_ptns_node_e_ptn.setDest(in.get_node_e_ptn_dest(child_context));
+		rr_node_e_ptns_node_e_ptn.setId(in.get_node_e_ptn_id(child_context));
+		write_node_e_ptn_capnp_type(in, rr_node_e_ptns_node_e_ptn, child_context);
+	}
 }
 
 template<class T, typename Context>
-inline void write_rr_graph_capnp_type(T& in, ucap::RrGraph::Builder& root, Context& context) {
-    (void)in;
-    (void)root;
+inline void write_edge_ptn_capnp_type(T &in, ucap::EdgePtn::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
 
-    {
-        auto child_context = in.get_rr_graph_channels(context);
-        auto rr_graph_channels = root.initChannels();
-        write_channels_capnp_type(in, rr_graph_channels, child_context);
-    }
-
-    {
-        auto child_context = in.get_rr_graph_switches(context);
-        auto rr_graph_switches = root.initSwitches();
-        write_switches_capnp_type(in, rr_graph_switches, child_context);
-    }
-
-    {
-        auto child_context = in.get_rr_graph_segments(context);
-        auto rr_graph_segments = root.initSegments();
-        write_segments_capnp_type(in, rr_graph_segments, child_context);
-    }
-
-    {
-        auto child_context = in.get_rr_graph_block_types(context);
-        auto rr_graph_block_types = root.initBlockTypes();
-        write_block_types_capnp_type(in, rr_graph_block_types, child_context);
-    }
-
-    {
-        auto child_context = in.get_rr_graph_grid(context);
-        auto rr_graph_grid = root.initGrid();
-        write_grid_locs_capnp_type(in, rr_graph_grid, child_context);
-    }
-
-    {
-        auto child_context = in.get_rr_graph_rr_nodes(context);
-        auto rr_graph_rr_nodes = root.initRrNodes();
-        write_rr_nodes_capnp_type(in, rr_graph_rr_nodes, child_context);
-    }
-
-    {
-        auto child_context = in.get_rr_graph_rr_edges(context);
-        auto rr_graph_rr_edges = root.initRrEdges();
-        write_rr_edges_capnp_type(in, rr_graph_rr_edges, child_context);
-    }
+	size_t num_edge_ptn_ddiffs = in.num_edge_ptn_ddiff(context);
+	auto edge_ptn_ddiffs = root.initDdiffs(num_edge_ptn_ddiffs);
+	for(size_t i = 0; i < num_edge_ptn_ddiffs; i++) {
+		auto edge_ptn_ddiff = edge_ptn_ddiffs[i];
+		auto child_context = in.get_edge_ptn_ddiff(i, context);
+		edge_ptn_ddiff.setId(in.get_ddiff_id(child_context));
+	}
 }
+
+template<class T, typename Context>
+inline void write_rr_edge_ptns_capnp_type(T &in, ucap::RrEdgePtns::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
+
+	size_t num_rr_edge_ptns_edge_ptns = in.num_rr_edge_ptns_edge_ptn(context);
+	auto rr_edge_ptns_edge_ptns = root.initEdgePtns(num_rr_edge_ptns_edge_ptns);
+	for(size_t i = 0; i < num_rr_edge_ptns_edge_ptns; i++) {
+		auto rr_edge_ptns_edge_ptn = rr_edge_ptns_edge_ptns[i];
+		auto child_context = in.get_rr_edge_ptns_edge_ptn(i, context);
+		rr_edge_ptns_edge_ptn.setId(in.get_edge_ptn_id(child_context));
+		rr_edge_ptns_edge_ptn.setSwitchId(in.get_edge_ptn_switch_id(child_context));
+		write_edge_ptn_capnp_type(in, rr_edge_ptns_edge_ptn, child_context);
+	}
+}
+
+template<class T, typename Context>
+inline void write_rr_graph_capnp_type(T &in, ucap::RrGraph::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
+
+	{
+		auto child_context = in.get_rr_graph_channels(context);
+		auto rr_graph_channels = root.initChannels();
+		write_channels_capnp_type(in, rr_graph_channels, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_switches(context);
+		auto rr_graph_switches = root.initSwitches();
+		write_switches_capnp_type(in, rr_graph_switches, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_segments(context);
+		auto rr_graph_segments = root.initSegments();
+		write_segments_capnp_type(in, rr_graph_segments, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_block_types(context);
+		auto rr_graph_block_types = root.initBlockTypes();
+		write_block_types_capnp_type(in, rr_graph_block_types, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_grid(context);
+		auto rr_graph_grid = root.initGrid();
+		write_grid_locs_capnp_type(in, rr_graph_grid, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_rr_nodes(context);
+		auto rr_graph_rr_nodes = root.initRrNodes();
+		write_rr_nodes_capnp_type(in, rr_graph_rr_nodes, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_rr_node_e_ptns(context);
+		auto rr_graph_rr_node_e_ptns = root.initRrNodeEPtns();
+		write_rr_node_e_ptns_capnp_type(in, rr_graph_rr_node_e_ptns, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_rr_edge_ptns(context);
+		auto rr_graph_rr_edge_ptns = root.initRrEdgePtns();
+		write_rr_edge_ptns_capnp_type(in, rr_graph_rr_edge_ptns, child_context);
+	}
+}
+
 
 } /* namespace uxsd */

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_capnp.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcap.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
  * Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
- * md5sum of input file: 5c529f385cc39043f69229d620e94c98
+ * md5sum of input file: f70492b177e0daf17b52aa153b3fae93
  */
 
 #include <functional>
@@ -72,17 +72,17 @@ void load_node_capnp_type(const ucap::Node::Reader &root, T &out, Context &conte
 template <class T, typename Context>
 void load_rr_nodes_capnp_type(const ucap::RrNodes::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
 template <class T, typename Context>
-void load_e_ptn_capnp_type(const ucap::EPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
-template <class T, typename Context>
-void load_node_e_ptn_capnp_type(const ucap::NodeEPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
-template <class T, typename Context>
-void load_rr_node_e_ptns_capnp_type(const ucap::RrNodeEPtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
-template <class T, typename Context>
 void load_ddiff_capnp_type(const ucap::Ddiff::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
 template <class T, typename Context>
 void load_edge_ptn_capnp_type(const ucap::EdgePtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
 template <class T, typename Context>
 void load_rr_edge_ptns_capnp_type(const ucap::RrEdgePtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_e_ptn_capnp_type(const ucap::EPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_node_e_ptn_capnp_type(const ucap::NodeEPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
+template <class T, typename Context>
+void load_rr_node_e_ptns_capnp_type(const ucap::RrNodeEPtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
 template <class T, typename Context>
 void load_rr_graph_capnp_type(const ucap::RrGraph::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack);
 
@@ -116,13 +116,13 @@ inline void write_node_capnp_type(T &in, ucap::Node::Builder &root, Context &con
 template <class T, typename Context>
 inline void write_rr_nodes_capnp_type(T &in, ucap::RrNodes::Builder &root, Context &context);
 template <class T, typename Context>
-inline void write_node_e_ptn_capnp_type(T &in, ucap::NodeEPtn::Builder &root, Context &context);
-template <class T, typename Context>
-inline void write_rr_node_e_ptns_capnp_type(T &in, ucap::RrNodeEPtns::Builder &root, Context &context);
-template <class T, typename Context>
 inline void write_edge_ptn_capnp_type(T &in, ucap::EdgePtn::Builder &root, Context &context);
 template <class T, typename Context>
 inline void write_rr_edge_ptns_capnp_type(T &in, ucap::RrEdgePtns::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_node_e_ptn_capnp_type(T &in, ucap::NodeEPtn::Builder &root, Context &context);
+template <class T, typename Context>
+inline void write_rr_node_e_ptns_capnp_type(T &in, ucap::RrNodeEPtns::Builder &root, Context &context);
 template <class T, typename Context>
 inline void write_rr_graph_capnp_type(T &in, ucap::RrGraph::Builder &root, Context &context);
 
@@ -841,60 +841,6 @@ inline void load_rr_nodes_capnp_type(const ucap::RrNodes::Reader &root, T &out, 
 }
 
 template<class T, typename Context>
-inline void load_e_ptn_capnp_type(const ucap::EPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
-	(void)root;
-	(void)out;
-	(void)context;
-	(void)report_error;
-	(void)stack;
-
-}
-
-template<class T, typename Context>
-inline void load_node_e_ptn_capnp_type(const ucap::NodeEPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
-	(void)root;
-	(void)out;
-	(void)context;
-	(void)report_error;
-	(void)stack;
-
-	stack->push_back(std::make_pair("getEPtn", 0));
-	{
-		auto data = root.getEPtns();
-		out.preallocate_node_e_ptn_e_ptn(context, data.size());
-		for(const auto & el : data) {
-			auto child_context = out.add_node_e_ptn_e_ptn(context, el.getId());
-			load_e_ptn_capnp_type(el, out, child_context, report_error, stack);
-			out.finish_node_e_ptn_e_ptn(child_context);
-			stack->back().second += 1;
-		}
-	}
-	stack->pop_back();
-}
-
-template<class T, typename Context>
-inline void load_rr_node_e_ptns_capnp_type(const ucap::RrNodeEPtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
-	(void)root;
-	(void)out;
-	(void)context;
-	(void)report_error;
-	(void)stack;
-
-	stack->push_back(std::make_pair("getNodeEPtn", 0));
-	{
-		auto data = root.getNodeEPtns();
-		out.preallocate_rr_node_e_ptns_node_e_ptn(context, data.size());
-		for(const auto & el : data) {
-			auto child_context = out.add_rr_node_e_ptns_node_e_ptn(context, el.getDest(), el.getId());
-			load_node_e_ptn_capnp_type(el, out, child_context, report_error, stack);
-			out.finish_rr_node_e_ptns_node_e_ptn(child_context);
-			stack->back().second += 1;
-		}
-	}
-	stack->pop_back();
-}
-
-template<class T, typename Context>
 inline void load_ddiff_capnp_type(const ucap::Ddiff::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
 	(void)root;
 	(void)out;
@@ -942,6 +888,60 @@ inline void load_rr_edge_ptns_capnp_type(const ucap::RrEdgePtns::Reader &root, T
 			auto child_context = out.add_rr_edge_ptns_edge_ptn(context, el.getId(), el.getSwitchId());
 			load_edge_ptn_capnp_type(el, out, child_context, report_error, stack);
 			out.finish_rr_edge_ptns_edge_ptn(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
+}
+
+template<class T, typename Context>
+inline void load_e_ptn_capnp_type(const ucap::EPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+}
+
+template<class T, typename Context>
+inline void load_node_e_ptn_capnp_type(const ucap::NodeEPtn::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+	stack->push_back(std::make_pair("getEPtn", 0));
+	{
+		auto data = root.getEPtns();
+		out.preallocate_node_e_ptn_e_ptn(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_node_e_ptn_e_ptn(context, el.getId());
+			load_e_ptn_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_node_e_ptn_e_ptn(child_context);
+			stack->back().second += 1;
+		}
+	}
+	stack->pop_back();
+}
+
+template<class T, typename Context>
+inline void load_rr_node_e_ptns_capnp_type(const ucap::RrNodeEPtns::Reader &root, T &out, Context &context, const std::function<void(const char*)> * report_error, std::vector<std::pair<const char *, size_t>> * stack){
+	(void)root;
+	(void)out;
+	(void)context;
+	(void)report_error;
+	(void)stack;
+
+	stack->push_back(std::make_pair("getNodeEPtn", 0));
+	{
+		auto data = root.getNodeEPtns();
+		out.preallocate_rr_node_e_ptns_node_e_ptn(context, data.size());
+		for(const auto & el : data) {
+			auto child_context = out.add_rr_node_e_ptns_node_e_ptn(context, el.getDest(), el.getId());
+			load_node_e_ptn_capnp_type(el, out, child_context, report_error, stack);
+			out.finish_rr_node_e_ptns_node_e_ptn(child_context);
 			stack->back().second += 1;
 		}
 	}
@@ -1007,20 +1007,20 @@ inline void load_rr_graph_capnp_type(const ucap::RrGraph::Reader &root, T &out, 
 		out.finish_rr_graph_rr_nodes(child_context);
 	}
 	stack->pop_back();
-	stack->push_back(std::make_pair("getRrNodeEPtns", 0));
-	if (root.hasRrNodeEPtns()) {
-		auto child_el = root.getRrNodeEPtns();
-		auto child_context = out.init_rr_graph_rr_node_e_ptns(context);
-		load_rr_node_e_ptns_capnp_type(child_el, out, child_context, report_error, stack);
-		out.finish_rr_graph_rr_node_e_ptns(child_context);
-	}
-	stack->pop_back();
 	stack->push_back(std::make_pair("getRrEdgePtns", 0));
 	if (root.hasRrEdgePtns()) {
 		auto child_el = root.getRrEdgePtns();
 		auto child_context = out.init_rr_graph_rr_edge_ptns(context);
 		load_rr_edge_ptns_capnp_type(child_el, out, child_context, report_error, stack);
 		out.finish_rr_graph_rr_edge_ptns(child_context);
+	}
+	stack->pop_back();
+	stack->push_back(std::make_pair("getRrNodeEPtns", 0));
+	if (root.hasRrNodeEPtns()) {
+		auto child_el = root.getRrNodeEPtns();
+		auto child_context = out.init_rr_graph_rr_node_e_ptns(context);
+		load_rr_node_e_ptns_capnp_type(child_el, out, child_context, report_error, stack);
+		out.finish_rr_graph_rr_node_e_ptns(child_context);
 	}
 	stack->pop_back();
 }
@@ -1290,36 +1290,6 @@ inline void write_rr_nodes_capnp_type(T &in, ucap::RrNodes::Builder &root, Conte
 }
 
 template<class T, typename Context>
-inline void write_node_e_ptn_capnp_type(T &in, ucap::NodeEPtn::Builder &root, Context &context) {
-	(void)in;
-	(void)root;
-
-	size_t num_node_e_ptn_e_ptns = in.num_node_e_ptn_e_ptn(context);
-	auto node_e_ptn_e_ptns = root.initEPtns(num_node_e_ptn_e_ptns);
-	for(size_t i = 0; i < num_node_e_ptn_e_ptns; i++) {
-		auto node_e_ptn_e_ptn = node_e_ptn_e_ptns[i];
-		auto child_context = in.get_node_e_ptn_e_ptn(i, context);
-		node_e_ptn_e_ptn.setId(in.get_e_ptn_id(child_context));
-	}
-}
-
-template<class T, typename Context>
-inline void write_rr_node_e_ptns_capnp_type(T &in, ucap::RrNodeEPtns::Builder &root, Context &context) {
-	(void)in;
-	(void)root;
-
-	size_t num_rr_node_e_ptns_node_e_ptns = in.num_rr_node_e_ptns_node_e_ptn(context);
-	auto rr_node_e_ptns_node_e_ptns = root.initNodeEPtns(num_rr_node_e_ptns_node_e_ptns);
-	for(size_t i = 0; i < num_rr_node_e_ptns_node_e_ptns; i++) {
-		auto rr_node_e_ptns_node_e_ptn = rr_node_e_ptns_node_e_ptns[i];
-		auto child_context = in.get_rr_node_e_ptns_node_e_ptn(i, context);
-		rr_node_e_ptns_node_e_ptn.setDest(in.get_node_e_ptn_dest(child_context));
-		rr_node_e_ptns_node_e_ptn.setId(in.get_node_e_ptn_id(child_context));
-		write_node_e_ptn_capnp_type(in, rr_node_e_ptns_node_e_ptn, child_context);
-	}
-}
-
-template<class T, typename Context>
 inline void write_edge_ptn_capnp_type(T &in, ucap::EdgePtn::Builder &root, Context &context) {
 	(void)in;
 	(void)root;
@@ -1346,6 +1316,36 @@ inline void write_rr_edge_ptns_capnp_type(T &in, ucap::RrEdgePtns::Builder &root
 		rr_edge_ptns_edge_ptn.setId(in.get_edge_ptn_id(child_context));
 		rr_edge_ptns_edge_ptn.setSwitchId(in.get_edge_ptn_switch_id(child_context));
 		write_edge_ptn_capnp_type(in, rr_edge_ptns_edge_ptn, child_context);
+	}
+}
+
+template<class T, typename Context>
+inline void write_node_e_ptn_capnp_type(T &in, ucap::NodeEPtn::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
+
+	size_t num_node_e_ptn_e_ptns = in.num_node_e_ptn_e_ptn(context);
+	auto node_e_ptn_e_ptns = root.initEPtns(num_node_e_ptn_e_ptns);
+	for(size_t i = 0; i < num_node_e_ptn_e_ptns; i++) {
+		auto node_e_ptn_e_ptn = node_e_ptn_e_ptns[i];
+		auto child_context = in.get_node_e_ptn_e_ptn(i, context);
+		node_e_ptn_e_ptn.setId(in.get_e_ptn_id(child_context));
+	}
+}
+
+template<class T, typename Context>
+inline void write_rr_node_e_ptns_capnp_type(T &in, ucap::RrNodeEPtns::Builder &root, Context &context) {
+	(void)in;
+	(void)root;
+
+	size_t num_rr_node_e_ptns_node_e_ptns = in.num_rr_node_e_ptns_node_e_ptn(context);
+	auto rr_node_e_ptns_node_e_ptns = root.initNodeEPtns(num_rr_node_e_ptns_node_e_ptns);
+	for(size_t i = 0; i < num_rr_node_e_ptns_node_e_ptns; i++) {
+		auto rr_node_e_ptns_node_e_ptn = rr_node_e_ptns_node_e_ptns[i];
+		auto child_context = in.get_rr_node_e_ptns_node_e_ptn(i, context);
+		rr_node_e_ptns_node_e_ptn.setDest(in.get_node_e_ptn_dest(child_context));
+		rr_node_e_ptns_node_e_ptn.setId(in.get_node_e_ptn_id(child_context));
+		write_node_e_ptn_capnp_type(in, rr_node_e_ptns_node_e_ptn, child_context);
 	}
 }
 
@@ -1391,15 +1391,15 @@ inline void write_rr_graph_capnp_type(T &in, ucap::RrGraph::Builder &root, Conte
 	}
 
 	{
-		auto child_context = in.get_rr_graph_rr_node_e_ptns(context);
-		auto rr_graph_rr_node_e_ptns = root.initRrNodeEPtns();
-		write_rr_node_e_ptns_capnp_type(in, rr_graph_rr_node_e_ptns, child_context);
-	}
-
-	{
 		auto child_context = in.get_rr_graph_rr_edge_ptns(context);
 		auto rr_graph_rr_edge_ptns = root.initRrEdgePtns();
 		write_rr_edge_ptns_capnp_type(in, rr_graph_rr_edge_ptns, child_context);
+	}
+
+	{
+		auto child_context = in.get_rr_graph_rr_node_e_ptns(context);
+		auto rr_graph_rr_node_e_ptns = root.initRrNodeEPtns();
+		write_rr_node_e_ptns_capnp_type(in, rr_graph_rr_node_e_ptns, child_context);
 	}
 }
 

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_interface.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_interface.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
  * Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
- * md5sum of input file: 5c529f385cc39043f69229d620e94c98
+ * md5sum of input file: f70492b177e0daf17b52aa153b3fae93
  */
 
 #include <functional>
@@ -57,12 +57,12 @@ using ChannelReadContext = void *;
 	using MetadataReadContext = void *;
 	using NodeReadContext = void *;
 	using RrNodesReadContext = void *;
-	using EPtnReadContext = void *;
-	using NodeEPtnReadContext = void *;
-	using RrNodeEPtnsReadContext = void *;
 	using DdiffReadContext = void *;
 	using EdgePtnReadContext = void *;
 	using RrEdgePtnsReadContext = void *;
+	using EPtnReadContext = void *;
+	using NodeEPtnReadContext = void *;
+	using RrNodeEPtnsReadContext = void *;
 	using RrGraphReadContext = void *;
 using ChannelWriteContext = void *;
 	using XListWriteContext = void *;
@@ -88,12 +88,12 @@ using ChannelWriteContext = void *;
 	using MetadataWriteContext = void *;
 	using NodeWriteContext = void *;
 	using RrNodesWriteContext = void *;
-	using EPtnWriteContext = void *;
-	using NodeEPtnWriteContext = void *;
-	using RrNodeEPtnsWriteContext = void *;
 	using DdiffWriteContext = void *;
 	using EdgePtnWriteContext = void *;
 	using RrEdgePtnsWriteContext = void *;
+	using EPtnWriteContext = void *;
+	using NodeEPtnWriteContext = void *;
+	using RrNodeEPtnsWriteContext = void *;
 	using RrGraphWriteContext = void *;
 };
 
@@ -473,43 +473,6 @@ public:
 	virtual inline size_t num_rr_nodes_node(typename ContextTypes::RrNodesReadContext &ctx) = 0;
 	virtual inline typename ContextTypes::NodeReadContext get_rr_nodes_node(int n, typename ContextTypes::RrNodesReadContext &ctx) = 0;
 
-	/** Generated for complex type "e_ptn":
-	 * <xs:complexType name="e_ptn">
-	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
-	 * </xs:complexType>
-	*/
-	virtual inline unsigned int get_e_ptn_id(typename ContextTypes::EPtnReadContext &ctx) = 0;
-
-	/** Generated for complex type "node_e_ptn":
-	 * <xs:complexType name="node_e_ptn">
-	 *   <xs:choice maxOccurs="unbounded">
-	 *     <xs:element name="e_ptn" type="e_ptn" />
-	 *   </xs:choice>
-	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
-	 *   <xs:attribute name="dest" type="xs:unsignedInt" use="required" />
-	 * </xs:complexType>
-	*/
-	virtual inline unsigned int get_node_e_ptn_dest(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
-	virtual inline unsigned int get_node_e_ptn_id(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
-	virtual inline void preallocate_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx, size_t size) = 0;
-	virtual inline typename ContextTypes::EPtnWriteContext add_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx, unsigned int id) = 0;
-	virtual inline void finish_node_e_ptn_e_ptn(typename ContextTypes::EPtnWriteContext &ctx) = 0;
-	virtual inline size_t num_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
-	virtual inline typename ContextTypes::EPtnReadContext get_node_e_ptn_e_ptn(int n, typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
-
-	/** Generated for complex type "rr_node_e_ptns":
-	 * <xs:complexType name="rr_node_e_ptns">
-	 *   <xs:choice maxOccurs="unbounded">
-	 *     <xs:element name="node_e_ptn" type="node_e_ptn" />
-	 *   </xs:choice>
-	 * </xs:complexType>
-	*/
-	virtual inline void preallocate_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsWriteContext &ctx, size_t size) = 0;
-	virtual inline typename ContextTypes::NodeEPtnWriteContext add_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsWriteContext &ctx, unsigned int dest, unsigned int id) = 0;
-	virtual inline void finish_rr_node_e_ptns_node_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx) = 0;
-	virtual inline size_t num_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsReadContext &ctx) = 0;
-	virtual inline typename ContextTypes::NodeEPtnReadContext get_rr_node_e_ptns_node_e_ptn(int n, typename ContextTypes::RrNodeEPtnsReadContext &ctx) = 0;
-
 	/** Generated for complex type "ddiff":
 	 * <xs:complexType name="ddiff">
 	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
@@ -547,6 +510,43 @@ public:
 	virtual inline size_t num_rr_edge_ptns_edge_ptn(typename ContextTypes::RrEdgePtnsReadContext &ctx) = 0;
 	virtual inline typename ContextTypes::EdgePtnReadContext get_rr_edge_ptns_edge_ptn(int n, typename ContextTypes::RrEdgePtnsReadContext &ctx) = 0;
 
+	/** Generated for complex type "e_ptn":
+	 * <xs:complexType name="e_ptn">
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_e_ptn_id(typename ContextTypes::EPtnReadContext &ctx) = 0;
+
+	/** Generated for complex type "node_e_ptn":
+	 * <xs:complexType name="node_e_ptn">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="e_ptn" type="e_ptn" />
+	 *   </xs:choice>
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="dest" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_node_e_ptn_dest(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+	virtual inline unsigned int get_node_e_ptn_id(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+	virtual inline void preallocate_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::EPtnWriteContext add_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx, unsigned int id) = 0;
+	virtual inline void finish_node_e_ptn_e_ptn(typename ContextTypes::EPtnWriteContext &ctx) = 0;
+	virtual inline size_t num_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::EPtnReadContext get_node_e_ptn_e_ptn(int n, typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+
+	/** Generated for complex type "rr_node_e_ptns":
+	 * <xs:complexType name="rr_node_e_ptns">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="node_e_ptn" type="node_e_ptn" />
+	 *   </xs:choice>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::NodeEPtnWriteContext add_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsWriteContext &ctx, unsigned int dest, unsigned int id) = 0;
+	virtual inline void finish_rr_node_e_ptns_node_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx) = 0;
+	virtual inline size_t num_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeEPtnReadContext get_rr_node_e_ptns_node_e_ptn(int n, typename ContextTypes::RrNodeEPtnsReadContext &ctx) = 0;
+
 	/** Generated for complex type "rr_graph":
 	 * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	 *     <xs:all>
@@ -556,8 +556,9 @@ public:
 	 *       <xs:element name="block_types" type="block_types" />
 	 *       <xs:element name="grid" type="grid_locs" />
 	 *       <xs:element name="rr_nodes" type="rr_nodes" />
-	 *       <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns" />
+	 *       
 	 *       <xs:element name="rr_edge_ptns" type="rr_edge_ptns" />
+	 *       <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns" />
 	 *       
 	 *     </xs:all>
 	 *     <xs:attribute name="tool_name" type="xs:string" />
@@ -589,12 +590,12 @@ public:
 	virtual inline typename ContextTypes::RrNodesWriteContext init_rr_graph_rr_nodes(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
 	virtual inline void finish_rr_graph_rr_nodes(typename ContextTypes::RrNodesWriteContext &ctx) = 0;
 	virtual inline typename ContextTypes::RrNodesReadContext get_rr_graph_rr_nodes(typename ContextTypes::RrGraphReadContext &ctx) = 0;
-	virtual inline typename ContextTypes::RrNodeEPtnsWriteContext init_rr_graph_rr_node_e_ptns(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
-	virtual inline void finish_rr_graph_rr_node_e_ptns(typename ContextTypes::RrNodeEPtnsWriteContext &ctx) = 0;
-	virtual inline typename ContextTypes::RrNodeEPtnsReadContext get_rr_graph_rr_node_e_ptns(typename ContextTypes::RrGraphReadContext &ctx) = 0;
 	virtual inline typename ContextTypes::RrEdgePtnsWriteContext init_rr_graph_rr_edge_ptns(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
 	virtual inline void finish_rr_graph_rr_edge_ptns(typename ContextTypes::RrEdgePtnsWriteContext &ctx) = 0;
 	virtual inline typename ContextTypes::RrEdgePtnsReadContext get_rr_graph_rr_edge_ptns(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrNodeEPtnsWriteContext init_rr_graph_rr_node_e_ptns(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_rr_node_e_ptns(typename ContextTypes::RrNodeEPtnsWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrNodeEPtnsReadContext get_rr_graph_rr_node_e_ptns(typename ContextTypes::RrGraphReadContext &ctx) = 0;
 };
 
 } /* namespace uxsd */

--- a/vpr/src/route/gen/rr_graph_uxsdcxx_interface.h
+++ b/vpr/src/route/gen/rr_graph_uxsdcxx_interface.h
@@ -4,12 +4,13 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcxx.py /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
- * Input file: /research/ece/lnis/USERS/tang/github/vtr-verilog-to-routing/vpr/src/route/rr_graph.xsd
- * md5sum of input file: cd57d47fc9dfa62c7030397ca759217e
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+ * Input file: /home/ethan/workspaces/ethanroj23/vtr/vpr/src/route/rr_graph.xsd
+ * md5sum of input file: 5c529f385cc39043f69229d620e94c98
  */
 
 #include <functional>
+
 
 /* All uxsdcxx functions and structs live in this namespace. */
 
@@ -20,556 +21,580 @@ namespace uxsd {
 
 /* Enum tokens generated from XSD enumerations. */
 
-enum class enum_switch_type { UXSD_INVALID = 0,
-                              MUX,
-                              TRISTATE,
-                              PASS_GATE,
-                              SHORT,
-                              BUFFER };
+enum class enum_switch_type {UXSD_INVALID = 0, MUX, TRISTATE, PASS_GATE, SHORT, BUFFER};
 
-enum class enum_pin_type { UXSD_INVALID = 0,
-                           OPEN,
-                           OUTPUT,
-                           INPUT };
+enum class enum_pin_type {UXSD_INVALID = 0, OPEN, OUTPUT, INPUT};
 
-enum class enum_node_type { UXSD_INVALID = 0,
-                            CHANX,
-                            CHANY,
-                            SOURCE,
-                            SINK,
-                            OPIN,
-                            IPIN };
+enum class enum_node_type {UXSD_INVALID = 0, CHANX, CHANY, SOURCE, SINK, OPIN, IPIN};
 
-enum class enum_node_direction { UXSD_INVALID = 0,
-                                 INC_DIR,
-                                 DEC_DIR,
-                                 BI_DIR };
+enum class enum_node_direction {UXSD_INVALID = 0, INC_DIR, DEC_DIR, BI_DIR};
 
-enum class enum_loc_side { UXSD_INVALID = 0,
-                           LEFT,
-                           RIGHT,
-                           TOP,
-                           BOTTOM,
-                           RIGHT_LEFT,
-                           RIGHT_BOTTOM,
-                           RIGHT_BOTTOM_LEFT,
-                           TOP_RIGHT,
-                           TOP_BOTTOM,
-                           TOP_LEFT,
-                           TOP_RIGHT_BOTTOM,
-                           TOP_RIGHT_LEFT,
-                           TOP_BOTTOM_LEFT,
-                           TOP_RIGHT_BOTTOM_LEFT,
-                           BOTTOM_LEFT };
+enum class enum_loc_side {UXSD_INVALID = 0, LEFT, RIGHT, TOP, BOTTOM, RIGHT_LEFT, RIGHT_BOTTOM, RIGHT_BOTTOM_LEFT, TOP_RIGHT, TOP_BOTTOM, TOP_LEFT, TOP_RIGHT_BOTTOM, TOP_RIGHT_LEFT, TOP_BOTTOM_LEFT, TOP_RIGHT_BOTTOM_LEFT, BOTTOM_LEFT};
 
 /* Base class for the schema. */
 struct DefaultRrGraphContextTypes {
-    using ChannelReadContext = void*;
-    using XListReadContext = void*;
-    using YListReadContext = void*;
-    using ChannelsReadContext = void*;
-    using TimingReadContext = void*;
-    using SizingReadContext = void*;
-    using SwitchReadContext = void*;
-    using SwitchesReadContext = void*;
-    using SegmentTimingReadContext = void*;
-    using SegmentReadContext = void*;
-    using SegmentsReadContext = void*;
-    using PinReadContext = void*;
-    using PinClassReadContext = void*;
-    using BlockTypeReadContext = void*;
-    using BlockTypesReadContext = void*;
-    using GridLocReadContext = void*;
-    using GridLocsReadContext = void*;
-    using NodeLocReadContext = void*;
-    using NodeTimingReadContext = void*;
-    using NodeSegmentReadContext = void*;
-    using MetaReadContext = void*;
-    using MetadataReadContext = void*;
-    using NodeReadContext = void*;
-    using RrNodesReadContext = void*;
-    using EdgeReadContext = void*;
-    using RrEdgesReadContext = void*;
-    using RrGraphReadContext = void*;
-    using ChannelWriteContext = void*;
-    using XListWriteContext = void*;
-    using YListWriteContext = void*;
-    using ChannelsWriteContext = void*;
-    using TimingWriteContext = void*;
-    using SizingWriteContext = void*;
-    using SwitchWriteContext = void*;
-    using SwitchesWriteContext = void*;
-    using SegmentTimingWriteContext = void*;
-    using SegmentWriteContext = void*;
-    using SegmentsWriteContext = void*;
-    using PinWriteContext = void*;
-    using PinClassWriteContext = void*;
-    using BlockTypeWriteContext = void*;
-    using BlockTypesWriteContext = void*;
-    using GridLocWriteContext = void*;
-    using GridLocsWriteContext = void*;
-    using NodeLocWriteContext = void*;
-    using NodeTimingWriteContext = void*;
-    using NodeSegmentWriteContext = void*;
-    using MetaWriteContext = void*;
-    using MetadataWriteContext = void*;
-    using NodeWriteContext = void*;
-    using RrNodesWriteContext = void*;
-    using EdgeWriteContext = void*;
-    using RrEdgesWriteContext = void*;
-    using RrGraphWriteContext = void*;
+using ChannelReadContext = void *;
+	using XListReadContext = void *;
+	using YListReadContext = void *;
+	using ChannelsReadContext = void *;
+	using TimingReadContext = void *;
+	using SizingReadContext = void *;
+	using SwitchReadContext = void *;
+	using SwitchesReadContext = void *;
+	using SegmentTimingReadContext = void *;
+	using SegmentReadContext = void *;
+	using SegmentsReadContext = void *;
+	using PinReadContext = void *;
+	using PinClassReadContext = void *;
+	using BlockTypeReadContext = void *;
+	using BlockTypesReadContext = void *;
+	using GridLocReadContext = void *;
+	using GridLocsReadContext = void *;
+	using NodeLocReadContext = void *;
+	using NodeTimingReadContext = void *;
+	using NodeSegmentReadContext = void *;
+	using MetaReadContext = void *;
+	using MetadataReadContext = void *;
+	using NodeReadContext = void *;
+	using RrNodesReadContext = void *;
+	using EPtnReadContext = void *;
+	using NodeEPtnReadContext = void *;
+	using RrNodeEPtnsReadContext = void *;
+	using DdiffReadContext = void *;
+	using EdgePtnReadContext = void *;
+	using RrEdgePtnsReadContext = void *;
+	using RrGraphReadContext = void *;
+using ChannelWriteContext = void *;
+	using XListWriteContext = void *;
+	using YListWriteContext = void *;
+	using ChannelsWriteContext = void *;
+	using TimingWriteContext = void *;
+	using SizingWriteContext = void *;
+	using SwitchWriteContext = void *;
+	using SwitchesWriteContext = void *;
+	using SegmentTimingWriteContext = void *;
+	using SegmentWriteContext = void *;
+	using SegmentsWriteContext = void *;
+	using PinWriteContext = void *;
+	using PinClassWriteContext = void *;
+	using BlockTypeWriteContext = void *;
+	using BlockTypesWriteContext = void *;
+	using GridLocWriteContext = void *;
+	using GridLocsWriteContext = void *;
+	using NodeLocWriteContext = void *;
+	using NodeTimingWriteContext = void *;
+	using NodeSegmentWriteContext = void *;
+	using MetaWriteContext = void *;
+	using MetadataWriteContext = void *;
+	using NodeWriteContext = void *;
+	using RrNodesWriteContext = void *;
+	using EPtnWriteContext = void *;
+	using NodeEPtnWriteContext = void *;
+	using RrNodeEPtnsWriteContext = void *;
+	using DdiffWriteContext = void *;
+	using EdgePtnWriteContext = void *;
+	using RrEdgePtnsWriteContext = void *;
+	using RrGraphWriteContext = void *;
 };
 
-template<typename ContextTypes = DefaultRrGraphContextTypes>
+template<typename ContextTypes=DefaultRrGraphContextTypes>
 class RrGraphBase {
-  public:
-    virtual ~RrGraphBase() {}
-    virtual void start_load(const std::function<void(const char*)>* report_error) = 0;
-    virtual void finish_load() = 0;
-    virtual void start_write() = 0;
-    virtual void finish_write() = 0;
-    virtual void error_encountered(const char* file, int line, const char* message) = 0;
-    /** Generated for complex type "channel":
-     * <xs:complexType name="channel">
-     *   <xs:attribute name="chan_width_max" type="xs:int" use="required" />
-     *   <xs:attribute name="x_min" type="xs:int" use="required" />
-     *   <xs:attribute name="y_min" type="xs:int" use="required" />
-     *   <xs:attribute name="x_max" type="xs:int" use="required" />
-     *   <xs:attribute name="y_max" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline int get_channel_chan_width_max(typename ContextTypes::ChannelReadContext& ctx) = 0;
-    virtual inline int get_channel_x_max(typename ContextTypes::ChannelReadContext& ctx) = 0;
-    virtual inline int get_channel_x_min(typename ContextTypes::ChannelReadContext& ctx) = 0;
-    virtual inline int get_channel_y_max(typename ContextTypes::ChannelReadContext& ctx) = 0;
-    virtual inline int get_channel_y_min(typename ContextTypes::ChannelReadContext& ctx) = 0;
+public:
+	virtual ~RrGraphBase() {}
+	virtual void start_load(const std::function<void(const char*)> *report_error) = 0;
+	virtual void finish_load() = 0;
+	virtual void start_write() = 0;
+	virtual void finish_write() = 0;
+	virtual void error_encountered(const char * file, int line, const char *message) = 0;
+	/** Generated for complex type "channel":
+	 * <xs:complexType name="channel">
+	 *   <xs:attribute name="chan_width_max" type="xs:int" use="required" />
+	 *   <xs:attribute name="x_min" type="xs:int" use="required" />
+	 *   <xs:attribute name="y_min" type="xs:int" use="required" />
+	 *   <xs:attribute name="x_max" type="xs:int" use="required" />
+	 *   <xs:attribute name="y_max" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_channel_chan_width_max(typename ContextTypes::ChannelReadContext &ctx) = 0;
+	virtual inline int get_channel_x_max(typename ContextTypes::ChannelReadContext &ctx) = 0;
+	virtual inline int get_channel_x_min(typename ContextTypes::ChannelReadContext &ctx) = 0;
+	virtual inline int get_channel_y_max(typename ContextTypes::ChannelReadContext &ctx) = 0;
+	virtual inline int get_channel_y_min(typename ContextTypes::ChannelReadContext &ctx) = 0;
 
-    /** Generated for complex type "x_list":
-     * <xs:complexType name="x_list">
-     *
-     *   <xs:attribute name="index" type="xs:unsignedInt" use="required" />
-     *   <xs:attribute name="info" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline unsigned int get_x_list_index(typename ContextTypes::XListReadContext& ctx) = 0;
-    virtual inline int get_x_list_info(typename ContextTypes::XListReadContext& ctx) = 0;
+	/** Generated for complex type "x_list":
+	 * <xs:complexType name="x_list">
+	 *   
+	 *   <xs:attribute name="index" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="info" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_x_list_index(typename ContextTypes::XListReadContext &ctx) = 0;
+	virtual inline int get_x_list_info(typename ContextTypes::XListReadContext &ctx) = 0;
 
-    /** Generated for complex type "y_list":
-     * <xs:complexType name="y_list">
-     *   <xs:attribute name="index" type="xs:unsignedInt" use="required" />
-     *   <xs:attribute name="info" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline unsigned int get_y_list_index(typename ContextTypes::YListReadContext& ctx) = 0;
-    virtual inline int get_y_list_info(typename ContextTypes::YListReadContext& ctx) = 0;
+	/** Generated for complex type "y_list":
+	 * <xs:complexType name="y_list">
+	 *   <xs:attribute name="index" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="info" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_y_list_index(typename ContextTypes::YListReadContext &ctx) = 0;
+	virtual inline int get_y_list_info(typename ContextTypes::YListReadContext &ctx) = 0;
 
-    /** Generated for complex type "channels":
-     * <xs:complexType name="channels">
-     *   <xs:sequence>
-     *     <xs:element name="channel" type="channel" />
-     *     <xs:element maxOccurs="unbounded" name="x_list" type="x_list" />
-     *     <xs:element maxOccurs="unbounded" name="y_list" type="y_list" />
-     *   </xs:sequence>
-     * </xs:complexType>
-     */
-    virtual inline typename ContextTypes::ChannelWriteContext init_channels_channel(typename ContextTypes::ChannelsWriteContext& ctx, int chan_width_max, int x_max, int x_min, int y_max, int y_min) = 0;
-    virtual inline void finish_channels_channel(typename ContextTypes::ChannelWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::ChannelReadContext get_channels_channel(typename ContextTypes::ChannelsReadContext& ctx) = 0;
-    virtual inline void preallocate_channels_x_list(typename ContextTypes::ChannelsWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::XListWriteContext add_channels_x_list(typename ContextTypes::ChannelsWriteContext& ctx, unsigned int index, int info) = 0;
-    virtual inline void finish_channels_x_list(typename ContextTypes::XListWriteContext& ctx) = 0;
-    virtual inline size_t num_channels_x_list(typename ContextTypes::ChannelsReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::XListReadContext get_channels_x_list(int n, typename ContextTypes::ChannelsReadContext& ctx) = 0;
-    virtual inline void preallocate_channels_y_list(typename ContextTypes::ChannelsWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::YListWriteContext add_channels_y_list(typename ContextTypes::ChannelsWriteContext& ctx, unsigned int index, int info) = 0;
-    virtual inline void finish_channels_y_list(typename ContextTypes::YListWriteContext& ctx) = 0;
-    virtual inline size_t num_channels_y_list(typename ContextTypes::ChannelsReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::YListReadContext get_channels_y_list(int n, typename ContextTypes::ChannelsReadContext& ctx) = 0;
+	/** Generated for complex type "channels":
+	 * <xs:complexType name="channels">
+	 *   <xs:sequence>
+	 *     <xs:element name="channel" type="channel" />
+	 *     <xs:element maxOccurs="unbounded" name="x_list" type="x_list" />
+	 *     <xs:element maxOccurs="unbounded" name="y_list" type="y_list" />
+	 *   </xs:sequence>
+	 * </xs:complexType>
+	*/
+	virtual inline typename ContextTypes::ChannelWriteContext init_channels_channel(typename ContextTypes::ChannelsWriteContext &ctx, int chan_width_max, int x_max, int x_min, int y_max, int y_min) = 0;
+	virtual inline void finish_channels_channel(typename ContextTypes::ChannelWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::ChannelReadContext get_channels_channel(typename ContextTypes::ChannelsReadContext &ctx) = 0;
+	virtual inline void preallocate_channels_x_list(typename ContextTypes::ChannelsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::XListWriteContext add_channels_x_list(typename ContextTypes::ChannelsWriteContext &ctx, unsigned int index, int info) = 0;
+	virtual inline void finish_channels_x_list(typename ContextTypes::XListWriteContext &ctx) = 0;
+	virtual inline size_t num_channels_x_list(typename ContextTypes::ChannelsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::XListReadContext get_channels_x_list(int n, typename ContextTypes::ChannelsReadContext &ctx) = 0;
+	virtual inline void preallocate_channels_y_list(typename ContextTypes::ChannelsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::YListWriteContext add_channels_y_list(typename ContextTypes::ChannelsWriteContext &ctx, unsigned int index, int info) = 0;
+	virtual inline void finish_channels_y_list(typename ContextTypes::YListWriteContext &ctx) = 0;
+	virtual inline size_t num_channels_y_list(typename ContextTypes::ChannelsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::YListReadContext get_channels_y_list(int n, typename ContextTypes::ChannelsReadContext &ctx) = 0;
 
-    /** Generated for complex type "timing":
-     * <xs:complexType name="timing">
-     *
-     *   <xs:attribute name="R" type="xs:float" />
-     *   <xs:attribute name="Cin" type="xs:float" />
-     *   <xs:attribute name="Cinternal" type="xs:float" />
-     *   <xs:attribute name="Cout" type="xs:float" />
-     *   <xs:attribute name="Tdel" type="xs:float" />
-     * </xs:complexType>
-     */
-    virtual inline float get_timing_Cin(typename ContextTypes::TimingReadContext& ctx) = 0;
-    virtual inline void set_timing_Cin(float Cin, typename ContextTypes::TimingWriteContext& ctx) = 0;
-    virtual inline float get_timing_Cinternal(typename ContextTypes::TimingReadContext& ctx) = 0;
-    virtual inline void set_timing_Cinternal(float Cinternal, typename ContextTypes::TimingWriteContext& ctx) = 0;
-    virtual inline float get_timing_Cout(typename ContextTypes::TimingReadContext& ctx) = 0;
-    virtual inline void set_timing_Cout(float Cout, typename ContextTypes::TimingWriteContext& ctx) = 0;
-    virtual inline float get_timing_R(typename ContextTypes::TimingReadContext& ctx) = 0;
-    virtual inline void set_timing_R(float R, typename ContextTypes::TimingWriteContext& ctx) = 0;
-    virtual inline float get_timing_Tdel(typename ContextTypes::TimingReadContext& ctx) = 0;
-    virtual inline void set_timing_Tdel(float Tdel, typename ContextTypes::TimingWriteContext& ctx) = 0;
+	/** Generated for complex type "timing":
+	 * <xs:complexType name="timing">
+	 *   
+	 *   <xs:attribute name="R" type="xs:float" />
+	 *   <xs:attribute name="Cin" type="xs:float" />
+	 *   <xs:attribute name="Cinternal" type="xs:float" />
+	 *   <xs:attribute name="Cout" type="xs:float" />
+	 *   <xs:attribute name="Tdel" type="xs:float" />
+	 * </xs:complexType>
+	*/
+	virtual inline float get_timing_Cin(typename ContextTypes::TimingReadContext &ctx) = 0;
+	virtual inline void set_timing_Cin(float Cin, typename ContextTypes::TimingWriteContext &ctx) = 0;
+	virtual inline float get_timing_Cinternal(typename ContextTypes::TimingReadContext &ctx) = 0;
+	virtual inline void set_timing_Cinternal(float Cinternal, typename ContextTypes::TimingWriteContext &ctx) = 0;
+	virtual inline float get_timing_Cout(typename ContextTypes::TimingReadContext &ctx) = 0;
+	virtual inline void set_timing_Cout(float Cout, typename ContextTypes::TimingWriteContext &ctx) = 0;
+	virtual inline float get_timing_R(typename ContextTypes::TimingReadContext &ctx) = 0;
+	virtual inline void set_timing_R(float R, typename ContextTypes::TimingWriteContext &ctx) = 0;
+	virtual inline float get_timing_Tdel(typename ContextTypes::TimingReadContext &ctx) = 0;
+	virtual inline void set_timing_Tdel(float Tdel, typename ContextTypes::TimingWriteContext &ctx) = 0;
 
-    /** Generated for complex type "sizing":
-     * <xs:complexType name="sizing">
-     *   <xs:attribute name="mux_trans_size" type="xs:float" use="required" />
-     *   <xs:attribute name="buf_size" type="xs:float" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline float get_sizing_buf_size(typename ContextTypes::SizingReadContext& ctx) = 0;
-    virtual inline float get_sizing_mux_trans_size(typename ContextTypes::SizingReadContext& ctx) = 0;
+	/** Generated for complex type "sizing":
+	 * <xs:complexType name="sizing">
+	 *   <xs:attribute name="mux_trans_size" type="xs:float" use="required" />
+	 *   <xs:attribute name="buf_size" type="xs:float" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline float get_sizing_buf_size(typename ContextTypes::SizingReadContext &ctx) = 0;
+	virtual inline float get_sizing_mux_trans_size(typename ContextTypes::SizingReadContext &ctx) = 0;
 
-    /** Generated for complex type "switch":
-     * <xs:complexType name="switch">
-     *   <xs:all>
-     *     <xs:element minOccurs="0" name="timing" type="timing" />
-     *     <xs:element name="sizing" type="sizing" />
-     *   </xs:all>
-     *   <xs:attribute name="id" type="xs:int" use="required" />
-     *
-     *   <xs:attribute name="name" type="xs:string" use="required" />
-     *
-     *   <xs:attribute name="type" type="switch_type" />
-     * </xs:complexType>
-     */
-    virtual inline int get_switch_id(typename ContextTypes::SwitchReadContext& ctx) = 0;
-    virtual inline const char* get_switch_name(typename ContextTypes::SwitchReadContext& ctx) = 0;
-    virtual inline void set_switch_name(const char* name, typename ContextTypes::SwitchWriteContext& ctx) = 0;
-    virtual inline enum_switch_type get_switch_type(typename ContextTypes::SwitchReadContext& ctx) = 0;
-    virtual inline void set_switch_type(enum_switch_type type, typename ContextTypes::SwitchWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::TimingWriteContext init_switch_timing(typename ContextTypes::SwitchWriteContext& ctx) = 0;
-    virtual inline void finish_switch_timing(typename ContextTypes::TimingWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::TimingReadContext get_switch_timing(typename ContextTypes::SwitchReadContext& ctx) = 0;
-    virtual inline bool has_switch_timing(typename ContextTypes::SwitchReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::SizingWriteContext init_switch_sizing(typename ContextTypes::SwitchWriteContext& ctx, float buf_size, float mux_trans_size) = 0;
-    virtual inline void finish_switch_sizing(typename ContextTypes::SizingWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::SizingReadContext get_switch_sizing(typename ContextTypes::SwitchReadContext& ctx) = 0;
+	/** Generated for complex type "switch":
+	 * <xs:complexType name="switch">
+	 *   <xs:all>
+	 *     <xs:element minOccurs="0" name="timing" type="timing" />
+	 *     <xs:element name="sizing" type="sizing" />
+	 *   </xs:all>
+	 *   <xs:attribute name="id" type="xs:int" use="required" />
+	 *   
+	 *   <xs:attribute name="name" type="xs:string" use="required" />
+	 *   
+	 *   <xs:attribute name="type" type="switch_type" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_switch_id(typename ContextTypes::SwitchReadContext &ctx) = 0;
+	virtual inline const char * get_switch_name(typename ContextTypes::SwitchReadContext &ctx) = 0;
+	virtual inline void set_switch_name(const char * name, typename ContextTypes::SwitchWriteContext &ctx) = 0;
+	virtual inline enum_switch_type get_switch_type(typename ContextTypes::SwitchReadContext &ctx) = 0;
+	virtual inline void set_switch_type(enum_switch_type type, typename ContextTypes::SwitchWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::TimingWriteContext init_switch_timing(typename ContextTypes::SwitchWriteContext &ctx) = 0;
+	virtual inline void finish_switch_timing(typename ContextTypes::TimingWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::TimingReadContext get_switch_timing(typename ContextTypes::SwitchReadContext &ctx) = 0;
+	virtual inline bool has_switch_timing(typename ContextTypes::SwitchReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::SizingWriteContext init_switch_sizing(typename ContextTypes::SwitchWriteContext &ctx, float buf_size, float mux_trans_size) = 0;
+	virtual inline void finish_switch_sizing(typename ContextTypes::SizingWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::SizingReadContext get_switch_sizing(typename ContextTypes::SwitchReadContext &ctx) = 0;
 
-    /** Generated for complex type "switches":
-     * <xs:complexType name="switches">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="switch" type="switch" />
-     *   </xs:sequence>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_switches_switch(typename ContextTypes::SwitchesWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::SwitchWriteContext add_switches_switch(typename ContextTypes::SwitchesWriteContext& ctx, int id) = 0;
-    virtual inline void finish_switches_switch(typename ContextTypes::SwitchWriteContext& ctx) = 0;
-    virtual inline size_t num_switches_switch(typename ContextTypes::SwitchesReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::SwitchReadContext get_switches_switch(int n, typename ContextTypes::SwitchesReadContext& ctx) = 0;
+	/** Generated for complex type "switches":
+	 * <xs:complexType name="switches">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" name="switch" type="switch" />
+	 *   </xs:sequence>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_switches_switch(typename ContextTypes::SwitchesWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::SwitchWriteContext add_switches_switch(typename ContextTypes::SwitchesWriteContext &ctx, int id) = 0;
+	virtual inline void finish_switches_switch(typename ContextTypes::SwitchWriteContext &ctx) = 0;
+	virtual inline size_t num_switches_switch(typename ContextTypes::SwitchesReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::SwitchReadContext get_switches_switch(int n, typename ContextTypes::SwitchesReadContext &ctx) = 0;
 
-    /** Generated for complex type "segment_timing":
-     * <xs:complexType name="segment_timing">
-     *   <xs:attribute name="R_per_meter" type="xs:float" />
-     *   <xs:attribute name="C_per_meter" type="xs:float" />
-     * </xs:complexType>
-     */
-    virtual inline float get_segment_timing_C_per_meter(typename ContextTypes::SegmentTimingReadContext& ctx) = 0;
-    virtual inline void set_segment_timing_C_per_meter(float C_per_meter, typename ContextTypes::SegmentTimingWriteContext& ctx) = 0;
-    virtual inline float get_segment_timing_R_per_meter(typename ContextTypes::SegmentTimingReadContext& ctx) = 0;
-    virtual inline void set_segment_timing_R_per_meter(float R_per_meter, typename ContextTypes::SegmentTimingWriteContext& ctx) = 0;
+	/** Generated for complex type "segment_timing":
+	 * <xs:complexType name="segment_timing">
+	 *   <xs:attribute name="R_per_meter" type="xs:float" />
+	 *   <xs:attribute name="C_per_meter" type="xs:float" />
+	 * </xs:complexType>
+	*/
+	virtual inline float get_segment_timing_C_per_meter(typename ContextTypes::SegmentTimingReadContext &ctx) = 0;
+	virtual inline void set_segment_timing_C_per_meter(float C_per_meter, typename ContextTypes::SegmentTimingWriteContext &ctx) = 0;
+	virtual inline float get_segment_timing_R_per_meter(typename ContextTypes::SegmentTimingReadContext &ctx) = 0;
+	virtual inline void set_segment_timing_R_per_meter(float R_per_meter, typename ContextTypes::SegmentTimingWriteContext &ctx) = 0;
 
-    /** Generated for complex type "segment":
-     * <xs:complexType name="segment">
-     *   <xs:all>
-     *     <xs:element minOccurs="0" name="timing" type="segment_timing" />
-     *   </xs:all>
-     *   <xs:attribute name="id" type="xs:int" use="required" />
-     *   <xs:attribute name="name" type="xs:string" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline int get_segment_id(typename ContextTypes::SegmentReadContext& ctx) = 0;
-    virtual inline const char* get_segment_name(typename ContextTypes::SegmentReadContext& ctx) = 0;
-    virtual inline void set_segment_name(const char* name, typename ContextTypes::SegmentWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::SegmentTimingWriteContext init_segment_timing(typename ContextTypes::SegmentWriteContext& ctx) = 0;
-    virtual inline void finish_segment_timing(typename ContextTypes::SegmentTimingWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::SegmentTimingReadContext get_segment_timing(typename ContextTypes::SegmentReadContext& ctx) = 0;
-    virtual inline bool has_segment_timing(typename ContextTypes::SegmentReadContext& ctx) = 0;
+	/** Generated for complex type "segment":
+	 * <xs:complexType name="segment">
+	 *   <xs:all>
+	 *     <xs:element minOccurs="0" name="timing" type="segment_timing" />
+	 *   </xs:all>
+	 *   <xs:attribute name="id" type="xs:int" use="required" />
+	 *   <xs:attribute name="name" type="xs:string" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_segment_id(typename ContextTypes::SegmentReadContext &ctx) = 0;
+	virtual inline const char * get_segment_name(typename ContextTypes::SegmentReadContext &ctx) = 0;
+	virtual inline void set_segment_name(const char * name, typename ContextTypes::SegmentWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::SegmentTimingWriteContext init_segment_timing(typename ContextTypes::SegmentWriteContext &ctx) = 0;
+	virtual inline void finish_segment_timing(typename ContextTypes::SegmentTimingWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::SegmentTimingReadContext get_segment_timing(typename ContextTypes::SegmentReadContext &ctx) = 0;
+	virtual inline bool has_segment_timing(typename ContextTypes::SegmentReadContext &ctx) = 0;
 
-    /** Generated for complex type "segments":
-     * <xs:complexType name="segments">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="segment" type="segment" />
-     *   </xs:sequence>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_segments_segment(typename ContextTypes::SegmentsWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::SegmentWriteContext add_segments_segment(typename ContextTypes::SegmentsWriteContext& ctx, int id) = 0;
-    virtual inline void finish_segments_segment(typename ContextTypes::SegmentWriteContext& ctx) = 0;
-    virtual inline size_t num_segments_segment(typename ContextTypes::SegmentsReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::SegmentReadContext get_segments_segment(int n, typename ContextTypes::SegmentsReadContext& ctx) = 0;
+	/** Generated for complex type "segments":
+	 * <xs:complexType name="segments">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" name="segment" type="segment" />
+	 *   </xs:sequence>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_segments_segment(typename ContextTypes::SegmentsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::SegmentWriteContext add_segments_segment(typename ContextTypes::SegmentsWriteContext &ctx, int id) = 0;
+	virtual inline void finish_segments_segment(typename ContextTypes::SegmentWriteContext &ctx) = 0;
+	virtual inline size_t num_segments_segment(typename ContextTypes::SegmentsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::SegmentReadContext get_segments_segment(int n, typename ContextTypes::SegmentsReadContext &ctx) = 0;
 
-    /** Generated for complex type "pin":
-     * <xs:complexType name="pin">
-     *   <xs:simpleContent>
-     *     <xs:extension base="xs:string">
-     *       <xs:attribute name="ptc" type="xs:int" use="required" />
-     *     </xs:extension>
-     *   </xs:simpleContent>
-     * </xs:complexType>
-     */
-    virtual inline int get_pin_ptc(typename ContextTypes::PinReadContext& ctx) = 0;
-    virtual inline void set_pin_value(const char* value, typename ContextTypes::PinWriteContext& ctx) = 0;
-    virtual inline const char* get_pin_value(typename ContextTypes::PinReadContext& ctx) = 0;
+	/** Generated for complex type "pin":
+	 * <xs:complexType name="pin">
+	 *   <xs:simpleContent>
+	 *     <xs:extension base="xs:string">
+	 *       <xs:attribute name="ptc" type="xs:int" use="required" />
+	 *     </xs:extension>
+	 *   </xs:simpleContent>
+	 * </xs:complexType>
+	*/
+	virtual inline int get_pin_ptc(typename ContextTypes::PinReadContext &ctx) = 0;
+	virtual inline void set_pin_value(const char * value, typename ContextTypes::PinWriteContext &ctx) = 0;
+	virtual inline const char * get_pin_value(typename ContextTypes::PinReadContext &ctx) = 0;
 
-    /** Generated for complex type "pin_class":
-     * <xs:complexType name="pin_class">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="pin" type="pin" />
-     *   </xs:sequence>
-     *   <xs:attribute name="type" type="pin_type" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline enum_pin_type get_pin_class_type(typename ContextTypes::PinClassReadContext& ctx) = 0;
-    virtual inline void preallocate_pin_class_pin(typename ContextTypes::PinClassWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::PinWriteContext add_pin_class_pin(typename ContextTypes::PinClassWriteContext& ctx, int ptc) = 0;
-    virtual inline void finish_pin_class_pin(typename ContextTypes::PinWriteContext& ctx) = 0;
-    virtual inline size_t num_pin_class_pin(typename ContextTypes::PinClassReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::PinReadContext get_pin_class_pin(int n, typename ContextTypes::PinClassReadContext& ctx) = 0;
+	/** Generated for complex type "pin_class":
+	 * <xs:complexType name="pin_class">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" name="pin" type="pin" />
+	 *   </xs:sequence>
+	 *   <xs:attribute name="type" type="pin_type" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline enum_pin_type get_pin_class_type(typename ContextTypes::PinClassReadContext &ctx) = 0;
+	virtual inline void preallocate_pin_class_pin(typename ContextTypes::PinClassWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::PinWriteContext add_pin_class_pin(typename ContextTypes::PinClassWriteContext &ctx, int ptc) = 0;
+	virtual inline void finish_pin_class_pin(typename ContextTypes::PinWriteContext &ctx) = 0;
+	virtual inline size_t num_pin_class_pin(typename ContextTypes::PinClassReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::PinReadContext get_pin_class_pin(int n, typename ContextTypes::PinClassReadContext &ctx) = 0;
 
-    /** Generated for complex type "block_type":
-     * <xs:complexType name="block_type">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" minOccurs="0" name="pin_class" type="pin_class" />
-     *   </xs:sequence>
-     *   <xs:attribute name="id" type="xs:int" use="required" />
-     *   <xs:attribute name="name" type="xs:string" use="required" />
-     *   <xs:attribute name="width" type="xs:int" use="required" />
-     *   <xs:attribute name="height" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline int get_block_type_height(typename ContextTypes::BlockTypeReadContext& ctx) = 0;
-    virtual inline int get_block_type_id(typename ContextTypes::BlockTypeReadContext& ctx) = 0;
-    virtual inline const char* get_block_type_name(typename ContextTypes::BlockTypeReadContext& ctx) = 0;
-    virtual inline void set_block_type_name(const char* name, typename ContextTypes::BlockTypeWriteContext& ctx) = 0;
-    virtual inline int get_block_type_width(typename ContextTypes::BlockTypeReadContext& ctx) = 0;
-    virtual inline void preallocate_block_type_pin_class(typename ContextTypes::BlockTypeWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::PinClassWriteContext add_block_type_pin_class(typename ContextTypes::BlockTypeWriteContext& ctx, enum_pin_type type) = 0;
-    virtual inline void finish_block_type_pin_class(typename ContextTypes::PinClassWriteContext& ctx) = 0;
-    virtual inline size_t num_block_type_pin_class(typename ContextTypes::BlockTypeReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::PinClassReadContext get_block_type_pin_class(int n, typename ContextTypes::BlockTypeReadContext& ctx) = 0;
+	/** Generated for complex type "block_type":
+	 * <xs:complexType name="block_type">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" minOccurs="0" name="pin_class" type="pin_class" />
+	 *   </xs:sequence>
+	 *   <xs:attribute name="id" type="xs:int" use="required" />
+	 *   <xs:attribute name="name" type="xs:string" use="required" />
+	 *   <xs:attribute name="width" type="xs:int" use="required" />
+	 *   <xs:attribute name="height" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_block_type_height(typename ContextTypes::BlockTypeReadContext &ctx) = 0;
+	virtual inline int get_block_type_id(typename ContextTypes::BlockTypeReadContext &ctx) = 0;
+	virtual inline const char * get_block_type_name(typename ContextTypes::BlockTypeReadContext &ctx) = 0;
+	virtual inline void set_block_type_name(const char * name, typename ContextTypes::BlockTypeWriteContext &ctx) = 0;
+	virtual inline int get_block_type_width(typename ContextTypes::BlockTypeReadContext &ctx) = 0;
+	virtual inline void preallocate_block_type_pin_class(typename ContextTypes::BlockTypeWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::PinClassWriteContext add_block_type_pin_class(typename ContextTypes::BlockTypeWriteContext &ctx, enum_pin_type type) = 0;
+	virtual inline void finish_block_type_pin_class(typename ContextTypes::PinClassWriteContext &ctx) = 0;
+	virtual inline size_t num_block_type_pin_class(typename ContextTypes::BlockTypeReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::PinClassReadContext get_block_type_pin_class(int n, typename ContextTypes::BlockTypeReadContext &ctx) = 0;
 
-    /** Generated for complex type "block_types":
-     * <xs:complexType name="block_types">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="block_type" type="block_type" />
-     *   </xs:sequence>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_block_types_block_type(typename ContextTypes::BlockTypesWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::BlockTypeWriteContext add_block_types_block_type(typename ContextTypes::BlockTypesWriteContext& ctx, int height, int id, int width) = 0;
-    virtual inline void finish_block_types_block_type(typename ContextTypes::BlockTypeWriteContext& ctx) = 0;
-    virtual inline size_t num_block_types_block_type(typename ContextTypes::BlockTypesReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::BlockTypeReadContext get_block_types_block_type(int n, typename ContextTypes::BlockTypesReadContext& ctx) = 0;
+	/** Generated for complex type "block_types":
+	 * <xs:complexType name="block_types">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" name="block_type" type="block_type" />
+	 *   </xs:sequence>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_block_types_block_type(typename ContextTypes::BlockTypesWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::BlockTypeWriteContext add_block_types_block_type(typename ContextTypes::BlockTypesWriteContext &ctx, int height, int id, int width) = 0;
+	virtual inline void finish_block_types_block_type(typename ContextTypes::BlockTypeWriteContext &ctx) = 0;
+	virtual inline size_t num_block_types_block_type(typename ContextTypes::BlockTypesReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::BlockTypeReadContext get_block_types_block_type(int n, typename ContextTypes::BlockTypesReadContext &ctx) = 0;
 
-    /** Generated for complex type "grid_loc":
-     * <xs:complexType name="grid_loc">
-     *   <xs:attribute name="x" type="xs:int" use="required" />
-     *   <xs:attribute name="y" type="xs:int" use="required" />
-     *   <xs:attribute name="block_type_id" type="xs:int" use="required" />
-     *   <xs:attribute name="width_offset" type="xs:int" use="required" />
-     *   <xs:attribute name="height_offset" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline int get_grid_loc_block_type_id(typename ContextTypes::GridLocReadContext& ctx) = 0;
-    virtual inline int get_grid_loc_height_offset(typename ContextTypes::GridLocReadContext& ctx) = 0;
-    virtual inline int get_grid_loc_width_offset(typename ContextTypes::GridLocReadContext& ctx) = 0;
-    virtual inline int get_grid_loc_x(typename ContextTypes::GridLocReadContext& ctx) = 0;
-    virtual inline int get_grid_loc_y(typename ContextTypes::GridLocReadContext& ctx) = 0;
+	/** Generated for complex type "grid_loc":
+	 * <xs:complexType name="grid_loc">
+	 *   <xs:attribute name="x" type="xs:int" use="required" />
+	 *   <xs:attribute name="y" type="xs:int" use="required" />
+	 *   <xs:attribute name="block_type_id" type="xs:int" use="required" />
+	 *   <xs:attribute name="width_offset" type="xs:int" use="required" />
+	 *   <xs:attribute name="height_offset" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_grid_loc_block_type_id(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline int get_grid_loc_height_offset(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline int get_grid_loc_width_offset(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline int get_grid_loc_x(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline int get_grid_loc_y(typename ContextTypes::GridLocReadContext &ctx) = 0;
 
-    /** Generated for complex type "grid_locs":
-     * <xs:complexType name="grid_locs">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="grid_loc" type="grid_loc" />
-     *   </xs:sequence>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::GridLocWriteContext add_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext& ctx, int block_type_id, int height_offset, int width_offset, int x, int y) = 0;
-    virtual inline void finish_grid_locs_grid_loc(typename ContextTypes::GridLocWriteContext& ctx) = 0;
-    virtual inline size_t num_grid_locs_grid_loc(typename ContextTypes::GridLocsReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::GridLocReadContext get_grid_locs_grid_loc(int n, typename ContextTypes::GridLocsReadContext& ctx) = 0;
+	/** Generated for complex type "grid_locs":
+	 * <xs:complexType name="grid_locs">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" name="grid_loc" type="grid_loc" />
+	 *   </xs:sequence>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::GridLocWriteContext add_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, int block_type_id, int height_offset, int width_offset, int x, int y) = 0;
+	virtual inline void finish_grid_locs_grid_loc(typename ContextTypes::GridLocWriteContext &ctx) = 0;
+	virtual inline size_t num_grid_locs_grid_loc(typename ContextTypes::GridLocsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::GridLocReadContext get_grid_locs_grid_loc(int n, typename ContextTypes::GridLocsReadContext &ctx) = 0;
 
-    /** Generated for complex type "node_loc":
-     * <xs:complexType name="node_loc">
-     *   <xs:attribute name="xlow" type="xs:int" use="required" />
-     *   <xs:attribute name="ylow" type="xs:int" use="required" />
-     *   <xs:attribute name="xhigh" type="xs:int" use="required" />
-     *   <xs:attribute name="yhigh" type="xs:int" use="required" />
-     *   <xs:attribute name="side" type="loc_side" />
-     *   <xs:attribute name="ptc" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline int get_node_loc_ptc(typename ContextTypes::NodeLocReadContext& ctx) = 0;
-    virtual inline enum_loc_side get_node_loc_side(typename ContextTypes::NodeLocReadContext& ctx) = 0;
-    virtual inline void set_node_loc_side(enum_loc_side side, typename ContextTypes::NodeLocWriteContext& ctx) = 0;
-    virtual inline int get_node_loc_xhigh(typename ContextTypes::NodeLocReadContext& ctx) = 0;
-    virtual inline int get_node_loc_xlow(typename ContextTypes::NodeLocReadContext& ctx) = 0;
-    virtual inline int get_node_loc_yhigh(typename ContextTypes::NodeLocReadContext& ctx) = 0;
-    virtual inline int get_node_loc_ylow(typename ContextTypes::NodeLocReadContext& ctx) = 0;
+	/** Generated for complex type "node_loc":
+	 * <xs:complexType name="node_loc">
+	 *   <xs:attribute name="xlow" type="xs:int" use="required" />
+	 *   <xs:attribute name="ylow" type="xs:int" use="required" />
+	 *   <xs:attribute name="xhigh" type="xs:int" use="required" />
+	 *   <xs:attribute name="yhigh" type="xs:int" use="required" />
+	 *   <xs:attribute name="side" type="loc_side" />
+	 *   <xs:attribute name="ptc" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_node_loc_ptc(typename ContextTypes::NodeLocReadContext &ctx) = 0;
+	virtual inline enum_loc_side get_node_loc_side(typename ContextTypes::NodeLocReadContext &ctx) = 0;
+	virtual inline void set_node_loc_side(enum_loc_side side, typename ContextTypes::NodeLocWriteContext &ctx) = 0;
+	virtual inline int get_node_loc_xhigh(typename ContextTypes::NodeLocReadContext &ctx) = 0;
+	virtual inline int get_node_loc_xlow(typename ContextTypes::NodeLocReadContext &ctx) = 0;
+	virtual inline int get_node_loc_yhigh(typename ContextTypes::NodeLocReadContext &ctx) = 0;
+	virtual inline int get_node_loc_ylow(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 
-    /** Generated for complex type "node_timing":
-     * <xs:complexType name="node_timing">
-     *   <xs:attribute name="R" type="xs:float" use="required" />
-     *   <xs:attribute name="C" type="xs:float" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline float get_node_timing_C(typename ContextTypes::NodeTimingReadContext& ctx) = 0;
-    virtual inline float get_node_timing_R(typename ContextTypes::NodeTimingReadContext& ctx) = 0;
+	/** Generated for complex type "node_timing":
+	 * <xs:complexType name="node_timing">
+	 *   <xs:attribute name="R" type="xs:float" use="required" />
+	 *   <xs:attribute name="C" type="xs:float" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline float get_node_timing_C(typename ContextTypes::NodeTimingReadContext &ctx) = 0;
+	virtual inline float get_node_timing_R(typename ContextTypes::NodeTimingReadContext &ctx) = 0;
 
-    /** Generated for complex type "node_segment":
-     * <xs:complexType name="node_segment">
-     *   <xs:attribute name="segment_id" type="xs:int" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline int get_node_segment_segment_id(typename ContextTypes::NodeSegmentReadContext& ctx) = 0;
+	/** Generated for complex type "node_segment":
+	 * <xs:complexType name="node_segment">
+	 *   <xs:attribute name="segment_id" type="xs:int" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline int get_node_segment_segment_id(typename ContextTypes::NodeSegmentReadContext &ctx) = 0;
 
-    /** Generated for complex type "meta":
-     * <xs:complexType name="meta">
-     *   <xs:simpleContent>
-     *     <xs:extension base="xs:string">
-     *       <xs:attribute name="name" type="xs:string" use="required" />
-     *     </xs:extension>
-     *   </xs:simpleContent>
-     * </xs:complexType>
-     */
-    virtual inline const char* get_meta_name(typename ContextTypes::MetaReadContext& ctx) = 0;
-    virtual inline void set_meta_name(const char* name, typename ContextTypes::MetaWriteContext& ctx) = 0;
-    virtual inline void set_meta_value(const char* value, typename ContextTypes::MetaWriteContext& ctx) = 0;
-    virtual inline const char* get_meta_value(typename ContextTypes::MetaReadContext& ctx) = 0;
+	/** Generated for complex type "meta":
+	 * <xs:complexType name="meta">
+	 *   <xs:simpleContent>
+	 *     <xs:extension base="xs:string">
+	 *       <xs:attribute name="name" type="xs:string" use="required" />
+	 *     </xs:extension>
+	 *   </xs:simpleContent>
+	 * </xs:complexType>
+	*/
+	virtual inline const char * get_meta_name(typename ContextTypes::MetaReadContext &ctx) = 0;
+	virtual inline void set_meta_name(const char * name, typename ContextTypes::MetaWriteContext &ctx) = 0;
+	virtual inline void set_meta_value(const char * value, typename ContextTypes::MetaWriteContext &ctx) = 0;
+	virtual inline const char * get_meta_value(typename ContextTypes::MetaReadContext &ctx) = 0;
 
-    /** Generated for complex type "metadata":
-     * <xs:complexType name="metadata">
-     *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="meta" type="meta" />
-     *   </xs:sequence>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_metadata_meta(typename ContextTypes::MetadataWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::MetaWriteContext add_metadata_meta(typename ContextTypes::MetadataWriteContext& ctx) = 0;
-    virtual inline void finish_metadata_meta(typename ContextTypes::MetaWriteContext& ctx) = 0;
-    virtual inline size_t num_metadata_meta(typename ContextTypes::MetadataReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::MetaReadContext get_metadata_meta(int n, typename ContextTypes::MetadataReadContext& ctx) = 0;
+	/** Generated for complex type "metadata":
+	 * <xs:complexType name="metadata">
+	 *   <xs:sequence>
+	 *     <xs:element maxOccurs="unbounded" name="meta" type="meta" />
+	 *   </xs:sequence>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_metadata_meta(typename ContextTypes::MetadataWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::MetaWriteContext add_metadata_meta(typename ContextTypes::MetadataWriteContext &ctx) = 0;
+	virtual inline void finish_metadata_meta(typename ContextTypes::MetaWriteContext &ctx) = 0;
+	virtual inline size_t num_metadata_meta(typename ContextTypes::MetadataReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::MetaReadContext get_metadata_meta(int n, typename ContextTypes::MetadataReadContext &ctx) = 0;
 
-    /** Generated for complex type "node":
-     * <xs:complexType name="node">
-     *   <xs:all>
-     *     <xs:element name="loc" type="node_loc" />
-     *     <xs:element minOccurs="0" name="timing" type="node_timing" />
-     *     <xs:element minOccurs="0" name="segment" type="node_segment" />
-     *     <xs:element minOccurs="0" name="metadata" type="metadata" />
-     *   </xs:all>
-     *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
-     *   <xs:attribute name="type" type="node_type" use="required" />
-     *   <xs:attribute name="direction" type="node_direction" />
-     *   <xs:attribute name="capacity" type="xs:unsignedInt" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline unsigned int get_node_capacity(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline enum_node_direction get_node_direction(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline void set_node_direction(enum_node_direction direction, typename ContextTypes::NodeWriteContext& ctx) = 0;
-    virtual inline unsigned int get_node_id(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline enum_node_type get_node_type(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeLocWriteContext init_node_loc(typename ContextTypes::NodeWriteContext& ctx, int ptc, int xhigh, int xlow, int yhigh, int ylow) = 0;
-    virtual inline void finish_node_loc(typename ContextTypes::NodeLocWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeLocReadContext get_node_loc(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeTimingWriteContext init_node_timing(typename ContextTypes::NodeWriteContext& ctx, float C, float R) = 0;
-    virtual inline void finish_node_timing(typename ContextTypes::NodeTimingWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeTimingReadContext get_node_timing(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline bool has_node_timing(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeSegmentWriteContext init_node_segment(typename ContextTypes::NodeWriteContext& ctx, int segment_id) = 0;
-    virtual inline void finish_node_segment(typename ContextTypes::NodeSegmentWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeSegmentReadContext get_node_segment(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline bool has_node_segment(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::MetadataWriteContext init_node_metadata(typename ContextTypes::NodeWriteContext& ctx) = 0;
-    virtual inline void finish_node_metadata(typename ContextTypes::MetadataWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::MetadataReadContext get_node_metadata(typename ContextTypes::NodeReadContext& ctx) = 0;
-    virtual inline bool has_node_metadata(typename ContextTypes::NodeReadContext& ctx) = 0;
+	/** Generated for complex type "node":
+	 * <xs:complexType name="node">
+	 *   <xs:all>
+	 *     <xs:element name="loc" type="node_loc" />
+	 *     <xs:element minOccurs="0" name="timing" type="node_timing" />
+	 *     <xs:element minOccurs="0" name="segment" type="node_segment" />
+	 *     <xs:element minOccurs="0" name="metadata" type="metadata" />
+	 *   </xs:all>
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="type" type="node_type" use="required" />
+	 *   <xs:attribute name="direction" type="node_direction" />
+	 *   <xs:attribute name="capacity" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_node_capacity(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline enum_node_direction get_node_direction(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline void set_node_direction(enum_node_direction direction, typename ContextTypes::NodeWriteContext &ctx) = 0;
+	virtual inline unsigned int get_node_id(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline enum_node_type get_node_type(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeLocWriteContext init_node_loc(typename ContextTypes::NodeWriteContext &ctx, int ptc, int xhigh, int xlow, int yhigh, int ylow) = 0;
+	virtual inline void finish_node_loc(typename ContextTypes::NodeLocWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeLocReadContext get_node_loc(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeTimingWriteContext init_node_timing(typename ContextTypes::NodeWriteContext &ctx, float C, float R) = 0;
+	virtual inline void finish_node_timing(typename ContextTypes::NodeTimingWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeTimingReadContext get_node_timing(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline bool has_node_timing(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeSegmentWriteContext init_node_segment(typename ContextTypes::NodeWriteContext &ctx, int segment_id) = 0;
+	virtual inline void finish_node_segment(typename ContextTypes::NodeSegmentWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeSegmentReadContext get_node_segment(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline bool has_node_segment(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::MetadataWriteContext init_node_metadata(typename ContextTypes::NodeWriteContext &ctx) = 0;
+	virtual inline void finish_node_metadata(typename ContextTypes::MetadataWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::MetadataReadContext get_node_metadata(typename ContextTypes::NodeReadContext &ctx) = 0;
+	virtual inline bool has_node_metadata(typename ContextTypes::NodeReadContext &ctx) = 0;
 
-    /** Generated for complex type "rr_nodes":
-     * <xs:complexType name="rr_nodes">
-     *   <xs:choice maxOccurs="unbounded">
-     *     <xs:element name="node" type="node" />
-     *   </xs:choice>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_rr_nodes_node(typename ContextTypes::RrNodesWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::NodeWriteContext add_rr_nodes_node(typename ContextTypes::RrNodesWriteContext& ctx, unsigned int capacity, unsigned int id, enum_node_type type) = 0;
-    virtual inline void finish_rr_nodes_node(typename ContextTypes::NodeWriteContext& ctx) = 0;
-    virtual inline size_t num_rr_nodes_node(typename ContextTypes::RrNodesReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::NodeReadContext get_rr_nodes_node(int n, typename ContextTypes::RrNodesReadContext& ctx) = 0;
+	/** Generated for complex type "rr_nodes":
+	 * <xs:complexType name="rr_nodes">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="node" type="node" />
+	 *   </xs:choice>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_rr_nodes_node(typename ContextTypes::RrNodesWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::NodeWriteContext add_rr_nodes_node(typename ContextTypes::RrNodesWriteContext &ctx, unsigned int capacity, unsigned int id, enum_node_type type) = 0;
+	virtual inline void finish_rr_nodes_node(typename ContextTypes::NodeWriteContext &ctx) = 0;
+	virtual inline size_t num_rr_nodes_node(typename ContextTypes::RrNodesReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeReadContext get_rr_nodes_node(int n, typename ContextTypes::RrNodesReadContext &ctx) = 0;
 
-    /** Generated for complex type "edge":
-     * <xs:complexType name="edge">
-     *   <xs:all>
-     *     <xs:element minOccurs="0" name="metadata" type="metadata" />
-     *   </xs:all>
-     *   <xs:attribute name="src_node" type="xs:unsignedInt" use="required" />
-     *   <xs:attribute name="sink_node" type="xs:unsignedInt" use="required" />
-     *   <xs:attribute name="switch_id" type="xs:unsignedInt" use="required" />
-     * </xs:complexType>
-     */
-    virtual inline unsigned int get_edge_sink_node(typename ContextTypes::EdgeReadContext& ctx) = 0;
-    virtual inline unsigned int get_edge_src_node(typename ContextTypes::EdgeReadContext& ctx) = 0;
-    virtual inline unsigned int get_edge_switch_id(typename ContextTypes::EdgeReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::MetadataWriteContext init_edge_metadata(typename ContextTypes::EdgeWriteContext& ctx) = 0;
-    virtual inline void finish_edge_metadata(typename ContextTypes::MetadataWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::MetadataReadContext get_edge_metadata(typename ContextTypes::EdgeReadContext& ctx) = 0;
-    virtual inline bool has_edge_metadata(typename ContextTypes::EdgeReadContext& ctx) = 0;
+	/** Generated for complex type "e_ptn":
+	 * <xs:complexType name="e_ptn">
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_e_ptn_id(typename ContextTypes::EPtnReadContext &ctx) = 0;
 
-    /** Generated for complex type "rr_edges":
-     * <xs:complexType name="rr_edges">
-     *   <xs:choice maxOccurs="unbounded">
-     *     <xs:element name="edge" type="edge" />
-     *   </xs:choice>
-     * </xs:complexType>
-     */
-    virtual inline void preallocate_rr_edges_edge(typename ContextTypes::RrEdgesWriteContext& ctx, size_t size) = 0;
-    virtual inline typename ContextTypes::EdgeWriteContext add_rr_edges_edge(typename ContextTypes::RrEdgesWriteContext& ctx, unsigned int sink_node, unsigned int src_node, unsigned int switch_id) = 0;
-    virtual inline void finish_rr_edges_edge(typename ContextTypes::EdgeWriteContext& ctx) = 0;
-    virtual inline size_t num_rr_edges_edge(typename ContextTypes::RrEdgesReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::EdgeReadContext get_rr_edges_edge(int n, typename ContextTypes::RrEdgesReadContext& ctx) = 0;
+	/** Generated for complex type "node_e_ptn":
+	 * <xs:complexType name="node_e_ptn">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="e_ptn" type="e_ptn" />
+	 *   </xs:choice>
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="dest" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_node_e_ptn_dest(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+	virtual inline unsigned int get_node_e_ptn_id(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+	virtual inline void preallocate_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::EPtnWriteContext add_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx, unsigned int id) = 0;
+	virtual inline void finish_node_e_ptn_e_ptn(typename ContextTypes::EPtnWriteContext &ctx) = 0;
+	virtual inline size_t num_node_e_ptn_e_ptn(typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::EPtnReadContext get_node_e_ptn_e_ptn(int n, typename ContextTypes::NodeEPtnReadContext &ctx) = 0;
 
-    /** Generated for complex type "rr_graph":
-     * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
-     *     <xs:all>
-     *       <xs:element name="channels" type="channels" />
-     *       <xs:element name="switches" type="switches" />
-     *       <xs:element name="segments" type="segments" />
-     *       <xs:element name="block_types" type="block_types" />
-     *       <xs:element name="grid" type="grid_locs" />
-     *       <xs:element name="rr_nodes" type="rr_nodes" />
-     *       <xs:element name="rr_edges" type="rr_edges" />
-     *     </xs:all>
-     *     <xs:attribute name="tool_name" type="xs:string" />
-     *     <xs:attribute name="tool_version" type="xs:string" />
-     *     <xs:attribute name="tool_comment" type="xs:string" />
-     *   </xs:complexType>
-     */
-    virtual inline const char* get_rr_graph_tool_comment(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline void set_rr_graph_tool_comment(const char* tool_comment, typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline const char* get_rr_graph_tool_name(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline void set_rr_graph_tool_name(const char* tool_name, typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline const char* get_rr_graph_tool_version(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline void set_rr_graph_tool_version(const char* tool_version, typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::ChannelsWriteContext init_rr_graph_channels(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_channels(typename ContextTypes::ChannelsWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::ChannelsReadContext get_rr_graph_channels(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::SwitchesWriteContext init_rr_graph_switches(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_switches(typename ContextTypes::SwitchesWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::SwitchesReadContext get_rr_graph_switches(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::SegmentsWriteContext init_rr_graph_segments(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_segments(typename ContextTypes::SegmentsWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::SegmentsReadContext get_rr_graph_segments(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::BlockTypesWriteContext init_rr_graph_block_types(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_block_types(typename ContextTypes::BlockTypesWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::BlockTypesReadContext get_rr_graph_block_types(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::GridLocsWriteContext init_rr_graph_grid(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_grid(typename ContextTypes::GridLocsWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::GridLocsReadContext get_rr_graph_grid(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::RrNodesWriteContext init_rr_graph_rr_nodes(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_rr_nodes(typename ContextTypes::RrNodesWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::RrNodesReadContext get_rr_graph_rr_nodes(typename ContextTypes::RrGraphReadContext& ctx) = 0;
-    virtual inline typename ContextTypes::RrEdgesWriteContext init_rr_graph_rr_edges(typename ContextTypes::RrGraphWriteContext& ctx) = 0;
-    virtual inline void finish_rr_graph_rr_edges(typename ContextTypes::RrEdgesWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::RrEdgesReadContext get_rr_graph_rr_edges(typename ContextTypes::RrGraphReadContext& ctx) = 0;
+	/** Generated for complex type "rr_node_e_ptns":
+	 * <xs:complexType name="rr_node_e_ptns">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="node_e_ptn" type="node_e_ptn" />
+	 *   </xs:choice>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::NodeEPtnWriteContext add_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsWriteContext &ctx, unsigned int dest, unsigned int id) = 0;
+	virtual inline void finish_rr_node_e_ptns_node_e_ptn(typename ContextTypes::NodeEPtnWriteContext &ctx) = 0;
+	virtual inline size_t num_rr_node_e_ptns_node_e_ptn(typename ContextTypes::RrNodeEPtnsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::NodeEPtnReadContext get_rr_node_e_ptns_node_e_ptn(int n, typename ContextTypes::RrNodeEPtnsReadContext &ctx) = 0;
+
+	/** Generated for complex type "ddiff":
+	 * <xs:complexType name="ddiff">
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_ddiff_id(typename ContextTypes::DdiffReadContext &ctx) = 0;
+
+	/** Generated for complex type "edge_ptn":
+	 * <xs:complexType name="edge_ptn">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="ddiff" type="ddiff" />
+	 *   </xs:choice>
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="switch_id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	virtual inline unsigned int get_edge_ptn_id(typename ContextTypes::EdgePtnReadContext &ctx) = 0;
+	virtual inline unsigned int get_edge_ptn_switch_id(typename ContextTypes::EdgePtnReadContext &ctx) = 0;
+	virtual inline void preallocate_edge_ptn_ddiff(typename ContextTypes::EdgePtnWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::DdiffWriteContext add_edge_ptn_ddiff(typename ContextTypes::EdgePtnWriteContext &ctx, unsigned int id) = 0;
+	virtual inline void finish_edge_ptn_ddiff(typename ContextTypes::DdiffWriteContext &ctx) = 0;
+	virtual inline size_t num_edge_ptn_ddiff(typename ContextTypes::EdgePtnReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::DdiffReadContext get_edge_ptn_ddiff(int n, typename ContextTypes::EdgePtnReadContext &ctx) = 0;
+
+	/** Generated for complex type "rr_edge_ptns":
+	 * <xs:complexType name="rr_edge_ptns">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="edge_ptn" type="edge_ptn" />
+	 *   </xs:choice>
+	 * </xs:complexType>
+	*/
+	virtual inline void preallocate_rr_edge_ptns_edge_ptn(typename ContextTypes::RrEdgePtnsWriteContext &ctx, size_t size) = 0;
+	virtual inline typename ContextTypes::EdgePtnWriteContext add_rr_edge_ptns_edge_ptn(typename ContextTypes::RrEdgePtnsWriteContext &ctx, unsigned int id, unsigned int switch_id) = 0;
+	virtual inline void finish_rr_edge_ptns_edge_ptn(typename ContextTypes::EdgePtnWriteContext &ctx) = 0;
+	virtual inline size_t num_rr_edge_ptns_edge_ptn(typename ContextTypes::RrEdgePtnsReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::EdgePtnReadContext get_rr_edge_ptns_edge_ptn(int n, typename ContextTypes::RrEdgePtnsReadContext &ctx) = 0;
+
+	/** Generated for complex type "rr_graph":
+	 * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	 *     <xs:all>
+	 *       <xs:element name="channels" type="channels" />
+	 *       <xs:element name="switches" type="switches" />
+	 *       <xs:element name="segments" type="segments" />
+	 *       <xs:element name="block_types" type="block_types" />
+	 *       <xs:element name="grid" type="grid_locs" />
+	 *       <xs:element name="rr_nodes" type="rr_nodes" />
+	 *       <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns" />
+	 *       <xs:element name="rr_edge_ptns" type="rr_edge_ptns" />
+	 *       
+	 *     </xs:all>
+	 *     <xs:attribute name="tool_name" type="xs:string" />
+	 *     <xs:attribute name="tool_version" type="xs:string" />
+	 *     <xs:attribute name="tool_comment" type="xs:string" />
+	 *   </xs:complexType>
+	*/
+	virtual inline const char * get_rr_graph_tool_comment(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline void set_rr_graph_tool_comment(const char * tool_comment, typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline const char * get_rr_graph_tool_name(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline void set_rr_graph_tool_name(const char * tool_name, typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline const char * get_rr_graph_tool_version(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline void set_rr_graph_tool_version(const char * tool_version, typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::ChannelsWriteContext init_rr_graph_channels(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_channels(typename ContextTypes::ChannelsWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::ChannelsReadContext get_rr_graph_channels(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::SwitchesWriteContext init_rr_graph_switches(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_switches(typename ContextTypes::SwitchesWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::SwitchesReadContext get_rr_graph_switches(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::SegmentsWriteContext init_rr_graph_segments(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_segments(typename ContextTypes::SegmentsWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::SegmentsReadContext get_rr_graph_segments(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::BlockTypesWriteContext init_rr_graph_block_types(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_block_types(typename ContextTypes::BlockTypesWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::BlockTypesReadContext get_rr_graph_block_types(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::GridLocsWriteContext init_rr_graph_grid(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_grid(typename ContextTypes::GridLocsWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::GridLocsReadContext get_rr_graph_grid(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrNodesWriteContext init_rr_graph_rr_nodes(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_rr_nodes(typename ContextTypes::RrNodesWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrNodesReadContext get_rr_graph_rr_nodes(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrNodeEPtnsWriteContext init_rr_graph_rr_node_e_ptns(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_rr_node_e_ptns(typename ContextTypes::RrNodeEPtnsWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrNodeEPtnsReadContext get_rr_graph_rr_node_e_ptns(typename ContextTypes::RrGraphReadContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrEdgePtnsWriteContext init_rr_graph_rr_edge_ptns(typename ContextTypes::RrGraphWriteContext &ctx) = 0;
+	virtual inline void finish_rr_graph_rr_edge_ptns(typename ContextTypes::RrEdgePtnsWriteContext &ctx) = 0;
+	virtual inline typename ContextTypes::RrEdgePtnsReadContext get_rr_graph_rr_edge_ptns(typename ContextTypes::RrGraphReadContext &ctx) = 0;
 };
 
 } /* namespace uxsd */

--- a/vpr/src/route/route_breadth_first.cpp
+++ b/vpr/src/route/route_breadth_first.cpp
@@ -388,7 +388,7 @@ static void breadth_first_expand_neighbours(BinaryHeap& heap, int inode, float p
     auto& route_ctx = g_vpr_ctx.routing();
 
     for (RREdgeId from_edge : device_ctx.rr_nodes.edge_range(RRNodeId(inode))) {
-        RRNodeId to_node = device_ctx.rr_nodes.edge_sink_node(from_edge);
+        RRNodeId to_node = device_ctx.rr_nodes.edge_sink_node_abs(RRNodeId(inode), from_edge);
 
         vtr::Point<int> lower_left(route_ctx.route_bb[net_id].xmin, route_ctx.route_bb[net_id].ymin);
         vtr::Point<int> upper_right(route_ctx.route_bb[net_id].xmax, route_ctx.route_bb[net_id].ymax);

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -568,7 +568,7 @@ static t_trace_branch traceback_branch(int node, int target_net_pin_index, std::
         t_trace* prev_ptr = alloc_trace_data();
         prev_ptr->index = inode;
         prev_ptr->net_pin_index = OPEN; //Net pin index is invalid for Non-SINK nodes
-        prev_ptr->iswitch = device_ctx.rr_nodes.edge_switch(iedge);
+        prev_ptr->iswitch = device_ctx.rr_nodes.edge_switch_abs(RRNodeId(inode), iedge);
         prev_ptr->next = branch_head;
         branch_head = prev_ptr;
 
@@ -1638,7 +1638,7 @@ void print_rr_node_route_inf() {
         if (!std::isinf(route_ctx.rr_node_route_inf[inode].path_cost)) {
             int prev_node = route_ctx.rr_node_route_inf[inode].prev_node;
             RREdgeId prev_edge = route_ctx.rr_node_route_inf[inode].prev_edge;
-            auto switch_id = device_ctx.rr_nodes.edge_switch(prev_edge);
+            auto switch_id = device_ctx.rr_nodes.edge_switch_abs(RRNodeId(prev_node), prev_edge);
             VTR_LOG("rr_node: %d prev_node: %d prev_edge: %zu",
                     inode, prev_node, (size_t)prev_edge);
 
@@ -1672,7 +1672,7 @@ void print_rr_node_route_inf_dot() {
         if (!std::isinf(route_ctx.rr_node_route_inf[inode].path_cost)) {
             int prev_node = route_ctx.rr_node_route_inf[inode].prev_node;
             RREdgeId prev_edge = route_ctx.rr_node_route_inf[inode].prev_edge;
-            auto switch_id = device_ctx.rr_nodes.edge_switch(prev_edge);
+            auto switch_id = device_ctx.rr_nodes.edge_switch_abs(RRNodeId(prev_node), prev_edge);
 
             if (prev_node != OPEN && bool(prev_edge)) {
                 VTR_LOG("\tnode%d -> node%zu [", prev_node, inode);

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -322,7 +322,7 @@ add_subtree_to_route_tree(t_heap* hptr, int target_net_pin_index, t_rt_node** si
     std::unordered_set<int> all_visited;         //does not include sink
     inode = hptr->prev_node();
     RREdgeId edge = hptr->prev_edge();
-    short iswitch = device_ctx.rr_nodes.edge_switch(edge);
+    short iswitch = device_ctx.rr_nodes.edge_switch_abs((RRNodeId)inode, edge);
 
     /* For all "new" nodes in the main path */
     // inode is node index of previous node
@@ -361,7 +361,7 @@ add_subtree_to_route_tree(t_heap* hptr, int target_net_pin_index, t_rt_node** si
         downstream_rt_node = rt_node;
         edge = route_ctx.rr_node_route_inf[inode].prev_edge;
         inode = route_ctx.rr_node_route_inf[inode].prev_node;
-        iswitch = device_ctx.rr_nodes.edge_switch(edge);
+        iswitch = device_ctx.rr_nodes.edge_switch_abs(RRNodeId(inode), edge);
     }
 
     //Inode is now the branch point to the old routing; do not need

--- a/vpr/src/route/route_tree_timing.cpp
+++ b/vpr/src/route/route_tree_timing.cpp
@@ -420,16 +420,20 @@ static t_rt_node* add_non_configurable_to_route_tree(const int rr_node, const bo
                 VTR_ASSERT(rt_node->inode == rr_node);
             }
         }
-        for (int iedge : rr_graph.non_configurable_edges(RRNodeId(rr_node))) {
+        std::vector<t_dest_switch> rr_edges;
+        g_vpr_ctx.mutable_device().rr_graph.get_non_configurable_edges(RRNodeId(rr_node), rr_edges);
+        for (auto rr_edge : rr_edges) {  
+        // for (int iedge : rr_graph.non_configurable_edges(RRNodeId(rr_node))) {
             //Recursive case: expand children
-            VTR_ASSERT(!device_ctx.rr_nodes[rr_node].edge_is_configurable(iedge));
-            int to_rr_node = size_t(rr_graph.edge_sink_node(RRNodeId(rr_node), iedge));
+            // VTR_ASSERT(!device_ctx.rr_nodes[rr_node].edge_is_configurable(iedge));
+            VTR_ASSERT(!device_ctx.rr_nodes[rr_node].edge_is_configurable(0)); // fix this
+            int to_rr_node = size_t(rr_edge.dest);
 
             //Recurse
             t_rt_node* child_rt_node = add_non_configurable_to_route_tree(to_rr_node, true, visited);
 
             if (!child_rt_node) continue;
-            int iswitch = rr_graph.edge_switch(RRNodeId(rr_node), iedge);
+            int iswitch = rr_edge.switch_id;
 
             //Create the edge
             t_linked_rt_edge* linked_rt_edge = alloc_linked_rt_edge();

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -649,118 +649,6 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
 
     RRNodeId parent = parent_entry.rr_node;
 
-    // int first_dest = rr_graph.node_first_dest(parent);
-    // int k = 0;
-    // short switch_ind;
-    // for (const auto& p : rr_graph.node_to_edge_ptns(parent)){
-    //     // const auto& p = rr_graph.edge_ptn(ptn);
-    //     switch_ind = p.switch_id;
-    //     while (k < p.edge_count){
-    //         RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));
-    //         k++;
-    //         if (rr_graph.node_type(child_node) == SINK) return;
-
-    //         /* skip this child if it has already been expanded from */
-    //         if (node_expanded[child_node]) {
-    //             continue;
-    //         }
-
-    //         PQ_Entry child_entry(child_node, switch_ind, parent_entry.delay,
-    //                          parent_entry.R_upstream, parent_entry.congestion_upstream, false);
-
-    //         //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
-
-    //         /* skip this child if it has been visited with smaller cost */
-    //         if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
-    //             continue;
-    //         }
-
-    //         /* finally, record the cost with which the child was visited and put the child entry on the queue */
-    //         node_visited_costs[child_node] = child_entry.cost;
-    //         pq.push(child_entry);
-
-
-
-    //     }
-    //     k = 0;
-    // }
-
-
-
-
-    // size_t first_edge = (size_t)rr_graph.node_first_edge(parent);
-    // int rel = 1;
-    // int first_dest = rr_graph.node_first_dest(parent);
-    // int edges_num = rr_graph.num_edges(parent);
-
-    // // First Edge
-    // int e_ptn_idx = rr_graph.node_to_edge_ptns_new(parent); 
-    // int edges_added = 0;
-    // t_switch_edge_ptn p;
-    // while (edges_added < 1*(edges_num>0)){
-    //     p = rr_graph.edge_ptns(e_ptn_idx);
-    //     edges_added++;
-
-    //     RRNodeId child_node = RRNodeId(first_dest);
-    //     if (rr_graph.node_type(child_node) == SINK) return;
-
-    //     /* skip this child if it has already been expanded from */
-    //     if (node_expanded[child_node]) {
-    //         continue;
-    //     }
-
-    //     PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
-    //                         parent_entry.R_upstream, parent_entry.congestion_upstream, false);
-
-    //     //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
-
-    //     /* skip this child if it has been visited with smaller cost */
-    //     if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
-    //         continue;
-    //     }
-
-    //     /* finally, record the cost with which the child was visited and put the child entry on the queue */
-    //     node_visited_costs[child_node] = child_entry.cost;
-    //     pq.push(child_entry);
-
-    // }
-
-    // int k = 1; // skip the first edge
-    // while (edges_added < edges_num) { // only for nodes with more than one edge
-    //     while (k < p.edge_count){
-
-    //         RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));
-    //         k++;
-    //         rel++;
-    //         edges_added++;
-    //         if (rr_graph.node_type(child_node) == SINK) return;
-
-    //         /* skip this child if it has already been expanded from */
-    //         if (node_expanded[child_node]) {
-    //             continue;
-    //         }
-
-    //         PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
-    //                             parent_entry.R_upstream, parent_entry.congestion_upstream, false);
-
-    //         //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
-
-    //         /* skip this child if it has been visited with smaller cost */
-    //         if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
-    //             continue;
-    //         }
-
-    //         /* finally, record the cost with which the child was visited and put the child entry on the queue */
-    //         node_visited_costs[child_node] = child_entry.cost;
-    //         pq.push(child_entry);
-
-    //     }
-    //     k = 0;
-    //     e_ptn_idx++;
-    //     p = rr_graph.edge_ptns(e_ptn_idx);
-    // }
-
-
     int first_dest = rr_graph.node_first_dest(parent);
     int e_ptn_idx = rr_graph.node_to_edge_ptns_new(parent); 
     int edges_num = rr_graph.num_edges(parent);
@@ -768,7 +656,6 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
 
     t_switch_edge_ptn p = rr_graph.edge_ptns(e_ptn_idx);
     int k = 0;
-    // while (edges_count < edges_num){
     int num_ptns = rr_graph.num_edge_ptns(parent);
     for (int j=0; j<num_ptns; j++){
         const int p_edge_count = p.edge_count;
@@ -802,15 +689,7 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
         p = rr_graph.edge_ptns(e_ptn_idx);
     }
 
-
-
-
-
-
-
-
-
-
+    // --- Previous Method for accessing edges ---
 
     // for (t_edge_size edge : rr_graph.edges(parent)) {
     //     RRNodeId child_node = rr_graph.edge_sink_node(parent, edge);

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -688,51 +688,94 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
 
 
 
-    size_t first_edge = (size_t)rr_graph.node_first_edge(parent);
-    int rel = 1;
+    // size_t first_edge = (size_t)rr_graph.node_first_edge(parent);
+    // int rel = 1;
+    // int first_dest = rr_graph.node_first_dest(parent);
+    // int edges_num = rr_graph.num_edges(parent);
+
+    // // First Edge
+    // int e_ptn_idx = rr_graph.node_to_edge_ptns_new(parent); 
+    // int edges_added = 0;
+    // t_switch_edge_ptn p;
+    // while (edges_added < 1*(edges_num>0)){
+    //     p = rr_graph.edge_ptns(e_ptn_idx);
+    //     edges_added++;
+
+    //     RRNodeId child_node = RRNodeId(first_dest);
+    //     if (rr_graph.node_type(child_node) == SINK) return;
+
+    //     /* skip this child if it has already been expanded from */
+    //     if (node_expanded[child_node]) {
+    //         continue;
+    //     }
+
+    //     PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
+    //                         parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+    //     //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
+
+    //     /* skip this child if it has been visited with smaller cost */
+    //     if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
+    //         continue;
+    //     }
+
+    //     /* finally, record the cost with which the child was visited and put the child entry on the queue */
+    //     node_visited_costs[child_node] = child_entry.cost;
+    //     pq.push(child_entry);
+
+    // }
+
+    // int k = 1; // skip the first edge
+    // while (edges_added < edges_num) { // only for nodes with more than one edge
+    //     while (k < p.edge_count){
+
+    //         RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));
+    //         k++;
+    //         rel++;
+    //         edges_added++;
+    //         if (rr_graph.node_type(child_node) == SINK) return;
+
+    //         /* skip this child if it has already been expanded from */
+    //         if (node_expanded[child_node]) {
+    //             continue;
+    //         }
+
+    //         PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
+    //                             parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+    //         //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
+
+    //         /* skip this child if it has been visited with smaller cost */
+    //         if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
+    //             continue;
+    //         }
+
+    //         /* finally, record the cost with which the child was visited and put the child entry on the queue */
+    //         node_visited_costs[child_node] = child_entry.cost;
+    //         pq.push(child_entry);
+
+    //     }
+    //     k = 0;
+    //     e_ptn_idx++;
+    //     p = rr_graph.edge_ptns(e_ptn_idx);
+    // }
+
+
     int first_dest = rr_graph.node_first_dest(parent);
-    int edges_num = rr_graph.num_edges(parent);
-
-    // First Edge
     int e_ptn_idx = rr_graph.node_to_edge_ptns_new(parent); 
-    int edges_added = 0;
-    t_switch_edge_ptn p;
-    while (edges_added < 1*(edges_num>0)){
-        p = rr_graph.edge_ptns(e_ptn_idx);
-        edges_added++;
+    int edges_num = rr_graph.num_edges(parent);
+    int edges_count = 0;
 
-        RRNodeId child_node = RRNodeId(first_dest);
-        if (rr_graph.node_type(child_node) == SINK) return;
-
-        /* skip this child if it has already been expanded from */
-        if (node_expanded[child_node]) {
-            continue;
-        }
-
-        PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
-                            parent_entry.R_upstream, parent_entry.congestion_upstream, false);
-
-        //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
-
-        /* skip this child if it has been visited with smaller cost */
-        if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
-            continue;
-        }
-
-        /* finally, record the cost with which the child was visited and put the child entry on the queue */
-        node_visited_costs[child_node] = child_entry.cost;
-        pq.push(child_entry);
-
-    }
-
-    int k = 1; // skip the first edge
-    while (edges_added < edges_num) { // only for nodes with more than one edge
-        while (k < p.edge_count){
-
+    t_switch_edge_ptn p = rr_graph.edge_ptns(e_ptn_idx);
+    int k = 0;
+    // while (edges_count < edges_num){
+    int num_ptns = rr_graph.num_edge_ptns(parent);
+    for (int j=0; j<num_ptns; j++){
+        const int p_edge_count = p.edge_count;
+        for (int i=0; i<p_edge_count; i++){
             RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));
+            edges_count += 1;
             k++;
-            rel++;
-            edges_added++;
             if (rr_graph.node_type(child_node) == SINK) return;
 
             /* skip this child if it has already been expanded from */
@@ -753,16 +796,11 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
             /* finally, record the cost with which the child was visited and put the child entry on the queue */
             node_visited_costs[child_node] = child_entry.cost;
             pq.push(child_entry);
-
         }
         k = 0;
         e_ptn_idx++;
         p = rr_graph.edge_ptns(e_ptn_idx);
     }
-
-
-
-
 
 
 

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -523,7 +523,7 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
                                  &dijkstra_data);
                 }
 
-                if (false) print_router_cost_map(routing_cost_map);
+                if (true) print_router_cost_map(routing_cost_map);
 
                 /* boil down the cost list in routing_cost_map at each coordinate to a representative cost entry and store it in the lookahead
                  * cost map */
@@ -536,7 +536,7 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
         }
     }
 
-    if (false) print_wire_cost_map(segment_inf);
+    if (true) print_wire_cost_map(segment_inf);
 }
 
 /* returns index of a node from which to start routing */

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -652,8 +652,8 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
     int first_dest = rr_graph.node_first_dest(parent);
     int k = 0;
     short switch_ind;
-    for (const auto& ptn : rr_graph.node_to_edge_ptns(parent)){
-        const auto& p = rr_graph.edge_ptn(ptn);
+    for (const auto& p : rr_graph.node_to_edge_ptns(parent)){
+        // const auto& p = rr_graph.edge_ptn(ptn);
         switch_ind = p.switch_id;
         while (k < p.edge_count){
             RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -650,7 +650,7 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
     RRNodeId parent = parent_entry.rr_node;
 
     int first_dest = rr_graph.node_first_dest(parent);
-    int e_ptn_idx = rr_graph.node_to_edge_ptns_new(parent); 
+    int e_ptn_idx = rr_graph.node_to_edge_ptns(parent); 
     int edges_num = rr_graph.num_edges(parent);
     int edges_count = 0;
 

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -649,15 +649,90 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
 
     RRNodeId parent = parent_entry.rr_node;
 
+    // int first_dest = rr_graph.node_first_dest(parent);
+    // int k = 0;
+    // short switch_ind;
+    // for (const auto& p : rr_graph.node_to_edge_ptns(parent)){
+    //     // const auto& p = rr_graph.edge_ptn(ptn);
+    //     switch_ind = p.switch_id;
+    //     while (k < p.edge_count){
+    //         RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));
+    //         k++;
+    //         if (rr_graph.node_type(child_node) == SINK) return;
+
+    //         /* skip this child if it has already been expanded from */
+    //         if (node_expanded[child_node]) {
+    //             continue;
+    //         }
+
+    //         PQ_Entry child_entry(child_node, switch_ind, parent_entry.delay,
+    //                          parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+    //         //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
+
+    //         /* skip this child if it has been visited with smaller cost */
+    //         if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
+    //             continue;
+    //         }
+
+    //         /* finally, record the cost with which the child was visited and put the child entry on the queue */
+    //         node_visited_costs[child_node] = child_entry.cost;
+    //         pq.push(child_entry);
+
+
+
+    //     }
+    //     k = 0;
+    // }
+
+
+
+
+    size_t first_edge = (size_t)rr_graph.node_first_edge(parent);
+    int rel = 1;
     int first_dest = rr_graph.node_first_dest(parent);
-    int k = 0;
-    short switch_ind;
-    for (const auto& p : rr_graph.node_to_edge_ptns(parent)){
-        // const auto& p = rr_graph.edge_ptn(ptn);
-        switch_ind = p.switch_id;
+    int edges_num = rr_graph.num_edges(parent);
+
+    // First Edge
+    int e_ptn_idx = rr_graph.node_to_edge_ptns_new(parent); 
+    int edges_added = 0;
+    t_switch_edge_ptn p;
+    while (edges_added < 1*(edges_num>0)){
+        p = rr_graph.edge_ptns(e_ptn_idx);
+        edges_added++;
+
+        RRNodeId child_node = RRNodeId(first_dest);
+        if (rr_graph.node_type(child_node) == SINK) return;
+
+        /* skip this child if it has already been expanded from */
+        if (node_expanded[child_node]) {
+            continue;
+        }
+
+        PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
+                            parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+        //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
+
+        /* skip this child if it has been visited with smaller cost */
+        if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
+            continue;
+        }
+
+        /* finally, record the cost with which the child was visited and put the child entry on the queue */
+        node_visited_costs[child_node] = child_entry.cost;
+        pq.push(child_entry);
+
+    }
+
+    int k = 1; // skip the first edge
+    while (edges_added < edges_num) { // only for nodes with more than one edge
         while (k < p.edge_count){
+
             RRNodeId child_node = RRNodeId(first_dest+rr_graph.edge_ptn_data(p.ptn_idx+k));
             k++;
+            rel++;
+            edges_added++;
             if (rr_graph.node_type(child_node) == SINK) return;
 
             /* skip this child if it has already been expanded from */
@@ -665,8 +740,8 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
                 continue;
             }
 
-            PQ_Entry child_entry(child_node, switch_ind, parent_entry.delay,
-                             parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+            PQ_Entry child_entry(child_node, p.switch_id, parent_entry.delay,
+                                parent_entry.R_upstream, parent_entry.congestion_upstream, false);
 
             //VTR_ASSERT(child_entry.cost >= 0); //Asertion fails in practise. TODO: debug
 
@@ -679,11 +754,25 @@ static void expand_dijkstra_neighbours(PQ_Entry parent_entry, vtr::vector<RRNode
             node_visited_costs[child_node] = child_entry.cost;
             pq.push(child_entry);
 
-
-
         }
         k = 0;
+        e_ptn_idx++;
+        p = rr_graph.edge_ptns(e_ptn_idx);
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     // for (t_edge_size edge : rr_graph.edges(parent)) {
     //     RRNodeId child_node = rr_graph.edge_sink_node(parent, edge);

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -499,7 +499,7 @@ static void dijkstra_flood_to_wires(int itile, RRNodeId node, util::t_src_opin_d
                 int iswitch = rr_graph.edge_switch(edge);
                 float incr_delay = temp_rr_graph.rr_switch_inf(RRSwitchId(iswitch)).Tdel;
 
-                RRNodeId next_node = rr_graph.edge_sink_node(edge);
+                RRNodeId next_node = rr_graph.edge_sink_node_abs(curr.node, edge);
 
                 t_pq_entry next;
                 next.congestion = curr.congestion + incr_cong; //Of current node
@@ -591,10 +591,10 @@ static void dijkstra_flood_to_ipins(RRNodeId node, util::t_chan_ipins_delays& ch
             float new_cong = device_ctx.rr_indexed_data[cost_index].base_cost; //Current nodes congestion cost
 
             for (RREdgeId edge : rr_graph.edge_range(curr.node)) {
-                int iswitch = rr_graph.edge_switch(edge);
+                int iswitch = rr_graph.edge_switch_abs(curr.node, edge);
                 float new_delay = temp_rr_graph.rr_switch_inf(RRSwitchId(iswitch)).Tdel;
 
-                RRNodeId next_node = rr_graph.edge_sink_node(edge);
+                RRNodeId next_node = rr_graph.edge_sink_node_abs(curr.node, edge);
 
                 t_pq_entry next;
                 next.congestion = new_cong; //Of current node

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2986,7 +2986,7 @@ static void create_edge_groups(EdgeGroups* groups) {
     const auto& rr_graph = device_ctx.rr_graph;
     rr_nodes.for_each_edge(
         [&](RREdgeId edge, RRNodeId src, RRNodeId sink) {
-            if (!rr_graph.rr_switch_inf(RRSwitchId(rr_graph.edge_switch(edge))).configurable()) {
+            if (!rr_graph.rr_switch_inf(RRSwitchId(rr_graph.edge_switch_abs(src, edge))).configurable()) {
                 groups->add_non_config_edge(size_t(src), size_t(sink));
             }
         });

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2986,7 +2986,7 @@ static void create_edge_groups(EdgeGroups* groups) {
     const auto& rr_graph = device_ctx.rr_graph;
     rr_nodes.for_each_edge(
         [&](RREdgeId edge, RRNodeId src, RRNodeId sink) {
-            if (!rr_graph.rr_switch_inf(RRSwitchId(rr_nodes.edge_switch(edge))).configurable()) {
+            if (!rr_graph.rr_switch_inf(RRSwitchId(rr_graph.edge_switch(edge))).configurable()) {
                 groups->add_non_config_edge(size_t(src), size_t(sink));
             }
         });

--- a/vpr/src/route/rr_graph.xsd
+++ b/vpr/src/route/rr_graph.xsd
@@ -288,14 +288,47 @@
     <xs:attribute name="capacity" type="xs:unsignedInt" use="required"/>
   </xs:complexType>
 
-  <xs:complexType name="edge">
+<!-- # </edge_ptn>
+# <edge_ptn id="7939" switch_id="2">
+# <ddiff id="3155">
+# <ddiff id="6409">
+# </edge_ptn> -->
+  <xs:complexType name="edge_ptn">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="ddiff" type="ddiff"/>
+    </xs:choice>
+    <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+    <xs:attribute name="switch_id" type="xs:unsignedInt" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="ddiff">
+    <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+  </xs:complexType>
+
+<!-- # <node_e_ptn id="1" dest="25">
+  # <ptn id="0"/>
+  # </node_e_ptn> -->
+
+  <xs:complexType name="node_e_ptn">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="e_ptn" type="e_ptn"/>
+    </xs:choice>
+    <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+    <xs:attribute name="dest" type="xs:unsignedInt" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="e_ptn">
+    <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+  </xs:complexType>
+
+  <!-- <xs:complexType name="edge">
     <xs:all>
       <xs:element name="metadata" type="metadata" minOccurs="0"/>
     </xs:all>
     <xs:attribute name="src_node" type="xs:unsignedInt" use="required"/>
     <xs:attribute name="sink_node" type="xs:unsignedInt" use="required"/>
     <xs:attribute name="switch_id" type="xs:unsignedInt" use="required"/>
-  </xs:complexType>
+  </xs:complexType> -->
 
   <xs:complexType name="switches">
     <xs:sequence>
@@ -327,11 +360,30 @@
     </xs:choice>
   </xs:complexType>
 
-  <xs:complexType name="rr_edges">
+
+  <!-- <rr_node_e_ptns>
+  <node_e_ptn id="1" dest="25">
+  <e_ptn id="0"/>
+  </node_e_ptn> -->
+  <xs:complexType name="rr_node_e_ptns">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="node_e_ptn" type="node_e_ptn"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="rr_edge_ptns">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="edge_ptn" type="edge_ptn"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+
+  <!-- <xs:complexType name="rr_edges">
     <xs:choice maxOccurs="unbounded">
       <xs:element name="edge" type="edge"/>
     </xs:choice>
-  </xs:complexType>
+  </xs:complexType> -->
 
   <!-- This last definition is the root tag definition.  The name of the
        xs:element is the root tag, and the contents of the xs:complexType
@@ -346,7 +398,9 @@
         <xs:element name="block_types" type="block_types"/>
         <xs:element name="grid" type="grid_locs"/>
         <xs:element name="rr_nodes" type="rr_nodes"/>
-        <xs:element name="rr_edges" type="rr_edges"/>
+        <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns"/>
+        <xs:element name="rr_edge_ptns" type="rr_edge_ptns"/>
+        <!-- <xs:element name="rr_edges" type="rr_edges"/> -->
       </xs:all>
 
       <xs:attribute name="tool_name" type="xs:string"/>

--- a/vpr/src/route/rr_graph.xsd
+++ b/vpr/src/route/rr_graph.xsd
@@ -398,8 +398,9 @@
         <xs:element name="block_types" type="block_types"/>
         <xs:element name="grid" type="grid_locs"/>
         <xs:element name="rr_nodes" type="rr_nodes"/>
-        <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns"/>
+        <!-- <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns"/> -->
         <xs:element name="rr_edge_ptns" type="rr_edge_ptns"/>
+        <xs:element name="rr_node_e_ptns" type="rr_node_e_ptns"/>
         <!-- <xs:element name="rr_edges" type="rr_edges"/> -->
       </xs:all>
 

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -111,7 +111,7 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
     float *unsharable_switch_trans, *sharable_switch_trans; /* [0..num_switch-1] */
 
     t_rr_type from_rr_type, to_rr_type;
-    int iedge, num_edges, maxlen;
+    int iedge, maxlen;
     int iswitch, i, j, iseg, max_inputs_to_cblock;
     float input_cblock_trans, shared_opin_buffer_trans;
 
@@ -161,13 +161,16 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
         size_t from_node = (size_t)from_rr_node;
         from_rr_type = rr_graph.node_type(from_rr_node);
 
+        std::vector<t_dest_switch> rr_edges;
         switch (from_rr_type) {
             case CHANX:
             case CHANY:
                 num_edges = rr_graph.num_edges(RRNodeId(from_node));
 
-                for (iedge = 0; iedge < num_edges; iedge++) {
-                    RRNodeId to_node = rr_graph.edge_sink_node(RRNodeId(from_node), iedge);
+                g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);
+                for (auto rr_edge : rr_edges) {  
+                // for (iedge = 0; iedge < num_edges; iedge++) {
+                    RRNodeId to_node = rr_edge.dest;
                     to_rr_type = rr_graph.node_type(to_node);
 
                     /* Ignore any uninitialized rr_graph nodes */
@@ -178,7 +181,7 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
                     switch (to_rr_type) {
                         case CHANX:
                         case CHANY:
-                            iswitch = rr_graph.edge_switch(RRNodeId(from_node), iedge);
+                            iswitch = rr_edge.switch_id;
 
                             if (rr_graph.rr_switch_inf(RRSwitchId(iswitch)).buffered()) {
                                 iseg = seg_index_of_sblock(from_node, size_t(to_node));
@@ -252,8 +255,10 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
                 num_edges = rr_graph.num_edges(RRNodeId(from_node));
                 shared_opin_buffer_trans = 0.;
 
-                for (iedge = 0; iedge < num_edges; iedge++) {
-                    iswitch = rr_graph.edge_switch(RRNodeId(from_node), iedge);
+                g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);
+                for (auto rr_edge : rr_edges) {  
+                // for (iedge = 0; iedge < num_edges; iedge++) {
+                    iswitch = rr_edge.switch_id;
                     ntrans_no_sharing += unsharable_switch_trans[iswitch]
                                          + sharable_switch_trans[iswitch];
                     ntrans_sharing += unsharable_switch_trans[iswitch];
@@ -309,7 +314,7 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
     /* corresponding to IPINs will be 0.           */
 
     t_rr_type from_rr_type, to_rr_type;
-    int i, j, iseg, iedge, num_edges, maxlen;
+    int i, j, iseg, maxlen;
     int max_inputs_to_cblock;
     float input_cblock_trans;
 
@@ -357,15 +362,17 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
     for (const RRNodeId& from_rr_node : device_ctx.rr_graph.nodes()) {
         size_t from_node = size_t(from_rr_node);
         from_rr_type = rr_graph.node_type(from_rr_node);
-
+        std::vector<t_dest_switch> rr_edges;
         switch (from_rr_type) {
             case CHANX:
             case CHANY:
                 num_edges = rr_graph.num_edges(RRNodeId(from_node));
 
                 /* Increment number of inputs per cblock if IPIN */
-                for (iedge = 0; iedge < num_edges; iedge++) {
-                    RRNodeId to_node = rr_graph.edge_sink_node(RRNodeId(from_node), iedge);
+                g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);
+                for (auto rr_edge : rr_edges) { 
+                // for (iedge = 0; iedge < num_edges; iedge++) {
+                    RRNodeId to_node = rr_edge.dest;
                     to_rr_type = rr_graph.node_type(to_node);
 
                     /* Ignore any uninitialized rr_graph nodes */
@@ -377,7 +384,7 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
                         case CHANX:
                         case CHANY:
                             if (!chan_node_switch_done[size_t(to_node)]) {
-                                int switch_index = rr_graph.edge_switch(RRNodeId(from_node), iedge);
+                                int switch_index = rr_edge.switch_id;
                                 auto switch_type = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).type();
 
                                 int fan_in = rr_graph.node_fan_in(to_node);

--- a/vpr/src/route/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_area.cpp
@@ -165,7 +165,6 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
         switch (from_rr_type) {
             case CHANX:
             case CHANY:
-                num_edges = rr_graph.num_edges(RRNodeId(from_node));
 
                 g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);
                 for (auto rr_edge : rr_edges) {  
@@ -252,7 +251,6 @@ void count_bidir_routing_transistors(int num_switch, int wire_to_ipin_switch, fl
                 break;
 
             case OPIN:
-                num_edges = rr_graph.num_edges(RRNodeId(from_node));
                 shared_opin_buffer_trans = 0.;
 
                 g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);
@@ -366,7 +364,6 @@ void count_unidir_routing_transistors(std::vector<t_segment_inf>& /*segment_inf*
         switch (from_rr_type) {
             case CHANX:
             case CHANY:
-                num_edges = rr_graph.num_edges(RRNodeId(from_node));
 
                 /* Increment number of inputs per cblock if IPIN */
                 g_vpr_ctx.mutable_device().rr_graph.get_edges(RRNodeId(from_node), rr_edges);

--- a/vpr/src/route/rr_graph_folding/README.md
+++ b/vpr/src/route/rr_graph_folding/README.md
@@ -1,0 +1,45 @@
+# RRGraph Folding
+This directory is used for storing / folding routing resource graphs using different folding methods.
+
+## Files / Directories
+- `flat_graphs/` is the directory where the folding scripts will look for the flat rr_graph.xml files
+    - to save flat rr_graphs to this directory, run vpr with the argument 
+    ```
+    --write_rr_graph /path/to/flat_graphs/your_graph.xml
+    ```
+    - for convenience, the [rr_graph](https://docs.verilogtorouting.org/en/latest/quickstart/#running-vpr-on-a-pre-synthesized-circuit) for architecture EArch.xml and circuit tseng.blif is already included in `flat_graphs/`
+- `folded_graphs/` is the directory where the folding scripts will save the folded rr_graph.xml files
+    - to generate folded rr_graphs, follow the instructions below
+- `fold_rr_graph.py` is the script that takes care of folding and saving rr_graphs from flat to folded
+
+## Generating Folded RR Graphs
+- To generate a folded rr_graph, run `fold_rr_graph.py` with the following command
+```
+python fold_rr_graph.py <folding_method> <flat_graph_name>
+```
+- the `<folding_method>` argument refers to the folding method script in the `folding_methods/` directory to be used for folding
+- the `<flat_graph_name>` refers to the name of the flat graph in the `flat_graphs` directory that you wish to fold
+- If you want to fold all the graphs in the `flat_graphs` directory, simply omit the `<flat_graph_name>` argument, and every flat graph will be folded.
+- `fold_rr_graph.py` will execute in the following order
+    1. Read flat rr_graph into memory from `flat_graphs/<flat_graph_name>.xml`
+    2. Fold the flat rr_graph using the desired `<folding_method>`
+    3. Save the folded rr_graph as `<folding_method>_<flat_graph_name>.xml` in the `folded_graphs` directory
+    4. Print out folding metrics to the console including data such as nodes and edges % of original size.
+
+## Using Folded RR Graphs in VTR
+- Currently the only working method to use a folded rr_graph in VTR requires that the folded graph is read from a file.
+- This means that a custom rr_graph reader must be implemented for each folding method.
+- Instructions on how to implement changes to the rr_graph reader can be found at `$VTR_ROOT/vpr/src/route/SCHEMA_GENERATOR.md`
+
+# Working Example
+
+- Branches for each folding method follow the naming convention that the git branch name is the same as the folding method name.
+- A working example of the `nodes_all_attr` folding method can be found on the nodes_all_attr branch. (add link...)
+- To run this example, simply checkout the branch, build VTR and then run the following command
+```
+This is the command...
+```
+- To compare with the flat graph, checkout this (add link...) branch, build VTR and then run the following command
+```
+This is the command...
+```

--- a/vpr/src/route/rr_graph_folding/fold_rr_graph.py
+++ b/vpr/src/route/rr_graph_folding/fold_rr_graph.py
@@ -1,0 +1,122 @@
+# This file is used to fold VTR's Routing Resource Graph
+# Inputs include
+#   - folding method
+#   - flat_graph name
+# author: Ethan Rogers @ethanroj23 (github)
+
+import os
+import sys
+import re
+sys.path.insert(0, os.getcwd()+'/folding_methods')
+
+# Indices into flat_graph object
+NODE = 0
+EDGE = 1
+EDGE_COUNT = 2
+
+XLOW = 0
+YLOW = 1
+XHIGH = 2
+YHIGH = 3
+TYPE = 4
+R = 5
+C = 6
+CAPACITY = 7
+SIDE = 8
+PTC = 9
+DIRECTION = 10
+SEGMENT = 11
+
+def read_flat_graph(graph_name):
+    rr_graph_file = f'flat_graphs/{graph_name}.xml'
+    print(f'Reading {graph_name} from file...')
+    flat_graph = [[], []] # nodes, edges
+    total_nodes = 0
+    edge_count = 0
+    with open(rr_graph_file, 'r') as file:
+        for line in file:
+            writeline = line
+            if '<segment segment_id=' in line:
+                segment_id = int(re.findall('segment_id="([0-9]+)"', line)[0])
+                flat_graph[NODE][prev_id][SEGMENT] = segment_id
+            if '<timing C=' in line:
+                cap = re.findall('C="(.*?)"', line)[0]
+                res = re.findall('R="(.*?)"', line)[0]
+                flat_graph[NODE][prev_id][C] = cap
+                flat_graph[NODE][prev_id][R] = res
+            if '<node' in line:
+                flat_graph[NODE] += [[]] # add new list for node
+                total_nodes += 1
+                if total_nodes % 1000000 == 0:
+                    print(total_nodes)
+                id = int(re.findall('id="([0-9]+)"', line)[0])
+                prev_id = id
+                xlow = int(re.findall('xlow="([0-9]+)"', line)[0])
+                ylow = int(re.findall('ylow="([0-9]+)"', line)[0])
+                xhigh = int(re.findall('xhigh="([0-9]+)"', line)[0])
+                yhigh = int(re.findall('yhigh="([0-9]+)"', line)[0])
+                capacity = int(re.findall('capacity="([0-9]+)"', line)[0])
+                ptc = int(re.findall('ptc="([0-9]+)"', line)[0])
+                direction = re.findall('direction="(.*?)"', line)
+                if direction:
+                    direction = direction[0]
+                else:
+                    direction = None
+                side = re.findall('side="(.*?)"', line)
+                if side:
+                    side = side[0]
+                else:
+                    side = None
+                node_type = re.findall('type="([A-Z]+)"', line)[0]
+                # retrieve node
+                flat_graph[NODE][id] = [xlow, ylow, xhigh, yhigh, node_type, None,  None, #R and C will be filled in later
+                                    capacity, side, ptc, direction, None]
+
+            if '<edge' in line:
+                edge_count += 1
+                sink_node = int(re.findall('sink_node="([0-9]+)"', line)[0])
+                src_node = int(re.findall('src_node="([0-9]+)"', line)[0])
+                switch_id = int(re.findall('switch_id="([0-9]+)"', line)[0])
+                edge_diff = src_node - len(flat_graph[EDGE])
+                if edge_diff >= 0:
+                    for _ in range(edge_diff+1):
+                        flat_graph[EDGE].append([])
+                flat_graph[EDGE][src_node].append([sink_node, switch_id])
+
+    print(f'Total nodes: {total_nodes}')
+    print(f'Total edges: {edge_count}')
+    flat_graph.append(edge_count)
+    return flat_graph
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Please provide the: \n\t- folding method \n\t- graph_name if desired (If no graph_name is provided, all graphs in the flat_graphs/ directory will be folded)")
+        print("\tPotential Folding methods:")
+        for file in os.listdir('folding_methods'):
+            if '.py' in file:
+                print(f'\t\t{file[:-3]}')
+        exit()
+    graphs_to_fold = []
+    if len(sys.argv) == 2:
+        for file in os.listdir('flat_graphs'):
+            graphs_to_fold.append(file[:-4])
+    elif len(sys.argv) == 3:
+        graphs_to_fold.append(sys.argv[2])
+    
+    # Dynamically import the folding module based on the input argument
+    folding_method = sys.argv[1]
+    folding_module = __import__(folding_method)
+    print(f'Using folding method {folding_module.name()}')
+
+    # Iterate over all graphs to fold and fold/save them
+    for graph_name in graphs_to_fold:
+        flat_graph = read_flat_graph(graph_name)
+        folding_module.fold_save_metrics(flat_graph, graph_name)
+
+        
+
+# import importlib
+# my_module = importlib.import_module("module.submodule")
+# MyClass = getattr(my_module, "MyClass")
+# instance = MyClass()

--- a/vpr/src/route/rr_graph_folding/folding_methods/nodes_all_attr.py
+++ b/vpr/src/route/rr_graph_folding/folding_methods/nodes_all_attr.py
@@ -1,0 +1,152 @@
+import os
+import re
+
+'''
+------------------------------- NODES_ALL_ATTR folding method --------------------------------------
+
+Every attribute of a node is stored into a node pattern
+
+Data stored for each NODE:
+ptn_idx
+
+Data stored for each NODE PATTERN:
+xlow
+ylow
+xhigh
+yhigh
+type
+capacity
+R
+C
+Segment Id
+Direction
+Side
+
+Example NODE in xml:
+<node id="11626" ptn_idx="0"/>
+
+Example NODE PATTERN in xml:
+<node_ptn capacity="1" direction="INC_DIR" id="11626" type="CHANX"><loc ptc="0" xhigh="8" xlow="5" yhigh="8" ylow="8"/>
+<timing C="1.1619003e-13" R="404"/>
+<segment segment_id="0"/>
+</node_ptn>
+
+
+------------------------------- NODES_ALL_ATTR folding method --------------------------------------
+
+'''
+
+
+
+# Indices into flat_graph object
+NODE = 0
+EDGE = 1
+EDGE_COUNT = 2
+
+XLOW = 0
+YLOW = 1
+XHIGH = 2
+YHIGH = 3
+TYPE = 4
+R = 5
+C = 6
+CAPACITY = 7
+SIDE = 8
+PTC = 9
+DIRECTION = 10
+SEGMENT = 11
+
+# Indices into folded_graph object
+F_NODE_TO_PATTERN = 0
+F_NODE_PATTERNS = 1
+F_EDGES = 2
+F_SEGMENT = 9 # segment is the only index that is different from flat -> folded
+
+# Size constants
+FLAT_NODE_BYTES = 16 # bytes per node
+FLAT_EDGE_BYTES = 10 # bytes per edge
+
+def fold_save_metrics(flat_graph, graph_name):
+    folded_graph = fold(flat_graph)
+    save(folded_graph, graph_name)
+    metrics(flat_graph, folded_graph, graph_name)
+
+def fold(graph):
+    np = {} # node_patterns
+    node_to_pattern = [] # mapping from node_id -> node pattern idx
+    p_idx = 0
+    for i, node in enumerate(graph[NODE]):
+        cur_p = (node[XLOW], node[YLOW], node[XHIGH], node[YHIGH], node[TYPE], node[R],
+                node[C], node[CAPACITY], node[SIDE], node[SEGMENT], node[DIRECTION],)
+        if cur_p not in np:
+            np[cur_p] = p_idx
+            p_idx += 1
+        node_to_pattern.append(np[cur_p])
+    
+    folded_graph = [node_to_pattern, np, graph[EDGE]]
+    return folded_graph
+
+def save(graph, graph_name):
+    '''
+    Saves the folded graph into an xml file with nodes and node_patterns
+    '''
+    save_file = f'{os.getcwd()}/folded_graphs/{name()}_{graph_name}.xml'
+    flat_file = f'{os.getcwd()}/flat_graphs/{graph_name}.xml'
+    print(f'Saving graph to {save_file}')
+    with open(save_file, 'w') as folded_file:
+        with open(flat_file, 'r') as file:
+            for line in file:
+                write_line = line
+                if '<node' in line:
+                    node = int(re.findall('id="([0-9]+)"', line)[0])
+                    ptc = int(re.findall('ptc="([0-9]+)"', line)[0])
+                    pattern_idx = graph[F_NODE_TO_PATTERN][node]
+                    write_line = f'<node id="{node}" ptn_idx="{pattern_idx}" ptc="{ptc}"/>\n'
+                if '</node>' in line:
+                    continue
+                if '<timing C="' in line or '<segment segment_id="' in line:
+                    continue
+                if '<rr_nodes>' in line:
+                    folded_file.write('<rr_node_patterns>\n')
+                    for ptn_idx, ptn in enumerate(graph[F_NODE_PATTERNS]):
+                        direction = f'direction="{ptn[DIRECTION]}" ' if ptn[DIRECTION] else ''
+                        side = f'side="{ptn[SIDE]}" ' if ptn[SIDE] else ''
+                        ptn_line = f'<node_ptn capacity="{ptn[CAPACITY]}" {direction}id="{ptn_idx}" type="{ptn[TYPE]}"><loc {side}xhigh="{ptn[XHIGH]}" xlow="{ptn[XLOW]}" yhigh="{ptn[YHIGH]}" ylow="{ptn[YLOW]}"/>\n'
+                        if ptn[R] is not None:
+                            ptn_line += f'<timing C="{ptn[C]}" R="{ptn[R]}"/>\n'
+                        if ptn[F_SEGMENT] is not None:
+                            ptn_line += f'<segment segment_id="{ptn[F_SEGMENT]}"/>\n'
+                        ptn_line += '</node_ptn>\n'
+                        folded_file.write(ptn_line)
+                    folded_file.write('</rr_node_patterns>\n')
+                folded_file.write(write_line)
+
+
+
+def metrics(flat_graph, folded_graph, graph_name):
+    MiB = 1024*1024
+    flat_nodes_size = len(flat_graph[NODE])*FLAT_NODE_BYTES/MiB
+    flat_size = (len(flat_graph[NODE])*FLAT_NODE_BYTES + flat_graph[EDGE_COUNT]*FLAT_EDGE_BYTES)/MiB
+    
+    np_count = len(folded_graph[F_NODE_PATTERNS])
+    node_count = len(folded_graph[F_NODE_TO_PATTERN])
+    edge_count = flat_graph[EDGE_COUNT]
+    folded_nodes_size = (node_count*4+np_count*FLAT_NODE_BYTES)/MiB
+    folded_size = (np_count*FLAT_NODE_BYTES + node_count*4 + edge_count*FLAT_EDGE_BYTES)/MiB
+
+    print(f'\n{graph_name} metrics [{name()}]:\n\t' \
+          f'Node patterns: {np_count} ({np_count*FLAT_NODE_BYTES/MiB:.2f} MiB) [{100*np_count/node_count:.1f}%]\n\t' \
+          f'Node to patterns: {node_count} ({node_count*4/MiB:.2f} MiB)\n\t' \
+          f'Nodes: {node_count} ({flat_nodes_size:.2f} -> {folded_nodes_size:.2f} MiB) [{100*folded_nodes_size/flat_nodes_size:.1f}%]\n\t' \
+          f'Edges: {edge_count} ({edge_count*FLAT_EDGE_BYTES/MiB:.2f} MiB)\n\t'
+          f'Total Size: {flat_size:.2f} -> {folded_size:.2f} MiB [{100*folded_size/flat_size:.1f}%]')
+
+
+
+def name():
+    return 'nodes_all_attr'
+
+if __name__ == '__main__':
+    print(f"This folding method is '{name()}'")
+    print(f"To fold an rr_graph with this method, run the following command from the directory one level up")
+    print(f"\tpython fold_rr_graph.py {name()} <flat_graph_name>")

--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -451,7 +451,6 @@ static void load_rr_indexed_data_T_values() {
 static void calculate_average_switch(int inode, double& avg_switch_R, double& avg_switch_T, double& avg_switch_Cinternal, int& num_switches, short& buffered, vtr::vector<RRNodeId, std::vector<RREdgeId>>& fan_in_list) {
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
-    const auto& rr_nodes = device_ctx.rr_nodes.view();
 
     auto node = RRNodeId(inode);
 
@@ -463,7 +462,7 @@ static void calculate_average_switch(int inode, double& avg_switch_R, double& av
     for (const auto& edge : fan_in_list[node]) {
         /* want to get C/R/Tdel/Cinternal of switches that connect this track segment to other track segments */
         if (rr_graph.node_type(node) == CHANX || rr_graph.node_type(node) == CHANY) {
-            int switch_index = rr_nodes.edge_switch(edge);
+            int switch_index = rr_graph.edge_switch(edge);
 
             if (rr_graph.rr_switch_inf(RRSwitchId(switch_index)).type() == SwitchType::SHORT) continue;
 

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -319,7 +319,15 @@ class edge_compare_dest_node {
 void t_rr_graph_storage::assign_first_edges() {
     VTR_ASSERT(node_first_edge_.empty());
 
-    
+    int cur_idx = 0;
+    for (int i=0; i < node_storage_.size(); i++){
+        RRNodeId node = RRNodeId(i);
+        node_to_edge_ptns_new_[node] = cur_idx;
+        cur_idx += node_num_edge_patterns_[node];
+    }
+    node_to_edge_ptns_new_.push_back(cur_idx);
+
+
     // Last element is a dummy element
     node_first_edge_.resize(node_storage_.size() + 1);
 
@@ -591,6 +599,10 @@ t_edge_size t_rr_graph_storage::num_configurable_edges(const RRNodeId& id) const
 
 t_edge_size t_rr_graph_storage::num_non_configurable_edges(const RRNodeId& id) const {
     return num_edges(id) - num_configurable_edges(id);
+}
+
+bool t_rr_graph_storage::switch_is_configurable(short switch_id) const {
+    return g_vpr_ctx.device().rr_graph.rr_switch_inf(RRSwitchId(switch_id)).configurable();
 }
 
 bool t_rr_graph_storage::validate() const {

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -328,8 +328,9 @@ void t_rr_graph_storage::assign_first_edges() {
         RRNodeId node = RRNodeId(i);
         node_first_edge_[node] = RREdgeId(edge_number);
         int edge_count = 0;
-        for (auto ptn : node_to_edge_ptns_[node]){
-            edge_number += edge_ptn_[ptn].edge_count;
+        for (auto p : node_to_edge_ptns_[node]){
+            // edge_number += edge_ptn_[ptn].edge_count;
+            edge_number += p.edge_count;
         }
     }
     node_first_edge_[(RRNodeId)node_storage_.size()] = RREdgeId(edge_number);
@@ -432,8 +433,8 @@ void t_rr_graph_storage::init_fan_in() {
         size_t dest = (size_t)node_first_dest_[node];
         int k = 0;
         short cur_switch;
-        for (auto ptn : node_to_edge_ptns_[node]){
-            const auto p = edge_ptn_[ptn];
+        for (auto p : node_to_edge_ptns_[node]){
+            // const auto p = edge_ptn_[ptn];
             cur_switch = p.switch_id;
             while (k < p.edge_count){
                 node_fan_in_[RRNodeId(dest+edge_ptn_data_[p.ptn_idx+k])] += 1;
@@ -572,8 +573,8 @@ t_edge_size t_rr_graph_storage::num_configurable_edges(const RRNodeId& id) const
     int edge_count = 0;
     short cur_switch;
     const auto& rr_graph = g_vpr_ctx.device().rr_graph;
-    for (auto ptn : node_to_edge_ptns_[id]){
-        const auto p = edge_ptn_[ptn];
+    for (auto p : node_to_edge_ptns_[id]){
+        // const auto p = edge_ptn_[ptn];
         edge_count += rr_graph.rr_switch_inf(RRSwitchId(p.switch_id)).configurable()*p.edge_count;
     }
     return edge_count;

--- a/vpr/src/route/rr_graph_storage.cpp
+++ b/vpr/src/route/rr_graph_storage.cpp
@@ -322,10 +322,10 @@ void t_rr_graph_storage::assign_first_edges() {
     int cur_idx = 0;
     for (int i=0; i < node_storage_.size(); i++){
         RRNodeId node = RRNodeId(i);
-        node_to_edge_ptns_new_[node] = cur_idx;
+        node_to_edge_ptns_[node] = cur_idx;
         cur_idx += node_num_edge_patterns_[node];
     }
-    node_to_edge_ptns_new_.push_back(cur_idx);
+    node_to_edge_ptns_.push_back(cur_idx);
 
 
     // Last element is a dummy element
@@ -336,7 +336,7 @@ void t_rr_graph_storage::assign_first_edges() {
         RRNodeId node = RRNodeId(i);
         node_first_edge_[node] = RREdgeId(edge_number);
 
-        int e_ptn_idx = node_to_edge_ptns_new_[node]; 
+        int e_ptn_idx = node_to_edge_ptns_[node]; 
         t_switch_edge_ptn p = edge_ptns_[e_ptn_idx];
         int num_ptns = num_edge_ptns(node);
         for (int j=0; j<num_ptns; j++){
@@ -444,7 +444,7 @@ void t_rr_graph_storage::init_fan_in() {
         RRNodeId node = RRNodeId(i);
 
         int first_dest = node_first_dest(node);
-        int e_ptn_idx = node_to_edge_ptns_new(node); 
+        int e_ptn_idx = node_to_edge_ptns(node); 
 
         t_switch_edge_ptn p = edge_ptns(e_ptn_idx);
         int k = 0;
@@ -595,7 +595,7 @@ t_edge_size t_rr_graph_storage::num_configurable_edges(const RRNodeId& id) const
     int edge_count = 0;
     short cur_switch;
     const auto& rr_graph = g_vpr_ctx.device().rr_graph;
-    int e_ptn_idx = node_to_edge_ptns_new(id); 
+    int e_ptn_idx = node_to_edge_ptns(id); 
     t_switch_edge_ptn p = edge_ptns(e_ptn_idx);
     int num_ptns = num_edge_ptns(id);
     for (int j=0; j<num_ptns; j++){

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -399,6 +399,9 @@ class t_rr_graph_storage {
     }
 
 
+    /*
+        Fills a vector with the edges of the input node
+    */
     inline void get_edges(RRNodeId id, std::vector<t_dest_switch> &edges)  {
         edges.reserve(num_edges(id));
         int first_dest = node_first_dest(id);
@@ -923,13 +926,20 @@ class t_rr_graph_storage {
 
     /* Vector from node to the destination node of its first edge */
     vtr::vector<RRNodeId, int> node_first_dest_;
+
+    /* Vector from node to number of edge patterns it has.
+       This is only used while reading in the routing resource graph */
     vtr::vector<RRNodeId, int> node_num_edge_patterns_;
 
     RRNodeId cur_node_; // used during reading of rr_graph
 
     /* Vector from edge_ptn_idx to switch, starting idx, and count */
     std::vector<t_switch_edge_ptn> edge_ptn_;
+
+    /* Vector of t_switch_edge_ptn for all patterns of a node */
     std::vector<t_switch_edge_ptn> edge_ptns_;
+
+    /* Vector of differences between given node and starting dest node */
     std::vector<int> edge_ptn_data_;
 
 

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -349,6 +349,24 @@ class t_rr_graph_storage {
         return get_t_dest_switch(edge).dest;
         // return edge_dest_node_[edge];
     }
+    int node_first_dest(RRNodeId node) const {
+        return node_first_dest_[node];
+    }
+
+    inline std::vector<int> node_to_edge_ptns(RRNodeId node) const {
+        return node_to_edge_ptns_[node];
+    }
+
+    inline t_switch_edge_ptn edge_ptn(int ptn) const {
+        return edge_ptn_[ptn];
+    }
+
+    inline int edge_ptn_data(int ptn) const {
+        return edge_ptn_data_[ptn];
+    }
+
+
+
 
     t_dest_switch kth_edge_for_node(RRNodeId node, int kth_edge) const {
         std::vector<t_dest_switch> edges;
@@ -907,11 +925,13 @@ class t_rr_graph_view {
 
     // Get the destination node for the specified edge.
     RRNodeId edge_sink_node(RREdgeId edge) const {
+        VTR_ASSERT(false);
         return edge_dest_node_[edge];
     }
 
     // Get the switch used for the specified edge.
     short edge_switch(RREdgeId edge) const {
+        VTR_ASSERT(false);
         return edge_switch_[edge];
     }
 

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -248,8 +248,6 @@ class t_rr_graph_storage {
         cur_node_ = id;
     }
     inline void add_node_to_edge_ptn(int edge_ptn_idx){
-        node_to_edge_ptns_[cur_node_].push_back(edge_ptn_[edge_ptn_idx]);
-
         // new
         // if (node_to_edge_ptns_new_[cur_node_] == 0){
         //     node_to_edge_ptns_new_[cur_node_] = edge_ptns_.size();
@@ -365,9 +363,6 @@ class t_rr_graph_storage {
         return node_first_dest_[node];
     }
 
-    inline std::vector<t_switch_edge_ptn> node_to_edge_ptns(RRNodeId node) const {
-        return node_to_edge_ptns_[node];
-    }
     inline int node_to_edge_ptns_new(RRNodeId node) const {
         return node_to_edge_ptns_new_[node];
     }
@@ -387,26 +382,6 @@ class t_rr_graph_storage {
 
     inline int edge_ptn_data(int ptn) const {
         return edge_ptn_data_[ptn];
-    }
-
-
-
-
-    t_dest_switch kth_edge_for_node(RRNodeId node, int kth_edge) const {
-        std::vector<t_dest_switch> edges;
-        size_t dest = (size_t)node_first_dest_[node];
-        int k = 0;
-        short cur_switch;
-        for (auto p : node_to_edge_ptns_[node]){
-            // const auto p = edge_ptn_[ptn];
-            cur_switch = p.switch_id;
-            while (k < p.edge_count){
-                edges.push_back({RRNodeId(dest+edge_ptn_data_[p.ptn_idx+k]), cur_switch});
-                k++;
-            }
-            k = 0;
-        }
-        return edges[kth_edge];
     }
 
     t_dest_switch kth_edge_for_node_new(RRNodeId node, int kth_edge) const {
@@ -542,25 +517,6 @@ class t_rr_graph_storage {
     //     }
     // }
 
-    // Call the `apply` function with the edge id, source, and sink nodes of every edge.
-    // void for_each_edge(std::function<void(RREdgeId, RRNodeId, RRNodeId)> apply) const {
-    //     int edge = 0;
-    //     for (size_t i=0; i < node_storage_.size(); i++){
-    //         RRNodeId node = RRNodeId(i);
-    //         size_t dest = (size_t)node_first_dest_[node];
-    //         int k = 0;
-    //         for (auto p : node_to_edge_ptns_[node]){
-    //             // const auto p = edge_ptn_[ptn];
-    //             while (k < p.edge_count){
-    //                 apply(RREdgeId(edge), node, RRNodeId(dest+edge_ptn_data_[p.ptn_idx+k]));
-    //                 k++;
-    //                 edge++;
-    //             }
-    //             k = 0;
-    //         }
-    //     }
-    // }
-
     void for_each_edge(std::function<void(RREdgeId, RRNodeId, RRNodeId)> apply) const {
         int edge = 0;
         for (size_t i=0; i < node_storage_.size(); i++){
@@ -682,7 +638,6 @@ class t_rr_graph_storage {
     void make_room_for_node(RRNodeId elem_position) {
         make_room_in_vector(&node_storage_, size_t(elem_position));
         make_room_in_vector(&node_first_dest_, size_t(elem_position));
-        make_room_in_vector(&node_to_edge_ptns_, size_t(elem_position));
         make_room_in_vector(&node_to_edge_ptns_new_, size_t(elem_position));
         make_room_in_vector(&node_num_edge_patterns_, size_t(elem_position));
         node_ptc_.reserve(node_storage_.capacity());
@@ -964,7 +919,6 @@ class t_rr_graph_storage {
     vtr::vector<RREdgeId, short> edge_switch_;
 
     /* Vector from node to list of edge pattern idxs */
-    vtr::vector<RRNodeId, std::vector<t_switch_edge_ptn>> node_to_edge_ptns_;
     vtr::vector<RRNodeId, int> node_to_edge_ptns_new_;
 
     /* Vector from node to the destination node of its first edge */

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -248,7 +248,7 @@ class t_rr_graph_storage {
         cur_node_ = id;
     }
     inline void add_node_to_edge_ptn(int edge_ptn_idx){
-        node_to_edge_ptns_[cur_node_].push_back(edge_ptn_idx);
+        node_to_edge_ptns_[cur_node_].push_back(edge_ptn_[edge_ptn_idx]);
     }
 
     inline void add_edge_ddiff(int id){
@@ -353,7 +353,7 @@ class t_rr_graph_storage {
         return node_first_dest_[node];
     }
 
-    inline std::vector<int> node_to_edge_ptns(RRNodeId node) const {
+    inline std::vector<t_switch_edge_ptn> node_to_edge_ptns(RRNodeId node) const {
         return node_to_edge_ptns_[node];
     }
 
@@ -373,8 +373,8 @@ class t_rr_graph_storage {
         size_t dest = (size_t)node_first_dest_[node];
         int k = 0;
         short cur_switch;
-        for (auto ptn : node_to_edge_ptns_[node]){
-            const auto p = edge_ptn_[ptn];
+        for (auto p : node_to_edge_ptns_[node]){
+            // const auto p = edge_ptn_[ptn];
             cur_switch = p.switch_id;
             while (k < p.edge_count){
                 edges.push_back({RRNodeId(dest+edge_ptn_data_[p.ptn_idx+k]), cur_switch});
@@ -427,8 +427,8 @@ class t_rr_graph_storage {
             RRNodeId node = RRNodeId(i);
             size_t dest = (size_t)node_first_dest_[node];
             int k = 0;
-            for (auto ptn : node_to_edge_ptns_[node]){
-                const auto p = edge_ptn_[ptn];
+            for (auto p : node_to_edge_ptns_[node]){
+                // const auto p = edge_ptn_[ptn];
                 while (k < p.edge_count){
                     apply(RREdgeId(edge), node, RRNodeId(dest+edge_ptn_data_[p.ptn_idx+k]));
                     k++;
@@ -788,7 +788,7 @@ class t_rr_graph_storage {
     vtr::vector<RREdgeId, short> edge_switch_;
 
     /* Vector from node to list of edge pattern idxs */
-    vtr::vector<RRNodeId, std::vector<int>> node_to_edge_ptns_;
+    vtr::vector<RRNodeId, std::vector<t_switch_edge_ptn>> node_to_edge_ptns_;
 
     /* Vector from node to the destination node of its first edge */
     vtr::vector<RRNodeId, int> node_first_dest_;

--- a/vpr/src/route/rr_graph_storage.h
+++ b/vpr/src/route/rr_graph_storage.h
@@ -249,8 +249,8 @@ class t_rr_graph_storage {
     }
     inline void add_node_to_edge_ptn(int edge_ptn_idx){
         // new
-        // if (node_to_edge_ptns_new_[cur_node_] == 0){
-        //     node_to_edge_ptns_new_[cur_node_] = edge_ptns_.size();
+        // if (node_to_edge_ptns_[cur_node_] == 0){
+        //     node_to_edge_ptns_[cur_node_] = edge_ptns_.size();
         // }
         node_num_edge_patterns_[cur_node_] += 1;
         edge_ptns_.push_back(edge_ptn_[edge_ptn_idx]);
@@ -363,12 +363,12 @@ class t_rr_graph_storage {
         return node_first_dest_[node];
     }
 
-    inline int node_to_edge_ptns_new(RRNodeId node) const {
-        return node_to_edge_ptns_new_[node];
+    inline int node_to_edge_ptns(RRNodeId node) const {
+        return node_to_edge_ptns_[node];
     }
 
     inline int num_edge_ptns(const RRNodeId& id) const {
-        return (&node_to_edge_ptns_new_[id])[1] - node_to_edge_ptns_new_[id];
+        return (&node_to_edge_ptns_[id])[1] - node_to_edge_ptns_[id];
     }
 
     inline t_switch_edge_ptn edge_ptns(int node) const {
@@ -386,7 +386,7 @@ class t_rr_graph_storage {
 
     t_dest_switch kth_edge_for_node_new(RRNodeId node, int kth_edge) const {
         int first_dest = node_first_dest_[node];
-        int e_ptn_idx = node_to_edge_ptns_new_[node]; 
+        int e_ptn_idx = node_to_edge_ptns_[node]; 
         t_switch_edge_ptn p = edge_ptns_[e_ptn_idx];
         // int num_ptns = num_edge_ptns(node);
         // for (int i=0; i<num_ptns; i++){
@@ -405,7 +405,7 @@ class t_rr_graph_storage {
     inline void get_edges(RRNodeId id, std::vector<t_dest_switch> &edges)  {
         edges.reserve(num_edges(id));
         int first_dest = node_first_dest(id);
-        int e_ptn_idx = node_to_edge_ptns_new(id); 
+        int e_ptn_idx = node_to_edge_ptns(id); 
 
         t_switch_edge_ptn p = edge_ptns(e_ptn_idx);
         int k = 0;
@@ -427,7 +427,7 @@ class t_rr_graph_storage {
     inline void get_non_configurable_edges(RRNodeId id, std::vector<t_dest_switch> &edges)  {
         edges.reserve(num_edges(id));
         int first_dest = node_first_dest(id);
-        int e_ptn_idx = node_to_edge_ptns_new(id); 
+        int e_ptn_idx = node_to_edge_ptns(id); 
 
         t_switch_edge_ptn p = edge_ptns(e_ptn_idx);
         int k = 0;
@@ -461,7 +461,7 @@ class t_rr_graph_storage {
         edges.reserve(edges_num);
 
         // First Edge
-        int e_ptn_idx = node_to_edge_ptns_new_[node]; 
+        int e_ptn_idx = node_to_edge_ptns_[node]; 
         int edges_added = 0;
         t_switch_edge_ptn p;
         while (edges_added < 1*(edges_num>0)){
@@ -528,7 +528,7 @@ class t_rr_graph_storage {
             size_t dest = (size_t)node_first_dest_[node];
             int edges_num = num_edges(node);
             // First Edge
-            int e_ptn_idx = node_to_edge_ptns_new_[node]; 
+            int e_ptn_idx = node_to_edge_ptns_[node]; 
             int edges_added = 0;
             t_switch_edge_ptn p;
             while (edges_added < 1*(edges_num>0)){
@@ -641,7 +641,7 @@ class t_rr_graph_storage {
     void make_room_for_node(RRNodeId elem_position) {
         make_room_in_vector(&node_storage_, size_t(elem_position));
         make_room_in_vector(&node_first_dest_, size_t(elem_position));
-        make_room_in_vector(&node_to_edge_ptns_new_, size_t(elem_position));
+        make_room_in_vector(&node_to_edge_ptns_, size_t(elem_position));
         make_room_in_vector(&node_num_edge_patterns_, size_t(elem_position));
         node_ptc_.reserve(node_storage_.capacity());
         node_ptc_.resize(node_storage_.size());
@@ -922,7 +922,7 @@ class t_rr_graph_storage {
     vtr::vector<RREdgeId, short> edge_switch_;
 
     /* Vector from node to list of edge pattern idxs */
-    vtr::vector<RRNodeId, int> node_to_edge_ptns_new_;
+    vtr::vector<RRNodeId, int> node_to_edge_ptns_;
 
     /* Vector from node to the destination node of its first edge */
     vtr::vector<RRNodeId, int> node_first_dest_;

--- a/vpr/src/route/rr_graph_timing_params.cpp
+++ b/vpr/src/route/rr_graph_timing_params.cpp
@@ -55,12 +55,16 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
         from_rr_type = rr_graph.node_type(rr_id);
 
         if (from_rr_type == CHANX || from_rr_type == CHANY) {
-            for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(rr_id); iedge++) {
-                to_node = size_t(rr_graph.edge_sink_node(rr_id, iedge));
+
+            std::vector<t_dest_switch> rr_edges;
+            g_vpr_ctx.mutable_device().rr_graph.get_edges(rr_id, rr_edges);
+            for (auto edge : rr_edges) {
+            // for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(rr_id); iedge++) {
+                to_node = size_t(edge.dest);
                 to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
                 if (to_rr_type == CHANX || to_rr_type == CHANY) {
-                    switch_index = rr_graph.edge_switch(rr_id, iedge);
+                    switch_index = edge.switch_id;
                     Cin = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).Cin;
                     Cout = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).Cout;
                     buffered = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).buffered();
@@ -150,9 +154,12 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
         }
         /* End node is CHANX or CHANY */
         else if (from_rr_type == OPIN) {
-            for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(rr_id); iedge++) {
-                switch_index = rr_graph.edge_switch(rr_id, iedge);
-                to_node = size_t(rr_graph.edge_sink_node(rr_id, iedge));
+            std::vector<t_dest_switch> rr_edges2;
+            g_vpr_ctx.mutable_device().rr_graph.get_edges(rr_id, rr_edges2);
+            for (auto rr_edge : rr_edges2) { 
+            // for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(rr_id); iedge++) {
+                switch_index = rr_edge.switch_id;
+                to_node = size_t(rr_edge.dest);
                 to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
                 if (to_rr_type != CHANX && to_rr_type != CHANY)
@@ -160,7 +167,7 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
 
                 if (rr_graph.node_direction(RRNodeId(to_node)) == Direction::BIDIR) {
                     Cout = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).Cout;
-                    to_node = size_t(rr_graph.edge_sink_node(rr_id, iedge)); /* Will be CHANX or CHANY */
+                    to_node = size_t(rr_edge.dest); /* Will be CHANX or CHANY */
                     rr_node_C[to_node] += Cout;
                 }
             }
@@ -174,9 +181,12 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
      * out what the Cout's should be */
     Couts_to_add = (float*)vtr::calloc(device_ctx.rr_nodes.size(), sizeof(float));
     for (const RRNodeId& inode : device_ctx.rr_graph.nodes()) {
-        for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(inode); iedge++) {
-            switch_index = rr_graph.edge_switch(inode, iedge);
-            to_node = size_t(rr_graph.edge_sink_node(inode, iedge));
+        std::vector<t_dest_switch> rr_edges;
+        g_vpr_ctx.mutable_device().rr_graph.get_edges(inode, rr_edges);
+        for (auto rr_edge : rr_edges) { 
+        // for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(inode); iedge++) {
+            switch_index = rr_edge.switch_id;
+            to_node = size_t(rr_edge.dest);
             to_rr_type = rr_graph.node_type(RRNodeId(to_node));
             if (to_rr_type == CHANX || to_rr_type == CHANY) {
                 if (rr_graph.node_direction(RRNodeId(to_node)) != Direction::BIDIR) {

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -916,10 +916,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     inline int init_rr_graph_rr_node_e_ptns(void*& /*ctx*/){
         return 0;
     }
-	inline void finish_rr_graph_rr_node_e_ptns(int &ctx){
-        (void) ctx;
-        return;
-    }
+	
 
 	inline int get_rr_graph_rr_node_e_ptns(void*& /*ctx*/){
         return 0;
@@ -927,7 +924,11 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 	inline int init_rr_graph_rr_edge_ptns(void*& /*ctx*/){
         return 0;
     }
-	inline void finish_rr_graph_rr_edge_ptns(int &ctx){
+    inline void finish_rr_graph_rr_edge_ptns(int &ctx){
+        (void) ctx;
+        return;
+    }
+	inline void finish_rr_graph_rr_node_e_ptns(int &ctx){
         /*initialize a vector that keeps track of the number of wire to ipin switches
          * There should be only one wire to ipin switch. In case there are more, make sure to
          * store the most frequent switch */

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -945,10 +945,13 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         rr_graph_builder_->partition_edges();
 
         for (int source_node = 0; source_node < (ssize_t)rr_nodes_->size(); ++source_node) {
-            int num_edges = rr_nodes_->num_edges(RRNodeId(source_node));
-            for (int iconn = 0; iconn < num_edges; ++iconn) {
-                size_t sink_node = size_t(rr_nodes_->edge_sink_node(RRNodeId(source_node), iconn));
-                size_t switch_id = rr_nodes_->edge_switch(RRNodeId(source_node), iconn);
+            // int num_edges = rr_nodes_->num_edges(RRNodeId(source_node));
+            std::vector<t_dest_switch> rr_edges;
+            (*rr_graph_).get_edges(RRNodeId(source_node), rr_edges);
+            for (auto rr_edge : rr_edges) { 
+            // for (int iconn = 0; iconn < num_edges; ++iconn) {
+                size_t sink_node = size_t(rr_edge.dest);
+                size_t switch_id = rr_edge.switch_id;
                 if (sink_node >= rr_nodes_->size()) {
                     report_error(
                         "sink_node %zu is larger than rr_nodes.size() %zu",

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -974,6 +974,8 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 }
             }
         }
+        VTR_ASSERT(wire_to_rr_ipin_switch_ != nullptr);
+        *wire_to_rr_ipin_switch_ = most_frequent_switch.first;
     }
     
 	inline int get_rr_graph_rr_edge_ptns(void*& /*ctx*/){
@@ -1781,8 +1783,8 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
     void finish_load() final {
         process_rr_node_indices();
-
         rr_graph_builder_->init_fan_in();
+        // rr_graph_builder_->remap_rr_node_switch_indices(const t_arch_switch_fanin& switch_fanin)
         /* Create a temp copy to convert from vtr::vector to std::vector
          * This is required because the ``alloc_and_load_rr_indexed_data()`` function supports only std::vector data
          * type for ``rr_segments``

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -247,6 +247,18 @@ struct RrGraphContextTypes : public uxsd::DefaultRrGraphContextTypes {
     using MetadataWriteContext = MetadataBind;
     using NodeWriteContext = int;
     using EdgeWriteContext = MetadataBind;
+    using EPtnReadContext = int;
+    using EPtnWriteContext = int;
+    using NodeEPtnReadContext = int;
+    using NodeEPtnWriteContext = int;
+    using RrNodeEPtnsReadContext = int;
+    using RrNodeEPtnsWriteContext = int;
+    using EdgePtnReadContext = int;
+    using EdgePtnWriteContext = int;
+    using RrEdgePtnsReadContext = int;
+    using RrEdgePtnsWriteContext = int;
+    using DdiffReadContext = int;
+    using DdiffWriteContext = int;
 };
 
 class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
@@ -749,6 +761,225 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         return itr != rr_node_metadata_->end();
     }
 
+    /* --- Added for edge_switch_subsets folded routing resource graph --- */
+
+    /** Generated for complex type "e_ptn":
+	 * <xs:complexType name="e_ptn">
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	inline unsigned int get_e_ptn_id(int &ctx){
+        return ctx;
+    }
+
+	/** Generated for complex type "node_e_ptn":
+	 * <xs:complexType name="node_e_ptn">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="e_ptn" type="e_ptn" />
+	 *   </xs:choice>
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="dest" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	inline unsigned int get_node_e_ptn_dest(int &ctx){
+        return ctx;
+    }
+	inline unsigned int get_node_e_ptn_id(int &ctx){
+        return ctx;
+    }
+	inline void preallocate_node_e_ptn_e_ptn(int &ctx, size_t size){
+        (void) ctx;
+        (void) size;
+        return;
+    }
+	inline int add_node_e_ptn_e_ptn(int &ctx, unsigned int id){
+        (void) id;
+        rr_graph_builder_->add_node_to_edge_ptn(id);
+        return ctx;
+    }
+	inline void finish_node_e_ptn_e_ptn(int &ctx){
+        (void) ctx;
+        return;
+    }
+	inline size_t num_node_e_ptn_e_ptn(int &ctx){
+        return ctx;
+    }
+	inline int get_node_e_ptn_e_ptn(int n, int &ctx){
+        (void) n;
+        return ctx;
+    }
+
+	/** Generated for complex type "rr_node_e_ptns":
+	 * <xs:complexType name="rr_node_e_ptns">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="node_e_ptn" type="node_e_ptn" />
+	 *   </xs:choice>
+	 * </xs:complexType>
+	*/
+	inline void preallocate_rr_node_e_ptns_node_e_ptn(int &ctx, size_t size){
+        (void) size;
+        (void) ctx;
+        return;
+    }
+	inline int add_rr_node_e_ptns_node_e_ptn(int &ctx, unsigned int dest, unsigned int id){
+        (void) ctx;
+        rr_graph_builder_->add_node_first_dest(RRNodeId(id), dest); //    vtr::vector<RRNodeId, int> node_first_dest_;
+        return id;
+    }
+	inline void finish_rr_node_e_ptns_node_e_ptn(int &ctx){
+        (void) ctx;
+        return;
+    }
+	inline size_t num_rr_node_e_ptns_node_e_ptn(int &ctx){
+        return ctx;
+    }
+	inline int get_rr_node_e_ptns_node_e_ptn(int n, int &ctx){
+        (void) ctx;
+        return n;
+    }
+
+	/** Generated for complex type "ddiff":
+	 * <xs:complexType name="ddiff">
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	inline unsigned int get_ddiff_id(int &ctx){
+        return ctx;
+    }
+
+	/** Generated for complex type "edge_ptn":
+	 * <xs:complexType name="edge_ptn">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="ddiff" type="ddiff" />
+	 *   </xs:choice>
+	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
+	 *   <xs:attribute name="switch_id" type="xs:unsignedInt" use="required" />
+	 * </xs:complexType>
+	*/
+	inline unsigned int get_edge_ptn_id(int &ctx){
+        return ctx;
+    }
+	inline unsigned int get_edge_ptn_switch_id(int &ctx){
+        return ctx;
+    }
+	inline void preallocate_edge_ptn_ddiff(int &ctx, size_t size){
+        (void) ctx;
+        (void) size;
+        return;
+    }
+	inline int add_edge_ptn_ddiff(int &ctx, unsigned int id){
+        (void) ctx;
+        rr_graph_builder_->add_edge_ddiff(id); //ddiff is the difference between that node's starting dest_node_id and this node id
+        return id;
+    }
+	inline void finish_edge_ptn_ddiff(int &ctx){
+        (void) ctx;
+        return;
+    }
+	inline size_t num_edge_ptn_ddiff(int &ctx){
+        return ctx;
+    }
+	inline int get_edge_ptn_ddiff(int n, int &ctx){
+        (void) ctx;
+        return n;
+    }
+
+	/** Generated for complex type "rr_edge_ptns":
+	 * <xs:complexType name="rr_edge_ptns">
+	 *   <xs:choice maxOccurs="unbounded">
+	 *     <xs:element name="edge_ptn" type="edge_ptn" />
+	 *   </xs:choice>
+	 * </xs:complexType>
+	*/
+	inline void preallocate_rr_edge_ptns_edge_ptn(int &ctx, size_t size){
+        (void) ctx;
+        (void) size;
+        return;
+    }
+	inline int add_rr_edge_ptns_edge_ptn(int &ctx, unsigned int id, unsigned int switch_id){
+        (void) ctx;
+        rr_graph_builder_->add_edge_ptn(switch_id);
+        return id;
+    }
+	inline void finish_rr_edge_ptns_edge_ptn(int &ctx){
+        (void) ctx;
+        return;
+    }
+	inline size_t num_rr_edge_ptns_edge_ptn(int &ctx){
+        return ctx;
+    }
+	inline int get_rr_edge_ptns_edge_ptn(int n, int &ctx){
+        (void) ctx;
+        return n;
+    }
+
+    inline int init_rr_graph_rr_node_e_ptns(void*& /*ctx*/){
+        return 0;
+    }
+	inline void finish_rr_graph_rr_node_e_ptns(int &ctx){
+        (void) ctx;
+        return;
+    }
+
+	inline int get_rr_graph_rr_node_e_ptns(void*& /*ctx*/){
+        return 0;
+    }
+	inline int init_rr_graph_rr_edge_ptns(void*& /*ctx*/){
+        return 0;
+    }
+	inline void finish_rr_graph_rr_edge_ptns(int &ctx){
+        /*initialize a vector that keeps track of the number of wire to ipin switches
+         * There should be only one wire to ipin switch. In case there are more, make sure to
+         * store the most frequent switch */
+        const auto& rr_graph = (*rr_graph_);
+        std::vector<int> count_for_wire_to_ipin_switches;
+        count_for_wire_to_ipin_switches.resize(rr_switch_inf_->size(), 0);
+        //first is index, second is count
+        std::pair<int, int> most_frequent_switch(-1, 0);
+
+        // Partition the rr graph edges for efficient access to
+        // configurable/non-configurable edge subsets. Must be done after RR
+        // switches have been allocated.
+        rr_graph_builder_->mark_edges_as_rr_switch_ids();
+        rr_graph_builder_->partition_edges();
+
+        for (int source_node = 0; source_node < (ssize_t)rr_nodes_->size(); ++source_node) {
+            int num_edges = rr_nodes_->num_edges(RRNodeId(source_node));
+            for (int iconn = 0; iconn < num_edges; ++iconn) {
+                size_t sink_node = size_t(rr_nodes_->edge_sink_node(RRNodeId(source_node), iconn));
+                size_t switch_id = rr_nodes_->edge_switch(RRNodeId(source_node), iconn);
+                if (sink_node >= rr_nodes_->size()) {
+                    report_error(
+                        "sink_node %zu is larger than rr_nodes.size() %zu",
+                        sink_node, rr_nodes_->size());
+                }
+
+                if (switch_id >= rr_switch_inf_->size()) {
+                    report_error(
+                        "switch_id %zu is larger than num_rr_switches %zu",
+                        switch_id, rr_switch_inf_->size());
+                }
+                auto node = (*rr_nodes_)[source_node];
+
+                /*Keeps track of the number of the specific type of switch that connects a wire to an ipin
+                 * use the pair data structure to keep the maximum*/
+                if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
+                    if (rr_graph.node_type(RRNodeId(sink_node)) == IPIN) {
+                        count_for_wire_to_ipin_switches[switch_id]++;
+                        if (count_for_wire_to_ipin_switches[switch_id] > most_frequent_switch.second) {
+                            most_frequent_switch.first = switch_id;
+                            most_frequent_switch.second = count_for_wire_to_ipin_switches[switch_id];
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+	inline int get_rr_graph_rr_edge_ptns(void*& /*ctx*/){
+        return 0;
+    }
+
     /** Generated for complex type "rr_nodes":
      * <xs:complexType name="rr_nodes">
      *   <xs:choice maxOccurs="unbounded">
@@ -873,137 +1104,137 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
      *   <xs:attribute name="switch_id" type="xs:unsignedInt" use="required" />
      * </xs:complexType>
      */
-    inline void preallocate_rr_edges_edge(void*& /*ctx*/, size_t size) final {
-        rr_graph_builder_->reserve_edges(size);
-        if (read_edge_metadata_) {
-            rr_edge_metadata_->reserve(size);
-        }
-    }
-    inline MetadataBind add_rr_edges_edge(void*& /*ctx*/, unsigned int sink_node, unsigned int src_node, unsigned int switch_id) final {
-        if (src_node >= rr_nodes_->size()) {
-            report_error(
-                "source_node %d is larger than rr_nodes.size() %d",
-                src_node, rr_nodes_->size());
-        }
+    // inline void preallocate_rr_edges_edge(void*& /*ctx*/, size_t size) final {
+    //     rr_graph_builder_->reserve_edges(size);
+    //     if (read_edge_metadata_) {
+    //         rr_edge_metadata_->reserve(size);
+    //     }
+    // }
+    // inline MetadataBind add_rr_edges_edge(void*& /*ctx*/, unsigned int sink_node, unsigned int src_node, unsigned int switch_id) final {
+    //     if (src_node >= rr_nodes_->size()) {
+    //         report_error(
+    //             "source_node %d is larger than rr_nodes.size() %d",
+    //             src_node, rr_nodes_->size());
+    //     }
 
-        MetadataBind bind(strings_, empty_);
-        if (read_edge_metadata_) {
-            bind.set_edge_target(src_node, sink_node, switch_id);
-        } else {
-            bind.set_ignore();
-        }
+    //     MetadataBind bind(strings_, empty_);
+    //     if (read_edge_metadata_) {
+    //         bind.set_edge_target(src_node, sink_node, switch_id);
+    //     } else {
+    //         bind.set_ignore();
+    //     }
 
-        rr_graph_builder_->emplace_back_edge(RRNodeId(src_node), RRNodeId(sink_node), switch_id);
-        return bind;
-    }
-    inline void finish_rr_edges_edge(MetadataBind& bind) final {
-        bind.finish();
-    }
-    inline size_t num_rr_edges_edge(EdgeWalker& walker) final {
-        return walker.num_edges();
-    }
-    inline const EdgeWalker* get_rr_edges_edge(int n, EdgeWalker& walker) final {
-        size_t cur = walker.advance(n);
-        if ((ssize_t)cur != n) {
-            report_error("Incorrect edge index %zu != %d", cur, n);
-        }
-        return &walker;
-    }
+    //     rr_graph_builder_->emplace_back_edge(RRNodeId(src_node), RRNodeId(sink_node), switch_id);
+    //     return bind;
+    // }
+    // inline void finish_rr_edges_edge(MetadataBind& bind) final {
+    //     bind.finish();
+    // }
+    // inline size_t num_rr_edges_edge(EdgeWalker& walker) final {
+    //     return walker.num_edges();
+    // }
+    // inline const EdgeWalker* get_rr_edges_edge(int n, EdgeWalker& walker) final {
+    //     size_t cur = walker.advance(n);
+    //     if ((ssize_t)cur != n) {
+    //         report_error("Incorrect edge index %zu != %d", cur, n);
+    //     }
+    //     return &walker;
+    // }
 
-    inline unsigned int get_edge_sink_node(const EdgeWalker*& walker) final {
-        return walker->current_sink_node();
-    }
-    inline unsigned int get_edge_src_node(const EdgeWalker*& walker) final {
-        return walker->current_src_node();
-    }
-    inline unsigned int get_edge_switch_id(const EdgeWalker*& walker) final {
-        return walker->current_switch_id_node();
-    }
+    // inline unsigned int get_edge_sink_node(const EdgeWalker*& walker) final {
+    //     return walker->current_sink_node();
+    // }
+    // inline unsigned int get_edge_src_node(const EdgeWalker*& walker) final {
+    //     return walker->current_src_node();
+    // }
+    // inline unsigned int get_edge_switch_id(const EdgeWalker*& walker) final {
+    //     return walker->current_switch_id_node();
+    // }
 
-    inline MetadataBind init_edge_metadata(MetadataBind& bind) final {
-        return bind;
-    }
-    inline void finish_edge_metadata(MetadataBind& bind) final {
-        bind.finish();
-    }
-    inline t_metadata_dict_iterator get_edge_metadata(const EdgeWalker*& walker) final {
-        return t_metadata_dict_iterator(&rr_edge_metadata_->find(
-                                                              std::make_tuple(
-                                                                  walker->current_src_node(),
-                                                                  walker->current_sink_node(),
-                                                                  walker->current_switch_id_node()))
-                                             ->second,
-                                        report_error_);
-    }
-    inline bool has_edge_metadata(const EdgeWalker*& walker) final {
-        return rr_edge_metadata_->find(
-                   std::make_tuple(
-                       walker->current_src_node(),
-                       walker->current_sink_node(),
-                       walker->current_switch_id_node()))
-               != rr_edge_metadata_->end();
-    }
+    // inline MetadataBind init_edge_metadata(MetadataBind& bind) final {
+    //     return bind;
+    // }
+    // inline void finish_edge_metadata(MetadataBind& bind) final {
+    //     bind.finish();
+    // }
+    // inline t_metadata_dict_iterator get_edge_metadata(const EdgeWalker*& walker) final {
+    //     return t_metadata_dict_iterator(&rr_edge_metadata_->find(
+    //                                                           std::make_tuple(
+    //                                                               walker->current_src_node(),
+    //                                                               walker->current_sink_node(),
+    //                                                               walker->current_switch_id_node()))
+    //                                          ->second,
+    //                                     report_error_);
+    // }
+    // inline bool has_edge_metadata(const EdgeWalker*& walker) final {
+    //     return rr_edge_metadata_->find(
+    //                std::make_tuple(
+    //                    walker->current_src_node(),
+    //                    walker->current_sink_node(),
+    //                    walker->current_switch_id_node()))
+    //            != rr_edge_metadata_->end();
+    // }
 
-    inline void* init_rr_graph_rr_edges(void*& /*ctx*/) final {
-        return nullptr;
-    }
-    inline void finish_rr_graph_rr_edges(void*& /*ctx*/) final {
-        /*initialize a vector that keeps track of the number of wire to ipin switches
-         * There should be only one wire to ipin switch. In case there are more, make sure to
-         * store the most frequent switch */
-        const auto& rr_graph = (*rr_graph_);
-        std::vector<int> count_for_wire_to_ipin_switches;
-        count_for_wire_to_ipin_switches.resize(rr_switch_inf_->size(), 0);
-        //first is index, second is count
-        std::pair<int, int> most_frequent_switch(-1, 0);
+    // inline void* init_rr_graph_rr_edges(void*& /*ctx*/) final {
+    //     return nullptr;
+    // }
+    // inline void finish_rr_graph_rr_edges(void*& /*ctx*/) final {
+    //     /*initialize a vector that keeps track of the number of wire to ipin switches
+    //      * There should be only one wire to ipin switch. In case there are more, make sure to
+    //      * store the most frequent switch */
+    //     const auto& rr_graph = (*rr_graph_);
+    //     std::vector<int> count_for_wire_to_ipin_switches;
+    //     count_for_wire_to_ipin_switches.resize(rr_switch_inf_->size(), 0);
+    //     //first is index, second is count
+    //     std::pair<int, int> most_frequent_switch(-1, 0);
 
-        // Partition the rr graph edges for efficient access to
-        // configurable/non-configurable edge subsets. Must be done after RR
-        // switches have been allocated.
-        rr_graph_builder_->mark_edges_as_rr_switch_ids();
-        rr_graph_builder_->partition_edges();
+    //     // Partition the rr graph edges for efficient access to
+    //     // configurable/non-configurable edge subsets. Must be done after RR
+    //     // switches have been allocated.
+    //     rr_graph_builder_->mark_edges_as_rr_switch_ids();
+    //     rr_graph_builder_->partition_edges();
 
-        for (int source_node = 0; source_node < (ssize_t)rr_nodes_->size(); ++source_node) {
-            int num_edges = rr_nodes_->num_edges(RRNodeId(source_node));
-            for (int iconn = 0; iconn < num_edges; ++iconn) {
-                size_t sink_node = size_t(rr_nodes_->edge_sink_node(RRNodeId(source_node), iconn));
-                size_t switch_id = rr_nodes_->edge_switch(RRNodeId(source_node), iconn);
-                if (sink_node >= rr_nodes_->size()) {
-                    report_error(
-                        "sink_node %zu is larger than rr_nodes.size() %zu",
-                        sink_node, rr_nodes_->size());
-                }
+    //     for (int source_node = 0; source_node < (ssize_t)rr_nodes_->size(); ++source_node) {
+    //         int num_edges = rr_nodes_->num_edges(RRNodeId(source_node));
+    //         for (int iconn = 0; iconn < num_edges; ++iconn) {
+    //             size_t sink_node = size_t(rr_nodes_->edge_sink_node(RRNodeId(source_node), iconn));
+    //             size_t switch_id = rr_nodes_->edge_switch(RRNodeId(source_node), iconn);
+    //             if (sink_node >= rr_nodes_->size()) {
+    //                 report_error(
+    //                     "sink_node %zu is larger than rr_nodes.size() %zu",
+    //                     sink_node, rr_nodes_->size());
+    //             }
 
-                if (switch_id >= rr_switch_inf_->size()) {
-                    report_error(
-                        "switch_id %zu is larger than num_rr_switches %zu",
-                        switch_id, rr_switch_inf_->size());
-                }
-                auto node = (*rr_nodes_)[source_node];
+    //             if (switch_id >= rr_switch_inf_->size()) {
+    //                 report_error(
+    //                     "switch_id %zu is larger than num_rr_switches %zu",
+    //                     switch_id, rr_switch_inf_->size());
+    //             }
+    //             auto node = (*rr_nodes_)[source_node];
 
-                /*Keeps track of the number of the specific type of switch that connects a wire to an ipin
-                 * use the pair data structure to keep the maximum*/
-                if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
-                    if (rr_graph.node_type(RRNodeId(sink_node)) == IPIN) {
-                        count_for_wire_to_ipin_switches[switch_id]++;
-                        if (count_for_wire_to_ipin_switches[switch_id] > most_frequent_switch.second) {
-                            most_frequent_switch.first = switch_id;
-                            most_frequent_switch.second = count_for_wire_to_ipin_switches[switch_id];
-                        }
-                    }
-                }
-            }
-        }
+    //             /*Keeps track of the number of the specific type of switch that connects a wire to an ipin
+    //              * use the pair data structure to keep the maximum*/
+    //             if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
+    //                 if (rr_graph.node_type(RRNodeId(sink_node)) == IPIN) {
+    //                     count_for_wire_to_ipin_switches[switch_id]++;
+    //                     if (count_for_wire_to_ipin_switches[switch_id] > most_frequent_switch.second) {
+    //                         most_frequent_switch.first = switch_id;
+    //                         most_frequent_switch.second = count_for_wire_to_ipin_switches[switch_id];
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //     }
 
-        VTR_ASSERT(wire_to_rr_ipin_switch_ != nullptr);
-        *wire_to_rr_ipin_switch_ = most_frequent_switch.first;
-    }
+    //     VTR_ASSERT(wire_to_rr_ipin_switch_ != nullptr);
+    //     *wire_to_rr_ipin_switch_ = most_frequent_switch.first;
+    // }
 
-    inline EdgeWalker get_rr_graph_rr_edges(void*& /*ctx*/) final {
-        EdgeWalker walker;
-        walker.initialize(rr_nodes_, rr_graph_);
-        return walker;
-    }
+    // inline EdgeWalker get_rr_graph_rr_edges(void*& /*ctx*/) final {
+    //     EdgeWalker walker;
+    //     walker.initialize(rr_nodes_, rr_graph_);
+    //     return walker;
+    // }
 
     /** Generated for complex type "channels":
      * <xs:complexType name="channels">

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1802,9 +1802,12 @@ void print_switch_usage() {
     std::map<int, int>* inward_switch_inf = new std::map<int, int>[device_ctx.rr_nodes.size()];
     for (const RRNodeId& inode : device_ctx.rr_graph.nodes()) {
         int num_edges = rr_graph.num_edges(inode);
-        for (int iedge = 0; iedge < num_edges; iedge++) {
-            int switch_index = rr_graph.edge_switch(inode, iedge);
-            int to_node_index = size_t(rr_graph.edge_sink_node(inode, iedge));
+        std::vector<t_dest_switch> rr_edges;
+        g_vpr_ctx.mutable_device().rr_graph.get_edges(inode, rr_edges);
+        for (auto rr_edge : rr_edges) { 
+        // for (int iedge = 0; iedge < num_edges; iedge++) {
+            int switch_index = rr_edge.switch_id;
+            int to_node_index = size_t(rr_edge.dest);
             // Assumption: suppose for a L4 wire (bi-directional): ----+----+----+----, it can be driven from any point (0, 1, 2, 3).
             //             physically, the switch driving from point 1 & 3 should be the same. But we will assign then different switch
             //             index; or there is no way to differentiate them after abstracting a 2D wire into a 1D node

--- a/vpr/test/test_connection_router.cpp
+++ b/vpr/test/test_connection_router.cpp
@@ -93,7 +93,7 @@ std::tuple<size_t, size_t, int> find_source_and_sink() {
             if (edge == rr_graph.last_edge(sink)) {
                 break;
             }
-            sink = rr_graph.edge_sink_node(edge);
+            sink = rr_graph.edge_sink_node_abs(RRNodeId(id), edge);
 
             // If this is the new longest walk, store it.
             if (hops > std::get<2>(longest)) {


### PR DESCRIPTION
## Overview
This folding method is represented in the image below and is the most compact representation explored thus far. This branch is still very much a work in progress, but I am looking for advice on how to optimize my implementation.

<img width="709" alt="edge_switch_subsets" src="https://user-images.githubusercontent.com/55202333/156847424-496daee3-a2ef-458a-95e2-ccdb097cfd74.png">

## Relevant Code Snippets
The following code snippets are places in the implementation that have great impact on its performance. If there are any ways to optimize these snippets, performance would benefit greatly.

#### Data structures used to implement RRGraph
https://github.com/ethanroj23/vtr-verilog-to-routing/blob/cd0d1716305b40a76253630f99f3294f69512abe/vpr/src/route/rr_graph_storage.h#L924-L943

#### This function fills a vector with a node's edges. Perhaps this could be replaced with iterators?
https://github.com/ethanroj23/vtr-verilog-to-routing/blob/cd0d1716305b40a76253630f99f3294f69512abe/vpr/src/route/rr_graph_storage.h#L402-L423

#### Primary access of edges in the router
https://github.com/ethanroj23/vtr-verilog-to-routing/blob/cd0d1716305b40a76253630f99f3294f69512abe/vpr/src/route/connection_router.cpp#L424-L467

#### Primary access of edges in lookahead
https://github.com/ethanroj23/vtr-verilog-to-routing/blob/cd0d1716305b40a76253630f99f3294f69512abe/vpr/src/route/router_lookahead_map.cpp#L650-L718