### PR TITLE
[Yosys+Odin]: creating extra pins to extend the mult output port

### DIFF
--- a/ODIN_II/SRC/BLIFElaborate.cpp
+++ b/ODIN_II/SRC/BLIFElaborate.cpp
@@ -485,7 +485,7 @@ static void resolve_arithmetic_nodes(nnode_t* node, uintptr_t traverse_mark_numb
             if (!hard_multipliers)
                 check_constant_multipication(node, traverse_mark_number, netlist);
             else
-                check_multiplier_port_size(node, netlist);
+                check_multiplier_port_size(node);
 
             /* Adding to mult_list for future checking on hard blocks */
             mult_list = insert_in_vptr_list(mult_list, node);

--- a/ODIN_II/SRC/include/multipliers.h
+++ b/ODIN_II/SRC/include/multipliers.h
@@ -56,7 +56,7 @@ extern void define_mult_function(nnode_t* node, FILE* out);
 extern void split_multiplier(nnode_t* node, int a0, int b0, int a1, int b1, netlist_t* netlist);
 extern void iterate_multipliers(netlist_t* netlist);
 extern bool check_constant_multipication(nnode_t* node, uintptr_t traverse_mark_number, netlist_t* netlist);
-extern void check_multiplier_port_size(nnode_t* node, netlist_t* netlist);
+extern void check_multiplier_port_size(nnode_t* node);
 extern bool is_ast_multiplier(ast_node_t* node);
 extern void clean_multipliers();
 extern void free_multipliers();

--- a/ODIN_II/SRC/multipliers.cpp
+++ b/ODIN_II/SRC/multipliers.cpp
@@ -1769,10 +1769,9 @@ bool is_ast_multiplier(ast_node_t* node) {
  * we need to expand output pins with pad pins
  * 
  * @param node pointer to the multiplication node
- * @param netlist pointer to the current netlist file
  * -----------------------------------------------------------------------
  */
-void check_multiplier_port_size(nnode_t* node, netlist_t* netlist) {
+void check_multiplier_port_size(nnode_t* node) {
     /* Can only perform the optimisation if hard multipliers exist! */
     if (hard_multipliers == NULL)
         return;
@@ -1795,8 +1794,16 @@ void check_multiplier_port_size(nnode_t* node, netlist_t* netlist) {
         for (int i = 0; i < node->num_output_pins; i++) {
             if (i < sizeout)
                 node->output_pins[i] = old_output_pins[i];
-            else
-                add_output_pin_to_node(node, get_pad_pin(netlist), i);
+            else {
+                npin_t* new_pin = allocate_npin();
+                new_pin->name = append_string("", "%s~dummy_output~%d", node->name, 0);
+                nnet_t* new_net = allocate_nnet();
+
+                // hook the output pin into the node
+                add_output_pin_to_node(node, new_pin, i);
+                // hook up new pin 1 into the new net
+                add_driver_pin_to_net(new_net, new_pin);
+            }
         }
         // CLEAN UP
         vtr::free(old_output_pins);


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->
Removing pins extension of the multipliers output ports, that were connected to PAD node, and extending the output port using new pins to avoid unconnected wires in the output BLIF (which is resulting in ABC segfault). 

NOTE: the new output pins are removed at the end of Odin-II execution since their nets do not have any fanouts. While PAD pins remained in the output netlist in the previous version

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
fix issue #2007

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
