### PR TITLE
Complete Search Revamp | Working Autocomplete

### DIFF
--- a/vpr/main.ui
+++ b/vpr/main.ui
@@ -274,4 +274,19 @@
       </object>
     </child>
   </object>
+  <object class="GtkListStore" id="NetNames">
+    <columns>
+      <!-- column-name Names -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkEntryCompletion" id="NetNameCompleter">
+    <property name="model">NetNames</property>
+    <child>
+      <object class="GtkCellRendererText" id="NetNameRenderer"/>
+      <attributes>
+        <attribute name="text">0</attribute>
+      </attributes>
+    </child>
+  </object>
 </interface>

--- a/vpr/main.ui
+++ b/vpr/main.ui
@@ -13,15 +13,22 @@
       </row>
     </data>
   </object>
-  <object class="GtkEntryCompletion" id="BlockNameCompleter">
-    <property name="model">BlockNames</property>
+  <object class="GtkEntryCompletion" id="Completion">
+    <property name="minimum_key_length">5</property>
     <property name="text_column">0</property>
     <child>
-      <object class="GtkCellRendererText" id="Renderer"/>
+      <object class="GtkCellRendererText" id="NetNameRenderer"/>
       <attributes>
         <attribute name="text">0</attribute>
       </attributes>
     </child>
+  </object>
+  <object class="GtkAdjustment" id="KeyLengthAdjustment">
+    <property name="lower">1</property>
+    <property name="upper">20</property>
+    <property name="value">5</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkWindow" id="MainWindow">
     <property name="visible">True</property>
@@ -263,7 +270,35 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkGrid" id="KeyLengthGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkSpinButton" id="KeyLength">
+                <property name="can_focus">True</property>
+                <property name="margin_left">6</property>
+                <property name="adjustment">KeyLengthAdjustment</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="KeyLengthLabel">
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Min. Match Len.</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">4</property>
+            <property name="top_attach">0</property>
+          </packing>
         </child>
         <child>
           <placeholder/>
@@ -279,15 +314,5 @@
       <!-- column-name Names -->
       <column type="gchararray"/>
     </columns>
-  </object>
-  <object class="GtkEntryCompletion" id="NetNameCompleter">
-    <property name="model">NetNames</property>
-    <property name="text_column">0</property>
-    <child>
-      <object class="GtkCellRendererText" id="NetNameRenderer"/>
-      <attributes>
-        <attribute name="text">0</attribute>
-      </attributes>
-    </child>
   </object>
 </interface>

--- a/vpr/main.ui
+++ b/vpr/main.ui
@@ -282,6 +282,7 @@
   </object>
   <object class="GtkEntryCompletion" id="NetNameCompleter">
     <property name="model">NetNames</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText" id="NetNameRenderer"/>
       <attributes>

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -357,7 +357,7 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
                                    "Block Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "RR Node ID");                                                      
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "RR Node ID");
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
@@ -455,7 +455,7 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
                                    "Block Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "RR Node ID");                                                      
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "RR Node ID");
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -2891,12 +2891,31 @@ static bool highlight_rr_nodes(float x, float y) {
 }
 
 #    if defined(X11) && !defined(__MINGW32__)
-void act_on_key_press(ezgl::application* /*app*/, GdkEventKey* /*event*/, char* key_name) {
+void act_on_key_press(ezgl::application* app, GdkEventKey* /*event*/, char* key_name) {
     //VTR_LOG("Key press %c (%d)\n", key_pressed, keysym);
     std::string key(key_name);
+    std::cout << "Pressed " << key << std::endl;
+    if(gtk_widget_is_focus(GTK_WIDGET(app->get_object("TextInput")))){
+        std::cout << "Typing" << std::endl;
+        if(key == "Return"){
+            std::cout << "Loading autocomplete results" << std::endl;
+            enable_autocomplete(app);
+        }
+    }
 }
 #    else
-void act_on_key_press(ezgl::application* /*app*/, GdkEventKey* /*event*/, char* /*key_name*/) {
+void act_on_key_press(ezgl::application* app, GdkEventKey* /*event*/, char* key_name) {
+    std::string key(key_name);
+    std::cout << "Pressed " << key << std::endl;
+    GtkWidget* searchBar = GTK_WIDGET(app->get_object("TextInput"));
+    if(gtk_widget_is_focus(searchBar)){
+        std::cout << "Typing" << std::endl;
+        std::string oldText(gtk_entry_get_text(GTK_ENTRY(searchBar)));
+        if(key == "Return"){
+            std::cout << "Loading autocomplete results" << std::endl;
+            enable_autocomplete(app);
+        }
+    }
 }
 #    endif
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -369,12 +369,6 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
     GtkEntryCompletion* wildcardComp = GTK_ENTRY_COMPLETION(app->get_object("Completion"));
     gtk_entry_completion_set_match_func(wildcardComp, (GtkEntryCompletionMatchFunc)customMatchingFunction, NULL, NULL);
 
-    //Hiding Match length Selecters
-    GtkSpinButton* completionKeyLength = GTK_SPIN_BUTTON(app->get_object("KeyLength"));
-    g_signal_connect(completionKeyLength, "value-changed", G_CALLBACK(key_length_val_changed), app);
-    gtk_widget_hide(GTK_WIDGET(completionKeyLength));
-    GtkWidget* keyLengthLabel = GTK_WIDGET(app->get_object("KeyLengthLabel"));
-    gtk_widget_hide(keyLengthLabel);
     button_for_toggle_nets();
     button_for_net_max_fanout();
     button_for_net_alpha();
@@ -468,9 +462,6 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     gtk_entry_completion_set_match_func(completion, (GtkEntryCompletionMatchFunc)customMatchingFunction, NULL, NULL);
 
     //Hiding Match length Selecters
-    GtkSpinButton* completionKeyLength = GTK_SPIN_BUTTON(app->get_object("KeyLength"));
-    g_signal_connect(completionKeyLength, "value-changed", G_CALLBACK(key_length_val_changed), app);
-    gtk_widget_hide(GTK_WIDGET(completionKeyLength));
     GtkWidget* keyLengthLabel = GTK_WIDGET(app->get_object("KeyLengthLabel"));
     gtk_widget_hide(keyLengthLabel);
 
@@ -2894,11 +2885,8 @@ static bool highlight_rr_nodes(float x, float y) {
 void act_on_key_press(ezgl::application* app, GdkEventKey* /*event*/, char* key_name) {
     //VTR_LOG("Key press %c (%d)\n", key_pressed, keysym);
     std::string key(key_name);
-    std::cout << "Pressed " << key << std::endl;
     if(gtk_widget_is_focus(GTK_WIDGET(app->get_object("TextInput")))){
-        std::cout << "Typing" << std::endl;
         if(key == "Return"){
-            std::cout << "Loading autocomplete results" << std::endl;
             enable_autocomplete(app);
         }
     }
@@ -2906,15 +2894,15 @@ void act_on_key_press(ezgl::application* app, GdkEventKey* /*event*/, char* key_
 #    else
 void act_on_key_press(ezgl::application* app, GdkEventKey* /*event*/, char* key_name) {
     std::string key(key_name);
-    std::cout << "Pressed " << key << std::endl;
     GtkWidget* searchBar = GTK_WIDGET(app->get_object("TextInput"));
     if(gtk_widget_is_focus(searchBar)){
-        std::cout << "Typing" << std::endl;
-        std::string oldText(gtk_entry_get_text(GTK_ENTRY(searchBar)));
         if(key == "Return"){
-            std::cout << "Loading autocomplete results" << std::endl;
             enable_autocomplete(app);
         }
+    }
+    else if(key == "Escape"){
+        get_selected_sub_block_info().clear();
+        app->refresh_drawing();
     }
 }
 #    endif

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -357,13 +357,12 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
                                    "Block Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
-                                   "RR Node ID");                                                      
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "RR Node ID");                                                      
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
 
-    load_block_names(app);  //Loading block and net names into GtkListStores
+    load_block_names(app); //Loading block and net names into GtkListStores
     load_net_names(app);
 
     //Setting custom matching function for entry completion (searches whole string instead of start)
@@ -456,13 +455,12 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
                                    "Block Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
-                                   "RR Node ID");                                                      
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "RR Node ID");                                                      
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
 
-    load_block_names(app);  //Loading block and net names into GtkListStores
+    load_block_names(app); //Loading block and net names into GtkListStores
     load_net_names(app);
 
     //Setting custom matching function for entry completion (searches whole string instead of start)

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -363,6 +363,7 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
     load_block_names(app);
+    load_net_names(app);
     button_for_toggle_nets();
     button_for_net_max_fanout();
     button_for_net_alpha();
@@ -448,6 +449,7 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
     load_block_names(app);
+    load_net_names(app);
 
     button_for_toggle_nets();
     button_for_net_max_fanout();

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -352,18 +352,30 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
 
     //combo box for search type, created in main.ui
     GObject* search_type = (GObject*)app->get_object("SearchType");
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Block ID"); // index 0
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Block ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
-                                   "Block Name");                                // index 1
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");   // index 2
-    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name"); // index 3
+                                   "Block Name");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
-                                   "RR Node ID"); // index 4
+                                   "RR Node ID");                                                      
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
-    load_block_names(app);
+
+    load_block_names(app);  //Loading block and net names into GtkListStores
     load_net_names(app);
+
+    //Setting custom matching function for entry completion (searches whole string instead of start)
+    GtkEntryCompletion* wildcardComp = GTK_ENTRY_COMPLETION(app->get_object("Completion"));
+    gtk_entry_completion_set_match_func(wildcardComp, (GtkEntryCompletionMatchFunc)customMatchingFunction, NULL, NULL);
+
+    //Hiding Match length Selecters
+    GtkSpinButton* completionKeyLength = GTK_SPIN_BUTTON(app->get_object("KeyLength"));
+    g_signal_connect(completionKeyLength, "value-changed", G_CALLBACK(key_length_val_changed), app);
+    gtk_widget_hide(GTK_WIDGET(completionKeyLength));
+    GtkWidget* keyLengthLabel = GTK_WIDGET(app->get_object("KeyLengthLabel"));
+    gtk_widget_hide(keyLengthLabel);
     button_for_toggle_nets();
     button_for_net_max_fanout();
     button_for_net_alpha();
@@ -437,6 +449,7 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     g_signal_connect(save, "clicked", G_CALLBACK(save_graphics_dialog_box),
                      app);
 
+    //combo box for search type, created in main.ui
     GObject* search_type = (GObject*)app->get_object("SearchType");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Block ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
@@ -444,12 +457,24 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net ID");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type), "Net Name");
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(search_type),
-                                   "RR Node ID");
+                                   "RR Node ID");                                                      
     //Important to have default option set, or else user can search w. no selected type which can cause crash
     gtk_combo_box_set_active((GtkComboBox*)search_type, 0); // default set to Block ID which has an index 0
     g_signal_connect(search_type, "changed", G_CALLBACK(search_type_changed), app);
-    load_block_names(app);
+
+    load_block_names(app);  //Loading block and net names into GtkListStores
     load_net_names(app);
+
+    //Setting custom matching function for entry completion (searches whole string instead of start)
+    GtkEntryCompletion* completion = GTK_ENTRY_COMPLETION(app->get_object("Completion"));
+    gtk_entry_completion_set_match_func(completion, (GtkEntryCompletionMatchFunc)customMatchingFunction, NULL, NULL);
+
+    //Hiding Match length Selecters
+    GtkSpinButton* completionKeyLength = GTK_SPIN_BUTTON(app->get_object("KeyLength"));
+    g_signal_connect(completionKeyLength, "value-changed", G_CALLBACK(key_length_val_changed), app);
+    gtk_widget_hide(GTK_WIDGET(completionKeyLength));
+    GtkWidget* keyLengthLabel = GTK_WIDGET(app->get_object("KeyLengthLabel"));
+    gtk_widget_hide(keyLengthLabel);
 
     button_for_toggle_nets();
     button_for_net_max_fanout();

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -344,7 +344,10 @@ void search_type_changed(GtkComboBox* self, ezgl::application* app) {
     if (searchType == "Block Name") {
         GtkEntryCompletion* blockCompleter = GTK_ENTRY_COMPLETION(app->get_object("BlockNameCompleter"));
         gtk_entry_set_completion(searchBar, blockCompleter);
-    } else { //If not, setting to null
+    } else if(searchType == "Net Name") {   //using netNameCompleter if type is nets
+        GtkEntryCompletion* netCompleter = GTK_ENTRY_COMPLETION(app->get_object("NetNameCompleter"));
+        gtk_entry_set_completion(searchBar, netCompleter);
+    } else {    //setting to null if option does not require auto-complete
         gtk_entry_set_completion(searchBar, nullptr);
     }
 }

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -108,10 +108,10 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
         AtomBlockId atom_blk_id = AtomBlockId::INVALID();
         atom_blk_id = atom_ctx.nlist.find_block(block_name);
         //If block is found, the CLB containing it is highlighted
-        if (atom_blk_id != AtomBlockId::INVALID()){
+        if (atom_blk_id != AtomBlockId::INVALID()) {
             ClusterBlockId block_id = atom_ctx.lookup.atom_clb(atom_blk_id);
             //Highlighting atom block. IF function returns false, highlighting clb that contains
-            if(!highlight_atom_block(atom_blk_id, block_id, app)){
+            if (!highlight_atom_block(atom_blk_id, block_id, app)) {
                 highlight_cluster_block(block_id);
             }
             return;
@@ -296,20 +296,20 @@ void highlight_cluster_block(ClusterBlockId clb_index) {
  * @return true | If sub-block can be highlighted
  * @return false | If sub-block not found (impossible in search case) or not shown at current zoom lvl
  */
-bool highlight_atom_block(AtomBlockId atom_blk, ClusterBlockId cl_blk, ezgl::application* app){
+bool highlight_atom_block(AtomBlockId atom_blk, ClusterBlockId cl_blk, ezgl::application* app) {
     auto& atom_ctx = g_vpr_ctx.atom();
     auto& cl_ctx = g_vpr_ctx.clustering();
     t_pb* pb = cl_ctx.clb_nlist.block_pb(cl_blk);
 
     //Getting the pb* for the atom block
     auto atom_block_pb = find_atom_block_in_pb(atom_ctx.nlist.block_name(atom_blk), pb);
-    if(!atom_block_pb) return false;    //If no block found, returning false
+    if (!atom_block_pb) return false;    //If no block found, returning false
 
     //Ensuring that block is drawn at current zoom lvl, returning false if not
     auto atom_block_depth = atom_block_pb->pb_graph_node->pb_type->depth;
     t_draw_state* draw_state = get_draw_state_vars();
     int max_depth = draw_state->show_blk_internal;
-    if(atom_block_depth > max_depth) return false;
+    if (atom_block_depth > max_depth) return false;
 
     //Highlighting block
     get_selected_sub_block_info().set(atom_block_pb, cl_blk);
@@ -324,7 +324,7 @@ bool highlight_atom_block(AtomBlockId atom_blk, ClusterBlockId cl_blk, ezgl::app
  * @param pb current node to be examined
  * @return t_pb* t_pb ptr of block w. name "name"
  */
-t_pb* find_atom_block_in_pb(std::string name, t_pb* pb){
+t_pb* find_atom_block_in_pb(std::string name, t_pb* pb) {
     //Checking if block is one being searched for
     std::string pbName(pb->name);
     if (pbName == name) return pb;
@@ -334,7 +334,7 @@ t_pb* find_atom_block_in_pb(std::string name, t_pb* pb){
     int num_child_types = pb->get_num_child_types();
     //Iterating through all child types
     for (int i = 0; i < num_child_types; ++i) {
-        if(pb->child_pbs[i] == nullptr) continue;
+        if (pb->child_pbs[i] == nullptr) continue;
         int num_children_of_type = pb->get_num_children_of_type(i);
         //Iterating through all of pb's children of given type
         for (int j = 0; j < num_children_of_type; ++j) {
@@ -347,7 +347,7 @@ t_pb* find_atom_block_in_pb(std::string name, t_pb* pb){
                     return subtree_result;
                 }
             }
-        }   
+        }
     }
     return nullptr;
 }
@@ -379,29 +379,6 @@ void highlight_nets(std::string net_name) {
     highlight_atom_net(net_id); //found net
 }
 
-void highlight_blocks(std::string block_name) {
-    auto& atom_ctx = g_vpr_ctx.atom();
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-
-    AtomBlockId a_block_id = AtomBlockId::INVALID();
-    a_block_id = atom_ctx.nlist.find_block(block_name);
-
-    if (a_block_id != AtomBlockId::INVALID()){
-        //Write a function here to highlight a specific internal
-        return;
-    }
-    //Continues if atom block not found
-
-    ClusterBlockId block_id = ClusterBlockId::INVALID();
-    block_id = cluster_ctx.clb_nlist.find_block(block_name);
-
-    if (block_id == ClusterBlockId::INVALID()) {
-        warning_dialog_box("Invalid Block Name");
-        return; //name not exist
-    }
-
-    highlight_cluster_block(block_id); //found block
-}
 
 void warning_dialog_box(const char* message) {
     GObject* main_window;    // parent window over which to add the dialog
@@ -455,21 +432,21 @@ void search_type_changed(GtkComboBox* self, ezgl::application* app) {
     std::string searchType(type);
 
     /*
-    If search type is name, connecting search bar to completion,
-    and connecting completion to the appropriate model (blocks or nets)
-    Additionally, visibility of key length setter is toggled by these changes
-    */
+     * If search type is name, connecting search bar to completion,
+     * and connecting completion to the appropriate model (blocks or nets)
+     * Additionally, visibility of key length setter is toggled by these changes
+     */
     if (searchType == "Block Name") {
         gtk_entry_completion_set_model(completion, blockNames);
         gtk_entry_set_completion(searchBar, completion);
         gtk_widget_show(keyLengthSpinButton);
         gtk_widget_show(keyLengthLabel);
-    } else if(searchType == "Net Name") {
+    } else if (searchType == "Net Name") {
         gtk_entry_completion_set_model(completion, netNames);
         gtk_entry_set_completion(searchBar, completion);
         gtk_widget_show(keyLengthSpinButton);
         gtk_widget_show(keyLengthLabel);
-    } else {    //setting to null if option does not require auto-complete
+    } else { //setting to null if option does not require auto-complete
         gtk_widget_hide(keyLengthSpinButton);
         gtk_widget_hide(keyLengthLabel);
         gtk_entry_set_completion(searchBar, nullptr);
@@ -491,7 +468,7 @@ void load_block_names(ezgl::application* app) {
         gtk_list_store_set(blockStorage, &iter,
                            0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
     }
-    for (AtomBlockId id : atom_ctx.nlist.blocks()){
+    for (AtomBlockId id : atom_ctx.nlist.blocks()) {
         gtk_list_store_append(blockStorage, &iter);
         gtk_list_store_set(blockStorage, &iter,
                            0, (atom_ctx.nlist.block_name(id)).c_str(), -1);   
@@ -503,7 +480,7 @@ void load_block_names(ezgl::application* app) {
  * 
  * @param app ezgl application used for ui
  */
-void load_net_names(ezgl::application* app){
+void load_net_names(ezgl::application* app) {
     auto netStorage = GTK_LIST_STORE(app->get_object("NetNames"));
     auto& atom_ctx = g_vpr_ctx.atom();
     GtkTreeIter iter;
@@ -526,11 +503,13 @@ void load_net_names(ezgl::application* app){
  * @return gboolean 
  */
 gboolean customMatchingFunction(
-    GtkEntryCompletion* completer, const gchar* key, 
-    GtkTreeIter* iter, gpointer /*user data*/
-){
-    GtkTreeModel *model = gtk_entry_completion_get_model(completer);
-    const gchar *text;
+    GtkEntryCompletion* completer,
+    const gchar* key, 
+    GtkTreeIter* iter,
+    gpointer /*user data*/
+) {
+    GtkTreeModel* model = gtk_entry_completion_get_model(completer);
+    const gchar* text;
     gtk_tree_model_get(model, iter, 0, &text, -1);
     //Removing case information
     g_utf8_casefold(text, -1);
@@ -543,7 +522,7 @@ gboolean customMatchingFunction(
 /**
  * @brief Updates min. key length when the value in spin button changes
  */
-void key_length_val_changed(GtkSpinButton* self, ezgl::application* app){
+void key_length_val_changed(GtkSpinButton* self, ezgl::application* app) {
     auto newLength = gtk_spin_button_get_value(self);
     GtkEntryCompletion* completion = GTK_ENTRY_COMPLETION(app->get_object("Completion"));
     gtk_entry_completion_set_minimum_key_length(completion, newLength);

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -365,18 +365,6 @@ void highlight_nets(ClusterNetId net_id) {
     }
 }
 
-void highlight_nets(std::string net_name) {
-    auto& atom_ctx = g_vpr_ctx.atom();
-
-    AtomNetId net_id = AtomNetId::INVALID();
-    net_id = atom_ctx.nlist.find_net(net_name);
-
-    if (net_id == AtomNetId::INVALID()) {
-        warning_dialog_box("Invalid Net Name");
-        return; //name not exist
-    }
-    highlight_atom_net(net_id); //found net
-}
 
 void warning_dialog_box(const char* message) {
     GObject* main_window;    // parent window over which to add the dialog

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -303,7 +303,7 @@ bool highlight_atom_block(AtomBlockId atom_blk, ClusterBlockId cl_blk, ezgl::app
 
     //Getting the pb* for the atom block
     auto atom_block_pb = find_atom_block_in_pb(atom_ctx.nlist.block_name(atom_blk), pb);
-    if (!atom_block_pb) return false;    //If no block found, returning false
+    if (!atom_block_pb) return false; //If no block found, returning false
 
     //Ensuring that block is drawn at current zoom lvl, returning false if not
     auto atom_block_depth = atom_block_pb->pb_graph_node->pb_type->depth;
@@ -352,7 +352,6 @@ t_pb* find_atom_block_in_pb(std::string name, t_pb* pb) {
     return nullptr;
 }
 
-
 void highlight_nets(ClusterNetId net_id) {
     t_trace* tptr;
     auto& route_ctx = g_vpr_ctx.routing();
@@ -378,7 +377,6 @@ void highlight_nets(std::string net_name) {
     }
     highlight_atom_net(net_id); //found net
 }
-
 
 void warning_dialog_box(const char* message) {
     GObject* main_window;    // parent window over which to add the dialog
@@ -471,7 +469,7 @@ void load_block_names(ezgl::application* app) {
     for (AtomBlockId id : atom_ctx.nlist.blocks()) {
         gtk_list_store_append(blockStorage, &iter);
         gtk_list_store_set(blockStorage, &iter,
-                           0, (atom_ctx.nlist.block_name(id)).c_str(), -1);   
+                           0, (atom_ctx.nlist.block_name(id)).c_str(), -1);
     }
 }
 
@@ -504,7 +502,7 @@ void load_net_names(ezgl::application* app) {
  */
 gboolean customMatchingFunction(
     GtkEntryCompletion* completer,
-    const gchar* key, 
+    const gchar* key,
     GtkTreeIter* iter,
     gpointer /*user data*/
 ) {

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -355,17 +355,34 @@ void search_type_changed(GtkComboBox* self, ezgl::application* app) {
 /**
  * @brief loads block names into gtk list store item used for completion
  * 
- * @param app ezgl application
+ * @param app ezgl application used for ui
  */
 void load_block_names(ezgl::application* app) {
     auto blockStorage = GTK_LIST_STORE(app->get_object("BlockNames"));
     auto& cluster_ctx = g_vpr_ctx.clustering();
     GtkTreeIter iter;
-    //Getting and storing all block names
+    int i = 0;
     for (ClusterBlockId id : cluster_ctx.clb_nlist.blocks()) {
         gtk_list_store_append(blockStorage, &iter);
         gtk_list_store_set(blockStorage, &iter,
                            0, (cluster_ctx.clb_nlist.block_name(id)).c_str(), -1);
+    }
+}
+
+/**
+ * @brief loads net names into gtk list store item used for completion
+ * 
+ * @param app ezgl application used for ui
+ */
+void load_net_names(ezgl::application* app){
+    auto netStorage = GTK_LIST_STORE(app->get_object("NetNames"));
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    GtkTreeIter iter;
+    //Loading net names
+    for (ClusterNetId id : cluster_ctx.clb_nlist.nets()) {
+        gtk_list_store_append(netStorage, &iter);
+        gtk_list_store_set(netStorage, &iter,
+                           0, (cluster_ctx.clb_nlist.net_name(id)).c_str(), -1);
     }
 }
 

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -365,7 +365,6 @@ void highlight_nets(ClusterNetId net_id) {
     }
 }
 
-
 void warning_dialog_box(const char* message) {
     GObject* main_window;    // parent window over which to add the dialog
     GtkWidget* content_area; // content area of the dialog

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -488,15 +488,6 @@ gboolean customMatchingFunction(
     return (cppText.find(key, 0) != std::string::npos);
 }
 
-/**
- * @brief Updates min. key length when the value in spin button changes
- */
-void key_length_val_changed(GtkSpinButton* self, ezgl::application* app) {
-    auto newLength = gtk_spin_button_get_value(self);
-    GtkEntryCompletion* completion = GTK_ENTRY_COMPLETION(app->get_object("Completion"));
-    gtk_entry_completion_set_minimum_key_length(completion, newLength);
-}
-
 void enable_autocomplete(ezgl::application* app){
     std::cout << "enabling autocomplete" << std::endl;
     GtkEntryCompletion* completion = GTK_ENTRY_COMPLETION(app->get_object("Completion"));

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -16,7 +16,6 @@ void auto_zoom_rr_node(int rr_node_id);
 void highlight_cluster_block(ClusterBlockId clb_index);
 void highlight_nets(ClusterNetId net_id);
 void highlight_nets(std::string net_name);
-void highlight_blocks(std::string block_name);
 
 void load_block_names(ezgl::application* app);
 void load_net_names(ezgl::application* app);
@@ -25,8 +24,10 @@ void highlight_atom_block(AtomBlockId block_id);
 void highlight_atom_net(AtomNetId net_id);
 
 gboolean customMatchingFunction(
-    GtkEntryCompletion* completer, const gchar* key, 
-    GtkTreeIter* iter, gpointer user_data
+    GtkEntryCompletion* completer,
+    const gchar* key, 
+    GtkTreeIter* iter,
+    gpointer user_data
 );
 
 //Function to manage entry completions when search type is changed

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -22,7 +22,6 @@ void load_net_names(ezgl::application* app);
 
 void highlight_atom_block(AtomBlockId block_id);
 
-
 gboolean customMatchingFunction(
     GtkEntryCompletion* completer,
     const gchar* key,

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -39,6 +39,10 @@ void key_length_val_changed(GtkSpinButton* self, ezgl::application* app);
 t_pb* find_atom_block_in_pb(std::string name, t_pb* pb);
 
 bool highlight_atom_block(AtomBlockId atom_blk, ClusterBlockId cl_blk, ezgl::application* app);
+
+void enable_autocomplete(ezgl::application* app);
+
+std::string get_search_type(ezgl::application* app);
 #endif /* NO_GRAPHICS */
 
 #endif /* SEARCH_BAR_H */

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -25,10 +25,9 @@ void highlight_atom_net(AtomNetId net_id);
 
 gboolean customMatchingFunction(
     GtkEntryCompletion* completer,
-    const gchar* key, 
+    const gchar* key,
     GtkTreeIter* iter,
-    gpointer user_data
-);
+    gpointer user_data);
 
 //Function to manage entry completions when search type is changed
 void search_type_changed(GtkComboBox* /*self*/, ezgl::application* app);

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -21,7 +21,7 @@ void load_block_names(ezgl::application* app);
 void load_net_names(ezgl::application* app);
 
 void highlight_atom_block(AtomBlockId block_id);
-void highlight_atom_net(AtomNetId net_id);
+
 
 gboolean customMatchingFunction(
     GtkEntryCompletion* completer,

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -19,6 +19,10 @@ void highlight_nets(std::string net_name);
 void highlight_blocks(std::string block_name);
 
 void load_block_names(ezgl::application* app);
+void load_net_names(ezgl::application* app);
+
+void highlight_atom_block(AtomBlockId block_id);
+void highlight_atom_net(AtomNetId net_id);
 
 //Function to manage entry completions when search type is changed
 void search_type_changed(GtkComboBox* /*self*/, ezgl::application* app);

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -34,7 +34,6 @@ void search_type_changed(GtkComboBox* /*self*/, ezgl::application* app);
 /*function below pops up a dialog box with no button, showing the input warning message*/
 void warning_dialog_box(const char* message);
 
-void key_length_val_changed(GtkSpinButton* self, ezgl::application* app);
 
 t_pb* find_atom_block_in_pb(std::string name, t_pb* pb);
 

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -13,7 +13,7 @@
 void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app);
 bool highlight_rr_nodes(int hit_node);
 void auto_zoom_rr_node(int rr_node_id);
-void highlight_blocks(ClusterBlockId clb_index);
+void highlight_cluster_block(ClusterBlockId clb_index);
 void highlight_nets(ClusterNetId net_id);
 void highlight_nets(std::string net_name);
 void highlight_blocks(std::string block_name);
@@ -24,12 +24,22 @@ void load_net_names(ezgl::application* app);
 void highlight_atom_block(AtomBlockId block_id);
 void highlight_atom_net(AtomNetId net_id);
 
+gboolean customMatchingFunction(
+    GtkEntryCompletion* completer, const gchar* key, 
+    GtkTreeIter* iter, gpointer user_data
+);
+
 //Function to manage entry completions when search type is changed
 void search_type_changed(GtkComboBox* /*self*/, ezgl::application* app);
 
 /*function below pops up a dialog box with no button, showing the input warning message*/
 void warning_dialog_box(const char* message);
 
+void key_length_val_changed(GtkSpinButton* self, ezgl::application* app);
+
+t_pb* find_atom_block_in_pb(std::string name, t_pb* pb);
+
+bool highlight_atom_block(AtomBlockId atom_blk, ClusterBlockId cl_blk, ezgl::application* app);
 #endif /* NO_GRAPHICS */
 
 #endif /* SEARCH_BAR_H */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added auto-complete options to the Block and Net Name search functions, managed by a Min. Search Term value.
The value is the min. number of characters before it searches through all names to find any that contain (not start with) the search term. At that point, the program may experience slight delays (1-2 sec.) as it searches, so its recommended to keep the Min. Value near the length of your search term.

Additionally, the search function is now able to find and highlight internal components. Based on lvl of internals visibility, it will highlight either the AtomBlock or the ClusterBlock that contains it.  

Also added a function able to highlight an Atom Block just from its Id, which was not present before. May be useful to someone. 

<!--- Describe your changes in detail -->


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The original search function had no form of automatic completion, required users to enter the full names of the block or net they were searching for, with no room for error, and was also fully based on the Clustered netlist, and thus could not search or highlight internals. It was pretty difficult to use as a result, as you'd need to know the full name of the thing you were searching for, and the names are often synthesized by VTR so you probably would not know that.

That has been rectified through the new features implemented in this PR. 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using PR auto-tester as well as visual tests to determine performance. Originally, auto-complete was too slow so key length selecting feature was implemented to mitigate this. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

