### PR TITLE
Graphics Command Documentation Updated

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -119,6 +119,7 @@ Graphics Options
 .. option:: --graphics_commands <string>
 
     A set of semi-colon seperated graphics commands.
+    Graphics commands must be surrounfed by quotation marks (e.g. --graphics_commands "save_graphics place.png;")
 
     * save_graphics <file>
          Saves graphics to the specified file (.png/.pdf/
@@ -152,14 +153,14 @@ Graphics Options
 
     .. code-block:: none
 
-        save_graphics place.png; \
+        "save_graphics place.png; \
         set_nets 1; save_graphics nets1.png;\
         set_nets 2; save_graphics nets2.png; set_nets 0;\
         set_cpd 1; save_graphics cpd1.png; \
         set_cpd 3; save_graphics cpd3.png; set_cpd 0; \
         set_routing_util 5; save_graphics routing_util5.png; \
         set_routing_util 0; \
-        set_congestion 1; save_graphics congestion1.png;
+        set_congestion 1; save_graphics congestion1.png;"
 
     The above toggles various graphics settings (e.g. drawing nets, drawing critical path) and then saves the results to .png files.
     

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -119,7 +119,7 @@ Graphics Options
 .. option:: --graphics_commands <string>
 
     A set of semi-colon seperated graphics commands.
-    Graphics commands must be surrounfed by quotation marks (e.g. --graphics_commands "save_graphics place.png;")
+    Graphics commands must be surrounded by quotation marks (e.g. --graphics_commands "save_graphics place.png;")
 
     * save_graphics <file>
          Saves graphics to the specified file (.png/.pdf/

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1278,7 +1278,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
     gfx_grp.add_argument(args.graphics_commands, "--graphics_commands")
         .help(
             "A set of semi-colon seperated graphics commands. \n"
-            "Commands must be surrounded by quotation marks (e.g. --graphics_commands \"save_graphics.png\")\n"
+            "Commands must be surrounded by quotation marks (e.g. --graphics_commands \"save_graphics place.png\")\n"
             "   Commands:\n"
             "      * save_graphics <file>\n"
             "           Saves graphics to the specified file (.png/.pdf/\n"

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1277,7 +1277,8 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
 
     gfx_grp.add_argument(args.graphics_commands, "--graphics_commands")
         .help(
-            "A set of semi-colon seperated graphics commands.\n"
+            "A set of semi-colon seperated graphics commands. \n"
+            "Commands must be surrounded by quotation marks (e.g. --graphics_commands \"save_graphics.png\")\n"
             "   Commands:\n"
             "      * save_graphics <file>\n"
             "           Saves graphics to the specified file (.png/.pdf/\n"


### PR DESCRIPTION
#### Description
Documentation for running graphics commands was made more clear. 

#### Related Issue
Running any graphics command examples from the documentation, such as sample command `$VTR_ROOT/vpr/vpr $VTR_ROOT/vtr_flow/arch/timing/EArch.xml $VTR_ROOT/vtr_flow/benchmarks/blif/tseng.blif --route_chan_width 100 --analysis --save_graphics on --graphics_commands save_graphics place.png`, did not work. The documentation neglected to mention that graphics commands must be surrounded by quotation marks, as argparse considers space filled strings as multiple arguments even if the user intended it to be just one. 

A fix to Issue #2001. 

#### How Has This Been Tested?
 Ran
 `$VTR_ROOT/vpr/vpr $VTR_ROOT/vtr_flow/arch/timing/EArch.xml $VTR_ROOT/vtr_flow/benchmarks/blif/tseng.blif --route_chan_width 100 --analysis --save_graphics on --graphics_commands save_graphics place.png; set_nets 1; save_graphics nets1.png; set_nets 2; save_graphics nets2.png; set_nets 0;`
and 
`$VTR_ROOT/vpr/vpr $VTR_ROOT/vtr_flow/arch/timing/EArch.xml $VTR_ROOT/vtr_flow/benchmarks/blif/tseng.blif --route_chan_width 100 --analysis --save_graphics on --graphics_commands "save_graphics place.png; set_nets 1; save_graphics nets1.png; set_nets 2; save_graphics nets2.png; set_nets 0;"`. 

The former returns 
```
Unexpected command-line argument 'place.png' 

usage: vpr architecture circuit [--pack] [--place] [--route] [--analysis]
       [--disp {on, off}] [--save_graphics {on, off}]
       [--graphics_commands GRAPHICS_COMMANDS] [-h] [--version]
       [--device DEVICE_NAME] [-j NUM_WORKERS] [--timing_analysis {on, off}]
       [--disable_errors DISABLE_ERRORS] [--suppress_warnings SUPPRESS_WARNINGS]
       [--route_chan_width CHANNEL_WIDTH] [OTHER_OPTIONS ...]
set_nets: command not found
save_graphics: command not found
set_nets: command not found
save_graphics: command not found
set_nets: command not found
```

while the latter works.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [X ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
