### PR TITLE
Pb graph bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ tags
 .history
 #eclipse project
 .project
+
+#
+# CLION
+#
+.idea
+cmake-build-debug

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -611,6 +611,7 @@ void alloc_and_load_default_child_for_pb_type(t_pb_type* pb_type,
     copy->num_clock_pins = pb_type->num_clock_pins;
     copy->num_input_pins = pb_type->num_input_pins;
     copy->num_output_pins = pb_type->num_output_pins;
+    copy->num_pins = pb_type->num_pins;
     copy->num_pb = 1;
 
     /* Power */
@@ -630,6 +631,8 @@ void alloc_and_load_default_child_for_pb_type(t_pb_type* pb_type,
         copy->ports[i].name = vtr::strdup(pb_type->ports[i].name);
         copy->ports[i].port_class = vtr::strdup(pb_type->ports[i].port_class);
         copy->ports[i].port_index_by_type = pb_type->ports[i].port_index_by_type;
+        copy->ports[i].index = pb_type->ports[i].index;
+        copy->ports[i].absolute_first_pin_index = pb_type->ports[i].absolute_first_pin_index;
 
         copy->ports[i].port_power = (t_port_power*)vtr::calloc(1,
                                                                sizeof(t_port_power));

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -3407,9 +3407,9 @@ static void ProcessSubTiles(pugi::xml_node Node,
         SubTile.num_phy_pins = pin_counts.total() * capacity;
 
         /* Assign pin counts to the Physical Tile Type */
-        PhysicalTileType->num_input_pins += pin_counts.input;
-        PhysicalTileType->num_output_pins += pin_counts.output;
-        PhysicalTileType->num_clock_pins += pin_counts.clock;
+        PhysicalTileType->num_input_pins += capacity * pin_counts.input;
+        PhysicalTileType->num_output_pins += capacity * pin_counts.output;
+        PhysicalTileType->num_clock_pins += capacity * pin_counts.clock;
         PhysicalTileType->num_pins += capacity * pin_counts.total();
         PhysicalTileType->num_inst_pins += pin_counts.total();
 


### PR DESCRIPTION
1- .gitignore file is changed to accommodate the files generated by Clion IDE.

2- Other than the pb_types defined in xml file, another level of pb_type is added to the structure if the pb_type in the XML file uses a [class](https://docs.verilogtorouting.org/en/latest/arch/reference/#classes).
Normal pb_types are initialized in "ProcessPb_Type" function in "libs/libarchfpga/src/read_xml_arch_file.cpp". However, the newly added pb_types are initialized in "alloc_and_load_default_child_for_pb_type" in "libs/libarchfpga/src/arch_util.cpp". Since they are initialized in two different functions, some pb_type members are missed in the second function.

3- Three members of t_physical_tile_type are not initialized properly. Each tile consists of, potentially, several types of sub_tiles. Each sub_tile has a capacity that is equal to the number of that sub_tile in the tile. In the current implementation, only the number of pins of one instance of a sub_tile is added to the corresponding member in tile data structure. There are two possible solutions for this problem: 1- change the name of num_*_pins to num_inst_*_pins 2- multiply the number of pins by the capacity of the sub_tile (In this PR, this solution is implemented)

@vaughnbetz 



