### PR TITLE
Fixed CI tests fail due to failure in installing required python packages

### DIFF
--- a/.github/scripts/hostsetup.sh
+++ b/.github/scripts/hostsetup.sh
@@ -76,6 +76,7 @@ export PATH="$PATH:/home/kbuilder/.local/bin"
 export CC=gcc-9
 export CXX=g++-9
 
+python3 -m pip install -U pip
 python3 -m pip install -r requirements.txt
 
 echo "----------------------------------------"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#### Description
<!--- Describe your changes in detail -->
The issue seems to be related to outdated python pip or setuptools on google servers that run the CI tests. I have added a command to update pip before installing python packages.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2072
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It will resolve failures in CI tests
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
