### PR TITLE
Added Auto-Complete Functionality for Block Names (VPR)

### DIFF
--- a/vpr/main.ui
+++ b/vpr/main.ui
@@ -1,13 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkListStore" id="BlockNames">
+    <columns>
+      <!-- column-name gchararray1 -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">test</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkEntryCompletion" id="BlockNameCompleter">
+    <property name="model">BlockNames</property>
+    <property name="text_column">0</property>
+    <child>
+      <object class="GtkCellRendererText" id="Renderer"/>
+      <attributes>
+        <attribute name="text">0</attribute>
+      </attributes>
+    </child>
+  </object>
   <object class="GtkWindow" id="MainWindow">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="title">VPR: Versatile Place and Route for FPGAs</property>
     <property name="default_width">800</property>
     <property name="default_height">600</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkGrid" id="OuterGrid">
         <property name="visible">True</property>
@@ -40,8 +64,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -54,16 +76,12 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="left_attach">4</property>
             <property name="top_attach">1</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
           </packing>
         </child>
         <child>
@@ -76,7 +94,6 @@
             <property name="left_attach">0</property>
             <property name="top_attach">4</property>
             <property name="width">4</property>
-            <property name="height">1</property>
           </packing>
         </child>
         <child>
@@ -88,8 +105,6 @@
           <packing>
             <property name="left_attach">0</property>
             <property name="top_attach">0</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
           </packing>
         </child>
         <child>
@@ -103,8 +118,6 @@
           <packing>
             <property name="left_attach">1</property>
             <property name="top_attach">0</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
           </packing>
         </child>
         <child>
@@ -117,8 +130,6 @@
           <packing>
             <property name="left_attach">2</property>
             <property name="top_attach">0</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
           </packing>
         </child>
         <child>
@@ -135,9 +146,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-		<property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
@@ -151,8 +160,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">3</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -166,8 +173,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">2</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -180,19 +185,15 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="left_attach">4</property>
             <property name="top_attach">3</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
           </packing>
         </child>
-         <child>
+        <child>
           <object class="GtkGrid" id="checkboxes">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -209,8 +210,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -226,11 +225,9 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
-           </child>
-	    <child>
+            </child>
+            <child>
               <object class="GtkCheckButton" id="clipRoutingUtil">
                 <property name="label" translatable="yes">Clip Routing Util</property>
                 <property name="visible">True</property>
@@ -243,8 +240,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">2</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -259,19 +254,14 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">3</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
-            </child>   
-
+            </child>
           </object>
           <packing>
             <property name="left_attach">4</property>
             <property name="top_attach">2</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
           </packing>
-  	</child>
+        </child>
         <child>
           <placeholder/>
         </child>

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -359,7 +359,7 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");   // index 2
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name"); // index 3
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
-                                   "RR Node ID");           // index 4
+                                   "RR Node ID"); // index 4
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -187,6 +187,7 @@ static void set_block_text(GtkWidget* widget, gint /*response_id*/, gpointer /*d
 static void clip_routing_util(GtkWidget* widget, gint /*response_id*/, gpointer /*data*/);
 static void run_graphics_commands(std::string commands);
 
+
 /************************** File Scope Variables ****************************/
 
 //The arrow head position for turning/straight-thru connections in a switch box
@@ -360,7 +361,8 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
                                    "RR Node ID");           // index 4
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
-
+    g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
+    load_block_names(app);
     button_for_toggle_nets();
     button_for_net_max_fanout();
     button_for_net_alpha();
@@ -443,6 +445,8 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
                                    "RR Node ID");
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
+    g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
+    load_block_names(app);
 
     button_for_toggle_nets();
     button_for_net_max_fanout();

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -187,7 +187,6 @@ static void set_block_text(GtkWidget* widget, gint /*response_id*/, gpointer /*d
 static void clip_routing_util(GtkWidget* widget, gint /*response_id*/, gpointer /*data*/);
 static void run_graphics_commands(std::string commands);
 
-
 /************************** File Scope Variables ****************************/
 
 //The arrow head position for turning/straight-thru connections in a switch box

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -360,6 +360,7 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name"); // index 3
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
                                    "RR Node ID");           // index 4
+    //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
     load_block_names(app);
@@ -444,6 +445,7 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
                                    "RR Node ID");
+    //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
     load_block_names(app);

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -323,4 +323,28 @@ void warning_dialog_box(const char* message) {
     return;
 }
 
+void search_type_changed(GtkComboBox* self, ezgl::application* app){
+    auto type = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self));
+    GtkEntry* searchBar = GTK_ENTRY(app->get_object("TextInput"));
+    if (!type) return;
+    if (type[0] == '\0') return;
+    if (type == "Block Name"){
+        GtkEntryCompletion* blockCompleter = GTK_ENTRY_COMPLETION(app->get_object("BlockNameCompleter"));
+        gtk_entry_set_completion(searchBar, blockCompleter);
+    } else {
+        gtk_entry_set_completion(searchBar, nullptr);
+    }
+}
+
+void load_block_names(ezgl::application* app){
+    auto blockStorage = GTK_LIST_STORE(app->get_object("BlockNames"));
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    GtkTreeIter iter;
+    for(ClusterBlockId id : cluster_ctx.clb_nlist.blocks()){
+        gtk_list_store_append(blockStorage, &iter);
+        gtk_list_store_set(blockStorage, &iter, 
+        0, cluster_ctx.clb_nlist.block_name(id), -1);
+    }
+}
+
 #endif /* NO_GRAPHICS */

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -59,9 +59,9 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
     GObject* combo_box = (GObject*)app->get_object("SearchType");
     gchar* type = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combo_box));
     //Checking that a type is selected
-    if(type && type[0] == '\0'){
+    if (type && type[0] == '\0') {
         warning_dialog_box("Please select a search type");
-        app -> refresh_drawing();
+        app->refresh_drawing();
         return;
     }
 
@@ -333,7 +333,7 @@ void warning_dialog_box(const char* message) {
  * @param self GtkComboBox that holds current Search Setting
  * @param app ezgl app used to access other objects
  */
-void search_type_changed(GtkComboBox* self, ezgl::application* app){
+void search_type_changed(GtkComboBox* self, ezgl::application* app) {
     auto type = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self));
     GtkEntry* searchBar = GTK_ENTRY(app->get_object("TextInput"));
     //Ensuring a valid type was selected
@@ -355,16 +355,15 @@ void search_type_changed(GtkComboBox* self, ezgl::application* app){
  * 
  * @param app ezgl application
  */
-void load_block_names(ezgl::application* app){
+void load_block_names(ezgl::application* app) {
     auto blockStorage = GTK_LIST_STORE(app->get_object("BlockNames"));
     auto& cluster_ctx = g_vpr_ctx.clustering();
     GtkTreeIter iter;
     //Getting and storing all block names
-    for(ClusterBlockId id : cluster_ctx.clb_nlist.blocks()){
+    for (ClusterBlockId id : cluster_ctx.clb_nlist.blocks()) {
         gtk_list_store_append(blockStorage, &iter);
         gtk_list_store_set(blockStorage, &iter, 
-        0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
-        ++i;
+                           0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
     }
 }
 

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -328,7 +328,8 @@ void search_type_changed(GtkComboBox* self, ezgl::application* app){
     GtkEntry* searchBar = GTK_ENTRY(app->get_object("TextInput"));
     if (!type) return;
     if (type[0] == '\0') return;
-    if (type == "Block Name"){
+    std::string searchType(type);
+    if (searchType == "Block Name"){
         GtkEntryCompletion* blockCompleter = GTK_ENTRY_COMPLETION(app->get_object("BlockNameCompleter"));
         gtk_entry_set_completion(searchBar, blockCompleter);
     } else {
@@ -343,8 +344,10 @@ void load_block_names(ezgl::application* app){
     for(ClusterBlockId id : cluster_ctx.clb_nlist.blocks()){
         gtk_list_store_append(blockStorage, &iter);
         gtk_list_store_set(blockStorage, &iter, 
-        0, cluster_ctx.clb_nlist.block_name(id), -1);
+        0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
+        std::cout << cluster_ctx.clb_nlist.block_name(id) << " ";
     }
+    std::cout << std::endl;
 }
 
 #endif /* NO_GRAPHICS */

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -323,31 +323,49 @@ void warning_dialog_box(const char* message) {
     return;
 }
 
+/**
+ * @brief manages auto-complete options when search type is changed
+ * 
+ * Selects appropriate gtkEntryCompletion item when changed signal is sent
+ * from gtkComboBox SearchType. Currently only sets a completion model for Block Name options, 
+ * sets null for anything else. brh
+ * 
+ * @param self GtkComboBox that holds current Search Setting
+ * @param app ezgl app used to access other objects
+ */
 void search_type_changed(GtkComboBox* self, ezgl::application* app){
     auto type = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(self));
     GtkEntry* searchBar = GTK_ENTRY(app->get_object("TextInput"));
+    //Ensuring a valid type was selected
     if (!type) return;
     if (type[0] == '\0') return;
     std::string searchType(type);
-    if (searchType == "Block Name"){
+    //Setting active completion model to blockCompleter if type selected is block Name
+    if (searchType == "Block Name") {
         GtkEntryCompletion* blockCompleter = GTK_ENTRY_COMPLETION(app->get_object("BlockNameCompleter"));
         gtk_entry_set_completion(searchBar, blockCompleter);
-    } else {
+    } else { //If not, setting to null
         gtk_entry_set_completion(searchBar, nullptr);
     }
 }
 
+
+/**
+ * @brief loads block names into gtk list store item used for completion
+ * 
+ * @param app ezgl application
+ */
 void load_block_names(ezgl::application* app){
     auto blockStorage = GTK_LIST_STORE(app->get_object("BlockNames"));
     auto& cluster_ctx = g_vpr_ctx.clustering();
     GtkTreeIter iter;
+    //Getting and storing all block names
     for(ClusterBlockId id : cluster_ctx.clb_nlist.blocks()){
         gtk_list_store_append(blockStorage, &iter);
         gtk_list_store_set(blockStorage, &iter, 
         0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
-        std::cout << cluster_ctx.clb_nlist.block_name(id) << " ";
+        ++i;
     }
-    std::cout << std::endl;
 }
 
 #endif /* NO_GRAPHICS */

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -349,7 +349,6 @@ void search_type_changed(GtkComboBox* self, ezgl::application* app) {
     }
 }
 
-
 /**
  * @brief loads block names into gtk list store item used for completion
  * 
@@ -362,7 +361,7 @@ void load_block_names(ezgl::application* app) {
     //Getting and storing all block names
     for (ClusterBlockId id : cluster_ctx.clb_nlist.blocks()) {
         gtk_list_store_append(blockStorage, &iter);
-        gtk_list_store_set(blockStorage, &iter, 
+        gtk_list_store_set(blockStorage, &iter,
                            0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
     }
 }

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -18,6 +18,11 @@ void highlight_nets(ClusterNetId net_id);
 void highlight_nets(std::string net_name);
 void highlight_blocks(std::string block_name);
 
+void load_block_names(ezgl::application* app);
+
+//Function to manage entry completions when search type is changed
+void search_type_changed(GtkComboBox* /*self*/, ezgl::application* app);
+
 /*function below pops up a dialog box with no button, showing the input warning message*/
 void warning_dialog_box(const char* message);
 


### PR DESCRIPTION
Added an auto-complete function for Block Names in VPR. Search bar still only searches on clicking search button, so selection of an option from auto-complete menu only fills it into the search bar. Should still be quite helpful considering how long some of the names get. 

#### Description
Uses GtkListStore to store objects and GtkEntryCompletion to display/auto-complete the different entries. Added two helper functions:
**search_type_changed**: Manages auto-completion models based on search type. Currently sets model to null unless selected type is block name
**load_block_names**: Stores block names in listStore that is set as completion model when appropriate

Also added a few comments on last pull request, where a default search option was set. 


#### How Has This Been Tested?
This was tested on some of the larger circuits (mcml.v and mes_noc (titan) ). It did not have a noticeable impact on load times, and was still responsive. If you find that this is slowing vpr down, please contact me. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
