### PR TITLE
RLplace move mismatch

### DIFF
--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -28,6 +28,7 @@ enum class e_move_type {
     CRIT_UNIFORM,
     FEASIBLE_REGION,
     MANUAL_MOVE,
+    NUMBER_OF_MOVES,
 };
 
 enum class e_create_move {

--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -27,8 +27,8 @@ enum class e_move_type {
     W_MEDIAN,
     CRIT_UNIFORM,
     FEASIBLE_REGION,
-    MANUAL_MOVE,
-    NUMBER_OF_MOVES,
+    NUMBER_OF_AUTO_MOVES,
+    MANUAL_MOVE = NUMBER_OF_AUTO_MOVES
 };
 
 enum class e_create_move {

--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -22,8 +22,8 @@ enum e_move_result {
 enum class e_move_type {
     UNIFORM,
     MEDIAN,
-    W_CENTROID,
     CENTROID,
+    W_CENTROID,
     W_MEDIAN,
     CRIT_UNIFORM,
     FEASIBLE_REGION,

--- a/vpr/src/place/simpleRL_move_generator.cpp
+++ b/vpr/src/place/simpleRL_move_generator.cpp
@@ -15,25 +15,29 @@ static float scaled_clipped_exp(float x) { return std::exp(std::min(1000000 * x,
  *                                     *
  *                                     */
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<SoftmaxAgent>& agent) {
-    avail_moves.emplace_back(std::make_unique<UniformMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<MedianMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<CentroidMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<WeightedCentroidMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<WeightedMedianMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<CriticalUniformMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<FeasibleRegionMoveGenerator>());
+    avail_moves.resize((int)e_move_type::NUMBER_OF_MOVES);
+
+    avail_moves[(int)e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>();
+    avail_moves[(int)e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>();
+    avail_moves[(int)e_move_type::CENTROID] = std::make_unique<CentroidMoveGenerator>();
+    avail_moves[(int)e_move_type::W_CENTROID] = std::make_unique<WeightedCentroidMoveGenerator>();
+    avail_moves[(int)e_move_type::W_MEDIAN] = std::make_unique<WeightedMedianMoveGenerator>();
+    avail_moves[(int)e_move_type::CRIT_UNIFORM] = std::make_unique<CriticalUniformMoveGenerator>();
+    avail_moves[(int)e_move_type::FEASIBLE_REGION] = std::make_unique<FeasibleRegionMoveGenerator>();
 
     karmed_bandit_agent = std::move(agent);
 }
 
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<EpsilonGreedyAgent>& agent) {
-    avail_moves.emplace_back(std::make_unique<UniformMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<MedianMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<CentroidMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<WeightedCentroidMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<WeightedMedianMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<CriticalUniformMoveGenerator>());
-    avail_moves.emplace_back(std::make_unique<FeasibleRegionMoveGenerator>());
+    avail_moves.resize((int)e_move_type::NUMBER_OF_MOVES);
+
+    avail_moves[(int)e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>();
+    avail_moves[(int)e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>();
+    avail_moves[(int)e_move_type::CENTROID] = std::make_unique<CentroidMoveGenerator>();
+    avail_moves[(int)e_move_type::W_CENTROID] = std::make_unique<WeightedCentroidMoveGenerator>();
+    avail_moves[(int)e_move_type::W_MEDIAN] = std::make_unique<WeightedMedianMoveGenerator>();
+    avail_moves[(int)e_move_type::CRIT_UNIFORM] = std::make_unique<CriticalUniformMoveGenerator>();
+    avail_moves[(int)e_move_type::FEASIBLE_REGION] = std::make_unique<FeasibleRegionMoveGenerator>();
 
     karmed_bandit_agent = std::move(agent);
 }

--- a/vpr/src/place/simpleRL_move_generator.cpp
+++ b/vpr/src/place/simpleRL_move_generator.cpp
@@ -15,7 +15,7 @@ static float scaled_clipped_exp(float x) { return std::exp(std::min(1000000 * x,
  *                                     *
  *                                     */
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<SoftmaxAgent>& agent) {
-    avail_moves.resize((int)e_move_type::NUMBER_OF_MOVES);
+    avail_moves.resize((int)e_move_type::NUMBER_OF_AUTO_MOVES);
 
     avail_moves[(int)e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>();
     avail_moves[(int)e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>();
@@ -29,7 +29,7 @@ SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<SoftmaxAgent>& agen
 }
 
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(std::unique_ptr<EpsilonGreedyAgent>& agent) {
-    avail_moves.resize((int)e_move_type::NUMBER_OF_MOVES);
+    avail_moves.resize((int)e_move_type::NUMBER_OF_AUTO_MOVES);
 
     avail_moves[(int)e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>();
     avail_moves[(int)e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
RL agent move generator had an order dependency with e_move_type data structure defined in the "moves_util.h" file. The previous code uses the enum structure as an index of an array to access different move generators. However, the order of enum variables and avail_moves (defined in the "simpleRL_move_generator.cpp" file) array were different.

Hence, placement output for centroid and weighted centroid move was inaccurate. This change expects no performance change but removes the order dependency between these structures.

Also, the centroid move in e_move_type should be the third option (it is used to be the fourth) since if the placement algorithm is not timing, it is only used three first moves (Uniform, Median, Centroid). Having the weighted centroid move as the third move type in the enum mentioned above will result in a segmentation fault since criticalities would be NULL.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
