### PR TITLE
Add missing include for <algorithm>.

### DIFF
--- a/libs/libvtrutil/src/vtr_ndmatrix.h
+++ b/libs/libvtrutil/src/vtr_ndmatrix.h
@@ -1,5 +1,6 @@
 #ifndef VTR_ND_MATRIX_H
 #define VTR_ND_MATRIX_H
+#include <algorithm>
 #include <array>
 #include <memory>
 


### PR DESCRIPTION
There is a [change in llvm](https://github.com/verilog-to-routing/vtr-verilog-to-routing.git) that soon won't automatically
surface symbols from a transitive include of `<algorithm>`, so we need to make sure to IWYU.