### PR TITLE
Revert "vpr: base: netlist writer: escape '[' and ']' for black boxes…

### DIFF
--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -696,12 +696,12 @@ class BlackBoxInst : public Instance {
                     os << indent(depth + 3) << "(IOPATH ";
                     os << escape_sdf_identifier(arc.source_name());
                     if (find_port_size(arc.source_name()) > 1) {
-                        os << "\\[" << arc.source_ipin() << "\\]";
+                        os << "[" << arc.source_ipin() << "]";
                     }
                     os << " ";
                     os << escape_sdf_identifier(arc.sink_name());
                     if (find_port_size(arc.sink_name()) > 1) {
-                        os << "\\[" << arc.sink_ipin() << "\\]";
+                        os << "[" << arc.sink_ipin() << "]";
                     }
                     os << " ";
                     os << delay_triple.str();


### PR DESCRIPTION
… in SDF"

This reverts commit 8135ebb4d5250ed26997b0aafdb2f1a2e198cdf5.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
In https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1957 we introduced https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1957/commits/8135ebb4d5250ed26997b0aafdb2f1a2e198cdf5 which unnecessary escapes '[' and ']' chars in SDF writer for `BlackBoxInst`. This causes conflicts in simulations because of inconsistency between generated SDF file and module instances in generated post-implementation netlist. I would like to fix that by reverting the commit in question.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
