### PR TITLE
(Bug-Fix) No default search type

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -442,6 +442,7 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
                                    "RR Node ID");
+    gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
 
     button_for_toggle_nets();
     button_for_net_max_fanout();

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -58,6 +58,13 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
 
     GObject* combo_box = (GObject*)app->get_object("SearchType");
     gchar* type = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combo_box));
+    //Checking that a type is selected
+    if(type && type[0] == '\0'){
+        warning_dialog_box("Please select a search type");
+        app -> refresh_drawing();
+        return;
+    }
+
     std::string search_type(type);
 
     // reset

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -59,9 +59,9 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
     GObject* combo_box = (GObject*)app->get_object("SearchType");
     gchar* type = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combo_box));
     //Checking that a type is selected
-    if(type && type[0] == '\0'){
+    if (type && type[0] == '\0') {
         warning_dialog_box("Please select a search type");
-        app -> refresh_drawing();
+        app->refresh_drawing();
         return;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
1) Added a missing line of code to the NO_PICTURE_TO_ROUTING version of the initial setup function to set a default search option
2) Added a check to ensure a type was selected, and create a warning dialog window if one was not selected. 


#### Motivation and Context
When opening vpr graphics, no initial search type is selected. Any attempts to search with no search type selected will crash the program. This fix aims to rectify that.

#### How Has This Been Tested?
Searches with all different search settings were attempted before and after the change, and produced identical results. It no longer crashes the program, and it now opens with a default search type selected.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
