### PR TITLE
Fix to QoR Comparison Script

### DIFF
--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -142,10 +142,10 @@ def main():
 
         base, ext = os.path.splitext(csv)
         if ext == ".txt":
-            sep = "\s+"
+            sep = "\t"
         else:
             sep = ","
-        df = pd.read_csv(csv, sep=sep, engine="python")
+        df = pd.read_csv(csv, skipinitialspace=True, sep=sep, engine="python")
 
         avail_metrics.update(df.columns)  # Record available metrics
 

--- a/vtr_flow/scripts/qor_compare.py
+++ b/vtr_flow/scripts/qor_compare.py
@@ -142,7 +142,7 @@ def main():
 
         base, ext = os.path.splitext(csv)
         if ext == ".txt":
-            sep = "\t  "
+            sep = "\s+"
         else:
             sep = ","
         df = pd.read_csv(csv, sep=sep, engine="python")


### PR DESCRIPTION
See Issue #2107.

#### Description
Different computers interpret parse_results.txt files differently in the number of spaces they add before/after every data entry. To address this, this PR fixes the initial correction to this problem (see PR #2108 ) by ignoring any whitespace after the delimitter. 
