### PR TITLE
Fixed Bug where VPR UI was not changing when switching mode

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -286,19 +286,16 @@ static void default_setup(ezgl::application* app) {
     search_setup(app);
 }
 
+// Initial Setup functions run default setup if they are a new window. Then, they will run
+// the specific hiding/showing functions that separate them from the other init. setup functions
+
 /* function below intializes the interface window with a set of buttons and links 
  * signals to corresponding functions for situation where the window is opened from 
  * NO_PICTURE_to_PLACEMENT */
 static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
                                                   bool is_new_window) {
-    if (!is_new_window)
-        return;
-
-    //Configuring visible buttons
-    default_setup(app);
-
-    //THIS WILL BE CHANGED SOON IGNORE
-    load_block_names(app);
+    if (is_new_window)
+        default_setup(app);
 
     //Hiding unused functionality
     hide_widget("RoutingMenuButton", app);
@@ -311,9 +308,10 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT(ezgl::application* app,
 static void initial_setup_NO_PICTURE_to_PLACEMENT_with_crit_path(
     ezgl::application* app,
     bool is_new_window) {
-    if (!is_new_window)
-        return;
-    default_setup(app);
+    if (is_new_window)
+        default_setup(app);
+
+    //Showing given functionality
     crit_path_button_setup(app);
 
     //Hiding unused routing menu
@@ -325,11 +323,10 @@ static void initial_setup_NO_PICTURE_to_PLACEMENT_with_crit_path(
  * PLACEMENT_to_ROUTING */
 static void initial_setup_PLACEMENT_to_ROUTING(ezgl::application* app,
                                                bool is_new_window) {
-    if (!is_new_window)
-        return;
-    default_setup(app);
-    routing_button_setup(app);
+    if (is_new_window)
+        default_setup(app);
 
+    routing_button_setup(app);
     hide_crit_path_button(app);
 }
 
@@ -338,9 +335,8 @@ static void initial_setup_PLACEMENT_to_ROUTING(ezgl::application* app,
  * ROUTING_to_PLACEMENT */
 static void initial_setup_ROUTING_to_PLACEMENT(ezgl::application* app,
                                                bool is_new_window) {
-    if (!is_new_window)
-        return;
-    default_setup(app);
+    if (is_new_window)
+        default_setup(app);
 
     //Hiding unused functionality
     hide_widget("RoutingMenuButton", app);
@@ -352,9 +348,9 @@ static void initial_setup_ROUTING_to_PLACEMENT(ezgl::application* app,
  * NO_PICTURE_to_ROUTING */
 static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
                                                 bool is_new_window) {
-    if (!is_new_window)
-        return;
-    default_setup(app);
+    if (is_new_window)
+        default_setup(app);
+
     routing_button_setup(app);
     hide_crit_path_button(app);
 }
@@ -365,9 +361,9 @@ static void initial_setup_NO_PICTURE_to_ROUTING(ezgl::application* app,
 static void initial_setup_NO_PICTURE_to_ROUTING_with_crit_path(
     ezgl::application* app,
     bool is_new_window) {
-    if (!is_new_window)
-        return;
-    default_setup(app);
+    if (is_new_window)
+        default_setup(app);
+
     routing_button_setup(app);
     crit_path_button_setup(app);
 }
@@ -379,7 +375,6 @@ void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type
     /* Updates the screen if the user has requested graphics.  The priority  *
      * value controls whether or not the Proceed button must be clicked to   *
      * continue.  Saves the pic_on_screen_val to allow pan and zoom redraws. */
-
     t_draw_state* draw_state = get_draw_state_vars();
 
     if (!draw_state->show_graphics)

--- a/vpr/src/draw/ui_setup.cpp
+++ b/vpr/src/draw/ui_setup.cpp
@@ -145,6 +145,7 @@ void routing_button_setup(ezgl::application* app) {
     //Toggle Router Util
     GtkComboBoxText* toggle_router_util = GTK_COMBO_BOX_TEXT(app->get_object("ToggleRoutingUtil"));
     g_signal_connect(toggle_router_util, "changed", G_CALLBACK(toggle_router_util_cbk), app);
+    show_widget("RoutingMenuButton", app);
 }
 
 /**
@@ -168,6 +169,7 @@ void search_setup(ezgl::application* app) {
 void crit_path_button_setup(ezgl::application* app) {
     GtkComboBoxText* toggle_crit_path = GTK_COMBO_BOX_TEXT(app->get_object("ToggleCritPath"));
     g_signal_connect(toggle_crit_path, "changed", G_CALLBACK(toggle_crit_path_cbk), app);
+    show_widget("ToggleCritPath", app);
 }
 
 /**
@@ -189,6 +191,11 @@ void hide_crit_path_button(ezgl::application* app) {
 void hide_widget(std::string widgetName, ezgl::application* app) {
     GtkWidget* widget = GTK_WIDGET(app->get_object(widgetName.c_str()));
     gtk_widget_hide(widget);
+}
+
+void show_widget(std::string widgetName, ezgl::application* app) {
+    GtkWidget* widget = GTK_WIDGET(app->get_object(widgetName.c_str()));
+    gtk_widget_show(widget);
 }
 
 /**


### PR DESCRIPTION
There was a bug where as you proceeded through placement and routing of a circuit, the UI options/buttons available would not update to reflect the new state of vpr. This was caused by two things:

1. In the new initial setup functions, a guard if statement was placed that would return if a new window was not being created, which worked in the old nested format, but now that we are not nesting initial setup functions, we need to instead check if it is a new window, and only run the default_setup function if it is new. 
2. When hiding menu options, we were using gtk_widget_hide, but were not using gtk_widget_show when showing menu options.

These bugs have been fixed in this PR.

