### PR TITLE
Dense initial placement

### DIFF
--- a/vpr/src/pack/re_cluster_util.cpp
+++ b/vpr/src/pack/re_cluster_util.cpp
@@ -82,7 +82,7 @@ void commit_mol_move(const ClusterBlockId& old_clb,
         g_vpr_ctx.mutable_placement().block_locs.resize(g_vpr_ctx.placement().block_locs.size() + 1);
         get_imacro_from_iblk(&imacro, old_clb, g_vpr_ctx.placement().pl_macros);
         set_imacro_for_iblk(&imacro, new_clb);
-        place_one_block(new_clb, device_ctx.pad_loc_type);
+        place_one_block(new_clb, device_ctx.pad_loc_type, NULL);
     }
 }
 

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -16,65 +16,69 @@
 #include <chrono>
 #include <time.h>
 
-//Used to assign each block a score for how difficult it is to place
+/**
+ * @brief Used to assign each block a score for how difficult it is to place. 
+ * The higher numbers indicate a block is expected to be more difficult to place.
+ * Hence, initial placement tries to place blocks with higher scores earlier.
+ */
 struct t_block_score {
-    int macro_size = 0; //how many members does the macro have, if the block is part of one - this value is zero if the block is not in a macro
+    int macro_size = 0; //How many members does the macro have, if the block is part of one - this value is zero if the block is not in a macro
 
-    /*
-     * The number of tiles NOT covered by the block's floorplan constraints. The higher this number, the more
-     * difficult the block is to place.
-     */
+    //The number of tiles NOT covered by the block's floorplan constraints.
     int tiles_outside_of_floorplan_constraints = 0;
 
-    /*
-     * If random initial placement failed to place all blocks, next iteration will increase unplaced blocks' 
-     * scores to place them earlier. 
-     */
+    //The number of initial placement iterations that the block was unplaced.
     int failed_to_place_in_prev_attempts;
 };
 
-/**
- * @brief keeps track of available empty locations of a specific block type during initial placement.
- * Used to densly place macros that failed to be placed in the first initial placement iteration (random placement)
- */
-struct t_grid_empty_locs_block_type {
-    t_pl_loc first_avail_loc; //first available location of a block type
-
-    int num_of_empty_locs_in_y_axis; //number of consecutive locations from first_avail_loc that can accomadate blocks with same block types
-};
-
-/// @brief sentinel value for indicating that a block does not have a valid x location, used to check whether a block has been placed
+/// @brief Sentinel value for indicating that a block does not have a valid x location, used to check whether a block has been placed
 constexpr int INVALID_X = -1;
 
 // Number of iterations that initial placement tries to place all blocks before throwing an error
 #define MAX_INIT_PLACE_ATTEMPTS 2
 
 // The amount of weight that will added to previous unplaced block scores to ensure that failed blocks would be placed earlier next iteration
-#define SORT_WEIGHT_PER_FAILED_BLOCKS 10
+#define SORT_WEIGHT_PER_FAILED_BLOCK 10
 
 /* The maximum number of tries when trying to place a macro at a    *
  * random location before trying exhaustive placement - find the first     *
  * legal position and place it during initial placement.                  */
 #define MAX_NUM_TRIES_TO_PLACE_MACROS_RANDOMLY 8
 
-// Keeps the first locations and number of remained blocks in each column for a specific block type.
-static std::vector<std::vector<t_grid_empty_locs_block_type>> blk_types_empty_locs_in_grid;
+/// @brief
 
-// initialize the grid before each placement iteration
-static void init_grid();
+/**
+ * @brief Set choosen grid locations to EMPTY block id before each placement iteration
+ *   
+ *   @param unplaced_blk_types_index Block types that their grid locations must be cleared.
+ * 
+ */
+static void clear_block_type_grid_locs(std::unordered_set<int> unplaced_blk_types_index);
 
-/*
- * Places the macro if the head position passed in is legal, and all the resulting
+/**
+ * @brief Places the macro if the head position passed in is legal, and all the resulting
  * member positions are legal
- * Returns true if macro was placed, false if not.
+ *   
+ *   @param pl_macro The macro to be placed.
+ *   @param head_pos The location of the macro head member.
+ * 
+ * @return true if macro was placed, false if not.
  */
 static bool try_place_macro(t_pl_macro pl_macro, t_pl_loc head_pos);
 
-/*
- * Control routine for placing a macro - first calls random placement for the max number of tries,
- * the calls the exhaustive placement routine. Errors out if the macro cannot be placed.
+/**
+ * @brief Control routine for placing a macro.
+ * First iterations calls random placement for the max number of tries,then calls the exhaustive placement routine.
+ * If first iteration failed, next iteration calls dense placement for specific block types.
+ *  
+ *   @param macros_max_num_tries Max number of tries for initial placement before switching to exhaustive placement. 
+ *   @param pl_macro The macro to be placed.
+ *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
+ *   @param blk_types_empty_locs_in_grid first location (lowest y) and number of remaining blocks in each column for the blk_id type
+ * 
+ * @return true if macro was placed, false if not.
  */
-static bool place_macro(int macros_max_num_tries, t_pl_macro pl_macro, enum e_pad_loc_type pad_loc_type);
+static bool place_macro(int macros_max_num_tries, t_pl_macro pl_macro, enum e_pad_loc_type pad_loc_type, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid);
 
 /*
  * Assign scores to each block based on macro size and floorplanning constraints.
@@ -87,46 +91,58 @@ static vtr::vector<ClusterBlockId, t_block_score> assign_block_scores();
 static std::vector<ClusterBlockId> sort_blocks(const vtr::vector<ClusterBlockId, t_block_score>& block_scores);
 
 /**
- * @brief  try to find y axis for macro head location based on macro direction
+ * @brief Tries to find y coordinate for macro head location based on macro direction
  *   
  *
  *   @param first_macro_loc The first available location that can place the macro blocks.
  *   @param pl_macro The macro to be placed.
  *
- *   Returns y axis of the location that macro head should be placed
+ * @return y coordinate of the location that macro head should be placed
  */
 static int get_y_loc_based_on_macro_direction(t_grid_empty_locs_block_type first_macro_loc, t_pl_macro pl_macro);
 
 /**
- * @brief  try to get the first available location of a specific block type that can accomodate macro blocks
+ * @brief Tries to get the first available location of a specific block type that can accomodate macro blocks
  *
  *   @param loc The first available location that can place the macro blocks.
+ *   @param pl_macro The macro to be placed.
+ *   @param blk_types_empty_locs_in_grid first location (lowest y) and number of remaining blocks in each column for the blk_id type 
+ *
+ * @return index to a column of blk_types_empty_locs_in_grid that can accomodate pl_macro and location of first available location returned by reference
+ */
+static int get_blk_type_first_loc(t_pl_loc& loc, t_pl_macro pl_macro, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid);
+
+/**
+ * @brief Updates the first available location (lowest y) and number of remaining blocks in the column that dense placement used to place the macro.
+ *
+ *   @param blk_type_column_index Index to a column in blk_types_empty_locs_in_grid that placed pl_macro in itself.
  *   @param block_type Logical block type of the macro blocks.
  *   @param pl_macro The macro to be placed.
- *
+ *   @param blk_types_empty_locs_in_grid first location (lowest y) and number of remaining blocks in each column for the blk_id type 
+ * 
  */
-static void get_blk_type_first_loc(t_pl_loc& loc, t_logical_block_type_ptr block_type, t_pl_macro pl_macro);
+static void update_blk_type_first_loc(int blk_type_column_index, t_logical_block_type_ptr block_type, t_pl_macro pl_macro, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid);
 
 /**
- * @brief  initialize empty locations of the grid with a specific block type into vector for dense initial placement 
+ * @brief  Initializes empty locations of the grid with a specific block type into vector for dense initial placement 
  *
  *   @param block_type_index block type index that failed in previous initial placement iterations
- *   @param block_type_empty_locs Vector that holds block type empty locations  
  *   
+ * @return first location (lowest y) and number of remaining blocks in each column for the block_type_index
  */
-static void init_blk_types_empty_locations(int block_type_index, std::vector<t_grid_empty_locs_block_type>& block_type_empty_locs);
+static std::vector<t_grid_empty_locs_block_type> init_blk_types_empty_locations(int block_type_index);
 
 /**
- * @brief  mark the macro members' locations fixed if necessary
+ * @brief  Helper function used when IO locations are to be randomly locked
  *
- *   @param pl_macro The macro to be fixed
- *   @param loc The location to check type
+ *   @param pl_macro The macro to be fixed.
+ *   @param loc The location at which the head of the macro is placed.
  *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
  */
 static inline void fix_IO_block_types(t_pl_macro pl_macro, t_pl_loc loc, enum e_pad_loc_type pad_loc_type);
 
 /**
- * @brief  try to place a macro at a random location
+ * @brief  tries to place a macro at a random location
  *
  *   @param pl_macro The macro to be placed.
  *   @param pr The PartitionRegion of the macro - represents its floorplanning constraints, is the size of the whole chip if the macro is not
@@ -134,12 +150,12 @@ static inline void fix_IO_block_types(t_pl_macro pl_macro, t_pl_loc loc, enum e_
  *   @param block_type Logical block type of the macro blocks.
  *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
  *
- *   Returns true if the macro gets placed, false if not.
+ * @return true if the macro gets placed, false if not.
  */
 static bool try_random_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logical_block_type_ptr block_type, enum e_pad_loc_type pad_loc_type);
 
 /**
- * @brief  Look for a valid placement location for macro exhaustively once the maximum number of random locations have been tried.
+ * @brief Looks for a valid placement location for macro exhaustively once the maximum number of random locations have been tried.
  *
  *   @param pl_macro The macro to be placed.
  *   @param pr The PartitionRegion of the macro - represents its floorplanning constraints, is the size of the whole chip if the macro is not
@@ -147,65 +163,66 @@ static bool try_random_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_log
  *   @param block_type Logical block type of the macro blocks.
  *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
  *
- *   Returns true if the macro gets placed, false if not.
+ * @return true if the macro gets placed, false if not.
  */
 static bool try_exhaustive_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logical_block_type_ptr block_type, enum e_pad_loc_type pad_loc_type);
 
 /**
- * @brief  Look for a valid placement location for macro in second iteration, tries to place as many macros as possible in one column 
- * and avoids to create any fragment location in one column. 
+ * @brief Looks for a valid placement location for macro in second iteration, tries to place as many macros as possible in one column 
+ * and avoids fragmenting the available locations in one column. 
  *   
  *   @param pl_macro The macro to be placed.
  *   @param pr The PartitionRegion of the macro - represents its floorplanning constraints, is the size of the whole chip if the macro is not
  *   constrained.
  *   @param block_type Logical block type of the macro blocks.
  *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
+ *   @param blk_types_empty_locs_in_grid first location (lowest y) and number of remaining blocks in each column for the blk_id type
  *
- *   Returns true if the macro gets placed, false if not.
+ * @return true if the macro gets placed, false if not.
  */
-static bool try_dense_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logical_block_type_ptr block_type, enum e_pad_loc_type pad_loc_type);
-
-void print_sorted_blocks(const std::vector<ClusterBlockId>& sorted_blocks, const vtr::vector<ClusterBlockId, t_block_score>& block_scores);
-
-static int place_all_blocks(enum e_pad_loc_type pad_loc_type);
+static bool try_dense_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logical_block_type_ptr block_type, enum e_pad_loc_type pad_loc_type, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid);
 
 /**
- * @brief If any blocks are unplaced after each initial placement iteration, this routine
- * prints an log message showing the names, types, and IDs of the unplaced blocks.
- *  
- *  @param init_placement_iter initial placement iteration that finished.
- *  @param unplaced_blocks Number of failed blocks after init_placement_iter.
+ * @brief Print all blocks based on how hard they are to place; Blocks with higher scores will be printed first. 
+ *   
+ *   @param sorted_blocks List of all blocks in desecending order of their scores.
+ *   @param block_scores scores assigned to each blocks based on how difficult they are to place.
  */
-static void print_unplaced_blocks(int init_placement_iter, int unplaced_blocks);
+void print_sorted_blocks(const std::vector<ClusterBlockId>& sorted_blocks, const vtr::vector<ClusterBlockId, t_block_score>& block_scores);
+
+/**
+ * @brief Tries for MAX_INIT_PLACE_ATTEMPTS times to place all blocks considering their floorplanning constraints and the device size
+ *   
+ *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
+ *   @param constraints_file Used to read block locations if any constraints is available.
+ */
+static void place_all_blocks(enum e_pad_loc_type pad_loc_type, const char* constraints_file);
 
 /**
  * @brief If any blocks remain unplaced after all initial placement iterations, this routine
- * throw an error indicating that initial placement can not be done with the current device size or
+ * throws an error indicating that initial placement can not be done with the current device size or
  * floorplanning constraints. 
- *  
- *  @param unplaced_blocks Number of failed blocks after all placement iterations.
  */
-static void check_initial_placement_legality(int unplaced_blocks);
+static void check_initial_placement_legality();
 
-static void check_initial_placement_legality(int unplaced_blocks) {
-    if (unplaced_blocks > 0) {
-        VPR_FATAL_ERROR(VPR_ERROR_PLACE,
-                        "%d blocks could not be placed during initial placement, no spaces were available for them on the grid.\n"
-                        "If VPR was run with floorplan constraints, the constraints may be too tight.\n",
-                        unplaced_blocks);
-    }
-}
-
-static void print_unplaced_blocks(int init_placement_iter, int unplaced_blocks) {
+static void check_initial_placement_legality() {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& place_ctx = g_vpr_ctx.placement();
 
-    VTR_LOG("Initial placement iteration %d has finished with %d unplaced blocks\n", init_placement_iter, unplaced_blocks);
+    int unplaced_blocks = 0;
 
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
         if (place_ctx.block_locs[blk_id].loc.x == INVALID_X) {
-            VTR_LOG("Block %s (# %d) of type %s could not be placed during initial placement iteration %d\n", cluster_ctx.clb_nlist.block_name(blk_id).c_str(), blk_id, cluster_ctx.clb_nlist.block_type(blk_id)->name, init_placement_iter);
+            VTR_LOG("Block %s (# %d) of type %s could not be placed during initial placement iteration %d\n", cluster_ctx.clb_nlist.block_name(blk_id).c_str(), blk_id, cluster_ctx.clb_nlist.block_type(blk_id)->name, MAX_INIT_PLACE_ATTEMPTS - 1);
+            unplaced_blocks++;
         }
+    }
+
+    if (unplaced_blocks > 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_PLACE,
+                        "%d blocks could not be placed during initial placement; no spaces were available for them on the grid.\n"
+                        "If VPR was run with floorplan constraints, the constraints may be too tight.\n",
+                        unplaced_blocks);
     }
 }
 
@@ -232,12 +249,23 @@ static int get_y_loc_based_on_macro_direction(t_grid_empty_locs_block_type first
     return y;
 }
 
-static void get_blk_type_first_loc(t_pl_loc& loc, t_logical_block_type_ptr block_type, t_pl_macro pl_macro) {
+static void update_blk_type_first_loc(int blk_type_column_index, t_logical_block_type_ptr block_type, t_pl_macro pl_macro, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid) {
+    //check if dense placement could place macro successfully
+    if (blk_type_column_index == -1 || blk_types_empty_locs_in_grid->size() <= abs(blk_type_column_index)) {
+        return;
+    }
+
     const auto& device_ctx = g_vpr_ctx.device();
 
+    //update the first available macro location in a specific column for the next macro
+    blk_types_empty_locs_in_grid->at(blk_type_column_index).first_avail_loc.y += device_ctx.physical_tile_types.at(block_type->index).height * pl_macro.members.size();
+    blk_types_empty_locs_in_grid->at(blk_type_column_index).num_of_empty_locs_in_y_axis -= pl_macro.members.size();
+}
+
+static int get_blk_type_first_loc(t_pl_loc& loc, t_pl_macro pl_macro, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid) {
     //loop over all empty locations and choose first column that can accomodate macro blocks
-    for (unsigned int empty_loc_index = 0; empty_loc_index < blk_types_empty_locs_in_grid[block_type->index].size(); empty_loc_index++) {
-        auto first_empty_loc = blk_types_empty_locs_in_grid[block_type->index].at(empty_loc_index);
+    for (unsigned int empty_loc_index = 0; empty_loc_index < blk_types_empty_locs_in_grid->size(); empty_loc_index++) {
+        auto first_empty_loc = blk_types_empty_locs_in_grid->at(empty_loc_index);
 
         //if macro size is larger than available locations in the specific column, should go to next available column
         if ((unsigned)first_empty_loc.num_of_empty_locs_in_y_axis < pl_macro.members.size()) {
@@ -249,18 +277,18 @@ static void get_blk_type_first_loc(t_pl_loc& loc, t_logical_block_type_ptr block
         loc.y = get_y_loc_based_on_macro_direction(first_empty_loc, pl_macro);
         loc.sub_tile = first_empty_loc.first_avail_loc.sub_tile;
 
-        //update the first available macro location in vector for the next macro
-        first_empty_loc.first_avail_loc.y += device_ctx.physical_tile_types.at(block_type->index).height * pl_macro.members.size();
-        first_empty_loc.num_of_empty_locs_in_y_axis -= pl_macro.members.size();
-        blk_types_empty_locs_in_grid[block_type->index][empty_loc_index] = first_empty_loc;
-
-        break;
+        return empty_loc_index;
     }
+
+    return -1;
 }
 
-static void init_blk_types_empty_locations(int block_type_index, std::vector<t_grid_empty_locs_block_type>& block_type_empty_locs) {
+static std::vector<t_grid_empty_locs_block_type> init_blk_types_empty_locations(int block_type_index) {
     const auto& compressed_block_grid = g_vpr_ctx.placement().compressed_block_grids[block_type_index];
     const auto& device_ctx = g_vpr_ctx.device();
+
+    //create a vector to store all columns containing block_type_index with their lowest y and number of remaining blocks
+    std::vector<t_grid_empty_locs_block_type> block_type_empty_locs;
 
     //create a region the size of grid to find out first location with a specific block type
     Region reg;
@@ -279,6 +307,8 @@ static void init_blk_types_empty_locations(int block_type_index, std::vector<t_g
         empty_loc.num_of_empty_locs_in_y_axis = compressed_block_grid.grid[x_loc].size();
         block_type_empty_locs.push_back(empty_loc);
     }
+
+    return block_type_empty_locs;
 }
 
 static inline void fix_IO_block_types(t_pl_macro pl_macro, t_pl_loc loc, enum e_pad_loc_type pad_loc_type) {
@@ -426,15 +456,13 @@ static bool try_exhaustive_placement(t_pl_macro pl_macro, PartitionRegion& pr, t
     return placed;
 }
 
-static bool try_dense_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logical_block_type_ptr block_type, enum e_pad_loc_type pad_loc_type) {
+static bool try_dense_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logical_block_type_ptr block_type, enum e_pad_loc_type pad_loc_type, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid) {
     t_pl_loc loc;
-    get_blk_type_first_loc(loc, block_type, pl_macro);
-
-    bool legal = false;
+    int column_index = get_blk_type_first_loc(loc, pl_macro, blk_types_empty_locs_in_grid);
 
     //check if first available location is within the chip and macro's partition region, otherwise placement is not legal
     if (!is_loc_on_chip(loc.x, loc.y) || !pr.is_loc_in_part_reg(loc)) {
-        return legal;
+        return false;
     }
 
     auto& device_ctx = g_vpr_ctx.device();
@@ -442,12 +470,16 @@ static bool try_dense_placement(t_pl_macro pl_macro, PartitionRegion& pr, t_logi
     VTR_ASSERT(device_ctx.grid[loc.x][loc.y].width_offset == 0);
     VTR_ASSERT(device_ctx.grid[loc.x][loc.y].height_offset == 0);
 
+    bool legal = false;
     legal = try_place_macro(pl_macro, loc);
 
     if (legal) {
         fix_IO_block_types(pl_macro, loc, pad_loc_type);
     }
 
+    //Dense placement found a legal position for pl_macro;
+    //We need to update first available location (lowest y) and number of remaining blocks for the next macro.
+    update_blk_type_first_loc(column_index, block_type, pl_macro, blk_types_empty_locs_in_grid);
     return legal;
 }
 
@@ -479,81 +511,56 @@ static bool try_place_macro(t_pl_macro pl_macro, t_pl_loc head_pos) {
     return (macro_placed);
 }
 
-static bool place_macro(int macros_max_num_tries, t_pl_macro pl_macro, enum e_pad_loc_type pad_loc_type) {
-    bool macro_placed;
-    int itry;
+static bool place_macro(int macros_max_num_tries, t_pl_macro pl_macro, enum e_pad_loc_type pad_loc_type, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid) {
     ClusterBlockId blk_id;
+    blk_id = pl_macro.members[0].blk_index;
 
+    if (is_block_placed(blk_id)) {
+        return true;
+    }
+
+    bool macro_placed = false;
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
     auto& device_ctx = g_vpr_ctx.device();
 
-    macro_placed = false;
+    // Assume that all the blocks in the macro are of the same type
+    auto block_type = cluster_ctx.clb_nlist.block_type(blk_id);
 
-    while (!macro_placed) {
-        blk_id = pl_macro.members[0].blk_index;
+    PartitionRegion pr;
 
-        if (is_block_placed(blk_id)) {
-            macro_placed = true;
-            continue;
-        }
-
-        // Assume that all the blocks in the macro are of the same type
-        auto block_type = cluster_ctx.clb_nlist.block_type(blk_id);
-
-        PartitionRegion pr;
-
-        //Enough to check head member of macro to see if its constrained because
-        //constraints propagation was done earlier in initial placement.
-        if (is_cluster_constrained(blk_id)) {
-            pr = floorplanning_ctx.cluster_constraints[blk_id];
-        } else { //If the block is not constrained, assign a region the size of the grid to its PartitionRegion
-            Region reg;
-            reg.set_region_rect(0, 0, device_ctx.grid.width() - 1, device_ctx.grid.height() - 1);
-            reg.set_sub_tile(NO_SUBTILE);
-            pr.add_to_part_region(reg);
-        }
-
-        //if the block type has failed in previous iteration, we need to start place densly to be able to find a legal initial placement solution
-        if (blk_types_empty_locs_in_grid[block_type->index].size() != 0) {
-            macro_placed = try_dense_placement(pl_macro, pr, block_type, pad_loc_type);
-        }
-
-        if (!macro_placed) {
-            // Try to place the macro randomly for the max number of random tries
-            for (itry = 0; itry < macros_max_num_tries && macro_placed == false; itry++) {
-                macro_placed = try_random_placement(pl_macro, pr, block_type, pad_loc_type);
-
-                // Try to place the macro
-                if (macro_placed) {
-                    break;
-                }
-
-            } // Finished all tries
-        }
-        if (!macro_placed) {
-            // if a macro still could not be placed after macros_max_num_tries times,
-            // go through the chip exhaustively to find a legal placement for the macro
-            // place the macro on the first location that is legal
-            // then set macro_placed = true;
-            // if there are no legal positions, error out
-
-            // Exhaustive placement of carry macros
-            macro_placed = try_exhaustive_placement(pl_macro, pr, block_type, pad_loc_type);
-
-            // If macro could not be placed after exhaustive placement, error out
-        }
-
-        if (!macro_placed) {
-            std::vector<std::string> tried_types;
-            for (auto tile_type : block_type->equivalent_tiles) {
-                tried_types.push_back(tile_type->name);
-            }
-            std::string tried_types_str = "{" + vtr::join(tried_types, ", ") + "}";
-            break;
-        }
+    //Enough to check head member of macro to see if its constrained because
+    //constraints propagation was done earlier in initial placement.
+    if (is_cluster_constrained(blk_id)) {
+        pr = floorplanning_ctx.cluster_constraints[blk_id];
+    } else { //If the block is not constrained, assign a region the size of the grid to its PartitionRegion
+        Region reg;
+        reg.set_region_rect(0, 0, device_ctx.grid.width() - 1, device_ctx.grid.height() - 1);
+        reg.set_sub_tile(NO_SUBTILE);
+        pr.add_to_part_region(reg);
     }
 
+    //If blk_types_empty_locs_in_grid is not NULL, means that initial placement has been failed in first iteration for this block type
+    //We need to place densely in second iteration to be able to find a legal initial placement solution
+    if (blk_types_empty_locs_in_grid != NULL && blk_types_empty_locs_in_grid->size() != 0) {
+        macro_placed = try_dense_placement(pl_macro, pr, block_type, pad_loc_type, blk_types_empty_locs_in_grid);
+    }
+
+    // If macro is not placed yet, try to place the macro randomly for the max number of random tries
+    for (int itry = 0; itry < macros_max_num_tries && macro_placed == false; itry++) {
+        macro_placed = try_random_placement(pl_macro, pr, block_type, pad_loc_type);
+    } // Finished all tries
+
+    if (!macro_placed) {
+        // if a macro still could not be placed after macros_max_num_tries times,
+        // go through the chip exhaustively to find a legal placement for the macro
+        // place the macro on the first location that is legal
+        // then set macro_placed = true;
+        // if there are no legal positions, error out
+
+        // Exhaustive placement of carry macros
+        macro_placed = try_exhaustive_placement(pl_macro, pr, block_type, pad_loc_type);
+    }
     return macro_placed;
 }
 
@@ -616,8 +623,8 @@ static std::vector<ClusterBlockId> sort_blocks(const vtr::vector<ClusterBlockId,
      * a more accurate picture of how difficult a block is to place.
      */
     auto criteria = [block_scores](ClusterBlockId lhs, ClusterBlockId rhs) {
-        int lhs_score = 10 * block_scores[lhs].macro_size + block_scores[lhs].tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCKS * block_scores[lhs].failed_to_place_in_prev_attempts;
-        int rhs_score = 10 * block_scores[rhs].macro_size + block_scores[rhs].tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCKS * block_scores[rhs].failed_to_place_in_prev_attempts;
+        int lhs_score = 10 * block_scores[lhs].macro_size + block_scores[lhs].tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCK * block_scores[lhs].failed_to_place_in_prev_attempts;
+        int rhs_score = 10 * block_scores[rhs].macro_size + block_scores[rhs].tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCK * block_scores[rhs].failed_to_place_in_prev_attempts;
 
         return lhs_score > rhs_score;
     };
@@ -635,7 +642,7 @@ void print_sorted_blocks(const std::vector<ClusterBlockId>& sorted_blocks, const
     }
 }
 
-static int place_all_blocks(enum e_pad_loc_type pad_loc_type) {
+static void place_all_blocks(enum e_pad_loc_type pad_loc_type, const char* constraints_file) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& place_ctx = g_vpr_ctx.placement();
     auto& device_ctx = g_vpr_ctx.device();
@@ -644,9 +651,19 @@ static int place_all_blocks(enum e_pad_loc_type pad_loc_type) {
     //keep tracks of which block types can not be placed in each iteration
     std::unordered_set<int> unplaced_blk_type_in_curr_itr;
 
+    // Keeps the first locations and number of remained blocks in each column for a specific block type.
+    //[0..device_ctx.logical_block_types.size()-1][0..num_of_grid_columns_containing_this_block_type-1]
+    std::vector<std::vector<t_grid_empty_locs_block_type>> blk_types_empty_locs_in_grid;
+
     for (auto iter_no = 0; iter_no < MAX_INIT_PLACE_ATTEMPTS; iter_no++) {
         //clear grid for a new placement iteration
-        init_grid();
+        clear_block_type_grid_locs(unplaced_blk_type_in_curr_itr);
+        unplaced_blk_type_in_curr_itr.clear();
+
+        //Check whether the constraint file is NULL, if not, read in the block locations from the constraints file here
+        if (strlen(constraints_file) != 0) {
+            read_constraints(constraints_file);
+        }
 
         //Sort blocks and placement macros according to how difficult they are to place
         vtr::vector<ClusterBlockId, t_block_score> block_scores = assign_block_scores();
@@ -658,15 +675,17 @@ static int place_all_blocks(enum e_pad_loc_type pad_loc_type) {
         number_of_unplaced_blks_in_curr_itr = 0;
 
         for (auto blk_id : sorted_blocks) {
-            bool block_placed = place_one_block(blk_id, pad_loc_type);
+            auto blk_id_type = cluster_ctx.clb_nlist.block_type(blk_id);
+            bool block_placed = place_one_block(blk_id, pad_loc_type, &blk_types_empty_locs_in_grid[blk_id_type->index]);
+
             if (!block_placed) {
                 //add current block to list to ensure it will be placed sooner in the next iteration in initial placement
                 number_of_unplaced_blks_in_curr_itr++;
                 block_scores[blk_id].failed_to_place_in_prev_attempts++;
                 int imacro;
                 get_imacro_from_iblk(&imacro, blk_id, place_ctx.pl_macros);
-                if (imacro != -1) { //the block belongs to macro that contain a chain, we need to turn on dense placement in next iteration
-                    unplaced_blk_type_in_curr_itr.insert(cluster_ctx.clb_nlist.block_type(blk_id)->index);
+                if (imacro != -1) { //the block belongs to macro that contain a chain, we need to turn on dense placement in next iteration for that type of block
+                    unplaced_blk_type_in_curr_itr.insert(blk_id_type->index);
                 }
             }
         }
@@ -674,31 +693,33 @@ static int place_all_blocks(enum e_pad_loc_type pad_loc_type) {
         //current iteration could place all of design's blocks, initial placement succeed
         if (number_of_unplaced_blks_in_curr_itr == 0) {
             VTR_LOG("Initial placement iteration %d has finished successfully\n", iter_no);
-            return 0;
+            return;
         }
 
-        //loop over block types that have been failed to be placed, and add their locations in grid for the next iteration
+        //loop over block types with macro that have failed to be placed, and add their locations in grid for the next iteration
         for (auto itype : unplaced_blk_type_in_curr_itr) {
-            init_blk_types_empty_locations(itype, blk_types_empty_locs_in_grid[itype]);
+            blk_types_empty_locs_in_grid[itype] = init_blk_types_empty_locations(itype);
         }
-
-        unplaced_blk_type_in_curr_itr.clear();
 
         //print unplaced blocks in the current iteration
-        print_unplaced_blocks(iter_no, number_of_unplaced_blks_in_curr_itr);
+        VTR_LOG("Initial placement iteration %d has finished with %d unplaced blocks\n", iter_no, number_of_unplaced_blks_in_curr_itr);
     }
-
-    return number_of_unplaced_blks_in_curr_itr;
 }
 
-static void init_grid() {
-    auto& place_ctx = g_vpr_ctx.mutable_placement();
-
-    // Set every grid location to an INVALID block id
-    zero_initialize_grid_blocks();
-
+static void clear_block_type_grid_locs(std::unordered_set<int> unplaced_blk_types_index) {
     auto& device_ctx = g_vpr_ctx.device();
+    bool clear_all_block_types = false;
+
+    /* check if all types should be cleared
+     * logical_block_types contain empty type, needs to be ignored.
+     * Not having any type in unplaced_blk_types_index means that it is the first iteration, hence all grids needs to be cleared
+     */
+    if (unplaced_blk_types_index.size() == device_ctx.logical_block_types.size() - 1 || unplaced_blk_types_index.size() == 0) {
+        clear_all_block_types = true;
+    }
+
     auto& cluster_ctx = g_vpr_ctx.clustering();
+    auto& place_ctx = g_vpr_ctx.mutable_placement();
     int itype;
 
     /* We'll use the grid to record where everything goes. Initialize to the grid has no
@@ -706,11 +727,13 @@ static void init_grid() {
      */
     for (size_t i = 0; i < device_ctx.grid.width(); i++) {
         for (size_t j = 0; j < device_ctx.grid.height(); j++) {
-            place_ctx.grid_blocks[i][j].usage = 0;
             itype = device_ctx.grid[i][j].type->index;
-            for (int k = 0; k < device_ctx.physical_tile_types[itype].capacity; k++) {
-                if (place_ctx.grid_blocks[i][j].blocks[k] != INVALID_BLOCK_ID) {
-                    place_ctx.grid_blocks[i][j].blocks[k] = EMPTY_BLOCK_ID;
+            if (clear_all_block_types || unplaced_blk_types_index.count(itype)) {
+                place_ctx.grid_blocks[i][j].usage = 0;
+                for (int k = 0; k < device_ctx.physical_tile_types[itype].capacity; k++) {
+                    if (place_ctx.grid_blocks[i][j].blocks[k] != INVALID_BLOCK_ID) {
+                        place_ctx.grid_blocks[i][j].blocks[k] = EMPTY_BLOCK_ID;
+                    }
                 }
             }
         }
@@ -718,12 +741,16 @@ static void init_grid() {
 
     /* Similarly, mark all blocks as not being placed yet. */
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
-        place_ctx.block_locs[blk_id].loc = t_pl_loc();
+        auto blk_type = cluster_ctx.clb_nlist.block_type(blk_id)->index;
+        if (clear_all_block_types || unplaced_blk_types_index.count(blk_type)) {
+            place_ctx.block_locs[blk_id].loc = t_pl_loc();
+        }
     }
 }
 
 bool place_one_block(const ClusterBlockId& blk_id,
-                     enum e_pad_loc_type pad_loc_type) {
+                     enum e_pad_loc_type pad_loc_type,
+                     std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid) {
     auto& place_ctx = g_vpr_ctx.placement();
 
     //Check if block has already been placed
@@ -740,7 +767,7 @@ bool place_one_block(const ClusterBlockId& blk_id,
 
     if (imacro != -1) { //If the block belongs to a macro, pass that macro to the placement routines
         pl_macro = place_ctx.pl_macros[imacro];
-        placed_macro = place_macro(MAX_NUM_TRIES_TO_PLACE_MACROS_RANDOMLY, pl_macro, pad_loc_type);
+        placed_macro = place_macro(MAX_NUM_TRIES_TO_PLACE_MACROS_RANDOMLY, pl_macro, pad_loc_type, blk_types_empty_locs_in_grid);
     } else {
         //If it does not belong to a macro, create a macro with the one block and then pass to the placement routines
         //This is done so that the initial placement flow can be the same whether the block belongs to a macro or not
@@ -750,7 +777,7 @@ bool place_one_block(const ClusterBlockId& blk_id,
         macro_member.blk_index = blk_id;
         macro_member.offset = block_offset;
         pl_macro.members.push_back(macro_member);
-        placed_macro = place_macro(MAX_NUM_TRIES_TO_PLACE_MACROS_RANDOMLY, pl_macro, pad_loc_type);
+        placed_macro = place_macro(MAX_NUM_TRIES_TO_PLACE_MACROS_RANDOMLY, pl_macro, pad_loc_type, blk_types_empty_locs_in_grid);
     }
 
     return placed_macro;
@@ -764,20 +791,15 @@ void initial_placement(enum e_pad_loc_type pad_loc_type, const char* constraints
      */
     propagate_place_constraints();
 
-    /*Check whether the constraint file is NULL, if not, read in the block locations from the constraints file here*/
-    if (strlen(constraints_file) != 0) {
-        read_constraints(constraints_file);
-    }
-
     /*Mark the blocks that have already been locked to one spot via floorplan constraints
      * as fixed so they do not get moved during initial placement or later during the simulated annealing stage of placement*/
     mark_fixed_blocks();
 
     //Place all blocks
-    int number_of_failed_blocks = place_all_blocks(pad_loc_type);
+    place_all_blocks(pad_loc_type, constraints_file);
 
     //if any blocks remain unplaced, print an error
-    check_initial_placement_legality(number_of_failed_blocks);
+    check_initial_placement_legality();
 
 #ifdef VERBOSE
     VTR_LOG("At end of initial_placement.\n");

--- a/vpr/src/place/initial_placement.h
+++ b/vpr/src/place/initial_placement.h
@@ -4,5 +4,5 @@
 #include "vpr_types.h"
 
 void initial_placement(enum e_pad_loc_type pad_loc_type, const char* constraints_file);
-void place_one_block(const ClusterBlockId& blk_id, enum e_pad_loc_type pad_loc_type);
+bool place_one_block(const ClusterBlockId& blk_id, enum e_pad_loc_type pad_loc_type);
 #endif

--- a/vpr/src/place/initial_placement.h
+++ b/vpr/src/place/initial_placement.h
@@ -3,6 +3,41 @@
 
 #include "vpr_types.h"
 
+/**
+ * @brief keeps track of available empty locations of a specific block type during initial placement.
+ * Used to densly place macros that failed to be placed in the first initial placement iteration (random placement)
+ */
+struct t_grid_empty_locs_block_type {
+    /*
+     * First available location of a block type that has not been occupied yet.
+     * It will be initialized to the leftmost and lowest (x,y) location of the block type in grid.
+     */
+    t_pl_loc first_avail_loc;
+    /*
+     * Number of consecutive y-locations starting (and including) from first_avail_loc
+     * that can accomadate blocks of the type at first_avail_loc.
+     */
+    int num_of_empty_locs_in_y_axis;
+};
+
+/**
+ * @brief Tries to find an initial placement location for each block considering floorplanning constraints
+ * and throws an error out if it fails after max number of attempts.
+ *   
+ *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
+ *   @param constraints_file Used to read block locations if any constraints is available.
+ */
 void initial_placement(enum e_pad_loc_type pad_loc_type, const char* constraints_file);
-bool place_one_block(const ClusterBlockId& blk_id, enum e_pad_loc_type pad_loc_type);
+
+/**
+ * @brief Looks for a valid placement location for block.
+ *   
+ *   @param blk_id The block that should be placed.
+ *   @param pad_loc_type Used to check whether an io block needs to be marked as fixed.
+ *   @param blk_types_empty_locs_in_grid First location (lowest y) and number of remaining blocks in each column for the blk_id type
+ *   
+ * 
+ * @return true if the block gets placed, false if not.
+ */
+bool place_one_block(const ClusterBlockId& blk_id, enum e_pad_loc_type pad_loc_type, std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid);
 #endif


### PR DESCRIPTION
Initial placement used to fail in case of high utilization or long chains. New approach called dense_placement has been added to initial placement, make it possible to redo initial placement if random placement could not find a legal solution for high utilization designs.
Relate issue : [https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2036#issuecomment-1184739027](Initial Placement issue)

List of Design that passing now:
- Brainwave
- tpu_like.small.os
- tpu_like.small.ws
- tpu_like.medium.os
- tpu_like.medium.ws
- dla_like.large

@MohamedElgammal @vaughnbetz 
