### PR TITLE
Odin check netlist discontinuity

### DIFF
--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -67,6 +67,7 @@
 #define GRAPH_CRUNCH 17
 #define STATS 18
 #define SEQUENTIAL_LEVELIZE 19
+#define NETLIST_DISCONTINUITY_TRAVERSE_VALUE 11
 /* a unique mark for the BLIF elaboration DFS traversal */
 #define BLIF_ELABORATE_TRAVERSE_VALUE 30
 

--- a/ODIN_II/SRC/netlist_check.cpp
+++ b/ODIN_II/SRC/netlist_check.cpp
@@ -46,11 +46,16 @@ void depth_first_traverse_check_if_forward_leveled(nnode_t* node, uintptr_t trav
 void sequential_levelized_dfs(short marker_value, netlist_t* netlist);
 void depth_first_traverse_until_next_ff_or_output(nnode_t* node, nnode_t* calling_node, uintptr_t traverse_mark_number, int seq_level, netlist_t* netlist);
 
+void check_discontinuity(netlist_t* netlist);
+void discontinuity_check_forward_traverse(nnode_t* node, operation_list op, long long &num_of_forward_elements, unsigned short mark);
+void discontinuity_check_backward_traverse(nnode_t* node, operation_list op, long long &num_of_backward_elements, unsigned short mark);
 /*---------------------------------------------------------------------------------------------
  * (function: check_netlist)
  * Note: netlist passed in needs to be initialized by allocate_netlist() to make sure correctly initialized.
  *-------------------------------------------------------------------------------------------*/
 void check_netlist(netlist_t* netlist) {
+    
+    check_discontinuity(netlist);
     /* create a graph output of this netlist */
     if (configuration.output_netlist_graphs) {
         /* Path is where we are */
@@ -717,3 +722,86 @@ nnode_t* find_node_at_top_of_combo_loop(nnode_t* start_node) {
         }
     }
 }
+
+/**
+ * @brief This function travseres the netlist both forwards and backwards and keeps the record of nodes with same type in each traverse.
+ * In case that there is a mismatch between the number of nodes counted in both traverses, It will throw a warning to
+ * indicate a discontinuity in the netlist.
+ */
+void check_discontinuity(netlist_t* netlist)
+{
+    //Declare variables that hold number of elements
+    long long num_of_forward_elements{0}, num_of_backward_elements{0};
+    //Declare type of the node
+    operation_list op{MULTIPLY};
+    
+    //Forward traverse starting from top input nodes
+    for(int i = 0; i < netlist->num_top_input_nodes; i++)
+    {
+        discontinuity_check_forward_traverse(netlist->top_input_nodes[i], op, num_of_forward_elements, NETLIST_DISCONTINUITY_TRAVERSE_VALUE);
+    }
+
+    //Backward traverse statring from top output nodes
+    for (int i = 0; i < netlist->num_top_output_nodes; i++)
+    {
+        discontinuity_check_backward_traverse(netlist->top_output_nodes[i], op, num_of_backward_elements, NETLIST_DISCONTINUITY_TRAVERSE_VALUE+1);
+    }
+
+    //Detect discontinuity
+    if (num_of_forward_elements != num_of_backward_elements) printf("\nWARNING! discontinuity detected within the netlist.\n");
+}
+
+/**
+ * @brief Recursive function that will mark the nodes present in the netlist by traversing forward starting from a top input node.
+ * This function will be called within the check_discontinuity(...) function.
+ * 
+ * @param node starting top input node
+ * @param num_of_forward_elements number of marked nodes of a same type found in forward search
+ * @param mark traverse mark value
+ */
+void discontinuity_check_forward_traverse(nnode_t* node, operation_list op, long long &num_of_forward_elements, unsigned short mark) {
+    int i, j;
+
+    if (node->traverse_visited == mark) return;
+    node->traverse_visited = mark;
+    if (node->type == op) num_of_forward_elements++;
+    for (i = 0; i < node->num_output_pins; i++) {
+        if (node->output_pins[i]->net) {
+            nnet_t* next_net = node->output_pins[i]->net;
+            if (next_net->fanout_pins) {
+                for (j = 0; j < next_net->num_fanout_pins; j++) {
+                    if (next_net->fanout_pins[j]) {
+                        if (next_net->fanout_pins[j]->node) {
+                            /* recursive call point */
+                            discontinuity_check_forward_traverse(next_net->fanout_pins[j]->node, op, num_of_forward_elements, mark);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief Recursive function that will mark the nodes present in the netlist by traversing backward starting from a top output node.
+ * This function will be called within the check_discontinuity(...) function.
+ * 
+ * @param node starting top input node
+ * @param num_of_backward_elements number of marked nodes of a same type found in backward search
+ * @param mark traverse mark value
+ */
+void discontinuity_check_backward_traverse(nnode_t* node, operation_list op, long long &num_of_backward_elements, unsigned short mark) {
+    if (node->traverse_visited == mark) return; // Already visited
+    node->traverse_visited = mark; // Mark as visited
+    if (node->type == op) num_of_backward_elements++;
+    int i;
+    for (i = 0; i < node->num_input_pins; i++) {
+        // ensure this net has a driver (i.e. skip undriven outputs)
+        for (int j = 0; j < node->input_pins[i]->net->num_driver_pins; j++) {
+            if (node->input_pins[i]->net->driver_pins[j]->node)
+                // Visit the drivers of this node
+                discontinuity_check_backward_traverse(node->input_pins[i]->net->driver_pins[j]->node, op, num_of_backward_elements, mark);
+        }
+    }
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a function that traverses the netlist forwards and backwards to find nodes of a specific type and generates a warning in case the results of the traverses do not match.

#### Description
<!--- Describe your changes in detail -->
I checked the ODIN optimization, techmap, and cleanup routines and found no problems in the code that could cause the nodes to be incorrectly removed. I added a function to the check_netlist() routine which is called after the elaboration and before the optimization phase. Just like the remove_unused_logic() function, it traverses the netlist forwards and backwards and searches for a specific node type (currently multiply nodes). If the number of the nodes found in the traverses doesn't match, it will generate a warning to indicate discontinuity within the netlist. I'm planning to extend this feature to check the netlist for main nodes types e.g. logical, addition. The feature can notify a user when there is a discontinuity in an input design, which will result in the main nodes being removed in the cleanup stage of Odin.


#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Isuue #2008 [Seemingly incorrect optimization of multipliers in ODIN](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2008#)
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
