### PR TITLE
Fix dsp models port sizes in the Verilog file generated by Odin-II

### DIFF
--- a/ODIN_II/SRC/VerilogWriter.cpp
+++ b/ODIN_II/SRC/VerilogWriter.cpp
@@ -169,7 +169,7 @@ std::string Verilog::Writer::declare_ports(t_model* model) {
         input_stream << TAB
                      << INPUT_PORT << TAB
                      << OPEN_SQUARE_BRACKET
-                     << input_port->size << COLON << "0"
+                     << input_port->size - 1 << COLON << "0"
                      << CLOSE_SQUARE_BRACKET
                      << TAB << input_port->name
                      << COMMA << std::endl;
@@ -184,7 +184,7 @@ std::string Verilog::Writer::declare_ports(t_model* model) {
         output_stream << TAB
                       << OUTPUT_PORT << TAB
                       << OPEN_SQUARE_BRACKET
-                      << output_port->size << COLON << "0"
+                      << output_port->size - 1 << COLON << "0"
                       << CLOSE_SQUARE_BRACKET
                       << TAB << output_port->name
                       << COMMA << std::endl;


### PR DESCRIPTION
Signed-off-by: Seyed Alireza Damghani <sdamghan@unb.ca>

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The generated Verilog file by Odin-II, including the black box declaration of complex blocks for the Yosys elaborator, has the upper limit of the ports in wrong values. The upper limit was considered as the size of the port while it should have been decremented by 1.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix issue related to the number of DSP blocks in `gemm_layer.v`, part of the new Koios++ benchmark suite

> Aman:
>> I was looking at the difference in resource usage when running benchmarks through ODIN-only flow and ODIN+Yosys flow.
>> In a couple cases, I see that both synthesis tools produced the same number of multipliers, but VPR packed them differently. For example, in the gemm_layer design, there are 400 multipliers (I think these are 8-bit multipliers). In one case, VPR packed 1 multiplier in each DSP slice (2 could have fit in 1 DSP). So, vpr.out shows 400 DSPs. This was the case when I ran with Yosys+ODIN. But in the other case, VPR packed 2 multipliers in one DSP and vpr.out shows 200 DSPs used. This was when I ran with ODIN-only synthesis.

> Mohamed
>>I think this issue is caused by the front-end tools. In the Odin case, the pre-vpr.blif is generated with many mac_fp_16 while all share the same clock and reset signal.
reset=gemm_layer.gemm_0_S00_AXI_inst.u_matmul.u_systolic_pe_matrix^bOR~8573^lOR~67975
clk=gemm_layer^s00_axi_aclk
>> However, in the yosys+odin tool, different clock and reset signals are created for each mac_fp_16 instance. e.g. 
reset=n206204abc
clk=n206207abc
>> Having different reset and clock signal for each mac_fp_16 block, prevent VPR from packing multiple instances in one dsp_top block. If Seyed can have a look to confirm would be great as I am not very familiar with the blif format.

@aman26kbm - The issue was due to having two signals for CLK and RST ports of the `mac_fp_16` complex block. This PR should resolve the issue. 


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
