### PR TITLE
Fixing a bug in receiving .sv extensions without Yosys plugins installed

### DIFF
--- a/ODIN_II/SRC/include/odin_error.h
+++ b/ODIN_II/SRC/include/odin_error.h
@@ -39,25 +39,30 @@ extern std::vector<std::pair<std::string, int>> include_file_names;
 extern int delayed_errors;
 extern const loc_t unknown_location;
 
-#ifdef ODIN_USE_YOSYS
+
+#define SYSTEMVERILOG_PARSER_ERROR \
+    "The SystemVerilog parser is provided within Yosys. " \
+    "Please use the Yosys elaborator to synthesize SystemVerilog files.\n"
+#define UHDM_PARSER_ERROR \
+    "The UHDM parser is provided within Yosys. " \
+    "Please use the Yosys elaborator to synthesize UHDM files.\n"
+
+#ifndef ODIN_USE_YOSYS
+#    define YOSYS_INSTALLATION_ERROR                              \
+        "It seems Yosys is not installed in the VTR repository. " \
+        "Please compile the VTR with (\" -DODIN_USE_YOSYS=ON \") flag.\n"
+#else
 #    define YOSYS_ELABORATION_ERROR             \
         "Yosys failed to perform elaboration, " \
         "Please look at the log file for the failure cause or pass \'--show_yosys_log\' to Odin-II to see the logs.\n"
 #    define YOSYS_FORK_ERROR \
         "Yosys child process failed to be created\n"
-#    define YOSYS_PLUGINS_WITH_ODIN_ERROR \
-        "Utilizing SystemVerilog/UHDM plugins requires activating the Yosys frontend.\
-        Please recompile the VTR project either with the \"WITH_YOSYS\" or \"ODIN_USE_YOSYS\" flag on."
-#else
-#    define YOSYS_INSTALLATION_ERROR                             \
-        "It seems Yosys is not installed in the VTR repository." \
-        " Please compile the VTR with (\" -DODIN_USE_YOSYS=ON \") flag.\n"
 #endif
 
 #ifndef YOSYS_SV_UHDM_PLUGIN
 #    define YOSYS_PLUGINS_NOT_COMPILED \
-        "SystemVerilog/UHDM plugins are not compiled.\
-        Please recompile the VTR project with the \"YOSYS_SV_UHDM_PLUGIN\" flag on."
+        "SystemVerilog/UHDM plugins are not compiled. " \
+        "Please recompile the VTR project with the \"YOSYS_SV_UHDM_PLUGIN\" flag on."
 #endif
 
 // causes an interrupt in GDB

--- a/ODIN_II/SRC/include/odin_error.h
+++ b/ODIN_II/SRC/include/odin_error.h
@@ -39,11 +39,10 @@ extern std::vector<std::pair<std::string, int>> include_file_names;
 extern int delayed_errors;
 extern const loc_t unknown_location;
 
-
-#define SYSTEMVERILOG_PARSER_ERROR \
+#define SYSTEMVERILOG_PARSER_ERROR                        \
     "The SystemVerilog parser is provided within Yosys. " \
     "Please use the Yosys elaborator to synthesize SystemVerilog files.\n"
-#define UHDM_PARSER_ERROR \
+#define UHDM_PARSER_ERROR                        \
     "The UHDM parser is provided within Yosys. " \
     "Please use the Yosys elaborator to synthesize UHDM files.\n"
 
@@ -60,7 +59,7 @@ extern const loc_t unknown_location;
 #endif
 
 #ifndef YOSYS_SV_UHDM_PLUGIN
-#    define YOSYS_PLUGINS_NOT_COMPILED \
+#    define YOSYS_PLUGINS_NOT_COMPILED                  \
         "SystemVerilog/UHDM plugins are not compiled. " \
         "Please recompile the VTR project with the \"YOSYS_SV_UHDM_PLUGIN\" flag on."
 #endif

--- a/ODIN_II/SRC/include/odin_util.h
+++ b/ODIN_II/SRC/include/odin_util.h
@@ -12,7 +12,7 @@ long shift_left_value_with_overflow_check(long input_value, long shift_by, loc_t
 std::string get_file_extension(std::string input_file);
 std::string get_directory(std::string input_file);
 void create_directory(std::string path);
-void assert_valid_file_extenstion(std::vector<std::string> name_list, file_type_e type);
+void report_frontend_elaborator();
 void assert_supported_file_extension(std::string input_file, loc_t loc);
 FILE* open_file(const char* file_name, const char* open_type);
 void get_current_path();

--- a/ODIN_II/SRC/odin_ii.cpp
+++ b/ODIN_II/SRC/odin_ii.cpp
@@ -349,7 +349,7 @@ netlist_t* start_odin_ii(int argc, char** argv) {
         ODIN_ERROR_CODE error_code;
 
         print_input_files_info();
-        assert_valid_file_extenstion(configuration.list_of_file_names, configuration.input_file_type);
+        report_frontend_elaborator();
 
         if (configuration.input_file_type != file_type_e::_BLIF || configuration.coarsen) {
             try {

--- a/ODIN_II/SRC/odin_util.cpp
+++ b/ODIN_II/SRC/odin_util.cpp
@@ -125,9 +125,9 @@ void report_frontend_elaborator() {
 #ifndef ODIN_USE_YOSYS
                 error_message(PARSE_ARGS, unknown_location, "%s", YOSYS_INSTALLATION_ERROR);
 #else
-#ifndef YOSYS_SV_UHDM_PLUGIN
+#    ifndef YOSYS_SV_UHDM_PLUGIN
                 error_message(PARSE_ARGS, unknown_location, "%s", YOSYS_PLUGINS_NOT_COMPILED);
-#endif
+#    endif
 #endif
             }
             printf("Using the Yosys elaborator with the Surelog parser for UHDM\n");

--- a/ODIN_II/SRC/odin_util.cpp
+++ b/ODIN_II/SRC/odin_util.cpp
@@ -92,80 +92,56 @@ void create_directory(std::string path) {
 }
 
 /**
- * @brief assert all input files have valid type and extenstion
- * 
- * @param name_list list of input files
- * @param type the type to be checked with
+ * @brief report the frontend elaborator and its parser
  */
-void assert_valid_file_extenstion(std::vector<std::string> name_list, file_type_e type) {
-    for (auto file_name : name_list) {
-        // lookup the file type string from file extension map
-        auto file_ext_str = string_to_lower(get_file_extension(file_name));
-        auto file_ext_it = file_extension_strmap.find(file_ext_str);
-
-        // Unsupported file types should be already check.
-        // However, we double-check here
-        if (file_ext_it == file_extension_strmap.end()) {
-            assert_supported_file_extension(file_name, unknown_location);
-        } else {
-            file_type_e file_type = file_ext_it->second;
-            // Check if the file_name extension matches with type
-            switch (type) {
-                case (file_type_e::_VERILOG): // fallthrough
-                case (file_type_e::_VERILOG_HEADER): {
-                    if (file_type != file_type_e::_VERILOG && file_type != file_type_e::_VERILOG_HEADER)
-                        error_message(UTIL, unknown_location,
-                                      "File (%s) has an invalid extension (%s), supposed to be a %s or %s file { %s, %s },\
-                                      please see ./odin --help",
-                                      file_name.c_str(),
-                                      file_ext_str.c_str(),
-                                      file_type_strmap.find(file_type_e::_VERILOG)->second.c_str(),
-                                      file_type_strmap.find(file_type_e::_VERILOG_HEADER)->second.c_str(),
-                                      file_extension_strmap.find(file_type_e::_VERILOG)->second.c_str(),
-                                      file_extension_strmap.find(file_type_e::_VERILOG_HEADER)->second.c_str());
-                    break;
-                }
-                case (file_type_e::_SYSTEM_VERILOG): //fallthrough
-                case (file_type_e::_UHDM): {
-                    if (configuration.elaborator_type != elaborator_e::_YOSYS) {
-#ifndef ODIN_USE_YOSYS
-                        error_message(PARSE_ARGS, unknown_location, "%s", YOSYS_INSTALLATION_ERROR);
-#else
-                        error_message(UTIL, unknown_location, "%s", YOSYS_PLUGINS_WITH_ODIN_ERROR);
-#endif
-                    } else {
-#ifndef YOSYS_SV_UHDM_PLUGIN
-                        error_message(UTIL, unknown_location, "%s", YOSYS_PLUGINS_NOT_COMPILED);
-#endif
-                    }
-                    if (file_type != type && type != file_type_e::_UHDM)
-                        error_message(UTIL, unknown_location,
-                                      "File (%s) has an invalid extension (%s), supposed to be a %s file { %s },\
-                                      please see ./odin --help",
-                                      file_name.c_str(),
-                                      file_ext_str.c_str(),
-                                      file_type_strmap.find(type)->second.c_str(),
-                                      file_extension_strmap.find(type)->second.c_str());
-                    break;
-                }
-                case (file_type_e::_BLIF): {
-                    if (file_type != type)
-                        error_message(UTIL, unknown_location,
-                                      "File (%s) has an invalid extension (%s), supposed to be a %s file { %s },\
-                                      please see ./odin --help",
-                                      file_name.c_str(),
-                                      file_ext_str.c_str(),
-                                      file_type_strmap.find(type)->second.c_str(),
-                                      file_extension_strmap.find(type)->second.c_str());
-                    break;
-                }
-                case (file_type_e::_EBLIF): //fallthrough
-                case (file_type_e::_ILANG): // fallthrough
-                default: {
-                    assert_supported_file_extension(file_name, unknown_location);
-                    break;
-                }
+void report_frontend_elaborator() {
+    // Check if the file_name extension matches with type
+    switch (configuration.input_file_type) {
+        case (file_type_e::_VERILOG): // fallthrough
+        case (file_type_e::_VERILOG_HEADER): {
+            if (configuration.elaborator_type == elaborator_e::_ODIN) {
+                printf("Using the ODIN_II parser for elaboration\n");
+            } else if (configuration.elaborator_type == elaborator_e::_YOSYS) {
+                printf("Using the Yosys elaborator with it's conventional Verilog/SystemVerilog parser\n");
             }
+            break;
+        }
+        case (file_type_e::_SYSTEM_VERILOG): {
+            if (configuration.elaborator_type != elaborator_e::_YOSYS) {
+                error_message(PARSE_ARGS, unknown_location, "%s", SYSTEMVERILOG_PARSER_ERROR);
+            }
+#ifndef YOSYS_SV_UHDM_PLUGIN
+            printf("Using the Yosys elaborator with it's conventional Verilog/SystemVerilog parser\n");
+#else
+            printf("Using the Yosys elaborator with the Yosys-F4PGA-Plugin parser for SystemVerilog\n");
+#endif
+            break;
+        }
+        case (file_type_e::_UHDM): {
+            if (configuration.elaborator_type != elaborator_e::_YOSYS) {
+                error_message(PARSE_ARGS, unknown_location, "%s", UHDM_PARSER_ERROR);
+
+            } else if (configuration.elaborator_type == elaborator_e::_YOSYS) {
+#ifndef ODIN_USE_YOSYS
+                error_message(PARSE_ARGS, unknown_location, "%s", YOSYS_INSTALLATION_ERROR);
+#else
+#ifndef YOSYS_SV_UHDM_PLUGIN
+                error_message(PARSE_ARGS, unknown_location, "%s", YOSYS_PLUGINS_NOT_COMPILED);
+#endif
+#endif
+            }
+            printf("Using the Yosys elaborator with the Surelog parser for UHDM\n");
+            break;
+        }
+        case (file_type_e::_BLIF): {
+            printf("Using the ODIN_II BLIF parser\n");
+            break;
+        }
+        case (file_type_e::_EBLIF): //fallthrough
+        case (file_type_e::_ILANG): //fallthrough
+        default: {
+            error_message(UTIL, unknown_location, "%s", "Invalid file type");
+            break;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR removes the input file extension checking function in Yosys+Odin-II as checking the file extension is not required, and such a process is not performed by Yosys and UHDM parsers. So, Yosys+Odin-II only decides the parser based on the user request, not the file extension.

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue reported by @aman26kbm 
An email thread:
> Hi Seyed,
> There is a problem with the .sv files in the master branch. It used to work earlier (maybe a month back). Did the UHDM related checkin mess it up?
> In the recent PR where you were upgrading Yosys+ODIN flow, you had fixed it with [this](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2148/commits/699ea98642f6bbf57545a646c737980d166d7542) commit. I think just this commit should be extracted into a separate PR. I'm thinking of merging just this commit into my fork for now.
> Thanks,
> Aman Arora

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
