### PR TITLE
Odin detailed report num of nodes

### DIFF
--- a/ODIN_II/SRC/enum_str.cpp
+++ b/ODIN_II/SRC/enum_str.cpp
@@ -42,14 +42,14 @@ const char* LUTRAM_string = "lutram_ram";
 
 const char* operation_list_STR[][2] = {
     {"NO_OP", "nOP"},
+    {"CLOCK_NODE", "CLK"},
+    {"INPUT_NODE", "IN"},
+    {"OUTPUT_NODE", "OUT"},
     {"MULTI_PORT_MUX", "nMUX"}, // port 1 = control, port 2+ = mux options
     {"FF_NODE", "FF"},
     {"BUF_NODE", "BUF"},
-    {"INPUT_NODE", "IN"},
-    {"OUTPUT_NODE", "OUT"},
     {"GND_NODE", "GND"},
     {"VCC_NODE", "VCC"},
-    {"CLOCK_NODE", "CLK"},
     {"ADD", "ADD"},             // +
     {"MINUS", "MIN"},           // -
     {"BITWISE_NOT", "bNOT"},    // ~

--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -240,14 +240,14 @@ enum init_value_e {
  */
 enum operation_list {
     NO_OP,
+    CLOCK_NODE,
+    INPUT_NODE,
+    OUTPUT_NODE,
     MULTI_PORT_MUX, // port 1 = control, port 2+ = mux options
     FF_NODE,
     BUF_NODE,
-    INPUT_NODE,
-    OUTPUT_NODE,
     GND_NODE,
     VCC_NODE,
-    CLOCK_NODE,
     ADD,            // +
     MINUS,          // -
     BITWISE_NOT,    // ~

--- a/ODIN_II/SRC/netlist_statistic.cpp
+++ b/ODIN_II/SRC/netlist_statistic.cpp
@@ -478,51 +478,43 @@ void compute_statistics(netlist_t* netlist, bool display) {
         get_upward_stat(&netlist->output_node_stat, netlist->top_output_nodes, netlist->num_top_output_nodes, netlist, travelsal_id + 1);
 
         if (display) {
+            std::string hdr = "";
             printf("\n\t==== Stats ====\n");
-            for (long long op = 0; op < operation_list_END; op += 1) {
+            for (auto op = 0; op < operation_list_END; op += 1) {
                 switch (op) {
                     // For top IO nodes generate detailed info since the design might have unconnected input nodes
-                    case CLOCK_NODE: {
-                        std::string hdr = std::string("Number of <")
-                                          + operation_list_STR[op][ODIN_LONG_STRING]
-                                          + "> node(s): ";
-                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
-                        break;
-                    }
                     case INPUT_NODE: {
-                        std::string hdr = std::string("Number of used <")
-                                          + operation_list_STR[op][ODIN_LONG_STRING]
-                                          + "> node(s): ";
-                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
-                        hdr = std::string("Number of unused <")
-                              + operation_list_STR[op][ODIN_LONG_STRING]
-                              + "> node(s): ";
-                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_top_input_nodes - netlist->num_of_type[op] - netlist->num_of_type[CLOCK_NODE]);
-                        break;
+                        auto unused_pi = netlist->num_top_input_nodes - netlist->num_of_type[op] - netlist->num_of_type[CLOCK_NODE];
+                        if (unused_pi > 0) {
+                            hdr = std::string("Number of unused <")
+                                  + operation_list_STR[op][ODIN_LONG_STRING]
+                                  + "> node: ";
+                            printf("%-42s%lld\n", hdr.c_str(), unused_pi);
+                        }
+                        [[fallthrough]];
                     }
                     case OUTPUT_NODE: {
-                        std::string hdr = std::string("Number of used <")
-                                          + operation_list_STR[op][ODIN_LONG_STRING]
-                                          + "> node(s): ";
-                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
-                        hdr = std::string("Number of unused <")
-                              + operation_list_STR[op][ODIN_LONG_STRING]
-                              + "> node(s): ";
-                        printf("%-42s%lld\n\n", hdr.c_str(), netlist->num_top_output_nodes - netlist->num_of_type[op]);
-                        break;
+                        auto unused_po = netlist->num_top_output_nodes - netlist->num_of_type[op];
+                        if (unused_po > 0) {
+                            hdr = std::string("Number of unused <")
+                                  + operation_list_STR[op][ODIN_LONG_STRING]
+                                  + "> node: ";
+                            printf("%-42s%lld\n", hdr.c_str(), unused_po);
+                        }
+                        [[fallthrough]];
                     }
                     default: {
                         if (netlist->num_of_type[op] > UNUSED_NODE_TYPE) {
-                            std::string hdr = std::string("Number of <")
-                                              + operation_list_STR[op][ODIN_LONG_STRING]
-                                              + "> node(s): ";
+                            hdr = std::string("Number of <")
+                                  + operation_list_STR[op][ODIN_LONG_STRING]
+                                  + "> node: ";
                             printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
                         }
                     }
                 }
             }
-            printf("%-42s%lld\n", "Total estimated number of lut(s): ", netlist->num_logic_element);
-            printf("%-42s%lld\n", "Total number of node(s): ", netlist->num_of_node);
+            printf("%-42s%lld\n", "Total estimated number of lut: ", netlist->num_logic_element);
+            printf("%-42s%lld\n", "Total number of node: ", netlist->num_of_node);
             printf("%-42s%0.0f\n", "Longest path: ", netlist->output_node_stat.max_depth);
             printf("%-42s%0.0f\n", "Average path: ", netlist->output_node_stat.avg_depth);
             printf("\n");

--- a/ODIN_II/SRC/netlist_statistic.cpp
+++ b/ODIN_II/SRC/netlist_statistic.cpp
@@ -480,16 +480,49 @@ void compute_statistics(netlist_t* netlist, bool display) {
         if (display) {
             printf("\n\t==== Stats ====\n");
             for (long long op = 0; op < operation_list_END; op += 1) {
-                if (netlist->num_of_type[op] > UNUSED_NODE_TYPE) {
-                    std::string hdr = std::string("Number of <")
-                                      + operation_list_STR[op][ODIN_LONG_STRING]
-                                      + "> node: ";
-
-                    printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
+                switch (op) {
+                    // For top IO nodes generate detailed info since the design might have unconnected input nodes
+                    case CLOCK_NODE: {
+                        std::string hdr = std::string("Number of <")
+                                          + operation_list_STR[op][ODIN_LONG_STRING]
+                                          + "> node(s): ";
+                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
+                        break;
+                    }
+                    case INPUT_NODE: {
+                        std::string hdr = std::string("Number of used <")
+                                          + operation_list_STR[op][ODIN_LONG_STRING]
+                                          + "> node(s): ";
+                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
+                        hdr = std::string("Number of unused <")
+                              + operation_list_STR[op][ODIN_LONG_STRING]
+                              + "> node(s): ";
+                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_top_input_nodes - netlist->num_of_type[op] - netlist->num_of_type[CLOCK_NODE]);
+                        break;
+                    }
+                    case OUTPUT_NODE: {
+                        std::string hdr = std::string("Number of used <")
+                                          + operation_list_STR[op][ODIN_LONG_STRING]
+                                          + "> node(s): ";
+                        printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
+                        hdr = std::string("Number of unused <")
+                              + operation_list_STR[op][ODIN_LONG_STRING]
+                              + "> node(s): ";
+                        printf("%-42s%lld\n\n", hdr.c_str(), netlist->num_top_output_nodes - netlist->num_of_type[op]);
+                        break;
+                    }
+                    default: {
+                        if (netlist->num_of_type[op] > UNUSED_NODE_TYPE) {
+                            std::string hdr = std::string("Number of <")
+                                              + operation_list_STR[op][ODIN_LONG_STRING]
+                                              + "> node(s): ";
+                            printf("%-42s%lld\n", hdr.c_str(), netlist->num_of_type[op]);
+                        }
+                    }
                 }
             }
-            printf("%-42s%lld\n", "Total estimated number of lut: ", netlist->num_logic_element);
-            printf("%-42s%lld\n", "Total number of node: ", netlist->num_of_node);
+            printf("%-42s%lld\n", "Total estimated number of lut(s): ", netlist->num_logic_element);
+            printf("%-42s%lld\n", "Total number of node(s): ", netlist->num_of_node);
             printf("%-42s%0.0f\n", "Longest path: ", netlist->output_node_stat.max_depth);
             printf("%-42s%0.0f\n", "Average path: ", netlist->output_node_stat.avg_depth);
             printf("\n");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR is enhances printing the synthesis statistics at the end of Odin.
#### Description
<!--- Describe your changes in detail -->
Added a case for printing used and unused top IO nodes separately in netlist_statistic.cpp.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2090
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the printed statistics at the end of synthesis stage only shows number of used top IO nodes. It's more convenient to print number of used and unused nodes since we don't delete unconnected IO nodes in Odin.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
