### PR TITLE
Add missing instruction to run tests to the documentation

### DIFF
--- a/README.developers.md
+++ b/README.developers.md
@@ -273,11 +273,12 @@ $ ./run_reg_test.py vtr_reg_basic
 $ ./run_reg_test.py vtr_reg_strong
 ```
 
-The *nightly* and *weekly* regressions require the Titan and ISPD benchmarks
+The *nightly* and *weekly* regressions require the Titan, ISPD, and Symbiflow benchmarks
 which can be integrated into your VTR tree with:
 ```shell
-make get_titan_benchmarks
-make get_ispd_benchmarks
+$ make get_titan_benchmarks
+$ make get_ispd_benchmarks
+$ make get_symbiflow_benchmarks
 ```
 They can then be run using `run_reg_test.py`:
 ```shell


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As vtr_nightly_test1 contains some symbiflow tests, we need to get_symbiflow_benchmarks to be able to run it. This is not included in the docs. Only titan and ISPD benchmarks are listed. In this PR, I have added the instruction of getting symbiflow benchmarks to the running tests section of the docs 