### PR TITLE
Placement constraints docs update

### DIFF
--- a/doc/src/vpr/index.rst
+++ b/doc/src/vpr/index.rst
@@ -55,6 +55,7 @@ The purpose of VPR is to make the packing, placement, and routing stages of the 
    graphics
 
    timing_constraints
+   placement_constraints
    sdc_commands
 
    file_formats

--- a/doc/src/vpr/placement_constraints.rst
+++ b/doc/src/vpr/placement_constraints.rst
@@ -9,25 +9,25 @@ A Constraints File Example
 --------------------------
 
 .. code-block:: xml
-    :caption: An example of a placement constraints file in XML format.
-    :linenos:
+	:caption: An example of a placement constraints file in XML format.
+	:linenos:
 
-<vpr_constraints tool_name="vpr">
-     <partition_list>
-	  <partition name="Part0">
-	       <add_atom name_pattern="li354">
-	       <add_atom name_pattern="alu*"> <!-- Regular expressions can be used to provide name patterns of the primitives to be added -->
-	       <add_atom name_pattern="n877">
-	       <add_region x_low="3" y_low="1" x_high="7" y_high="2"> <!-- Two rectangular regions are specified, together describing an L-shaped region -->
-	       <add_region x_low="7" y_low="3" x_high="7" y_high="6">
-	  </partition>
-	  <partition name="Part1">
-	       <add_region x_low="3" y_low="3" x_high="7" y_high="7" subtile="0"> <!-- One specific location is specified -->
-	       <add_atom name_pattern="n4917">
-	       <add_atom name_pattern="n6010">
-	  </partition>
-     </partition_list>
-</vpr_constraints>
+	<vpr_constraints tool_name="vpr">
+     		<partition_list>
+	  	<partition name="Part0">
+	       		<add_atom name_pattern="li354">
+	       		<add_atom name_pattern="alu*"> <!-- Regular expressions can be used to provide name patterns of the primitives to be added -->
+	       		<add_atom name_pattern="n877">
+	      		 <add_region x_low="3" y_low="1" x_high="7" y_high="2"> <!-- Two rectangular regions are specified, together describing an L-shaped region -->
+	       		<add_region x_low="7" y_low="3" x_high="7" y_high="6"
+	  	 </partition>
+	 	 <partition name="Part1">
+	       		<add_region x_low="3" y_low="3" x_high="7" y_high="7" subtile="0"> <!-- One specific location is specified -->
+	       		<add_atom name_pattern="n4917">
+	      		<add_atom name_pattern="n6010">
+	  	</partition>
+     		</partition_list>
+	</vpr_constraints>
 
 .. _end:
 

--- a/doc/src/vpr/placement_constraints.rst
+++ b/doc/src/vpr/placement_constraints.rst
@@ -9,8 +9,8 @@ A Constraints File Example
 --------------------------
 
 .. code-block:: xml
-:caption: An example of a placement constraints file in XML format.
-:linenos:
+    :caption: An example of a placement constraints file in XML format.
+    :linenos:
 
 <vpr_constraints tool_name="vpr">
      <partition_list>
@@ -19,7 +19,7 @@ A Constraints File Example
 	       <add_atom name_pattern="alu*"> <!-- Regular expressions can be used to provide name patterns of the primitives to be added -->
 	       <add_atom name_pattern="n877">
 	       <add_region x_low="3" y_low="1" x_high="7" y_high="2"> <!-- Two rectangular regions are specified, together describing an L-shaped region -->
-	       <add_region x_low="7" y_low="3" x_high="7" y_high="6"
+	       <add_region x_low="7" y_low="3" x_high="7" y_high="6">
 	  </partition>
 	  <partition name="Part1">
 	       <add_region x_low="3" y_low="3" x_high="7" y_high="7" subtile="0"> <!-- One specific location is specified -->


### PR DESCRIPTION
Indentation for documentation for https://docs.verilogtorouting.org/en/latest/vpr/placement_constraints/?highlight=floorplanning fixed. 

#### Description
xml example on the page wasn't showing up properly:
![image](https://user-images.githubusercontent.com/66747201/176519213-d2dac987-100e-46de-bbca-e7aacaf9b0b0.png)

Indented a code block to match that of working xml example (specifically, https://github.com/verilog-to-routing/vtr-verilog-to-routing/edit/master/doc/src/vpr/file_formats.rst#routing-resource-graph-format-example)

#### Related Issue
Mentioned in #2079 .
