### PR TITLE
Remove unnecessary std::move of temporary object.

### DIFF
--- a/vpr/src/place/simpleRL_move_generator.cpp
+++ b/vpr/src/place/simpleRL_move_generator.cpp
@@ -15,25 +15,25 @@ static float scaled_clipped_exp(float x) { return std::exp(std::min(1000000 * x,
  *                                     *
  *                                     */
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<SoftmaxAgent>& agent) {
-    avail_moves.push_back(std::move(std::make_unique<UniformMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<MedianMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<CentroidMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<WeightedCentroidMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<WeightedMedianMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<CriticalUniformMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<FeasibleRegionMoveGenerator>()));
+    avail_moves.emplace_back(std::make_unique<UniformMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<MedianMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<CentroidMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<WeightedCentroidMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<WeightedMedianMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<CriticalUniformMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<FeasibleRegionMoveGenerator>());
 
     karmed_bandit_agent = std::move(agent);
 }
 
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<EpsilonGreedyAgent>& agent) {
-    avail_moves.push_back(std::move(std::make_unique<UniformMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<MedianMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<CentroidMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<WeightedCentroidMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<WeightedMedianMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<CriticalUniformMoveGenerator>()));
-    avail_moves.push_back(std::move(std::make_unique<FeasibleRegionMoveGenerator>()));
+    avail_moves.emplace_back(std::make_unique<UniformMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<MedianMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<CentroidMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<WeightedCentroidMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<WeightedMedianMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<CriticalUniformMoveGenerator>());
+    avail_moves.emplace_back(std::make_unique<FeasibleRegionMoveGenerator>());
 
     karmed_bandit_agent = std::move(agent);
 }


### PR DESCRIPTION
The compiler warns about this with
"moving a temporary object prevents copy elision"
(if -Wpessimizing-move is enabled)

Signed-off-by: Henner Zeller <hzeller@google.com>

