### PR TITLE
Fix atom lookup

### DIFF
--- a/vpr/src/base/vpr_constraints_writer.cpp
+++ b/vpr/src/base/vpr_constraints_writer.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include "vpr_constraints_writer.h"
 #include "region.h"
+#include "re_cluster_util.h"
 
 void write_vpr_floorplan_constraints(const char* file_name, int expand, bool subtile, int horizontal_partitions, int vertical_partitions) {
     VprConstraints constraints;
@@ -46,7 +47,6 @@ void write_vpr_floorplan_constraints(const char* file_name, int expand, bool sub
 void setup_vpr_floorplan_constraints_one_loc(VprConstraints& constraints, int expand, bool subtile) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& place_ctx = g_vpr_ctx.placement();
-    ClusterAtomsLookup atoms_lookup;
 
     int part_id = 0;
     /*
@@ -77,9 +77,9 @@ void setup_vpr_floorplan_constraints_one_loc(VprConstraints& constraints, int ex
         part.set_part_region(pr);
         constraints.add_partition(part);
 
-        std::vector<AtomBlockId> atoms = atoms_lookup.atoms_in_cluster(blk_id);
+        std::unordered_set<AtomBlockId>* atoms = cluster_to_atoms(blk_id);
 
-        for (auto atom_id : atoms) {
+        for (auto atom_id : *atoms) {
             constraints.add_constrained_atom(atom_id, partid);
         }
         part_id++;
@@ -90,7 +90,6 @@ void setup_vpr_floorplan_constraints_cutpoints(VprConstraints& constraints, int 
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& place_ctx = g_vpr_ctx.placement();
     auto& device_ctx = g_vpr_ctx.device();
-    ClusterAtomsLookup atoms_lookup;
 
     //calculate the cutpoint values according to the grid size
     //load two arrays - one for horizontal cutpoints and one for vertical
@@ -151,7 +150,7 @@ void setup_vpr_floorplan_constraints_cutpoints(VprConstraints& constraints, int 
      * appropriate region accordingly
      */
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
-        std::vector<AtomBlockId> atoms = atoms_lookup.atoms_in_cluster(blk_id);
+        std::unordered_set<AtomBlockId>* atoms = cluster_to_atoms(blk_id);
         int x = place_ctx.block_locs[blk_id].loc.x;
         int y = place_ctx.block_locs[blk_id].loc.y;
         int width = device_ctx.grid.width();
@@ -183,7 +182,7 @@ void setup_vpr_floorplan_constraints_cutpoints(VprConstraints& constraints, int 
 
         VTR_ASSERT(got != region_atoms.end());
 
-        for (auto atom_id : atoms) {
+        for (auto atom_id : *atoms) {
             got->second.push_back(atom_id);
         }
     }

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -3676,3 +3676,17 @@ t_pb* get_top_level_pb(t_pb* pb) {
 
     return top_level_pb;
 }
+
+
+void init_clb_atoms_lookup(vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>>& atoms_lookup) {
+    auto& atom_ctx = g_vpr_ctx.atom();
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+
+    atoms_lookup.resize(cluster_ctx.clb_nlist.blocks().size());
+
+    for (auto atom_blk_id : atom_ctx.nlist.blocks()) {
+        ClusterBlockId clb_index = atom_ctx.lookup.atom_clb(atom_blk_id);
+
+        atoms_lookup[clb_index].insert(atom_blk_id);
+    }
+}

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -3677,7 +3677,6 @@ t_pb* get_top_level_pb(t_pb* pb) {
     return top_level_pb;
 }
 
-
 void init_clb_atoms_lookup(vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>>& atoms_lookup) {
     auto& atom_ctx = g_vpr_ctx.atom();
     auto& cluster_ctx = g_vpr_ctx.clustering();

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -3677,6 +3677,7 @@ t_pb* get_top_level_pb(t_pb* pb) {
     return top_level_pb;
 }
 
+
 void init_clb_atoms_lookup(vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>>& atoms_lookup) {
     auto& atom_ctx = g_vpr_ctx.atom();
     auto& cluster_ctx = g_vpr_ctx.clustering();

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -451,4 +451,5 @@ bool cleanup_pb(t_pb* pb);
 
 void alloc_and_load_pb_stats(t_pb* pb, const int feasible_block_array_size);
 
+void init_clb_atoms_lookup(vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>>& atoms_lookup);
 #endif

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -266,6 +266,7 @@ bool try_pack(t_packer_opts* packer_opts,
     /*       Use the re-cluster API to edit it        */
     /******************* Start *************************/
     VTR_LOG("Start the iterative improvement process\n");
+    init_clb_atoms_lookup(helper_ctx.atoms_lookup);
     //iteratively_improve_packing(*packer_opts, clustering_data, 2);
     VTR_LOG("the iterative improvement process is done\n");
 

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -266,7 +266,6 @@ bool try_pack(t_packer_opts* packer_opts,
     /*       Use the re-cluster API to edit it        */
     /******************* Start *************************/
     VTR_LOG("Start the iterative improvement process\n");
-    init_clb_atoms_lookup(helper_ctx.atoms_lookup);
     //iteratively_improve_packing(*packer_opts, clustering_data, 2);
     VTR_LOG("the iterative improvement process is done\n");
 

--- a/vpr/src/pack/re_cluster_util.cpp
+++ b/vpr/src/pack/re_cluster_util.cpp
@@ -50,6 +50,11 @@ ClusterBlockId atom_to_cluster(const AtomBlockId& atom) {
 
 std::unordered_set<AtomBlockId>* cluster_to_atoms(const ClusterBlockId& cluster) {
     auto& helper_ctx = g_vpr_ctx.mutable_cl_helper();
+
+    //If the lookup is not built yet, build it first
+    if (helper_ctx.atoms_lookup.empty())
+        init_clb_atoms_lookup(helper_ctx.atoms_lookup);
+
     return &(helper_ctx.atoms_lookup[cluster]);
 }
 

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -11,6 +11,7 @@
 #include "globals.h"
 #include "place_constraints.h"
 #include "place_util.h"
+#include "re_cluster_util.h"
 
 /*checks that each block's location is compatible with its floorplanning constraints if it has any*/
 int check_placement_floorplanning() {
@@ -228,18 +229,17 @@ bool cluster_floorplanning_legal(ClusterBlockId blk_id, const t_pl_loc& loc) {
 void load_cluster_constraints() {
     auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
     auto& cluster_ctx = g_vpr_ctx.clustering();
-    ClusterAtomsLookup atoms_lookup;
 
     floorplanning_ctx.cluster_constraints.resize(cluster_ctx.clb_nlist.blocks().size());
 
     for (auto cluster_id : cluster_ctx.clb_nlist.blocks()) {
-        std::vector<AtomBlockId> atoms = atoms_lookup.atoms_in_cluster(cluster_id);
+        std::unordered_set<AtomBlockId>* atoms = cluster_to_atoms(cluster_id);
         PartitionRegion empty_pr;
         floorplanning_ctx.cluster_constraints[cluster_id] = empty_pr;
 
         //if there are any constrainted atoms in the cluster,
         //we update the cluster's PartitionRegion
-        for (auto atom : atoms) {
+        for (auto atom : *atoms) {
             PartitionId partid = floorplanning_ctx.constraints.get_atom_partition(atom);
 
             if (partid != PartitionId::INVALID()) {

--- a/vpr/src/place/place_constraints.cpp
+++ b/vpr/src/place/place_constraints.cpp
@@ -11,7 +11,6 @@
 #include "globals.h"
 #include "place_constraints.h"
 #include "place_util.h"
-#include "re_cluster_util.h"
 
 /*checks that each block's location is compatible with its floorplanning constraints if it has any*/
 int check_placement_floorplanning() {
@@ -229,17 +228,18 @@ bool cluster_floorplanning_legal(ClusterBlockId blk_id, const t_pl_loc& loc) {
 void load_cluster_constraints() {
     auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
     auto& cluster_ctx = g_vpr_ctx.clustering();
+    ClusterAtomsLookup atoms_lookup;
 
     floorplanning_ctx.cluster_constraints.resize(cluster_ctx.clb_nlist.blocks().size());
 
     for (auto cluster_id : cluster_ctx.clb_nlist.blocks()) {
-        std::unordered_set<AtomBlockId>* atoms = cluster_to_atoms(cluster_id);
+        std::vector<AtomBlockId> atoms = atoms_lookup.atoms_in_cluster(cluster_id);
         PartitionRegion empty_pr;
         floorplanning_ctx.cluster_constraints[cluster_id] = empty_pr;
 
         //if there are any constrainted atoms in the cluster,
         //we update the cluster's PartitionRegion
-        for (auto atom : *atoms) {
+        for (auto atom : atoms) {
             PartitionId partid = floorplanning_ctx.constraints.get_atom_partition(atom);
 
             if (partid != PartitionId::INVALID()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In this PR, I am using the atom-cluster lookup in the context everywhere in the flow instead of rebuilding a lookup every time we need it. I am also changing all the queries to use the cluster_to_atoms function. The lookup is not built first time itis queried.
