### PR TITLE
Fix build errors with VERBOSE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,13 @@ jobs:
   Build:
     name: 'B: Building VtR'
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { build_type: 'release', verbose: '0' }
+        - { build_type: 'debug',   verbose: '0' }
+        - { build_type: 'debug',   verbose: '1' }
     steps:
 
     - uses: actions/setup-python@v2
@@ -79,10 +86,10 @@ jobs:
 
     - name: Test
       env:
-        BUILD_TYPE: release
+        BUILD_TYPE: ${{ matrix.build_type }}
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        ./.github/scripts/build.sh
+        ./.github/scripts/build.sh VERBOSE=${{ matrix.verbose }}
 
 
   Format:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(VTR_ENABLE_SANITIZE "Enable address/leak/undefined-behaviour sanitizers (
 option(VTR_ENABLE_PROFILING "Enable performance profiler (gprof)" OFF)
 option(VTR_ENABLE_COVERAGE "Enable code coverage tracking (gcov)" OFF)
 option(VTR_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
+option(VTR_ENABLE_VERBOSE "Enable increased debug verbosity" OFF)
 
 #Allow the user to decide whether to compile the graphics library
 set(VPR_USE_EZGL "auto" CACHE STRING "Specify whether vpr uses the graphics library")
@@ -283,6 +284,14 @@ if(VTR_ENABLE_DEBUG_LOGGING)
     #Enable gcov
     set(LOGGING_FLAGS "-DVTR_ENABLE_DEBUG_LOGGING")
     message(STATUS "Logging Flags: ${LOGGING_FLAGS}")
+endif()
+
+#
+# Increased debugging vebosity
+#
+if(VTR_ENABLE_VERBOSE)
+    set(EXTRA_FLAGS "${EXTRA_FLAGS} -DVTR_ENABLE_DEBUG_LOGGING")
+    message(STATUS "Enabling increased debugging verbosity")
 endif()
 
 if (CMAKE_MAKE_PROGRAM EQUAL "ninja" )

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@
 #
 # To perform a debug build use:
 #   'make BUILD_TYPE=debug'
+#
+# To enable debugging verbose messages as well use:
+#
+#   'make BUILD_TYPE=debug VERBOSE=1'
 
 #Default build type
 # Possible values:
@@ -18,6 +22,9 @@
 #    debug			#Build with debug info and no compiler optimization
 #    strict			#Build VPR with warnings treated as errors
 BUILD_TYPE ?= release
+
+#Debugging verbosity enable
+VERBOSE ?= 0
 
 #Convert to lower case for consistency
 BUILD_TYPE := $(shell echo $(BUILD_TYPE) | tr '[:upper:]' '[:lower:]')
@@ -35,6 +42,11 @@ ifneq (,$(findstring strict,$(BUILD_TYPE)))
 	#Configure for strict build with VPR warning treated as errors
 override CMAKE_PARAMS := -DVTR_ENABLE_STRICT_COMPILE=on ${CMAKE_PARAMS}
 endif #Strict build type
+
+#Enable verbosity
+ifeq ($(VERBOSE),1)
+override CMAKE_PARAMS := -DVTR_ENABLE_VERBOSE=on ${CMAKE_PARAMS}
+endif
 
 # -s : Suppresss makefile output (e.g. entering/leaving directories)
 # --output-sync target : For parallel compilation ensure output for each target is synchronized (make version >= 4.0)

--- a/vpr/src/base/read_circuit.cpp
+++ b/vpr/src/base/read_circuit.cpp
@@ -33,7 +33,7 @@ AtomNetlist read_and_process_circuit(e_circuit_format circuit_format, t_vpr_setu
     bool should_sweep_dangling_nets = vpr_setup.NetlistOpts.sweep_dangling_nets;
     bool should_sweep_dangling_blocks = vpr_setup.NetlistOpts.sweep_dangling_blocks;
     bool should_sweep_constant_primary_outputs = vpr_setup.NetlistOpts.sweep_constant_primary_outputs;
-    bool verbosity = vpr_setup.NetlistOpts.netlist_verbosity;
+    int  verbosity = vpr_setup.NetlistOpts.netlist_verbosity;
 
     if (circuit_format == e_circuit_format::AUTO) {
         auto name_ext = vtr::split_ext(circuit_file);

--- a/vpr/src/base/read_circuit.cpp
+++ b/vpr/src/base/read_circuit.cpp
@@ -33,7 +33,7 @@ AtomNetlist read_and_process_circuit(e_circuit_format circuit_format, t_vpr_setu
     bool should_sweep_dangling_nets = vpr_setup.NetlistOpts.sweep_dangling_nets;
     bool should_sweep_dangling_blocks = vpr_setup.NetlistOpts.sweep_dangling_blocks;
     bool should_sweep_constant_primary_outputs = vpr_setup.NetlistOpts.sweep_constant_primary_outputs;
-    int  verbosity = vpr_setup.NetlistOpts.netlist_verbosity;
+    int verbosity = vpr_setup.NetlistOpts.netlist_verbosity;
 
     if (circuit_format == e_circuit_format::AUTO) {
         auto name_ext = vtr::split_ext(circuit_file);

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -16,6 +16,10 @@
 #include <chrono>
 #include <time.h>
 
+#ifdef VERBOSE
+void print_clb_placement(const char* fname);
+#endif
+
 /**
  * @brief Used to assign each block a score for how difficult it is to place. 
  * The higher numbers indicate a block is expected to be more difficult to place.

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -245,7 +245,7 @@ std::unique_ptr<FILE, decltype(&vtr::fclose)> f_move_stats_file(nullptr,
 
 /********************* Static subroutines local to place.c *******************/
 #ifdef VERBOSE
-static void print_clb_placement(const char* fname);
+void print_clb_placement(const char* fname);
 #endif
 
 static void alloc_and_load_placement_structs(float place_cost_exp,
@@ -2848,7 +2848,7 @@ int check_macro_placement_consistency() {
 }
 
 #ifdef VERBOSE
-static void print_clb_placement(const char* fname) {
+void print_clb_placement(const char* fname) {
     /* Prints out the clb placements to a file.  */
     FILE* fp;
     auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -2859,7 +2859,7 @@ static void print_clb_placement(const char* fname) {
 
     fprintf(fp, "Block #\tName\t(X, Y, Z).\n");
     for (auto i : cluster_ctx.clb_nlist.blocks()) {
-        fprintf(fp, "#%d\t%s\t(%d, %d, %d).\n", i, cluster_ctx.clb_nlist.block_name(i), place_ctx.block_locs[i].x, place_ctx.block_locs[i].y, place_ctx.block_locs[i].sub_tile);
+        fprintf(fp, "#%d\t%s\t(%d, %d, %d).\n", i, cluster_ctx.clb_nlist.block_name(i).c_str(), place_ctx.block_locs[i].loc.x, place_ctx.block_locs[i].loc.y, place_ctx.block_locs[i].loc.sub_tile);
     }
 
     fclose(fp);

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -501,7 +501,7 @@ static void generic_compute_matrix_dijkstra_expansion(
 
 #ifdef VERBOSE
                         VTR_LOG("Computed delay: %12g delta: %d,%d (src: %d,%d sink: %d,%d)\n",
-                                delay,
+                                delays[size_t(sink_rr_node)],
                                 delta_x, delta_y,
                                 source_x, source_y,
                                 sink_x, sink_y);


### PR DESCRIPTION
This PR contains some general fixes

#### Description
The PR fixes build errors when `VERBOSE` is defined. It also fixes VPR ignoring netlist verbosity commandline option.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The need for debugging

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, and hopefully in the CI

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
