### PR TITLE
Removing "-nomem2reg" for input Verilog circuits in Yosys+Odin-II

### DIFF
--- a/ODIN_II/SRC/YYosys.cpp
+++ b/ODIN_II/SRC/YYosys.cpp
@@ -250,7 +250,7 @@ void YYosys::execute() {
         // Read the hardware decription Verilog circuits
         // FOR loop enables include feature for Yosys+Odin (multiple Verilog input files)
         for (auto verilog_circuit : this->verilog_circuits)
-            run_pass(std::string("read_verilog -nomem2reg -nolatches " + verilog_circuit));
+            run_pass(std::string("read_verilog -nolatches " + verilog_circuit));
 
         // Check whether cells match libraries and find top module
         run_pass(std::string("hierarchy -check -auto-top -purge_lib"));


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
A minor change to the Yosys synthesis script to make it more configurable for the Yosys+Odin-II synthesizer.  
Now, users can specify `(* nomem2reg/mem2reg = 1/0 *)` before a reg declaration in a Verilog file to specify whether it should be an array of registers or a memory hard block.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test and VTR regression tests


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
