### PR TITLE
fix a UHDM parser bug for the Yosys+Odin-II front-end

### DIFF
--- a/ODIN_II/Makefile
+++ b/ODIN_II/Makefile
@@ -10,7 +10,7 @@ endif
 
 # Yosys+Odin-II compile flags
 ifeq ($(_ELABORATOR), YOSYS)
-_YOSYS_COMPILE_FLAG="-DODIN_USE_YOSYS=ON"
+_YOSYS_COMPILE_FLAG="-DODIN_USE_YOSYS=ON -DYOSYS_SV_UHDM_PLUGIN=ON"
 endif
 
 ################

--- a/ODIN_II/SRC/enum_str.cpp
+++ b/ODIN_II/SRC/enum_str.cpp
@@ -213,7 +213,6 @@ extern const strbimap<file_type_e> file_extension_strmap({{".ilang", file_type_e
                                                           {".vh", file_type_e::_VERILOG_HEADER},
                                                           {".sv", file_type_e::_SYSTEM_VERILOG},
                                                           {".svh", file_type_e::_SYSTEM_VERILOG_HEADER},
-                                                          {".uhdm", file_type_e::_UHDM},
                                                           {".blif", file_type_e::_BLIF},
                                                           {".eblif", file_type_e::_EBLIF}});
 

--- a/ODIN_II/SRC/odin_util.cpp
+++ b/ODIN_II/SRC/odin_util.cpp
@@ -138,7 +138,15 @@ void assert_valid_file_extenstion(std::vector<std::string> name_list, file_type_
                         error_message(UTIL, unknown_location, "%s", YOSYS_PLUGINS_NOT_COMPILED);
 #endif
                     }
-                    [[fallthrough]];
+                    if (file_type != type && type != file_type_e::_UHDM)
+                        error_message(UTIL, unknown_location,
+                                      "File (%s) has an invalid extension (%s), supposed to be a %s file { %s },\
+                                      please see ./odin --help",
+                                      file_name.c_str(),
+                                      file_ext_str.c_str(),
+                                      file_type_strmap.find(type)->second.c_str(),
+                                      file_extension_strmap.find(type)->second.c_str());
+                    break;
                 }
                 case (file_type_e::_BLIF): {
                     if (file_type != type)

--- a/ODIN_II/verify_odin.sh
+++ b/ODIN_II/verify_odin.sh
@@ -745,12 +745,10 @@ function odin_file_type_arg() {
 			echo "-v"
 		;;sv|svh)
 			echo "-s"
-		;;uhdm)
-			echo "-u"
 		;;blif)
 			echo "-b"
 		;;*)
-			echo "Invalid input file type (${extenstion}), supported file types are { .v .vh .sv .svh .uhdm .blif }"
+			echo "Invalid input file type (${extenstion}), supported file types are { .v .vh .sv .svh .blif }"
 			_exit_with_code "-1"
 
 	esac

--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -61,7 +61,6 @@ if(${ODIN_USE_YOSYS} OR ${WITH_YOSYS})
             LOG_BUILD ON
             LOG_UPDATE ON
             LOG_INSTALL ON
-            LOG_DOWNLOAD ON
             LOG_CONFIGURE ON
             LOG_OUTPUT_ON_FAILURE ON
             
@@ -93,7 +92,6 @@ if(${ODIN_USE_YOSYS} OR ${WITH_YOSYS})
             LOG_BUILD ON
             LOG_UPDATE ON
             LOG_INSTALL ON
-            LOG_DOWNLOAD ON
             LOG_CONFIGURE ON
             LOG_OUTPUT_ON_FAILURE ON
             

--- a/vtr_flow/scripts/python_libs/vtr/__init__.py
+++ b/vtr_flow/scripts/python_libs/vtr/__init__.py
@@ -34,6 +34,7 @@ from .abc import run, run_lec
 from .vpr import run, run_relax_w, cmp_full_vs_incr_sta, run_second_time
 from .odin import run
 from .yosys import run
+from .yosys import YOSYS_PARSERS
 from .ace import run
 from .error import *
 from .flow import run, VtrStage

--- a/vtr_flow/scripts/python_libs/vtr/odin/odin.py
+++ b/vtr_flow/scripts/python_libs/vtr/odin/odin.py
@@ -94,7 +94,7 @@ def init_config_file(
     config_file.write(odin_config_full_path)
 
 
-# pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+# pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements
 def run(
     architecture_file,
     circuit_file,
@@ -213,9 +213,8 @@ def run(
             odin_parser_arg = YOSYS_ODIN_PARSER[odin_args["parser"]]
         else:
             raise vtr.VtrError(
-                "Invalid parser is specified for the Yosys elaborator, available parsers are [{}]".format(
-                    " ".join(str(x) for x in YOSYS_PARSERS)
-                )
+                "Invalid parser is specified for the Yosys elaborator,"
+                " available parsers are [{}]".format(" ".join(str(x) for x in YOSYS_PARSERS))
             )
     del odin_args["parser"]
 
@@ -270,4 +269,4 @@ def run(
         )
 
 
-# pylint: enable=too-many-arguments, too-many-locals, too-many-branches
+# pylint: enable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements

--- a/vtr_flow/scripts/python_libs/vtr/yosys/__init__.py
+++ b/vtr_flow/scripts/python_libs/vtr/yosys/__init__.py
@@ -2,3 +2,4 @@
     init for the YOSYS module
 """
 from .yosys import run
+from .yosys import YOSYS_PARSERS

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -381,7 +381,7 @@ def vtr_command_argparser(prog=None):
     )
     yosys.add_argument(
         "-parser",
-        default=None,
+        default="yosys",
         dest="parser",
         help="Specify a parser for the Yosys synthesizer [yosys (Verilog-2005), surelog (UHDM), "
         + "yosys-plugin (SystemVerilog)].The script determine the parser based on the input file"
@@ -686,6 +686,7 @@ def process_odin_args(args):
     Finds arguments needed in the ODIN stage of the flow
     """
     odin_args = OrderedDict()
+    odin_args["parser"] = args.parser
     odin_args["adder_type"] = args.adder_type
     odin_args["top_module"] = args.top_module
     odin_args["elaborator"] = args.elaborator
@@ -714,8 +715,7 @@ def process_yosys_args(args):
     Finds arguments needed in the YOSYS stage of the flow
     """
     yosys_args = OrderedDict()
-    if args.parser:
-        yosys_args["parser"] = args.parser
+    yosys_args["parser"] = args.parser
 
     return yosys_args
 

--- a/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/FX68K/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/FX68K/config/config.txt
@@ -33,4 +33,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize
+script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize -parser yosys-plugin

--- a/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/f4pga_button_controller/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/f4pga_button_controller/config/config.txt
@@ -33,4 +33,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize
+script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize -parser yosys-plugin

--- a/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/f4pga_pulse_width_led/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/f4pga_pulse_width_led/config/config.txt
@@ -31,4 +31,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize
+script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize -parser yosys-plugin

--- a/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/f4pga_timer/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/f4pga_timer/config/config.txt
@@ -34,4 +34,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize
+script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize -parser yosys-plugin

--- a/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/hdmi/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_yosys_odin/hdmi/config/config.txt
@@ -39,4 +39,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize
+script_params=-track_memory_usage -crit_path_router_iterations 100 -elaborator yosys -fflegalize -parser yosys-plugin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the UHDM file extension inference bug for the Yosys+Odin-II front-end.
After this PR,  Both Yosys and Yosys+Odin-II front-ends require the `-parser` option given to the `run_vtr_flow` script to specify the Yosys parser explicitly.

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
