### PR TITLE
Changed sep to be '\t  ' in QoR comparison script

### DIFF
--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -142,10 +142,10 @@ def main():
 
         base, ext = os.path.splitext(csv)
         if ext == ".txt":
-            sep = "\t"
+            sep = "\t  "
         else:
             sep = ","
-        df = pd.read_csv(csv, sep=sep)
+        df = pd.read_csv(csv, sep=sep, engine='python')
 
         avail_metrics.update(df.columns)  # Record available metrics
 

--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -145,7 +145,7 @@ def main():
             sep = "\t  "
         else:
             sep = ","
-        df = pd.read_csv(csv, sep=sep, engine='python')
+        df = pd.read_csv(csv, sep=sep, engine="python")
 
         avail_metrics.update(df.columns)  # Record available metrics
 


### PR DESCRIPTION
Fix to Issue #2107. Changed the seperator between QoR metrics in parse_results.txt files to be '\t  ' instead of '\t' so users don't have to change the parse_results.txt files in order to run the comparison script, QoR_compare.py. 
