### PR TITLE
Command line documentation

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -358,6 +358,30 @@ Use the options below to override this default naming behaviour.
 
     .. seealso:: :ref:`Routing Resource XML File <vpr_route_resource_file>`.
 
+.. option:: --read_vpr_constraints <file>
+
+    Reads the :ref:`floorplanning constraints <vpr_constraints_file>` that packing and placement must respect from the specified XML file.
+
+.. option:: --write_vpr_constraints <file>
+
+    Writes out new :ref:`floorplanning constraints <vpr_constraints_file>` based on current placement to the specified XML file.
+
+.. option:: --read_router_lookahead <file>
+
+    Reads the lookahead data from the specified file instead of computing it.
+
+.. option:: --write_router_lookahead <file>
+
+    Writes the lookahead data to the specified file.
+
+.. option:: --read_placement_delay_lookup <file>
+
+    Reads the placement delay lookup from the specified file instead of computing it.
+
+.. option:: --write_placement_delay_lookup <file>
+
+    Writes the placement delay lookup to the specified file.
+
 .. option:: --outfile_prefix <string>
 
     Prefix for output files

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -47,7 +47,12 @@ By default VPR will perform a binary search routing to find the minimum channel 
 
 Detailed Command-line Options
 -----------------------------
-VPR has a lot of options.
+VPR has a lot of options. Running :option:`vpr --help` will display all the available options and their usage information. 
+
+.. option:: -h, --help
+
+    Display help message then exit.
+    
 The options most people will be interested in are:
 
 * :option:`--route_chan_width` (route at a fixed channel width), and
@@ -172,10 +177,6 @@ Graphics Options
 
 General Options
 ^^^^^^^^^^^^^^^
-.. option:: -h, --help
-
-    Display help message then exit.
-
 .. option:: --version
 
     Display version information then exit.

--- a/doc/src/vpr/placement_constraints.rst
+++ b/doc/src/vpr/placement_constraints.rst
@@ -1,6 +1,7 @@
+
 VPR Placement Constraints
 =========================
-
+.. _vpr_constraints_file:
 VPR supports running flows with placement constraints. Placement constraints are set on primitives to lock them down to specified regions on the FPGA chip. For example, a user may use placement constraints to lock down pins to specific locations on the chip. Also, groups of primitives may be locked down to regions on the chip in CAD flows that use floorplanning or modular design, or to hand-place a timing critical piece.
 
 The placement constraints should be specified by the user using an XML constraints file format, as described in the section below. When VPR is run with placement constraints, both the packing and placement flows are performed in such a way that the constraints are respected. The packing stage does not pack any primitives together that have conflicting floorplan constraints. The placement stage considers the floorplan constraints when choosing a location for each clustered block during initial placement, and does not move any block outside of its constraint boundaries during place moves.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This is a pull request related to #2198 that adds some of the undocumented command lines to the web documentation. These command lines are all related to file formats:

-  --read_vpr_constraints <file>

-  --write_vpr_constraints <file>

-  --read_router_lookahead <file>

-  --write_router_lookahead <file>

-  --read_placement_delay_lookup <file>

-  --write_placement_delay_lookup <file>
