### PR TITLE
Speciy used hardblocks to print their model in the blif generation phase

### DIFF
--- a/ODIN_II/SRC/BLIFReader.cpp
+++ b/ODIN_II/SRC/BLIFReader.cpp
@@ -333,6 +333,7 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
     vtr::free(mappings);
     mappings = NULL;
 
+    t_model* hb_model = NULL;
     nnode_t* new_node = allocate_nnode(my_location);
 
     // Name the node subcircuit_name~hard_block_number so that the name is unique.
@@ -371,6 +372,11 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
                     new_node->type = HARD_IP;
                     /* specify node name */
                     odin_sprintf(new_name, "\\%s~%ld", subcircuit_stripped_name, hard_block_number - 1);
+                    /* Detect used hard block for the blif generation */
+                    hb_model = find_hard_block(subcircuit_stripped_name);
+                    if (hb_model) {
+                        hb_model->used = 1;
+                    }
                 } else {
                     error_message(PARSE_BLIF, unknown_location,
                                   "Unsupported subcircuit type (%s) in BLIF file.\n", subcircuit_name);
@@ -449,7 +455,8 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
                                 || new_node->type == ROM
                                 || new_node->type == SPRAM
                                 || new_node->type == DPRAM
-                                || new_node->type == MEMORY)
+                                || new_node->type == MEMORY
+                                || hb_model != NULL)
                                    ? get_hard_block_port_name(mapping)
                                    : NULL;
 
@@ -470,7 +477,8 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
                                 || new_node->type == ROM
                                 || new_node->type == SPRAM
                                 || new_node->type == DPRAM
-                                || new_node->type == MEMORY)
+                                || new_node->type == MEMORY
+                                || hb_model != NULL)
                                    ? get_hard_block_port_name(mapping)
                                    : NULL;
 

--- a/ODIN_II/SRC/hard_blocks.cpp
+++ b/ODIN_II/SRC/hard_blocks.cpp
@@ -273,7 +273,7 @@ void instantiate_hard_block(nnode_t* node, short mark, netlist_t* /*netlist*/) {
     /* Give names to the output pins */
     for (i = 0; i < node->num_output_pins; i++) {
         if (node->output_pins[i]->name == NULL)
-            node->output_pins[i]->name = make_full_ref_name(node->name, NULL, NULL, node->output_pins[i]->mapping, -1);
+            node->output_pins[i]->name = make_full_ref_name(node->name, NULL, NULL, node->output_pins[i]->mapping, (configuration.elaborator_type == elaborator_e::_YOSYS) ? i : -1);
 
         index++;
         if (node->output_port_sizes[port] == index) {


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Follow up on PR #1953 
Hardblocks, used by Yosys elaborator, are flaged to print their .model in the final BLIF file


#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
