### PR TITLE
install `LIB_HEADERS` to `CMAKE_INSTALL_INCLUDEDIR`

### DIFF
--- a/libs/EXTERNAL/libpugixml/CMakeLists.txt
+++ b/libs/EXTERNAL/libpugixml/CMakeLists.txt
@@ -26,3 +26,4 @@ if(NOT VTR_ENABLE_SANITIZE)
 endif()
 
 install(TARGETS libpugixml DESTINATION bin)
+install(FILES ${LIB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libpugixml)

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -48,6 +48,7 @@ if (WRITE_ARCH_BB_USES_IPO)
 endif()
 
 install(TARGETS libarchfpga read_arch write_arch_bb DESTINATION bin)
+install(FILES ${LIB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libarchfpga)
 
 #
 # install executables in the VTR source root directory

--- a/libs/liblog/CMakeLists.txt
+++ b/libs/liblog/CMakeLists.txt
@@ -22,3 +22,4 @@ add_executable(test_log ${EXEC_SOURCES})
 target_link_libraries(test_log liblog)
 
 install(TARGETS liblog DESTINATION bin)
+install(FILES ${LIB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/liblog)

--- a/libs/libpugiutil/CMakeLists.txt
+++ b/libs/libpugiutil/CMakeLists.txt
@@ -20,3 +20,4 @@ target_link_libraries(libpugiutil
                         libpugixml)
 
 install(TARGETS libpugiutil DESTINATION bin)
+install(FILES ${LIB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libpugiutil)

--- a/libs/librtlnumber/CMakeLists.txt
+++ b/libs/librtlnumber/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(rtl_number
                         librtlnumber)
 
 install(TARGETS rtl_number librtlnumber DESTINATION bin)
+install(FILES ${LIB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/librtlnumber)
+

--- a/libs/libvtrutil/CMakeLists.txt
+++ b/libs/libvtrutil/CMakeLists.txt
@@ -105,6 +105,7 @@ target_link_libraries(libvtrutil
                         liblog)
 
 install(TARGETS libvtrutil DESTINATION bin)
+install(FILES ${LIB_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libvtrutil)
 
 #
 # Unit Tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR provides minor modifications to the cmake build file of the following libraries to install their header files alongside their binaries:
- libarchfpga
- liblog
- libpugixml
- libpugiutil
- libvtrutil
- librtlnumber
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2218
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To reuse the compiled binaries of the libraries outside of the VTR scope in other projects.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
the library headers are installed to the `CMAKE_INSTALL_INCLUDEDIR` after running the `make install` command.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
