### PR TITLE
Do not make models with no pin-to-pin relations constant generators

### DIFF
--- a/vpr/src/base/atom_netlist_utils.cpp
+++ b/vpr/src/base/atom_netlist_utils.cpp
@@ -471,7 +471,7 @@ int mark_undriven_primitive_outputs_as_constant(AtomNetlist& netlist, int verbos
                 }
             }
 
-            if (!has_connected_inputs) {
+            if (!has_connected_inputs && !upstream_ports.empty()) {
                 //The current output port has no inputs driving the primitive's internal
                 //timing edges. Therefore we treat all its pins as constant generators.
                 for (AtomPinId output_pin : netlist.port_pins(output_port)) {
@@ -564,7 +564,7 @@ int infer_and_mark_block_combinational_outputs_constant(AtomNetlist& netlist, At
             }
         }
 
-        if (all_constant_inputs) {
+        if (all_constant_inputs && !upstream_ports.empty()) {
             //The current output port is combinational and has only constant upstream inputs.
             //Therefore we treat all its pins as constant generators.
             for (AtomPinId output_pin : netlist.port_pins(output_port)) {


### PR DESCRIPTION
#### Description
Currently for models with no pin-to-pin relations defined VPR assumes that their outputs become constant generators even though such models have inputs and they are connected to active logic.

This PR makes VPR stop implying that.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Generic blackbox support

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Not sure though how breaking the change is. Probably a discussion is needed.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
