### PR TITLE
RRGraphView node_is_wire() Implementation

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_obj.cpp
+++ b/libs/librrgraph/src/base/rr_graph_obj.cpp
@@ -42,6 +42,11 @@ bool RRGraph::node_is_wire(const RRNodeId& node) const {
     return node_type(node) == CHANX || node_type(node) == CHANY;
 }
 
+/* Check if RRGraph node type is a wire (CHANX or CHANY)*/
+bool RRGraph::type_is_wire(const t_rr_type curr_type) const {
+    return curr_type == CHANX || curr_type == CHANY;
+}
+
 size_t RRGraph::node_index(const RRNodeId& node) const {
     VTR_ASSERT_SAFE(valid_node_id(node));
     return size_t(node);
@@ -86,7 +91,7 @@ vtr::Rect<short> RRGraph::node_bounding_box(const RRNodeId& node) const {
  ***********************************************************************/
 vtr::Point<short> RRGraph::node_start_coordinate(const RRNodeId& node) const {
     /* Make sure we have CHANX or CHANY */
-    VTR_ASSERT((CHANX == node_type(node)) || (CHANY == node_type(node)));
+    VTR_ASSERT(node_is_wire(node));
 
     vtr::Point<short> start_coordinate(node_xlow(node), node_ylow(node));
 
@@ -110,7 +115,7 @@ vtr::Point<short> RRGraph::node_start_coordinate(const RRNodeId& node) const {
  ***********************************************************************/
 vtr::Point<short> RRGraph::node_end_coordinate(const RRNodeId& node) const {
     /* Make sure we have CHANX or CHANY */
-    VTR_ASSERT((CHANX == node_type(node)) || (CHANY == node_type(node)));
+    VTR_ASSERT(node_is_wire(node));
 
     vtr::Point<short> end_coordinate(node_xhigh(node), node_yhigh(node));
 
@@ -424,7 +429,7 @@ RRNodeId RRGraph::find_node(const short& x, const short& y, const t_rr_type& typ
 /* Find the channel width (number of tracks) of a channel [x][y] */
 short RRGraph::chan_num_tracks(const short& x, const short& y, const t_rr_type& type) const {
     /* Must be CHANX or CHANY */
-    VTR_ASSERT_MSG(CHANX == type || CHANY == type,
+    VTR_ASSERT_MSG(type_is_wire(type),
                    "Required node_type to be CHANX or CHANY!");
     initialize_fast_node_lookup();
 
@@ -470,8 +475,7 @@ void RRGraph::print_node(const RRNodeId& node) const {
 bool RRGraph::validate_node_segment(const RRNodeId& node) const {
     VTR_ASSERT_SAFE(valid_node_id(node));
     /* Only CHANX and CHANY requires a valid segment id */
-    if ((CHANX == node_type(node))
-        || (CHANY == node_type(node))) {
+    if (node_is_wire(node)) {
         return valid_segment_id(node_segments_[node]);
     } else {
         return true;
@@ -1033,8 +1037,7 @@ void RRGraph::set_node_segment(const RRNodeId& node, const RRSegmentId& segment_
     VTR_ASSERT(valid_node_id(node));
 
     /* Only CHANX and CHANY requires a valid segment id */
-    if ((CHANX == node_type(node))
-        || (CHANY == node_type(node))) {
+    if (node_is_wire(node)) {
         VTR_ASSERT(valid_segment_id(segment_id));
     }
 

--- a/libs/librrgraph/src/base/rr_graph_obj.cpp
+++ b/libs/librrgraph/src/base/rr_graph_obj.cpp
@@ -37,6 +37,11 @@ t_rr_type RRGraph::node_type(const RRNodeId& node) const {
     return node_types_[node];
 }
 
+/* Check if RRGraph node is a wire (CHANX or CHANY)*/
+bool RRGraph::node_is_wire(const RRNodeId& node) const {
+    return node_type(node) == CHANX || node_type(node) == CHANY;
+}
+
 size_t RRGraph::node_index(const RRNodeId& node) const {
     VTR_ASSERT_SAFE(valid_node_id(node));
     return size_t(node);
@@ -141,7 +146,7 @@ short RRGraph::node_pin_num(const RRNodeId& node) const {
 }
 
 short RRGraph::node_track_num(const RRNodeId& node) const {
-    VTR_ASSERT_MSG(node_type(node) == CHANX || node_type(node) == CHANY,
+    VTR_ASSERT_MSG(node_is_wire(node),
                    "Track number valid only for CHANX/CHANY RR nodes");
     return node_ptc_num(node);
 }
@@ -158,7 +163,7 @@ RRIndexedDataId RRGraph::node_cost_index(const RRNodeId& node) const {
 
 Direction RRGraph::node_direction(const RRNodeId& node) const {
     VTR_ASSERT_SAFE(valid_node_id(node));
-    VTR_ASSERT_MSG(node_type(node) == CHANX || node_type(node) == CHANY, "Direction valid only for CHANX/CHANY RR nodes");
+    VTR_ASSERT_MSG(node_is_wire(node), "Direction valid only for CHANX/CHANY RR nodes");
     return node_directions_[node];
 }
 
@@ -978,7 +983,7 @@ void RRGraph::set_node_pin_num(const RRNodeId& node, const short& pin_id) {
 
 void RRGraph::set_node_track_num(const RRNodeId& node, const short& track_id) {
     VTR_ASSERT(valid_node_id(node));
-    VTR_ASSERT_MSG(node_type(node) == CHANX || node_type(node) == CHANY, "Track number valid only for CHANX/CHANY RR nodes");
+    VTR_ASSERT_MSG(node_is_wire(node), "Track number valid only for CHANX/CHANY RR nodes");
 
     set_node_ptc_num(node, track_id);
 }
@@ -997,7 +1002,7 @@ void RRGraph::set_node_cost_index(const RRNodeId& node, const RRIndexedDataId& c
 
 void RRGraph::set_node_direction(const RRNodeId& node, const Direction& direction) {
     VTR_ASSERT(valid_node_id(node));
-    VTR_ASSERT_MSG(node_type(node) == CHANX || node_type(node) == CHANY, "Direct can only be specified on CHANX/CNAY rr nodes");
+    VTR_ASSERT_MSG(node_is_wire(node), "Direct can only be specified on CHANX/CNAY rr nodes");
 
     node_directions_[node] = direction;
 }

--- a/libs/librrgraph/src/base/rr_graph_obj.h
+++ b/libs/librrgraph/src/base/rr_graph_obj.h
@@ -261,9 +261,11 @@ class RRGraph {
      */
     t_rr_type node_type(const RRNodeId& node) const;
 
-    /* Check if RRGraph node is a wire (CHANX or CHANY)
-     */
+    /* Check if RRGraph node is a wire (CHANX or CHANY)*/
     bool node_is_wire(const RRNodeId& node) const;
+
+    /* Check if RRGraph node type is a wire (CHANX or CHANY)*/
+    bool type_is_wire(const t_rr_type curr_type) const;
 
     /* Get coordinate of a node. (xlow, xhigh, ylow, yhigh):
      *   For OPIN/IPIN/SOURCE/SINK, xlow = xhigh and ylow = yhigh

--- a/libs/librrgraph/src/base/rr_graph_obj.h
+++ b/libs/librrgraph/src/base/rr_graph_obj.h
@@ -261,6 +261,10 @@ class RRGraph {
      */
     t_rr_type node_type(const RRNodeId& node) const;
 
+    /* Check if RRGraph node is a wire (CHANX or CHANY)
+     */
+    bool node_is_wire(const RRNodeId& node) const;
+
     /* Get coordinate of a node. (xlow, xhigh, ylow, yhigh):
      *   For OPIN/IPIN/SOURCE/SINK, xlow = xhigh and ylow = yhigh
      *   This is still the case when a logic block has a height > 1

--- a/libs/librrgraph/src/base/rr_graph_storage.cpp
+++ b/libs/librrgraph/src/base/rr_graph_storage.cpp
@@ -602,7 +602,7 @@ void t_rr_graph_storage::set_node_pin_num(RRNodeId id, short new_pin_num) {
 }
 
 void t_rr_graph_storage::set_node_track_num(RRNodeId id, short new_track_num) {
-    if (node_type(id) != CHANX && node_type(id) != CHANY) {
+    if (!(node_is_wire(id))) {
         VTR_LOG_ERROR("Attempted to set RR node 'track_num' for non-CHANX/CHANY type '%s'", node_type_string(id));
     }
     node_ptc_[id].ptc_.track_num = new_track_num;
@@ -635,7 +635,7 @@ static short get_node_track_num(
     vtr::array_view_id<RRNodeId, const t_rr_node_ptc_data> node_ptc,
     RRNodeId id) {
     auto node_type = node_storage[id].type_;
-    if (node_type != CHANX && node_type != CHANY) {
+    if (  node_type != CHANX && node_type != CHANY) {
         VTR_LOG_ERROR("Attempted to access RR node 'track_num' for non-CHANX/CHANY type '%s'", rr_node_typename[node_type]);
     }
     return node_ptc[id].ptc_.track_num;

--- a/libs/librrgraph/src/base/rr_graph_storage.h
+++ b/libs/librrgraph/src/base/rr_graph_storage.h
@@ -164,6 +164,11 @@ class t_rr_graph_storage {
     t_rr_type node_type(RRNodeId id) const {
         return node_storage_[id].type_;
     }
+
+    bool node_is_wire(RRNodeId id) const {
+        return node_type(id) == CHANX || node_type(id) == CHANY;
+    }
+
     const char* node_type_string(RRNodeId id) const;
 
     int16_t node_rc_index(RRNodeId id) const {
@@ -733,6 +738,11 @@ class t_rr_graph_view {
     t_rr_type node_type(RRNodeId id) const {
         return node_storage_[id].type_;
     }
+
+    bool node_is_wire(RRNodeId id) const {
+        return node_type(id) == CHANX || node_type(id) == CHANY;
+    }
+
     const char* node_type_string(RRNodeId id) const;
 
     int16_t node_rc_index(RRNodeId id) const {

--- a/libs/librrgraph/src/base/rr_graph_view.h
+++ b/libs/librrgraph/src/base/rr_graph_view.h
@@ -175,7 +175,7 @@ class RRGraphView {
      * This function is inlined for runtime optimization.
      */
     inline int node_length(RRNodeId node) const {
-        VTR_ASSERT(node_type(node) == CHANX || node_type(node) == CHANY);
+        VTR_ASSERT(node_is_wire(node));
         int length = 1 + node_xhigh(node) - node_xlow(node) + node_yhigh(node) - node_ylow(node);
         VTR_ASSERT_SAFE(length > 0);
         return length;
@@ -186,6 +186,16 @@ class RRGraphView {
         return !((node_type(node) == NUM_RR_TYPES)
                  && (node_xlow(node) == -1) && (node_ylow(node) == -1)
                  && (node_xhigh(node) == -1) && (node_yhigh(node) == -1));
+    }
+
+    /** @brief Check if routing resource node is a wire. This function is inlined for runtime optimization. */
+    inline bool node_is_wire(RRNodeId node) const {
+        return node_type(node) == CHANX || node_type(node) == CHANY;
+    }
+
+    /** @brief Check if routing node type is a wire. This function is inlined for runtime optimization. */
+    inline bool type_is_wire(t_rr_type curr_type) const {
+        return curr_type == CHANX || curr_type == CHANY;
     }
 
     /** @brief Check if two routing resource nodes are adjacent (must be a CHANX and a CHANY). 
@@ -252,7 +262,7 @@ class RRGraphView {
             // For SOURCE and SINK the starting and ending coordinate are identical, so just use start
             start_x = "(" + std::to_string(node_xhigh(node)) + ",";
             start_y = std::to_string(node_yhigh(node)) + ")";
-        } else if (node_type(node) == CHANX || node_type(node) == CHANY) { //for channels, we would like to describe the component with segment specific information
+        } else if (node_is_wire(node)) { //for channels, we would like to describe the component with segment specific information
             RRIndexedDataId cost_index = node_cost_index(node);
             int seg_index = rr_indexed_data_[cost_index].seg_index;
             coordinate_string += rr_segments(RRSegmentId(seg_index)).name;       //Write the segment name

--- a/libs/librrgraph/src/base/rr_graph_view.h
+++ b/libs/librrgraph/src/base/rr_graph_view.h
@@ -198,6 +198,11 @@ class RRGraphView {
         return curr_type == CHANX || curr_type == CHANY;
     }
 
+    /** @brief Check if routing node type string is a wire. This function is inlined for runtime optimization. */
+    inline bool type_is_wire(std::string curr_type) const {
+        return curr_type == "CHANX" || curr_type == "CHANY";
+    }
+
     /** @brief Check if two routing resource nodes are adjacent (must be a CHANX and a CHANY). 
      * This function is used for error checking; it checks if two nodes are physically adjacent (could be connected) based on their geometry.
      * It does not check the routing edges to see if they are, in fact, possible to connect in the current routing graph.

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -300,7 +300,7 @@ static void process_nodes(std::ifstream& fp, ClusterNetId inet, const char* file
                     vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                               "Node %d is of the wrong type", inode);
                 }
-            } else if (tokens[2] == "CHANX" || tokens[2] == "CHANY") {
+            } else if (rr_graph.type_is_wire(tokens[2])) {
                 if (tokens[4 + offset] != "Track:") {
                     vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                               "A %s node have to have track info", tokens[2].c_str());

--- a/vpr/src/base/stats.cpp
+++ b/vpr/src/base/stats.cpp
@@ -309,11 +309,11 @@ void get_num_bends_and_length(ClusterNetId inet, int* bends_ptr, int* len_ptr, i
             curr_type = rr_graph.node_type(RRNodeId(tptr->index));
         }
 
-        else if (curr_type == CHANX || curr_type == CHANY) {
+        else if (rr_graph.type_is_wire(curr_type)) {
             segments++;
             length += rr_graph.node_length(RRNodeId(inode));
 
-            if (curr_type != prev_type && (prev_type == CHANX || prev_type == CHANY))
+            if (curr_type != prev_type && (rr_graph.type_is_wire(prev_type)))
                 bends++;
         }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1532,7 +1532,7 @@ static void draw_rr_chan(int inode, const ezgl::color color, ezgl::renderer* g) 
 
     t_rr_type type = rr_graph.node_type(rr_node);
 
-    VTR_ASSERT(type == CHANX || type == CHANY);
+    VTR_ASSERT(rr_graph.type_is_wire(type));
 
     ezgl::rectangle bound_box = draw_get_rr_chan_bbox(inode);
     Direction dir = rr_graph.node_direction(rr_node);

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -364,7 +364,7 @@ static bool check_adjacent(int from_node, int to_node) {
             break;
 
         case OPIN:
-            if (to_type == CHANX || to_type == CHANY) {
+            if (rr_graph.type_is_wire(to_type)) {
                 num_adj += 1; //adjacent
             } else {
                 VTR_ASSERT(to_type == IPIN); /* direct OPIN to IPIN connections not necessarily adjacent */

--- a/vpr/src/route/check_rr_graph.cpp
+++ b/vpr/src/route/check_rr_graph.cpp
@@ -540,7 +540,7 @@ static void check_unbuffered_edges(int from_node) {
     const auto& rr_graph = device_ctx.rr_graph;
 
     from_rr_type = rr_graph.node_type(RRNodeId(from_node));
-    if (from_rr_type != CHANX && from_rr_type != CHANY)
+    if (!rr_graph.type_is_wire(from_rr_type))
         return;
 
     from_num_edges = rr_graph.num_edges(RRNodeId(from_node));
@@ -549,7 +549,7 @@ static void check_unbuffered_edges(int from_node) {
         to_node = size_t(rr_graph.edge_sink_node(RRNodeId(from_node), from_edge));
         to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
-        if (to_rr_type != CHANX && to_rr_type != CHANY)
+        if (!rr_graph.type_is_wire(to_rr_type))
             continue;
 
         from_switch_type = rr_graph.edge_switch(RRNodeId(from_node), from_edge);

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -272,7 +272,7 @@ static void log_single_overused_node_status(int overuse_index, RRNodeId node_id)
     VTR_LOG(" %8s", rr_graph.node_type_string(node_id));
 
     //Direction
-    if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY) {
+    if (rr_graph.type_is_wire(node_type)) {
         VTR_LOG(" %12s", rr_graph.node_direction_string(node_id).c_str());
     } else {
         VTR_LOG(" %12s", "N/A");

--- a/vpr/src/route/route_timing.cpp
+++ b/vpr/src/route/route_timing.cpp
@@ -1670,7 +1670,7 @@ static size_t calculate_wirelength_available() {
     // But really what's happening is that this for loop iterates over every node and determines the available wirelength
     for (const RRNodeId& rr_id : device_ctx.rr_graph.nodes()) {
         const t_rr_type channel_type = rr_graph.node_type(rr_id);
-        if (channel_type == CHANX || channel_type == CHANY) {
+        if (rr_graph.type_is_wire(channel_type)) {
             available_wirelength += rr_graph.node_capacity(rr_id) * rr_graph.node_length(rr_id);
         }
     }

--- a/vpr/src/route/route_util.cpp
+++ b/vpr/src/route/route_util.cpp
@@ -2,10 +2,10 @@
 #include "globals.h"
 
 vtr::Matrix<float> calculate_routing_usage(t_rr_type rr_type) {
-    VTR_ASSERT(rr_type == CHANX || rr_type == CHANY);
 
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
+    VTR_ASSERT(rr_graph.type_is_wire(rr_type));
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& route_ctx = g_vpr_ctx.routing();
 
@@ -53,10 +53,9 @@ vtr::Matrix<float> calculate_routing_usage(t_rr_type rr_type) {
 
 vtr::Matrix<float> calculate_routing_avail(t_rr_type rr_type) {
     //Calculate the number of available resources in each x/y channel
-    VTR_ASSERT(rr_type == CHANX || rr_type == CHANY);
-
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
+    VTR_ASSERT(rr_graph.type_is_wire(rr_type));
 
     vtr::Matrix<float> avail({{device_ctx.grid.width(), device_ctx.grid.height()}}, 0.);
     for (const RRNodeId& rr_node : rr_graph.nodes()) {

--- a/vpr/src/route/route_util.cpp
+++ b/vpr/src/route/route_util.cpp
@@ -2,7 +2,6 @@
 #include "globals.h"
 
 vtr::Matrix<float> calculate_routing_usage(t_rr_type rr_type) {
-
     auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
     VTR_ASSERT(rr_graph.type_is_wire(rr_type));

--- a/vpr/src/route/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead.cpp
@@ -57,7 +57,7 @@ std::pair<float, float> ClassicLookahead::get_expected_delay_and_cong(RRNodeId n
 
     t_rr_type rr_type = rr_graph.node_type(node);
 
-    if (rr_type == CHANX || rr_type == CHANY) {
+    if (rr_graph.type_is_wire(rr_type)) {
         int num_segs_ortho_dir = 0;
         int num_segs_same_dir = get_expected_segs_to_target(node, target_node, &num_segs_ortho_dir);
 

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -574,7 +574,7 @@ float ExtendedMapLookahead::get_expected_cost(
 
     t_rr_type rr_type = rr_graph.node_type(current_node);
 
-    if (rr_type == CHANX || rr_type == CHANY || rr_type == SOURCE || rr_type == OPIN) {
+    if (rr_graph.type_is_wire(rr_type) || rr_type == SOURCE || rr_type == OPIN) {
         float delay_cost, cong_cost;
 
         // Get the total cost using the combined delay and congestion costs

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -548,7 +548,7 @@ static RRNodeId get_start_node(int start_x, int start_y, int target_x, int targe
 
     RRNodeId result = RRNodeId::INVALID();
 
-    if (rr_type != CHANX && rr_type != CHANY) {
+    if (!rr_graph.type_is_wire(rr_type)) {
         VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Must start lookahead routing from CHANX or CHANY node\n");
     }
 

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -237,7 +237,7 @@ float MapLookahead::get_expected_cost(RRNodeId current_node, RRNodeId target_nod
 
     t_rr_type rr_type = rr_graph.node_type(current_node);
 
-    if (rr_type == CHANX || rr_type == CHANY || rr_type == SOURCE || rr_type == OPIN) {
+    if (rr_graph.type_is_wire(rr_type) || rr_type == SOURCE || rr_type == OPIN) {
         float delay_cost, cong_cost;
 
         // Get the total cost using the combined delay and congestion costs
@@ -331,8 +331,8 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
                                             describe_rr_node(size_t(from_node)).c_str())
                                 .c_str());
 
-    } else if (from_type == CHANX || from_type == CHANY) {
-        VTR_ASSERT_SAFE(from_type == CHANX || from_type == CHANY);
+    } else if (rr_graph.type_is_wire(from_type)) {
+        VTR_ASSERT_SAFE(rr_graph.type_is_wire(from_type));
         //When estimating costs from a wire, we directly look-up the result in the wire lookahead (f_wire_cost_map)
 
         auto from_cost_index = rr_graph.node_cost_index(from_node);
@@ -390,7 +390,8 @@ void MapLookahead::write(const std::string& file) const {
 /******** Function Definitions ********/
 
 Cost_Entry get_wire_cost_entry(e_rr_type rr_type, int seg_index, int delta_x, int delta_y) {
-    VTR_ASSERT_SAFE(rr_type == CHANX || rr_type == CHANY);
+    const auto& rr_graph = g_vpr_ctx.device().rr_graph;
+    VTR_ASSERT_SAFE(rr_graph.type_is_wire(rr_type));
 
     int chan_index = 0;
     if (rr_type == CHANY) {

--- a/vpr/src/route/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead_map_utils.cpp
@@ -462,7 +462,7 @@ static void dijkstra_flood_to_wires(int itile, RRNodeId node, util::t_src_opin_d
         pq.pop();
 
         e_rr_type curr_rr_type = rr_graph.node_type(curr.node);
-        if (curr_rr_type == CHANX || curr_rr_type == CHANY || curr_rr_type == SINK) {
+        if (rr_graph.type_is_wire(curr_rr_type) || curr_rr_type == SINK) {
             //We stop expansion at any CHANX/CHANY/SINK
             int seg_index;
             if (curr_rr_type != SINK) {
@@ -579,7 +579,7 @@ static void dijkstra_flood_to_ipins(RRNodeId node, util::t_chan_ipins_delays& ch
             chan_ipins_delays[itile][ptc].wire_rr_type = curr_rr_type;
             chan_ipins_delays[itile][ptc].delay = site_pin_delay;
             chan_ipins_delays[itile][ptc].congestion = curr.congestion;
-        } else if (curr_rr_type == CHANX || curr_rr_type == CHANY) {
+        } else if (rr_graph.type_is_wire(curr_rr_type)) {
             if (curr.level >= MAX_EXPANSION_LEVEL) {
                 continue;
             }

--- a/vpr/src/route/router_lookahead_sampling.cpp
+++ b/vpr/src/route/router_lookahead_sampling.cpp
@@ -130,7 +130,7 @@ static std::tuple<int, int, int> get_node_info(const t_rr_node& node, int num_se
     const auto& rr_graph = device_ctx.rr_graph;
     RRNodeId rr_node = node.id();
 
-    if (rr_graph.node_type(rr_node) != CHANX && rr_graph.node_type(rr_node) != CHANY) {
+    if (!rr_graph.node_is_wire(rr_node)) {
         return std::tuple<int, int, int>(OPEN, OPEN, OPEN);
     }
 
@@ -203,7 +203,7 @@ std::vector<SampleRegion> find_sample_regions(int num_segments) {
     // compute bounding boxes for each segment type
     std::vector<vtr::Rect<int>> bounding_box_for_segment(num_segments, vtr::Rect<int>());
     for (auto& node : rr_graph.rr_nodes()) {
-        if (rr_graph.node_type(node.id()) != CHANX && rr_graph.node_type(node.id()) != CHANY) continue;
+        if (!rr_graph.node_is_wire(node.id())) continue;
         if (rr_graph.node_capacity(node.id()) == 0 || rr_graph.num_edges(node.id()) == 0) continue;
         int seg_index = device_ctx.rr_indexed_data[rr_graph.node_cost_index(node.id())].seg_index;
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -2483,7 +2483,7 @@ std::string describe_rr_node(int inode) {
 
     std::string msg = vtr::string_fmt("RR node: %d", inode);
 
-    if (rr_graph.node_type(RRNodeId(inode)) == CHANX || rr_graph.node_type(RRNodeId(inode)) == CHANY) {
+    if (rr_graph.node_is_wire(RRNodeId(inode))) {
         auto cost_index = rr_graph.node_cost_index(RRNodeId(inode));
 
         int seg_index = device_ctx.rr_indexed_data[cost_index].seg_index;

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1185,7 +1185,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
             for (t_rr_type rr_type : RR_TYPES) {
                 /* Get the list of nodes at a specific location (x, y) */
                 std::vector<RRNodeId> nodes_from_lookup;
-                if (rr_type == CHANX || rr_type == CHANY) {
+                if (rr_graph.type_is_wire(rr_type)) {
                     nodes_from_lookup = rr_graph.node_lookup().find_channel_nodes(x, y, rr_type);
                 } else {
                     nodes_from_lookup = rr_graph.node_lookup().find_grid_nodes_at_all_sides(x, y, rr_type);

--- a/vpr/src/route/rr_graph_folding/README.md
+++ b/vpr/src/route/rr_graph_folding/README.md
@@ -1,0 +1,45 @@
+# RRGraph Folding
+This directory is used for storing / folding routing resource graphs using different folding methods.
+
+## Files / Directories
+- `flat_graphs/` is the directory where the folding scripts will look for the flat rr_graph.xml files
+    - to save flat rr_graphs to this directory, run vpr with the argument 
+    ```
+    --write_rr_graph /path/to/flat_graphs/your_graph.xml
+    ```
+    - for convenience, the [rr_graph](https://docs.verilogtorouting.org/en/latest/quickstart/#running-vpr-on-a-pre-synthesized-circuit) for architecture EArch.xml and circuit tseng.blif is already included in `flat_graphs/`
+- `folded_graphs/` is the directory where the folding scripts will save the folded rr_graph.xml files
+    - to generate folded rr_graphs, follow the instructions below
+- `fold_rr_graph.py` is the script that takes care of folding and saving rr_graphs from flat to folded
+
+## Generating Folded RR Graphs
+- To generate a folded rr_graph, run `fold_rr_graph.py` with the following command
+```
+python fold_rr_graph.py <folding_method> <flat_graph_name>
+```
+- the `<folding_method>` argument refers to the folding method script in the `folding_methods/` directory to be used for folding
+- the `<flat_graph_name>` refers to the name of the flat graph in the `flat_graphs` directory that you wish to fold
+- If you want to fold all the graphs in the `flat_graphs` directory, simply omit the `<flat_graph_name>` argument, and every flat graph will be folded.
+- `fold_rr_graph.py` will execute in the following order
+    1. Read flat rr_graph into memory from `flat_graphs/<flat_graph_name>.xml`
+    2. Fold the flat rr_graph using the desired `<folding_method>`
+    3. Save the folded rr_graph as `<folding_method>_<flat_graph_name>.xml` in the `folded_graphs` directory
+    4. Print out folding metrics to the console including data such as nodes and edges % of original size.
+
+## Using Folded RR Graphs in VTR
+- Currently the only working method to use a folded rr_graph in VTR requires that the folded graph is read from a file.
+- This means that a custom rr_graph reader must be implemented for each folding method.
+- Instructions on how to implement changes to the rr_graph reader can be found at `$VTR_ROOT/vpr/src/route/SCHEMA_GENERATOR.md`
+
+# Working Example
+
+- Branches for each folding method follow the naming convention that the git branch name is the same as the folding method name.
+- A working example of the `nodes_all_attr` folding method can be found on the nodes_all_attr branch. (add link...)
+- To run this example, simply checkout the branch, build VTR and then run the following command
+```
+This is the command...
+```
+- To compare with the flat graph, checkout this (add link...) branch, build VTR and then run the following command
+```
+This is the command...
+```

--- a/vpr/src/route/rr_graph_folding/fold_rr_graph.py
+++ b/vpr/src/route/rr_graph_folding/fold_rr_graph.py
@@ -1,0 +1,122 @@
+# This file is used to fold VTR's Routing Resource Graph
+# Inputs include
+#   - folding method
+#   - flat_graph name
+# author: Ethan Rogers @ethanroj23 (github)
+
+import os
+import sys
+import re
+sys.path.insert(0, os.getcwd()+'/folding_methods')
+
+# Indices into flat_graph object
+NODE = 0
+EDGE = 1
+EDGE_COUNT = 2
+
+XLOW = 0
+YLOW = 1
+XHIGH = 2
+YHIGH = 3
+TYPE = 4
+R = 5
+C = 6
+CAPACITY = 7
+SIDE = 8
+PTC = 9
+DIRECTION = 10
+SEGMENT = 11
+
+def read_flat_graph(graph_name):
+    rr_graph_file = f'flat_graphs/{graph_name}.xml'
+    print(f'Reading {graph_name} from file...')
+    flat_graph = [[], []] # nodes, edges
+    total_nodes = 0
+    edge_count = 0
+    with open(rr_graph_file, 'r') as file:
+        for line in file:
+            writeline = line
+            if '<segment segment_id=' in line:
+                segment_id = int(re.findall('segment_id="([0-9]+)"', line)[0])
+                flat_graph[NODE][prev_id][SEGMENT] = segment_id
+            if '<timing C=' in line:
+                cap = re.findall('C="(.*?)"', line)[0]
+                res = re.findall('R="(.*?)"', line)[0]
+                flat_graph[NODE][prev_id][C] = cap
+                flat_graph[NODE][prev_id][R] = res
+            if '<node' in line:
+                flat_graph[NODE] += [[]] # add new list for node
+                total_nodes += 1
+                if total_nodes % 1000000 == 0:
+                    print(total_nodes)
+                id = int(re.findall('id="([0-9]+)"', line)[0])
+                prev_id = id
+                xlow = int(re.findall('xlow="([0-9]+)"', line)[0])
+                ylow = int(re.findall('ylow="([0-9]+)"', line)[0])
+                xhigh = int(re.findall('xhigh="([0-9]+)"', line)[0])
+                yhigh = int(re.findall('yhigh="([0-9]+)"', line)[0])
+                capacity = int(re.findall('capacity="([0-9]+)"', line)[0])
+                ptc = int(re.findall('ptc="([0-9]+)"', line)[0])
+                direction = re.findall('direction="(.*?)"', line)
+                if direction:
+                    direction = direction[0]
+                else:
+                    direction = None
+                side = re.findall('side="(.*?)"', line)
+                if side:
+                    side = side[0]
+                else:
+                    side = None
+                node_type = re.findall('type="([A-Z]+)"', line)[0]
+                # retrieve node
+                flat_graph[NODE][id] = [xlow, ylow, xhigh, yhigh, node_type, None,  None, #R and C will be filled in later
+                                    capacity, side, ptc, direction, None]
+
+            if '<edge' in line:
+                edge_count += 1
+                sink_node = int(re.findall('sink_node="([0-9]+)"', line)[0])
+                src_node = int(re.findall('src_node="([0-9]+)"', line)[0])
+                switch_id = int(re.findall('switch_id="([0-9]+)"', line)[0])
+                edge_diff = src_node - len(flat_graph[EDGE])
+                if edge_diff >= 0:
+                    for _ in range(edge_diff+1):
+                        flat_graph[EDGE].append([])
+                flat_graph[EDGE][src_node].append([sink_node, switch_id])
+
+    print(f'Total nodes: {total_nodes}')
+    print(f'Total edges: {edge_count}')
+    flat_graph.append(edge_count)
+    return flat_graph
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Please provide the: \n\t- folding method \n\t- graph_name if desired (If no graph_name is provided, all graphs in the flat_graphs/ directory will be folded)")
+        print("\tPotential Folding methods:")
+        for file in os.listdir('folding_methods'):
+            if '.py' in file:
+                print(f'\t\t{file[:-3]}')
+        exit()
+    graphs_to_fold = []
+    if len(sys.argv) == 2:
+        for file in os.listdir('flat_graphs'):
+            graphs_to_fold.append(file[:-4])
+    elif len(sys.argv) == 3:
+        graphs_to_fold.append(sys.argv[2])
+    
+    # Dynamically import the folding module based on the input argument
+    folding_method = sys.argv[1]
+    folding_module = __import__(folding_method)
+    print(f'Using folding method {folding_module.name()}')
+
+    # Iterate over all graphs to fold and fold/save them
+    for graph_name in graphs_to_fold:
+        flat_graph = read_flat_graph(graph_name)
+        folding_module.fold_save_metrics(flat_graph, graph_name)
+
+        
+
+# import importlib
+# my_module = importlib.import_module("module.submodule")
+# MyClass = getattr(my_module, "MyClass")
+# instance = MyClass()

--- a/vpr/src/route/rr_graph_folding/folding_methods/nodes_all_attr.py
+++ b/vpr/src/route/rr_graph_folding/folding_methods/nodes_all_attr.py
@@ -1,0 +1,152 @@
+import os
+import re
+
+'''
+------------------------------- NODES_ALL_ATTR folding method --------------------------------------
+
+Every attribute of a node is stored into a node pattern
+
+Data stored for each NODE:
+ptn_idx
+
+Data stored for each NODE PATTERN:
+xlow
+ylow
+xhigh
+yhigh
+type
+capacity
+R
+C
+Segment Id
+Direction
+Side
+
+Example NODE in xml:
+<node id="11626" ptn_idx="0"/>
+
+Example NODE PATTERN in xml:
+<node_ptn capacity="1" direction="INC_DIR" id="11626" type="CHANX"><loc ptc="0" xhigh="8" xlow="5" yhigh="8" ylow="8"/>
+<timing C="1.1619003e-13" R="404"/>
+<segment segment_id="0"/>
+</node_ptn>
+
+
+------------------------------- NODES_ALL_ATTR folding method --------------------------------------
+
+'''
+
+
+
+# Indices into flat_graph object
+NODE = 0
+EDGE = 1
+EDGE_COUNT = 2
+
+XLOW = 0
+YLOW = 1
+XHIGH = 2
+YHIGH = 3
+TYPE = 4
+R = 5
+C = 6
+CAPACITY = 7
+SIDE = 8
+PTC = 9
+DIRECTION = 10
+SEGMENT = 11
+
+# Indices into folded_graph object
+F_NODE_TO_PATTERN = 0
+F_NODE_PATTERNS = 1
+F_EDGES = 2
+F_SEGMENT = 9 # segment is the only index that is different from flat -> folded
+
+# Size constants
+FLAT_NODE_BYTES = 16 # bytes per node
+FLAT_EDGE_BYTES = 10 # bytes per edge
+
+def fold_save_metrics(flat_graph, graph_name):
+    folded_graph = fold(flat_graph)
+    save(folded_graph, graph_name)
+    metrics(flat_graph, folded_graph, graph_name)
+
+def fold(graph):
+    np = {} # node_patterns
+    node_to_pattern = [] # mapping from node_id -> node pattern idx
+    p_idx = 0
+    for i, node in enumerate(graph[NODE]):
+        cur_p = (node[XLOW], node[YLOW], node[XHIGH], node[YHIGH], node[TYPE], node[R],
+                node[C], node[CAPACITY], node[SIDE], node[SEGMENT], node[DIRECTION],)
+        if cur_p not in np:
+            np[cur_p] = p_idx
+            p_idx += 1
+        node_to_pattern.append(np[cur_p])
+    
+    folded_graph = [node_to_pattern, np, graph[EDGE]]
+    return folded_graph
+
+def save(graph, graph_name):
+    '''
+    Saves the folded graph into an xml file with nodes and node_patterns
+    '''
+    save_file = f'{os.getcwd()}/folded_graphs/{name()}_{graph_name}.xml'
+    flat_file = f'{os.getcwd()}/flat_graphs/{graph_name}.xml'
+    print(f'Saving graph to {save_file}')
+    with open(save_file, 'w') as folded_file:
+        with open(flat_file, 'r') as file:
+            for line in file:
+                write_line = line
+                if '<node' in line:
+                    node = int(re.findall('id="([0-9]+)"', line)[0])
+                    ptc = int(re.findall('ptc="([0-9]+)"', line)[0])
+                    pattern_idx = graph[F_NODE_TO_PATTERN][node]
+                    write_line = f'<node id="{node}" ptn_idx="{pattern_idx}" ptc="{ptc}"/>\n'
+                if '</node>' in line:
+                    continue
+                if '<timing C="' in line or '<segment segment_id="' in line:
+                    continue
+                if '<rr_nodes>' in line:
+                    folded_file.write('<rr_node_patterns>\n')
+                    for ptn_idx, ptn in enumerate(graph[F_NODE_PATTERNS]):
+                        direction = f'direction="{ptn[DIRECTION]}" ' if ptn[DIRECTION] else ''
+                        side = f'side="{ptn[SIDE]}" ' if ptn[SIDE] else ''
+                        ptn_line = f'<node_ptn capacity="{ptn[CAPACITY]}" {direction}id="{ptn_idx}" type="{ptn[TYPE]}"><loc {side}xhigh="{ptn[XHIGH]}" xlow="{ptn[XLOW]}" yhigh="{ptn[YHIGH]}" ylow="{ptn[YLOW]}"/>\n'
+                        if ptn[R] is not None:
+                            ptn_line += f'<timing C="{ptn[C]}" R="{ptn[R]}"/>\n'
+                        if ptn[F_SEGMENT] is not None:
+                            ptn_line += f'<segment segment_id="{ptn[F_SEGMENT]}"/>\n'
+                        ptn_line += '</node_ptn>\n'
+                        folded_file.write(ptn_line)
+                    folded_file.write('</rr_node_patterns>\n')
+                folded_file.write(write_line)
+
+
+
+def metrics(flat_graph, folded_graph, graph_name):
+    MiB = 1024*1024
+    flat_nodes_size = len(flat_graph[NODE])*FLAT_NODE_BYTES/MiB
+    flat_size = (len(flat_graph[NODE])*FLAT_NODE_BYTES + flat_graph[EDGE_COUNT]*FLAT_EDGE_BYTES)/MiB
+    
+    np_count = len(folded_graph[F_NODE_PATTERNS])
+    node_count = len(folded_graph[F_NODE_TO_PATTERN])
+    edge_count = flat_graph[EDGE_COUNT]
+    folded_nodes_size = (node_count*4+np_count*FLAT_NODE_BYTES)/MiB
+    folded_size = (np_count*FLAT_NODE_BYTES + node_count*4 + edge_count*FLAT_EDGE_BYTES)/MiB
+
+    print(f'\n{graph_name} metrics [{name()}]:\n\t' \
+          f'Node patterns: {np_count} ({np_count*FLAT_NODE_BYTES/MiB:.2f} MiB) [{100*np_count/node_count:.1f}%]\n\t' \
+          f'Node to patterns: {node_count} ({node_count*4/MiB:.2f} MiB)\n\t' \
+          f'Nodes: {node_count} ({flat_nodes_size:.2f} -> {folded_nodes_size:.2f} MiB) [{100*folded_nodes_size/flat_nodes_size:.1f}%]\n\t' \
+          f'Edges: {edge_count} ({edge_count*FLAT_EDGE_BYTES/MiB:.2f} MiB)\n\t'
+          f'Total Size: {flat_size:.2f} -> {folded_size:.2f} MiB [{100*folded_size/flat_size:.1f}%]')
+
+
+
+def name():
+    return 'nodes_all_attr'
+
+if __name__ == '__main__':
+    print(f"This folding method is '{name()}'")
+    print(f"To fold an rr_graph with this method, run the following command from the directory one level up")
+    print(f"\tpython fold_rr_graph.py {name()} <flat_graph_name>")

--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -461,7 +461,7 @@ static void calculate_average_switch(int inode, double& avg_switch_R, double& av
     buffered = UNDEFINED;
     for (const auto& edge : fan_in_list[node]) {
         /* want to get C/R/Tdel/Cinternal of switches that connect this track segment to other track segments */
-        if (rr_graph.node_type(node) == CHANX || rr_graph.node_type(node) == CHANY) {
+        if (rr_graph.node_is_wire(node)) {
             int switch_index = rr_graph.rr_nodes().edge_switch(edge);
 
             if (rr_graph.rr_switch_inf(RRSwitchId(switch_index)).type() == SwitchType::SHORT) continue;

--- a/vpr/src/route/rr_graph_indexed_data.cpp
+++ b/vpr/src/route/rr_graph_indexed_data.cpp
@@ -244,7 +244,7 @@ static std::vector<size_t> count_rr_segment_types() {
     const auto& rr_graph = device_ctx.rr_graph;
 
     for (const RRNodeId& id : rr_graph.nodes()) {
-        if (rr_graph.node_type(id) != CHANX && rr_graph.node_type(id) != CHANY) continue;
+        if (!rr_graph.node_is_wire(id)) continue;
 
         auto cost_index = rr_graph.node_cost_index(id);
 
@@ -346,7 +346,7 @@ static void load_rr_indexed_data_T_values() {
     for (const RRNodeId& rr_id : device_ctx.rr_graph.nodes()) {
         t_rr_type rr_type = rr_graph.node_type(rr_id);
 
-        if (rr_type != CHANX && rr_type != CHANY) {
+        if (!rr_graph.type_is_wire(rr_type)) {
             continue;
         }
 

--- a/vpr/src/route/rr_graph_timing_params.cpp
+++ b/vpr/src/route/rr_graph_timing_params.cpp
@@ -54,12 +54,12 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
 
         from_rr_type = rr_graph.node_type(rr_id);
 
-        if (from_rr_type == CHANX || from_rr_type == CHANY) {
+        if (rr_graph.type_is_wire(from_rr_type)) {
             for (t_edge_size iedge = 0; iedge < rr_graph.num_edges(rr_id); iedge++) {
                 to_node = size_t(rr_graph.edge_sink_node(rr_id, iedge));
                 to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
-                if (to_rr_type == CHANX || to_rr_type == CHANY) {
+                if (rr_graph.type_is_wire(to_rr_type)) {
                     switch_index = rr_graph.edge_switch(rr_id, iedge);
                     Cin = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).Cin;
                     Cout = rr_graph.rr_switch_inf(RRSwitchId(switch_index)).Cout;
@@ -178,7 +178,7 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
             switch_index = rr_graph.edge_switch(inode, iedge);
             to_node = size_t(rr_graph.edge_sink_node(inode, iedge));
             to_rr_type = rr_graph.node_type(RRNodeId(to_node));
-            if (to_rr_type == CHANX || to_rr_type == CHANY) {
+            if (rr_graph.type_is_wire(to_rr_type)) {
                 if (rr_graph.node_direction(RRNodeId(to_node)) != Direction::BIDIR) {
                     /* Cout was not added in these cases */
                     Couts_to_add[to_node] = std::max(Couts_to_add[to_node], rr_graph.rr_switch_inf(RRSwitchId(switch_index)).Cout);

--- a/vpr/src/route/rr_graph_timing_params.cpp
+++ b/vpr/src/route/rr_graph_timing_params.cpp
@@ -155,7 +155,7 @@ void add_rr_graph_C_from_switches(float C_ipin_cblock) {
                 to_node = size_t(rr_graph.edge_sink_node(rr_id, iedge));
                 to_rr_type = rr_graph.node_type(RRNodeId(to_node));
 
-                if (to_rr_type != CHANX && to_rr_type != CHANY)
+                if (!rr_graph.type_is_wire(to_rr_type))
                     continue;
 
                 if (rr_graph.node_direction(RRNodeId(to_node)) == Direction::BIDIR) {

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -827,7 +827,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         RRNodeId node_id = node.id();
 
         if (direction == uxsd::enum_node_direction::UXSD_INVALID) {
-            if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
+            if (rr_graph.node_is_wire(node.id())) {
                 report_error(
                     "inode %d is type %d, which requires a direction, but no direction was supplied.",
                     inode, rr_graph.node_type(node.id()));
@@ -838,7 +838,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     }
     inline uxsd::enum_node_direction get_node_direction(const t_rr_node& node) final {
         const auto& rr_graph = (*rr_graph_);
-        if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
+        if (rr_graph.node_is_wire(node.id())) {
             return to_uxsd_node_direction(rr_graph.node_direction(node.id()));
         } else {
             return uxsd::enum_node_direction::UXSD_INVALID;
@@ -983,7 +983,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
                 /*Keeps track of the number of the specific type of switch that connects a wire to an ipin
                  * use the pair data structure to keep the maximum*/
-                if (rr_graph.node_type(node.id()) == CHANX || rr_graph.node_type(node.id()) == CHANY) {
+                if (rr_graph.node_is_wire(node.id())) {
                     if (rr_graph.node_type(RRNodeId(sink_node)) == IPIN) {
                         count_for_wire_to_ipin_switches[switch_id]++;
                         if (count_for_wire_to_ipin_switches[switch_id] > most_frequent_switch.second) {

--- a/vpr/src/route/segment_stats.cpp
+++ b/vpr/src/route/segment_stats.cpp
@@ -51,7 +51,7 @@ void get_segment_usage_stats(std::vector<t_segment_inf>& segment_inf) {
 
     for (const RRNodeId& rr_id : device_ctx.rr_graph.nodes()) {
         size_t inode = (size_t)rr_id;
-        if (rr_graph.node_type(rr_id) == CHANX || rr_graph.node_type(rr_id) == CHANY) {
+        if (rr_graph.node_is_wire(rr_id)) {
             cost_index = rr_graph.node_cost_index(rr_id);
             size_t seg_type = device_ctx.rr_indexed_data[cost_index].seg_index;
 

--- a/vpr/src/timing/VprTimingGraphResolver.cpp
+++ b/vpr/src/timing/VprTimingGraphResolver.cpp
@@ -285,8 +285,7 @@ void VprTimingGraphResolver::get_detailed_interconnect_components_helper(std::ve
         auto rr_type = rr_graph.node_type(RRNodeId(node->inode));
         if (rr_type == OPIN
             || rr_type == IPIN
-            || rr_type == CHANX
-            || rr_type == CHANY
+            || rr_graph.type_is_wire(rr_type)
             || ((rr_type == SOURCE || rr_type == SINK) && (detail_level() == e_timing_report_detail::DEBUG))) {
             tatum::DelayComponent net_component; //declare a new instance of DelayComponent
 

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -214,7 +214,7 @@ std::string rr_node_arch_name(int inode) {
             rr_node_arch_name += pin_names[0];
         }
     } else {
-        VTR_ASSERT(rr_graph.node_type(RRNodeId(inode)) == CHANX || rr_graph.node_type(RRNodeId(inode)) == CHANY);
+        VTR_ASSERT(rr_graph.node_is_wire(RRNodeId(inode)));
         //Wire segment name
         auto cost_index = rr_graph.node_cost_index(RRNodeId(inode));
         int seg_index = device_ctx.rr_indexed_data[cost_index].seg_index;

--- a/vpr/test/test_vpr.cpp
+++ b/vpr/test/test_vpr.cpp
@@ -137,7 +137,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
         const auto& rr_graph = device_ctx.rr_graph;
 
         for (const RRNodeId& inode : device_ctx.rr_graph.nodes()) {
-            if ((rr_graph.node_type(inode) == CHANX || rr_graph.node_type(inode) == CHANY) && rr_graph.num_edges(inode) > 0) {
+            if ((rr_graph.node_is_wire(inode)) && rr_graph.num_edges(inode) > 0) {
                 src_inode = size_t(inode);
                 break;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In this PR, I have implemented `RRGraphView::node_is_wire()` throughout VTR. Every time `rr_graph.node_type(node) == CHANX || rr_graph.node_type(node) == CHANY` was used has been replaced with `rr_graph.node_is_wire(node)`. In order to do this, I followed a pattern similar to that in previous RRGraphView PRs.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes reliance upon CHANX and CHANY types when determining if node is a wire.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have run the regression QoR testing found at `    $ ../scripts/run_vtr_task.py regression_tests/vtr_reg_nightly_test3/vtr_reg_qor_chain`. Results from these QoR tests can be found below. The file containing all results can be found [here](https://github.com/verilog-to-routing/vtr-verilog-to-routing/files/8485315/node_is_wire.xlsx)


Only rows that are different are shown.

|	| VTR Before These Changes	|With Changes in this PR|
|---|---|---|
|vtr_flow_elapsed_time | 1 | 1.005244594 |
|odin_synth_time | 1 | 0.939894168 |
|abc_synth_time | 1 | 0.992427584 |
|max_vpr_mem | 1 | 1.000167355 |
|pack_time | 1 | 1.041704909 |
|place_time | 1 | 0.995212009 |
|min_chan_width_route_time | 1 | 1.002900235 |
|crit_path_route_time | 1 | 1.001591785 |




#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed