### PR TITLE
Improving Unrelated Clustering Feature in VPR

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -471,15 +471,29 @@ For people not working on CAD, you can probably leave all the options to their d
 
     **Default**: ``on``
 
-.. option:: --allow_unrelated_clustering {on | off | auto}
+.. option:: --allow_unrelated_clustering {on | off | auto | <string>:{on|off|auto}}
 
     Controls whether primitives with no attraction to a cluster may be packed into it.
 
     Unrelated clustering can increase packing density (decreasing the number of blocks required to implement the circuit), but can significantly impact routability.
+    
+    * ``auto`` Dynamically enabled/disabled (based on density).
 
-    When set to ``auto`` VPR automatically decides whether to enable unrelated clustring based on the targetted device and achieved packing density.
+    * ``on`` Unrelated clustering enabled.
+
+    * ``off`` Unrelated clustering disabled.
+
+    * ``<string>:{on|off|auto}`` Specify the unrelated clustering status for a specific block type.
 
     **Default**:  ``auto``
+
+    This option can also take multiple space-separated values.
+
+    For example::
+
+        --allow_unrelated_clustering auto io:on
+
+    would turn on unrelated clustering for io blocks and dynamically determine enable/disable unrelated clustering for all other blocks.
 
 .. option:: --alpha_clustering <float>
 

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -730,16 +730,7 @@ static void ShowAnalysisOpts(const t_analysis_opts& AnalysisOpts) {
 }
 
 static void ShowPackerOpts(const t_packer_opts& PackerOpts) {
-    VTR_LOG("PackerOpts.allow_unrelated_clustering: ");
-    if (PackerOpts.allow_unrelated_clustering == e_unrelated_clustering::ON) {
-        VTR_LOG("true\n");
-    } else if (PackerOpts.allow_unrelated_clustering == e_unrelated_clustering::OFF) {
-        VTR_LOG("false\n");
-    } else if (PackerOpts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
-        VTR_LOG("auto\n");
-    } else {
-        VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown packer allow_unrelated_clustering\n");
-    }
+    VTR_LOG("PackerOpts.allow_unrelated_clustering: %s\n", vtr::join(PackerOpts.allow_unrelated_clustering, " ").c_str());
     VTR_LOG("PackerOpts.alpha_clustering: %f\n", PackerOpts.alpha);
     VTR_LOG("PackerOpts.beta_clustering: %f\n", PackerOpts.beta);
     VTR_LOG("PackerOpts.cluster_seed_type: ");

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1604,7 +1604,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
             "   '--allow_unrelated_clustering auto io:on'\n"
             "would turn on unrelated clustering for io blocks and\n"
             "dynamically determine enable/disable unrelated clustering,\n"
-            "for all all other blocks.\n")
+            "for all other blocks.\n")
 
         .nargs('+')
         .default_value({"auto"})

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1605,7 +1605,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
             "would turn on unrelated clustering for io blocks and\n"
             "dynamically determine enable/disable unrelated clustering,\n"
             "for all all other blocks.\n")
-            
+
         .nargs('+')
         .default_value({"auto"})
         .show_in(argparse::ShowIn::HELP_ONLY);

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -9,7 +9,6 @@
 #include "vtr_log.h"
 #include "vtr_util.h"
 #include "vtr_path.h"
-#include <string>
 
 using argparse::ConvertedValue;
 using argparse::Provenance;
@@ -645,44 +644,6 @@ struct ParseClockModeling {
 
     std::vector<std::string> default_choices() {
         return {"ideal", "route", "dedicated_network"};
-    }
-};
-
-struct ParseUnrelatedClustering {
-    ConvertedValue<e_unrelated_clustering> from_str(std::string str) {
-        ConvertedValue<e_unrelated_clustering> conv_value;
-        if (str == "on")
-            conv_value.set_value(e_unrelated_clustering::ON);
-        else if (str == "off")
-            conv_value.set_value(e_unrelated_clustering::OFF);
-        else if (str == "auto")
-            conv_value.set_value(e_unrelated_clustering::AUTO);
-        else {
-            std::stringstream msg;
-            msg << "Invalid conversion from '"
-                << str
-                << "' to e_unrelated_clustering (expected one of: "
-                << argparse::join(default_choices(), ", ") << ")";
-            conv_value.set_error(msg.str());
-        }
-        return conv_value;
-    }
-
-    ConvertedValue<std::string> to_str(e_unrelated_clustering val) {
-        ConvertedValue<std::string> conv_value;
-        if (val == e_unrelated_clustering::ON)
-            conv_value.set_value("on");
-        else if (val == e_unrelated_clustering::OFF)
-            conv_value.set_value("off");
-        else {
-            VTR_ASSERT(val == e_unrelated_clustering::AUTO);
-            conv_value.set_value("auto");
-        }
-        return conv_value;
-    }
-
-    std::vector<std::string> default_choices() {
-        return {"on", "off", "auto"};
     }
 };
 
@@ -1629,14 +1590,24 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    pack_grp.add_argument<e_unrelated_clustering, ParseUnrelatedClustering>(args.allow_unrelated_clustering, "--allow_unrelated_clustering")
+    pack_grp.add_argument(args.allow_unrelated_clustering, "--allow_unrelated_clustering")
         .help(
             "Controls whether primitives with no attraction to a cluster can be packed into it.\n"
             "Turning unrelated clustering on can increase packing density (fewer blocks are used), but at the cost of worse routability.\n"
-            " * on  : Unrelated clustering enabled\n"
-            " * off : Unrelated clustering disabled\n"
-            " * auto: Dynamically enabled/disabled (based on density)\n")
-        .default_value("auto")
+            "This option can take multiple specifications in several\n"
+            "formats:\n"
+            "* auto (i.e. 'auto'): Dynamically enabled/disabled (based on density)\n"
+            "* on  : Unrelated clustering enabled\n"
+            "* off : Unrelated clustering disabled\n"
+            "* Specified for a certain block type: (e.g. 'clb:on')\n"
+            "These can be used in combination. For example:\n"
+            "   '--allow_unrelated_clustering auto io:on'\n"
+            "would turn on unrelated clustering for io blocks and\n"
+            "dynamically determine enable/disable unrelated clustering,\n"
+            "for all all other blocks.\n")
+            
+        .nargs('+')
+        .default_value({"auto"})
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     pack_grp.add_argument(args.alpha_clustering, "--alpha_clustering")
@@ -1771,19 +1742,6 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
     pack_grp.add_argument<bool, ParseOnOff>(args.use_attraction_groups, "--use_attraction_groups")
         .help("Whether attraction groups are used to make it easier to pack primitives in the same floorplan region together.")
         .default_value("on")
-        .show_in(argparse::ShowIn::HELP_ONLY);
-
-    pack_grp.add_argument(args.pack_num_moves, "--pack_num_moves")
-        .help(
-            "The number of moves that can be tried in packing stage")
-        .default_value("100000")
-        .show_in(argparse::ShowIn::HELP_ONLY);
-
-    pack_grp.add_argument(args.pack_move_type, "--pack_move_type")
-        .help(
-            "The move type used in packing."
-            "The available values are: randomSwap, semiDirectedSwap, semiDirectedSameTypeSwap")
-        .default_value("semiDirectedSwap")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     auto& place_grp = parser.add_argument_group("placement options");
@@ -2014,8 +1972,7 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
     place_grp.add_argument(args.place_reward_fun, "--place_reward_fun")
         .help(
             "The reward function used by placement RL agent."
-            "The available values are: basic, nonPenalizing_basic, runtime_aware, WLbiased_runtime_aware"
-            "The latter two are only available for timing-driven placement.")
+            "The available values are: basic, nonPenalizing_basic, runtime_aware, WLbiased_runtime_aware")
         .default_value("WLbiased_runtime_aware")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
@@ -2761,19 +2718,6 @@ void set_conditional_defaults(t_options& args) {
             args.PlaceAlgorithm.set(CRITICALITY_TIMING_PLACE, Provenance::INFERRED);
         } else {
             args.PlaceAlgorithm.set(BOUNDING_BOX_PLACE, Provenance::INFERRED);
-        }
-    }
-
-    // Check for correct options combinations
-    // If you are running WLdriven placement, the RL reward function should be
-    // either basic or nonPenalizing basic
-    if (args.RL_agent_placement && (args.PlaceAlgorithm == BOUNDING_BOX_PLACE || !args.timing_analysis)) {
-        if (args.place_reward_fun.value() != "basic" && args.place_reward_fun.value() != "nonPenalizing_basic") {
-            VTR_LOG_WARN(
-                "To use RLPlace for WLdriven placements, the reward function should be basic or nonPenalizing_basic.\n"
-                "you can specify the reward function using --place_reward_fun.\n"
-                "Setting the placement reward function to \"basic\"\n");
-            args.place_reward_fun.set("basic", Provenance::INFERRED);
         }
     }
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -82,7 +82,7 @@ struct t_options {
 
     /* Clustering options */
     argparse::ArgValue<bool> connection_driven_clustering;
-    argparse::ArgValue<e_unrelated_clustering> allow_unrelated_clustering;
+    argparse::ArgValue<std::vector<std::string>> allow_unrelated_clustering;
     argparse::ArgValue<float> alpha_clustering;
     argparse::ArgValue<float> beta_clustering;
     argparse::ArgValue<bool> timing_driven_clustering;

--- a/vpr/src/base/vpr_types.cpp
+++ b/vpr/src/base/vpr_types.cpp
@@ -23,6 +23,36 @@ void t_ext_pin_util_targets::set_default_pin_util(t_ext_pin_util default_target)
     defaults_ = default_target;
 }
 
+t_allow_unrelated_clustering::t_allow_unrelated_clustering(enum e_unrel_clust_stat default_stat, enum e_unrel_clust_mode default_mode) {
+    default_.first = default_stat;
+    default_.second = default_mode;
+}
+enum e_unrel_clust_stat t_allow_unrelated_clustering::get_block_status(std::string block_type_name) const{
+    auto itr = overrides_.find(block_type_name);
+    if (itr != overrides_.end()) {
+        std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status = itr->second;
+        return status.first;
+    }
+    return default_.first;
+}
+
+enum e_unrel_clust_mode t_allow_unrelated_clustering::get_block_mode(std::string block_type_name) const{
+    auto itr = overrides_.find(block_type_name);
+    if (itr != overrides_.end()) {
+        std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status = itr->second;
+        return status.second;
+    }
+    return default_.second;
+}
+
+void t_allow_unrelated_clustering::set_block_status(std::string block_type_name, std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status) {
+    overrides_[block_type_name] = status;
+}
+void t_allow_unrelated_clustering::set_default_status(std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status) {
+    default_ = status;
+}
+
+
 t_pack_high_fanout_thresholds::t_pack_high_fanout_thresholds(int threshold)
     : default_(threshold) {}
 

--- a/vpr/src/base/vpr_types.cpp
+++ b/vpr/src/base/vpr_types.cpp
@@ -27,7 +27,7 @@ t_allow_unrelated_clustering::t_allow_unrelated_clustering(enum e_unrel_clust_st
     default_.first = default_stat;
     default_.second = default_mode;
 }
-enum e_unrel_clust_stat t_allow_unrelated_clustering::get_block_status(std::string block_type_name) const{
+enum e_unrel_clust_stat t_allow_unrelated_clustering::get_block_status(std::string block_type_name) const {
     auto itr = overrides_.find(block_type_name);
     if (itr != overrides_.end()) {
         std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status = itr->second;
@@ -36,7 +36,7 @@ enum e_unrel_clust_stat t_allow_unrelated_clustering::get_block_status(std::stri
     return default_.first;
 }
 
-enum e_unrel_clust_mode t_allow_unrelated_clustering::get_block_mode(std::string block_type_name) const{
+enum e_unrel_clust_mode t_allow_unrelated_clustering::get_block_mode(std::string block_type_name) const {
     auto itr = overrides_.find(block_type_name);
     if (itr != overrides_.end()) {
         std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status = itr->second;
@@ -51,7 +51,6 @@ void t_allow_unrelated_clustering::set_block_status(std::string block_type_name,
 void t_allow_unrelated_clustering::set_default_status(std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status) {
     default_ = status;
 }
-
 
 t_pack_high_fanout_thresholds::t_pack_high_fanout_thresholds(int threshold)
     : default_(threshold) {}

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -140,9 +140,8 @@ enum class e_unrel_clust_stat {
 
 enum class e_unrel_clust_mode {
     FIXED, ///<Unrelated clustering status is given by the user and cannot be updated
-    AUTO ///<Unrelated clustering status can be updated by VPR throughout the packing flow
+    AUTO   ///<Unrelated clustering status can be updated by VPR throughout the packing flow
 };
-
 
 enum class e_balance_block_type_util {
     OFF,

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -133,11 +133,16 @@ enum class e_const_gen_inference {
     COMB_SEQ ///<Both combinational and sequential constant generator inference
 };
 
-enum class e_unrelated_clustering {
+enum class e_unrel_clust_stat {
     OFF,
-    ON,
-    AUTO
+    ON
 };
+
+enum class e_unrel_clust_mode {
+    FIXED, ///<Unrelated clustering status is given by the user and cannot be updated
+    AUTO ///<Unrelated clustering status can be updated by VPR throughout the packing flow
+};
+
 
 enum class e_balance_block_type_util {
     OFF,
@@ -206,6 +211,42 @@ class t_ext_pin_util_targets {
   private:
     t_ext_pin_util defaults_;
     std::map<std::string, t_ext_pin_util> overrides_;
+};
+
+class t_allow_unrelated_clustering {
+  public:
+    t_allow_unrelated_clustering() = default;
+    t_allow_unrelated_clustering(enum e_unrel_clust_stat status, enum e_unrel_clust_mode mode);
+    /**
+     * @brief Returns the unrelated clustering status for the specified block type
+     */
+    enum e_unrel_clust_stat get_block_status(std::string block_type_name) const;
+    /**
+     * @brief Returns the unrelated clustering mode for the specified block type
+     */
+    enum e_unrel_clust_mode get_block_mode(std::string block_type_name) const;
+
+  public:
+    /**
+     * @brief Sets the unrelated clustering status for the specified block type
+     * 
+     * The unrelated clustering status is represented as a pair of booleans. 
+     * The first boolean incidcates whether unrelated clustering is turned on or off. 
+     * The second variable indicates whether the status of the variable is provided
+     * by the user(bool = false) or user let it to be automatically determined by VPR(bool = ture). 
+     * If provided by the user, the status cannot be overriden later, otherwise
+     * it can be adjusted by VPR throughout the flow as necessary.
+     */
+    void set_block_status(std::string block_type_name, std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status);
+    /**
+     * @brief Sets the default value for unrelated clustering status
+     * 
+     */
+    void set_default_status(std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> status);
+
+  private:
+    std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> default_;
+    std::map<std::string, std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode>> overrides_;
 };
 
 class t_pack_high_fanout_thresholds {
@@ -840,7 +881,7 @@ struct t_packer_opts {
     float inter_cluster_net_delay;
     float target_device_utilization;
     bool auto_compute_inter_cluster_net_delay;
-    e_unrelated_clustering allow_unrelated_clustering;
+    std::vector<std::string> allow_unrelated_clustering;
     bool connection_driven;
     int pack_verbosity;
     bool enable_pin_feasibility_filter;

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -91,7 +91,7 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
                                                          int num_models,
                                                          const std::unordered_set<AtomNetId>& is_clock,
                                                          const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
-                                                         bool allow_unrelated_clustering,
+                                                         t_allow_unrelated_clustering allow_unrelated_clustering,
                                                          bool balance_block_type_utilization,
                                                          std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,
                                                          const t_ext_pin_util_targets& ext_pin_util_targets,
@@ -300,11 +300,16 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
                 /*it doesn't make sense to do a timing analysis here since there*
                  *is only one atom block clustered it would not change anything      */
             }
+            bool allow_unrel_clust_cur_blk = false;
+            if (allow_unrelated_clustering.get_block_status(cluster_ctx.clb_nlist.block_type(clb_index)->name) == e_unrel_clust_stat::ON) {
+                allow_unrel_clust_cur_blk = true;
+            }
+
             cur_cluster_placement_stats_ptr = &(helper_ctx.cluster_placement_stats[cluster_ctx.clb_nlist.block_type(clb_index)->index]);
             cluster_stats.num_unrelated_clustering_attempts = 0;
             next_molecule = get_molecule_for_cluster(cluster_ctx.clb_nlist.block_pb(clb_index),
                                                      attraction_groups,
-                                                     allow_unrelated_clustering,
+                                                     allow_unrel_clust_cur_blk,
                                                      packer_opts.prioritize_transitive_connectivity,
                                                      packer_opts.transitive_fanout_threshold,
                                                      packer_opts.feasible_block_array_size,
@@ -351,7 +356,7 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
                                  detailed_routing_stage,
                                  attraction_groups,
                                  clb_inter_blk_nets,
-                                 allow_unrelated_clustering,
+                                 allow_unrel_clust_cur_blk,
                                  high_fanout_threshold,
                                  is_clock,
                                  timing_info,

--- a/vpr/src/pack/cluster.h
+++ b/vpr/src/pack/cluster.h
@@ -18,7 +18,7 @@ std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& pa
                                                          int num_models,
                                                          const std::unordered_set<AtomNetId>& is_clock,
                                                          const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
-                                                         bool allow_unrelated_clustering,
+                                                         t_allow_unrelated_clustering allow_unrelated_clustering,
                                                          bool balance_block_type_utilization,
                                                          std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,
                                                          const t_ext_pin_util_targets& ext_pin_util_targets,

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -125,7 +125,6 @@ bool try_pack(t_packer_opts* packer_opts,
 
     t_allow_unrelated_clustering allow_unrelated_clustering = parse_unrelated_clustering_stat(packer_opts->allow_unrelated_clustering);
 
-
     bool balance_block_type_util = false;
     if (packer_opts->balance_block_type_utilization == e_balance_block_type_util::ON) {
         balance_block_type_util = true;
@@ -171,14 +170,13 @@ bool try_pack(t_packer_opts* packer_opts,
             //
             //Turn it on to increase packing density
             std::vector<std::string> fixed_blocks;
-            for(auto& overused_block : overused_blocks) {
+            for (auto& overused_block : overused_blocks) {
                 e_unrel_clust_mode block_mode = allow_unrelated_clustering.get_block_mode(overused_block);
-                if(block_mode == e_unrel_clust_mode::FIXED){
+                if (block_mode == e_unrel_clust_mode::FIXED) {
                     // The user has explicitly set unrelated clustering status for this block type
                     // so we can't change it
                     fixed_blocks.push_back(overused_block);
-                }
-                else{
+                } else {
                     allow_unrelated_clustering.set_block_status(overused_block, std::make_pair(e_unrel_clust_stat::ON, block_mode));
                 }
             }
@@ -187,7 +185,7 @@ bool try_pack(t_packer_opts* packer_opts,
                 balance_block_type_util = true;
             }
 
-            if(fixed_blocks.size() > 0){
+            if (fixed_blocks.size() > 0) {
                 std::stringstream msg;
                 msg << "Packing failed to fit on device.\n"
                     << "The following block types were overused, but unrelated clustering was disabled for them:\n"
@@ -404,24 +402,22 @@ static std::vector<std::string> try_size_device_grid(const t_arch& arch, const s
 
 std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> parse_unrel_clust_from_str(std::string str) {
     std::pair<enum e_unrel_clust_stat, enum e_unrel_clust_mode> conv_value;
-    if (str == "on"){
+    if (str == "on") {
         conv_value.first = e_unrel_clust_stat::ON;
         conv_value.second = e_unrel_clust_mode::FIXED;
-    }
-    else if (str == "off"){
+    } else if (str == "off") {
         conv_value.first = e_unrel_clust_stat::OFF;
         conv_value.second = e_unrel_clust_mode::FIXED;
-    }
-    else if (str == "auto"){
+    } else if (str == "auto") {
         conv_value.first = e_unrel_clust_stat::OFF;
         conv_value.second = e_unrel_clust_mode::AUTO;
-    }
-    else {
+    } else {
         std::stringstream msg;
         msg << "Invalid conversion from '"
             << str
             << "' to e_unrel_clust_stat (expected one of: "
-            << "on, off, auto" << ")";
+            << "on, off, auto"
+            << ")";
         VPR_FATAL_ERROR(VPR_ERROR_PACK, msg.str().c_str());
     }
     return conv_value;
@@ -430,7 +426,7 @@ static bool block_type_found(std::string block_type_name) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     auto logical_block_types = device_ctx.logical_block_types;
 
-    for(auto block_type : logical_block_types) {
+    for (auto block_type : logical_block_types) {
         if (strcmp(block_type.name, block_type_name.c_str()) == 0) {
             return true;
         }
@@ -440,7 +436,7 @@ static bool block_type_found(std::string block_type_name) {
 
 static t_allow_unrelated_clustering parse_unrelated_clustering_stat(std::vector<std::string> specs) {
     // If no options is specified by the user, unrelated clustering is turned off at first and the mode is set to auto
-    t_allow_unrelated_clustering urel_clust_stat(e_unrel_clust_stat::OFF,e_unrel_clust_mode::AUTO);
+    t_allow_unrelated_clustering urel_clust_stat(e_unrel_clust_stat::OFF, e_unrel_clust_mode::AUTO);
 
     bool default_set = false;
     std::set<std::string> seen_block_types;
@@ -461,7 +457,6 @@ static t_allow_unrelated_clustering parse_unrelated_clustering_stat(std::vector<
             VPR_FATAL_ERROR(VPR_ERROR_PACK, msg.str().c_str());
         }
 
-        
         if (block_type.empty()) {
             //Default value
             if (default_set) {
@@ -471,13 +466,11 @@ static t_allow_unrelated_clustering parse_unrelated_clustering_stat(std::vector<
             }
             urel_clust_stat.set_default_status(block_status);
             default_set = true;
-        } 
-        else if(!block_type_found(block_type)){
+        } else if (!block_type_found(block_type)) {
             std::stringstream msg;
             msg << "Block type '" << block_type << "' not found";
             VPR_FATAL_ERROR(VPR_ERROR_PACK, msg.str().c_str());
-        }
-        else {
+        } else {
             if (seen_block_types.count(block_type)) {
                 std::stringstream msg;
                 msg << "Only one unrelated clustering status should be specified for block type '" << block_type << "'";


### PR DESCRIPTION

#### Description
In this pull request, we aim to improve the unrelated clustering feature in VPR. The current feature allows the packer to group unrelated molecules together, but it applies to all block types indiscriminately. We address this limitation by allowing users to set the feature separately for each block type.

Additionally, when the packer fails to pack the design densely enough to fit on the device, it currently turns on unrelated clustering for all block types, which can lead to worsened results for block types that were already fit. To resolve this issue, we have enabled the packer to turn on unrelated clustering only for block types whose utilization exceeds a certain threshold.

#### Motivation and Context
This improvement was motivated by the results of running the Titan23 benchmarks on a Stratix 10 device model with a fixed layout. Many IO-dense designs experienced congestion and routing failures due to the packer's indiscriminate use of the unrelated clustering feature. When the packer was unable to pack the IO pins densely enough, the unrelated clustering feature was turned on for all block types, including LABs, which led to increased congestion in the routing.

#### How Has This Been Tested?
The improved feature has been tested by using it on the designs that failed in the Titan23 benchmarks.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (change which fixes an issue)
- [ x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change requires a change to the documentation
- [ x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed
