### PR TITLE
Node naming, including hierarchical history in Yosys+Odin-II 

### DIFF
--- a/ODIN_II/SRC/BLIFReader.cpp
+++ b/ODIN_II/SRC/BLIFReader.cpp
@@ -483,7 +483,10 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
             output_nets_hash->add(name, new_net);
         }
 
-        if (!configuration.coarsen || new_node->type == SPRAM || new_node->type == DPRAM) {
+        if (!configuration.coarsen
+            || !configuration.decode_names
+            || new_node->type == SPRAM
+            || new_node->type == DPRAM) {
             // Name the node subcircuit_name~hard_block_number so that the name is unique.
             odin_sprintf(buffer, "%s~%ld", subcircuit_name, hard_block_number++);
             new_node->name = make_full_ref_name(buffer, NULL, NULL, NULL, -1);

--- a/ODIN_II/SRC/BLIFReader.cpp
+++ b/ODIN_II/SRC/BLIFReader.cpp
@@ -336,10 +336,7 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
     t_model* hb_model = NULL;
     nnode_t* new_node = allocate_nnode(my_location);
 
-    // Name the node subcircuit_name~hard_block_number so that the name is unique.
     static long hard_block_number = 0;
-    odin_sprintf(buffer, "%s~%ld", subcircuit_name, hard_block_number++);
-    new_node->name = make_full_ref_name(buffer, NULL, NULL, NULL, -1);
 
     // init the edge sensitivity of hard block
     if (configuration.coarsen)
@@ -357,21 +354,15 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
                 new_node->type = yosys_subckt_strmap[subcircuit_stripped_name];
 
             if (new_node->type == NO_OP) {
-                char new_name[READ_BLIF_BUFFER];
-                vtr::free(new_node->name);
                 /* in case of weird names, need to add memories manually */
                 int sc_spot = -1;
                 char* yosys_subckt_str = NULL;
                 if ((yosys_subckt_str = retrieve_node_type_from_subckt_name(subcircuit_stripped_name)) != NULL) {
                     /* specify node type */
                     new_node->type = yosys_subckt_strmap[yosys_subckt_str];
-                    /* specify node name */
-                    odin_sprintf(new_name, "\\%s~%ld", yosys_subckt_str, hard_block_number - 1);
                 } else if ((sc_spot = sc_lookup_string(hard_block_names, subcircuit_stripped_name)) != -1) {
                     /* specify node type */
                     new_node->type = HARD_IP;
-                    /* specify node name */
-                    odin_sprintf(new_name, "\\%s~%ld", subcircuit_stripped_name, hard_block_number - 1);
                     /* Detect used hard block for the blif generation */
                     hb_model = find_hard_block(subcircuit_stripped_name);
                     if (hb_model) {
@@ -381,7 +372,6 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
                     error_message(PARSE_BLIF, unknown_location,
                                   "Unsupported subcircuit type (%s) in BLIF file.\n", subcircuit_name);
                 }
-                new_node->name = make_full_ref_name(new_name, NULL, NULL, NULL, -1);
 
                 // CLEAN UP
                 vtr::free(yosys_subckt_str);
@@ -491,6 +481,28 @@ void BLIF::Reader::create_hard_block_nodes(hard_block_models* models) {
 
             // Index the net by name.
             output_nets_hash->add(name, new_net);
+        }
+
+        if (!configuration.coarsen || new_node->type == SPRAM || new_node->type == DPRAM) {
+            // Name the node subcircuit_name~hard_block_number so that the name is unique.
+            odin_sprintf(buffer, "%s~%ld", subcircuit_name, hard_block_number++);
+            new_node->name = make_full_ref_name(buffer, NULL, NULL, NULL, -1);
+        } else {
+            // Find the basename of the output pin and name the node
+            // with BASENAME^TYPE
+            char* splitter = strrchr(new_node->output_pins[0]->net->name, '.');
+            char* output_pin_fullname = new_node->output_pins[0]->net->name;
+
+            // there is only a top module, no instantiation of submodules
+            if (splitter == NULL)
+                splitter = strchr(output_pin_fullname, '^');
+
+            char basename[READ_BLIF_BUFFER];
+            size_t basename_len = splitter - output_pin_fullname;
+
+            strncpy(basename, output_pin_fullname, basename_len);
+            basename[basename_len] = '\0';
+            new_node->name = node_name(new_node, basename);
         }
 
         // Create a fake ast node.

--- a/ODIN_II/SRC/include/config_t.h
+++ b/ODIN_II/SRC/include/config_t.h
@@ -17,6 +17,7 @@ struct config_t {
     bool fflegalize;     // Legalize DFFs by making them rising edge
     bool coarsen;        // Specify if the input BLIF is coarse-grain
     bool show_yosys_log; // Print Yosys logs into the standard output stream
+    bool decode_names;   // Extracting hierarchical information from Yosys coarse-grained BLIF file for signal naming
 
     bool output_ast_graphs;     // switch that outputs ast graphs per node for use with GRaphViz tools
     bool output_netlist_graphs; // switch that outputs netlist graphs per node for use with GraphViz tools

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -113,6 +113,7 @@ struct global_args_t {
     argparse::ArgValue<bool> fflegalize;     // makes flip-flops rising edge sensitive
     argparse::ArgValue<bool> coarsen;        // tells Odin-II that the input blif is coarse-grain
     argparse::ArgValue<bool> show_yosys_log; // Show Yosys output logs into the standard output stream
+    argparse::ArgValue<bool> decode_names;   // Extracting hierarchical information from Yosys coarse-grained BLIF file for signal naming
 
     argparse::ArgValue<std::string> adder_def; //DEPRECATED
 

--- a/ODIN_II/SRC/odin_ii.cpp
+++ b/ODIN_II/SRC/odin_ii.cpp
@@ -533,6 +533,12 @@ void get_options(int argc, char** argv) {
         .help("TCL file")
         .metavar("TCL_FILE");
 
+    ext_elaborator_group.add_argument(global_args.decode_names, "--decode_names")
+        .help("Enable extracting hierarchical information from Yosys coarse-grained BLIF file for signal naming")
+        .default_value("false")
+        .action(argparse::Action::STORE_TRUE)
+        .metavar("DECODE_NAMES");
+
     auto& other_grp = parser.add_argument_group("other options");
 
     other_grp.add_argument(global_args.show_help, "-h")
@@ -752,6 +758,10 @@ void get_options(int argc, char** argv) {
         configuration.elaborator_type = elaborator_e::_YOSYS;
     }
 
+    if (global_args.decode_names.provenance() == argparse::Provenance::SPECIFIED) {
+        configuration.decode_names = global_args.decode_names;
+    }
+
     if (global_args.write_netlist_as_dot.provenance() == argparse::Provenance::SPECIFIED) {
         configuration.output_netlist_graphs = global_args.write_netlist_as_dot;
     }
@@ -809,6 +819,7 @@ void set_default_config() {
     configuration.coarsen = false;
     configuration.fflegalize = false;
     configuration.show_yosys_log = false;
+    configuration.decode_names = false;
     configuration.tcl_file = "";
     configuration.output_file_type = file_type_e::_BLIF;
     configuration.elaborator_type = elaborator_e::_ODIN;

--- a/doc/src/yosys+odin/user_guide.rst
+++ b/doc/src/yosys+odin/user_guide.rst
@@ -26,6 +26,8 @@ Synthesis Arguments
      **`--elaborator`**        **[odin (default), yosys]**       **Specify the tool that should perform the HDL elaboration**  				 	         
      **`--fflegalize`**                                          **Converts latches' sensitivity to the rising edge as required by VPR** 						 
      **`--show_yosys_log`**                                      **Showing the Yosys elaboration logs in the console window**           
+     **`--decode_names`**                                        **Enable extracting hierarchical information from Yosys coarse-grained BLIF file for signal naming \
+	 															   (the VTR flow scripts take advantage of this option by default)**
     =======================   ==============================    =================================================================================================
 
 
@@ -41,6 +43,15 @@ Additional Examples using Odin-II with the Yosys elaborator
 Passes a Verilog file to Yosys for performing elaboration. 
 The BLIF elaboration and partial mapping phases will be executed on the generated netlist.
 However, all latches in the Yosys+Odin-II output file will be rising edge.
+
+.. code-block:: bash
+
+    ./odin_II --elaborator yosys -V <Path/to/Verilog/file> --decode_names
+
+
+Performs the design elaboration by Yosys parsers and generates a coarse-grained netlist in BLIF.
+Odin-II then extracts the hierarchical information of subcircuits to use for signal naming when reading the coarse-grained BLIF file.
+The BLIF elaboration and partial mapping phases will be executed on the generated netlist.
 
 .. code-block:: bash
 

--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -20,7 +20,7 @@ if(${ODIN_USE_YOSYS} OR ${WITH_YOSYS})
     add_subdirectory(libyosys)
 
     # In addition to libyosys in the build folder, we copy the libyosys directory
-    # into a temporary folder in the VTR root, name Yosys, to have access to Yosys 
+    # into a temporary folder in the VTR root, named Yosys, to have access to Yosys 
     # execs for using in VTR scripts (similar to VPR/vpr or ODIN_II/odin_II)
     add_custom_target(vtr-yosys ALL 
                       DEPENDS yosys

--- a/vtr_flow/scripts/python_libs/vtr/odin/odin.py
+++ b/vtr_flow/scripts/python_libs/vtr/odin/odin.py
@@ -87,7 +87,7 @@ def init_config_file(
     config_file.write(odin_config_full_path)
 
 
-# pylint: disable=too-many-arguments, too-many-locals
+# pylint: disable=too-many-arguments, too-many-locals, too-many-branches
 def run(
     architecture_file,
     circuit_file,
@@ -190,6 +190,11 @@ def run(
     cmd = [odin_exec]
     use_odin_simulation = False
 
+    # handling the Odin-II decode_name flag for Yosys coarse-grained BLIFs
+    if not odin_args["encode_names"]:
+        odin_args["decode_names"] = True
+    del odin_args["encode_names"]
+
     if "use_odin_simulation" in odin_args:
         use_odin_simulation = True
         del odin_args["use_odin_simulation"]
@@ -245,4 +250,4 @@ def run(
         )
 
 
-# pylint: enable=too-many-arguments, too-many-locals
+# pylint: enable=too-many-arguments, too-many-locals, too-many-branches

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -360,6 +360,14 @@ def vtr_command_argparser(prog=None):
         help="Make flip-flops rising edge for coarse-grain input BLIFs in the techmap"
         + "(Odin-II synthesis flow generates rising edge FFs by default)",
     )
+    odin.add_argument(
+        "-encode_names",
+        default=False,
+        action="store_true",
+        dest="encode_names",
+        help="Enable Odin-II utilization of operation-type-encoded naming style for Yosys"
+        + " coarse-grained RTLIL nodes",
+    )
     #
     # YOSYS arguments
     #
@@ -673,6 +681,7 @@ def process_odin_args(args):
     odin_args["adder_type"] = args.adder_type
     odin_args["top_module"] = args.top_module
     odin_args["elaborator"] = args.elaborator
+    odin_args["encode_names"] = args.encode_names
 
     if args.adder_cin_global:
         odin_args["adder_cin_global"] = True

--- a/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include_odin/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include_odin/config/config.txt
@@ -2,13 +2,14 @@
 # Configuration file for running experiments                    #
 #                                                               #
 # This config file is testing the ability to specify include    #
-# files that should pass to the VTR frontend with the top       #
-# module of the benchmark (ch_intrinsic_top.v). This is done    #
-# by specifying two Verilog header files that provide essential # 
-# definitions, and memory_controller design that provides the   #
-# design of an internal component for ch_intrinsic_top. If the  #
-# include files are not properly included during compilation    #
-# the benchmark is incomplete and the flow will error out.      #
+# files that should be passed to the VTR Odin-II frontend with  #
+# the top module of the benchmark (ch_intrinsic_modified.v).    #
+# This is done by specifying two Verilog header files that      #
+# provide essential definitions, and memory_controller design   #
+# that provides the design of an internal component for         #
+# "ch_intrinsic_modified.v". If the include files are not       #
+# properly included during compilation the benchmark is         #
+# incomplete and the flow will error out.                       #
 #################################################################
 
 # Path to directory of circuits to use

--- a/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include_yosys/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include_yosys/config/config.txt
@@ -2,13 +2,14 @@
 # Configuration file for running experiments                    #
 #                                                               #
 # This config file is testing the ability to specify include    #
-# files that should pass to the VTR frontend with the top       #
-# module of the benchmark (ch_intrinsic_top.v). This is done    #
-# by specifying two Verilog header files that provide essential # 
-# definitions, and memory_controller design that provides the   #
-# design of an internal component for ch_intrinsic_top. If the  #
-# include files are not properly included during compilation    #
-# the benchmark is incomplete and the flow will error out.      #
+# files that should be passed to the VTR Yosys frontend with    #
+# the top module of the benchmark (ch_intrinsic_modified.v).    #
+# This is done by specifying two Verilog header files that      #
+# provide essential definitions, and memory_controller design   #
+# that provides the design of an internal component for         #
+# "ch_intrinsic_modified.v". If the include files are not       #
+# properly included during compilation the benchmark is         #
+# incomplete and the flow will error out.                       #
 #################################################################
 
 # Path to directory of circuits to use

--- a/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include_yosys_odin/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_basic/hdl_include_yosys_odin/config/config.txt
@@ -2,13 +2,14 @@
 # Configuration file for running experiments                    #
 #                                                               #
 # This config file is testing the ability to specify include    #
-# files that should pass to the VTR frontend with the top       #
-# module of the benchmark (ch_intrinsic_top.v). This is done    #
-# by specifying two Verilog header files that provide essential # 
-# definitions, and memory_controller design that provides the   #
-# design of an internal component for ch_intrinsic_top. If the  #
-# include files are not properly included during compilation    #
-# the benchmark is incomplete and the flow will error out.      #
+# files that should be passed to the VTR Yosys+Odin-II frontend #
+# with the top module of the benchmark (ch_intrinsic_modified). #
+# This is done by specifying two Verilog header files that      #
+# provide essential definitions, and memory_controller design   #
+# that provides the design of an internal component for         #
+# "ch_intrinsic_modified.v". If the include files are not       #
+# properly included during compilation the benchmark is         #
+# incomplete and the flow will error out.                       #
 #################################################################
 
 # Path to directory of circuits to use


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
As Yosys generates a coarse-grained BLIF file for Odin-II partial mapper, all BLIF components were interpreted as black boxes at the beginning of Odin-II partial mapping. Therefore, node names were generated based on the type of each subcircuit, which was a unique name and did not include hierarchical information about modules/submodules. This PR extracts the hierarchical information related to each node from the name of its output signals and then sets the node(and its nets) name(s) based on the operation type of each node and the hierarchical information.

P.S: the similar approach is taken in Odin-II, which makes the readability of netlists better and eases the tracking of the critical path in the final VTR timing analysis.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
