### PR TITLE
vpr: changes to conform to c++17 standard

### DIFF
--- a/vpr/src/place/simpleRL_move_generator.cpp
+++ b/vpr/src/place/simpleRL_move_generator.cpp
@@ -245,8 +245,8 @@ void SoftmaxAgent::set_action_prob() {
     // normalize all the action probabilities to guarantee the sum(all action probs) = 1
     float sum_prob = std::accumulate(action_prob_.begin(), action_prob_.end(), 0.0);
     std::transform(action_prob_.begin(), action_prob_.end(), action_prob_.begin(),
-                   [sum_prob, this](float x){ return x + ((1.0 - sum_prob) / this->num_available_actions_); });
-    
+                   [sum_prob, this](float x) { return x + ((1.0 - sum_prob) / this->num_available_actions_); });
+
     // calculate the accumulative action probability of each action
     // e.g. if we have 5 actions with equal probability of 0.2, the cumm_action_prob will be {0.2,0.4,0.6,0.8,1.0}
     float accum = 0;

--- a/vpr/src/place/simpleRL_move_generator.cpp
+++ b/vpr/src/place/simpleRL_move_generator.cpp
@@ -242,12 +242,12 @@ void SoftmaxAgent::set_action_prob() {
         }
     }
 
-    // normalize all the action probabilities to guarantee the sum(all actyion probs) = 1
+    // normalize all the action probabilities to guarantee the sum(all action probs) = 1
     float sum_prob = std::accumulate(action_prob_.begin(), action_prob_.end(), 0.0);
     std::transform(action_prob_.begin(), action_prob_.end(), action_prob_.begin(),
-                   bind2nd(std::plus<float>(), (1.0 - sum_prob) / num_available_actions_));
-
-    //calulcate the accumulative action probability of each action
+                   [sum_prob, this](float x){ return x + ((1.0 - sum_prob) / this->num_available_actions_); });
+    
+    // calculate the accumulative action probability of each action
     // e.g. if we have 5 actions with equal probability of 0.2, the cumm_action_prob will be {0.2,0.4,0.6,0.8,1.0}
     float accum = 0;
     for (size_t i = 0; i < num_available_actions_; ++i) {

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -49,7 +49,8 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
     // Initialize random seed
     // Must be done during every call in order for restored rr_graphs after a binary
     // search to be consistent
-    std::srand(seed);
+    std::mt19937 rand_generator;
+    rand_generator.seed(seed);
 
     auto& device_ctx = g_vpr_ctx.device();
     const auto& node_lookup = device_ctx.rr_graph.node_lookup();
@@ -68,8 +69,8 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
 
     for (auto clock_index : clock_indices) {
         // Select wires to connect to at random
-        std::random_shuffle(x_wire_indices.begin(), x_wire_indices.end());
-        std::random_shuffle(y_wire_indices.begin(), y_wire_indices.end());
+        std::shuffle(x_wire_indices.begin(), x_wire_indices.end(), rand_generator);
+        std::shuffle(y_wire_indices.begin(), y_wire_indices.end(), rand_generator);
 
         // Connect to x-channel wires
         unsigned num_wires_x = x_wire_indices.size() * fc;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A few small edits to allow building with -std=c++17
#### Description
<!--- Describe your changes in detail -->

- std::bind was removed from c++17, as seen here: https://en.cppreference.com/w/cpp/utility/functional/bind12
- std::random_shuffle was removed from c++17, https://en.cppreference.com/w/cpp/algorithm/random_shuffle
- Replaced code with modern equivalents.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2202

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
vpr is being considered as a benchmark for the next SPEC CPU benchmark suite. We discovered this issue as part of that vetting process. Thus we are feeding back the changeset here.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested a handful of commandlines before and after the change, and there was no change in the output.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
