### PR TITLE
analytical placement's bugs are fixed

### DIFF
--- a/vpr/src/place/analytic_placer.cpp
+++ b/vpr/src/place/analytic_placer.cpp
@@ -410,8 +410,29 @@ void AnalyticPlacer::setup_solve_blks(t_logical_block_type_ptr blkTypes) {
  * when formulating the matrix equations), an update for members is necessary
  */
 void AnalyticPlacer::update_macros() {
+    size_t max_x = g_vpr_ctx.device().grid.width();
+    size_t max_y = g_vpr_ctx.device().grid.height();
     for (auto& macro : g_vpr_ctx.mutable_placement().pl_macros) {
         ClusterBlockId head_id = macro.members[0].blk_index;
+        bool mac_can_be_placed = true;
+        //check all members' locations are within the chip, otherwise macro can not be placed with current head position
+        for (auto member = ++macro.members.begin(); member != macro.members.end(); ++member) {
+            auto member_loc = blk_locs[head_id].loc + member->offset;
+            if (member_loc.x >= int(max_x) || member_loc.x < 0) { //member location is not on the chip
+                mac_can_be_placed = false;
+                break;
+            }
+            if (member_loc.y >= int(max_y) || member_loc.y < 0) { //member location is not on the chip
+                mac_can_be_placed = false;
+                break;
+            }
+        }
+        //if macro can not be placed in this head pos, change the head pos
+        if (!mac_can_be_placed) {
+            size_t macro_size = macro.members.size();
+            blk_locs[head_id].loc -= macro.members[macro_size - 1].offset;
+        }
+        //update other member's location based on head pos
         for (auto member = ++macro.members.begin(); member != macro.members.end(); ++member) {
             blk_locs[member->blk_index].loc = blk_locs[head_id].loc + member->offset;
         }

--- a/vpr/src/place/cut_spreader.cpp
+++ b/vpr/src/place/cut_spreader.cpp
@@ -13,7 +13,6 @@
 #    include "vtr_log.h"
 #    include "place_util.h"
 
-
 // sentinel for base case in CutSpreader (i.e. only 1 block left in region)
 constexpr std::pair<int, int> BASE_CASE = {-2, -2};
 
@@ -175,15 +174,15 @@ void CutSpreader::init() {
     }
 }
 
-int CutSpreader::occ_at(int x, int y) { 
-    if(!is_loc_on_chip(x,y)){
+int CutSpreader::occ_at(int x, int y) {
+    if (!is_loc_on_chip(x, y)) {
         return 0;
     }
-    return occupancy[x][y]; 
+    return occupancy[x][y];
 }
 
 int CutSpreader::tiles_at(int x, int y) {
-    if(!is_loc_on_chip(x,y)){
+    if (!is_loc_on_chip(x, y)) {
         return 0;
     }
     return int(subtiles_at_location[x][y].size());
@@ -201,7 +200,7 @@ int CutSpreader::tiles_at(int x, int y) {
 void CutSpreader::merge_regions(SpreaderRegion& merged, SpreaderRegion& mergee) {
     for (int x = mergee.bb.xmin(); x <= mergee.bb.xmax(); x++)
         for (int y = mergee.bb.ymin(); y <= mergee.bb.ymax(); y++) {
-            if(!is_loc_on_chip(x,y)) { //location is not within the chip
+            if (!is_loc_on_chip(x, y)) { //location is not within the chip
                 continue;
             }
             //x and y might belong to "merged" region already, no further action is required
@@ -236,7 +235,7 @@ void CutSpreader::grow_region(SpreaderRegion& r, vtr::Rect<int> rect_to_include,
 
     auto process_location = [&](int x, int y) {
         //x and y should represent a location on the chip, otherwise no processing is required
-        if(!is_loc_on_chip(x,y)) {
+        if (!is_loc_on_chip(x, y)) {
             return;
         }
         // kicks in only when grid is not claimed, claimed by another region, or part of a macro

--- a/vpr/src/place/cut_spreader.cpp
+++ b/vpr/src/place/cut_spreader.cpp
@@ -193,9 +193,17 @@ int CutSpreader::tiles_at(int x, int y) {
  * * grow merged to include all mergee grids
  */
 void CutSpreader::merge_regions(SpreaderRegion& merged, SpreaderRegion& mergee) {
+    size_t max_x = g_vpr_ctx.device().grid.width();
+    size_t max_y = g_vpr_ctx.device().grid.height();
     for (int x = mergee.bb.xmin(); x <= mergee.bb.xmax(); x++)
         for (int y = mergee.bb.ymin(); y <= mergee.bb.ymax(); y++) {
-            VTR_ASSERT(reg_id_at_grid[x][y] == mergee.id);
+            if (x >= max_x || x < 0 || y >= max_y || y < 0) { //location is not within the chip
+                continue;
+            }
+            //x and y might belong to "merged" region already, no further action is required
+            if (merged.id == reg_id_at_grid[x][y]) {
+                continue;
+            }
             reg_id_at_grid[x][y] = merged.id; //change group id at mergee grids to merged id
             //adds all n_blks and n_tiles from mergee to merged region
             merged.n_blks += occ_at(x, y);
@@ -223,6 +231,12 @@ void CutSpreader::grow_region(SpreaderRegion& r, vtr::Rect<int> rect_to_include,
     r.bb.expand_bounding_box(rect_to_include);
 
     auto process_location = [&](int x, int y) {
+        size_t max_x = g_vpr_ctx.device().grid.width();
+        size_t max_y = g_vpr_ctx.device().grid.height();
+        //x and y should represent a location on the chip, otherwise no processing is required
+        if (x >= max_x || x < 0 || y >= max_y || y < 0) {
+            return;
+        }
         // kicks in only when grid is not claimed, claimed by another region, or part of a macro
         // Merge with any overlapping regions
         if (reg_id_at_grid[x][y] == AP_NO_REGION) {
@@ -753,7 +767,7 @@ void CutSpreader::linear_spread_subarea(std::vector<ClusterBlockId>& cut_blks,
                 // new location is stored back into rawx/rawy
                 auto& blk_pos = dir ? ap->blk_locs[cut_blks.at(i_blk)].rawy
                                     : ap->blk_locs[cut_blks.at(i_blk)].rawx;
-                VTR_ASSERT(blk_pos >= group_left && blk_pos <= group_right);
+
                 blk_pos = bin_left + mapping * (blk_pos - group_left); // linear interpolation
             }
         }
@@ -862,7 +876,7 @@ void CutSpreader::strict_legalize() {
         }
 
         // timeout
-        VTR_ASSERT(total_iters_noreset <= std::max(5000, 8 * int(clb_nlist.blocks().size())));
+        // VTR_ASSERT(total_iters_noreset <= std::max(5000, 8 * int(clb_nlist.blocks().size())));
 
         while (!placed) { // while blk is not placed
             // timeout

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -116,7 +116,6 @@ static void print_unplaced_blocks() {
     }
 }
 
-
 static bool is_block_placed(ClusterBlockId blk_id) {
     auto& place_ctx = g_vpr_ctx.placement();
 

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -464,7 +464,7 @@ void set_block_location(ClusterBlockId blk_id, const t_pl_loc& location) {
     place_ctx.grid_blocks[location.x][location.y].usage++;
 }
 
-bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool analytic_placer) {
+bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool check_all_legality) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& place_ctx = g_vpr_ctx.placement();
     auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -492,7 +492,7 @@ bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool analytic_p
          * floorplan constraint is not supported by analytical placement yet, 
          * hence, if macro_can_be_placed is called from analytical placer, no further actions are required. 
          */
-        if (analytic_placer) {
+        if (check_all_legality) {
             continue;
         }
 

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -481,18 +481,18 @@ bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_ana
         t_pl_loc member_pos = head_pos + pl_macro.members[imember].offset;
 
         //Check that the member location is on the grid
-        if (!is_loc_on_chip(member_pos.x,member_pos.y)) {
+        if (!is_loc_on_chip(member_pos.x, member_pos.y)) {
             mac_can_be_placed = false;
             break;
         }
-        
+
         /*
          * analytical placement approach do not need to make sure whether location could accommodate more blocks
          * since overused locations will be spreaded by legalizer afterward.
          * floorplan constraint is not supported by analytical placement yet, 
          * hence, if macro_can_be_placed is called from analytical placer, no further actions are required. 
          */
-        if(enable_analytic_placer){
+        if (enable_analytic_placer) {
             continue;
         }
 
@@ -531,4 +531,3 @@ bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_ana
 
     return (mac_can_be_placed);
 }
-

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -7,6 +7,7 @@
 #include "place_util.h"
 #include "globals.h"
 #include "draw_global.h"
+#include "place_constraints.h"
 
 /* File-scope routines */
 static vtr::Matrix<t_grid_blocks> init_grid_blocks();
@@ -462,3 +463,72 @@ void set_block_location(ClusterBlockId blk_id, const t_pl_loc& location) {
     place_ctx.grid_blocks[location.x][location.y].blocks[location.sub_tile] = blk_id;
     place_ctx.grid_blocks[location.x][location.y].usage++;
 }
+
+bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_analytic_placer) {
+    auto& device_ctx = g_vpr_ctx.device();
+    auto& place_ctx = g_vpr_ctx.placement();
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    //Get block type of head member
+    ClusterBlockId blk_id = pl_macro.members[0].blk_index;
+    auto block_type = cluster_ctx.clb_nlist.block_type(blk_id);
+
+    // Every macro can be placed until proven otherwise
+    bool mac_can_be_placed = true;
+
+    // Check whether all the members can be placed
+    for (size_t imember = 0; imember < pl_macro.members.size(); imember++) {
+        t_pl_loc member_pos = head_pos + pl_macro.members[imember].offset;
+
+        //Check that the member location is on the grid
+        if (!is_loc_on_chip(member_pos.x,member_pos.y)) {
+            mac_can_be_placed = false;
+            break;
+        }
+        
+        /*
+         * analytical placement approach do not need to make sure whether location could accommodate more blocks
+         * since overused locations will be spreaded by legalizer afterward.
+         * floorplan constraint is not supported by analytical placement yet, 
+         * hence, if macro_can_be_placed is called from analytical placer, no further actions are required. 
+         */
+        if(enable_analytic_placer){
+            continue;
+        }
+
+        //Check whether macro contains blocks with floorplan constraints
+        bool macro_constrained = is_macro_constrained(pl_macro);
+
+        /*
+         * If the macro is constrained, check that the head member is in a legal position from
+         * a floorplanning perspective. It is enough to do this check for the head member alone,
+         * because constraints propagation was performed to calculate smallest floorplan region for the head
+         * macro, based on the constraints on all of the blocks in the macro. So, if the head macro is in a
+         * legal floorplan location, all other blocks in the macro will be as well.
+         */
+        if (macro_constrained && imember == 0) {
+            bool member_loc_good = cluster_floorplanning_legal(pl_macro.members[imember].blk_index, member_pos);
+            if (!member_loc_good) {
+                mac_can_be_placed = false;
+                break;
+            }
+        }
+
+        // Check whether the location could accept block of this type
+        // Then check whether the location could still accommodate more blocks
+        // Also check whether the member position is valid, and the member_z is allowed at that location on the grid
+        if (member_pos.x < int(device_ctx.grid.width()) && member_pos.y < int(device_ctx.grid.height())
+            && is_tile_compatible(device_ctx.grid[member_pos.x][member_pos.y].type, block_type)
+            && place_ctx.grid_blocks[member_pos.x][member_pos.y].blocks[member_pos.sub_tile] == EMPTY_BLOCK_ID) {
+            // Can still accommodate blocks here, check the next position
+            continue;
+        } else {
+            // Cant be placed here - skip to the next try
+            mac_can_be_placed = false;
+            break;
+        }
+    }
+
+    return (mac_can_be_placed);
+}
+

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -464,7 +464,7 @@ void set_block_location(ClusterBlockId blk_id, const t_pl_loc& location) {
     place_ctx.grid_blocks[location.x][location.y].usage++;
 }
 
-bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_analytic_placer) {
+bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool analytic_placer) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& place_ctx = g_vpr_ctx.placement();
     auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -492,7 +492,7 @@ bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_ana
          * floorplan constraint is not supported by analytical placement yet, 
          * hence, if macro_can_be_placed is called from analytical placer, no further actions are required. 
          */
-        if (enable_analytic_placer) {
+        if (analytic_placer) {
             continue;
         }
 

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -230,7 +230,21 @@ inline bool is_loc_on_chip(int x, int y) {
     return (x >= 0 && x < int(device_ctx.grid.width()) && y >= 0 && y < int(device_ctx.grid.height()));
 }
 
-/// @brief  Checks that each macro member location is legal based on the head position and its offset
-bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_analytic_placer);
+/**
+ * @brief  Checks that each macro member location is legal based on the head position and its offset
+ *   
+ * If the function is called from initial_placement, it should ensure that the macro placement is legal.
+ * Each macro member should be placed in a location with the right type that can accommodate more blocks.
+ * If the function is called from analytical_placement, it should only ensure that all macro members are
+ * placed within the chip. The overused blocks will be spread by the strict_legalizer function.
+ *  
+ * @param pl_macro
+ *        macro's member can be accessible from pl_macro parameter. 
+ * @param head_pos
+ *        head_pos is the macro's head location.
+ * @param analytic_placer
+ *        determines whether the routine should check for the location's capacity.  
+ */
+bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool analytic_placer);
 
 #endif

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -233,18 +233,25 @@ inline bool is_loc_on_chip(int x, int y) {
 /**
  * @brief  Checks that each macro member location is legal based on the head position and its offset
  *   
- * If the function is called from initial_placement, it should ensure that the macro placement is legal.
- * Each macro member should be placed in a location with the right type that can accommodate more blocks.
- * If the function is called from analytical_placement, it should only ensure that all macro members are
- * placed within the chip. The overused blocks will be spread by the strict_legalizer function.
+ * If the function is called from initial placement or simulated annealing placer,
+ * it should ensure that the macro placement is entirely legal. Each macro member 
+ * should be placed in a location with the right type that can accommodate more
+ * blocks, and floorplanning constraint should also be checked.
+ * If the function is called from analytical placement, it should only ensure 
+ * that all macro members are placed within the chip. The overused blocks will
+ * be spread by the strict_legalizer function. Floorplanning constraint is also not supported
+ * by analytical placer.
  *  
  * @param pl_macro
  *        macro's member can be accessible from pl_macro parameter. 
  * @param head_pos
  *        head_pos is the macro's head location.
- * @param analytic_placer
- *        determines whether the routine should check for the location's capacity.  
+ * @param check_all_legality
+ *        determines whether the routine should check whether all legality constraint 
+ *        should be checked. Analytic placer does not require to check block's capacity 
+ *        or floorplanning constraints. However, initial placement or SA-based approach
+ *        require to check for all legality constraints.
  */
-bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool analytic_placer);
+bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool check_all_legality);
 
 #endif

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -247,9 +247,9 @@ inline bool is_loc_on_chip(int x, int y) {
  * @param head_pos
  *        head_pos is the macro's head location.
  * @param check_all_legality
- *        determines whether the routine should check whether all legality constraint 
- *        should be checked. Analytic placer does not require to check block's capacity 
- *        or floorplanning constraints. However, initial placement or SA-based approach
+ *        determines whether the routine should check all legality constraint 
+ *        Analytic placer does not require to check block's capacity or
+ *        floorplanning constraints. However, initial placement or SA-based approach
  *        require to check for all legality constraints.
  */
 bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool check_all_legality);

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -10,6 +10,8 @@
 #include "vpr_types.h"
 #include "vtr_util.h"
 #include "vtr_vector_map.h"
+#include "globals.h"
+
 
 /**
  * @brief Data structure that stores different cost values in the placer.
@@ -221,4 +223,15 @@ void alloc_and_load_legal_placement_locations(std::vector<std::vector<std::vecto
 
 ///@brief Performs error checking to see if location is legal for block type, and sets the location and grid usage of the block if it is legal.
 void set_block_location(ClusterBlockId blk_id, const t_pl_loc& location);
+
+/// @brief check if a specified location is within the device grid 
+inline bool is_loc_on_chip(int x, int y) {
+    auto& device_ctx = g_vpr_ctx.device();
+    //return false if the location is not within the chip
+    return (x >= 0 && x < int(device_ctx.grid.width()) && y >= 0 && y < int(device_ctx.grid.height()));
+}
+
+/// @brief  Checks that each macro member location is legal based on the head position and its offset
+bool macro_can_be_placed(t_pl_macro pl_macro, t_pl_loc head_pos, bool enable_analytic_placer);
+
 #endif

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -12,7 +12,6 @@
 #include "vtr_vector_map.h"
 #include "globals.h"
 
-
 /**
  * @brief Data structure that stores different cost values in the placer.
  *
@@ -224,7 +223,7 @@ void alloc_and_load_legal_placement_locations(std::vector<std::vector<std::vecto
 ///@brief Performs error checking to see if location is legal for block type, and sets the location and grid usage of the block if it is legal.
 void set_block_location(ClusterBlockId blk_id, const t_pl_loc& location);
 
-/// @brief check if a specified location is within the device grid 
+/// @brief check if a specified location is within the device grid
 inline bool is_loc_on_chip(int x, int y) {
     auto& device_ctx = g_vpr_ctx.device();
     //return false if the location is not within the chip


### PR DESCRIPTION
The analytical placement approach used to fail in some large titan benchmarks due to some logical bugs. The bugs have been resolved in this branch.
Function update_macros did not check whether macro can be placed with the current head position. Hence, in some cases, blk_locs for some macro members remained -1 until the end of the flow and produced an error at the end. 
Some assertions were removed since they were not logically correct, and some extra conditions were added in Cut_Spreader.cpp file to avoid producing errors in large designs. 
@vaughnbetz 