### PR TITLE
Added documentation details for specifying separate x and y channel 

### DIFF
--- a/doc/src/arch/reference.rst
+++ b/doc/src/arch/reference.rst
@@ -1826,7 +1826,16 @@ Wire Segments
 The content within the ``<segmentlist>`` tag consists of a group of ``<segment>`` tags.
 The ``<segment>`` tag and its contents are described below.
 
-.. arch:tag:: <segment name="unique_name" length="int" type="{bidir|unidir}" freq="float" Rmetal="float" Cmetal="float">content</segment>
+.. arch:tag:: <segment axis="{x|y}" name="unique_name" length="int" type="{bidir|unidir}" freq="float" Rmetal="float" Cmetal="float">content</segment>
+
+
+    :opt_param axis:
+        Specifies if the given segment applies to either x or y channels only. If this tag is not given, it is assumed that the given segment
+        description applies to both x-directed and y-directed channels.
+
+        .. note:: It is required that both x and y segment axis details are given or that at least one segment within ``segmentlist`` 
+            is specified without the ``axis`` tag (i.e. at least one segment applies to both x-directed and y-directed 
+            chanels). 
 
     :req_param name:
         A unique alphanumeric name to identify this segment type.


### PR DESCRIPTION
#### Description
This PR is a minor documentation update that adds information on the new features created by PR #1836 (the ability to specify details for x and y channels separately).

#### Related Issue
This PR will resolve #2023. 

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
