### PR TITLE
New Keybind unselects highlighted blocks w. 'esc' key

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -719,9 +719,20 @@ bool draw_if_net_highlighted(ClusterNetId inet) {
 void act_on_key_press(ezgl::application* /*app*/, GdkEventKey* /*event*/, char* key_name) {
     //VTR_LOG("Key press %c (%d)\n", key_pressed, keysym);
     std::string key(key_name);
+    if (key == "Escape") {
+        get_selected_sub_block_info().clear();
+        deselect_all();
+        app->refresh_drawing();
+    }
 }
 #    else
-void act_on_key_press(ezgl::application* /*app*/, GdkEventKey* /*event*/, char* /*key_name*/) {
+void act_on_key_press(ezgl::application* app, GdkEventKey* /*event*/, char* key_name) {
+    std::string key(key_name);
+    if (key == "Escape") {
+        get_selected_sub_block_info().clear();
+        deselect_all();
+        app->refresh_drawing();
+    }
 }
 #    endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Simple ease of use change to unselect all highlighted options when user hits escape. Keybind is always active, escape currently did nothing so no real impact there. 



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The only way to unselect a highlighted block was clicking on empty space. This made it very annoying to deal with when you are very zoomed in on internals and wanted to unselect. This new option allows you to unselect without any movement or screen change required.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

