### PR TITLE
Route constraint for local clock and reset.

### DIFF
--- a/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
+++ b/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx.py vpr_constraints.xsd
- * Input file: /home/khalid88/Documents/uxsdcxx/vpr_constraints.xsd
- * md5sum of input file: 6b6011a6e6446347b234da82e517422e
+ * Cmdline: uxsdcxx.py /home/tao/works/dev/clock/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * Input file: /home/tao/works/dev/clock/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * md5sum of input file: 2d6f442d8044f76e8f1b1d276b7358da
  */
 
 #include <functional>
@@ -25,8 +25,6 @@
 #include "pugixml.hpp"
 
 #include "vpr_constraints_uxsdcxx_interface.h"
-#include "region.h"
-
 /* All uxsdcxx functions and structs live in this namespace. */
 namespace uxsd {
 
@@ -52,6 +50,10 @@ inline void load_partition(const pugi::xml_node& root, T& out, Context& context,
 template<class T, typename Context>
 inline void load_partition_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
 template<class T, typename Context>
+inline void load_set_global_signal(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+template<class T, typename Context>
+inline void load_global_route_constraints(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+template<class T, typename Context>
 inline void load_vpr_constraints(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
 
 /* Declarations for internal write functions for the complex types. */
@@ -59,6 +61,8 @@ template<class T>
 inline void write_partition(T& in, std::ostream& os, const void* data, void* iter);
 template<class T>
 inline void write_partition_list(T& in, std::ostream& os, const void* data, void* iter);
+template<class T>
+inline void write_global_route_constraints(T& in, std::ostream& os, const void* data, void* iter);
 template<class T>
 inline void write_vpr_constraints(T& in, std::ostream& os, const void* data, void* iter);
 
@@ -142,8 +146,17 @@ constexpr const char* atok_lookup_t_partition[] = {"name"};
 
 enum class gtok_t_partition_list { PARTITION };
 constexpr const char* gtok_lookup_t_partition_list[] = {"partition"};
-enum class gtok_t_vpr_constraints { PARTITION_LIST };
-constexpr const char* gtok_lookup_t_vpr_constraints[] = {"partition_list"};
+
+enum class atok_t_set_global_signal { NAME,
+                                      ROUTE_MODEL,
+                                      TYPE };
+constexpr const char* atok_lookup_t_set_global_signal[] = {"name", "route_model", "type"};
+
+enum class gtok_t_global_route_constraints { SET_GLOBAL_SIGNAL };
+constexpr const char* gtok_lookup_t_global_route_constraints[] = {"set_global_signal"};
+enum class gtok_t_vpr_constraints { PARTITION_LIST,
+                                    GLOBAL_ROUTE_CONSTRAINTS };
+constexpr const char* gtok_lookup_t_vpr_constraints[] = {"partition_list", "global_route_constraints"};
 enum class atok_t_vpr_constraints { TOOL_NAME };
 constexpr const char* atok_lookup_t_vpr_constraints[] = {"tool_name"};
 
@@ -348,6 +361,84 @@ inline gtok_t_partition_list lex_node_t_partition_list(const char* in, const std
     noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <partition_list>.").c_str());
 }
 
+inline atok_t_set_global_signal lex_attr_t_set_global_signal(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 4:
+            switch (*((triehash_uu32*)&in[0])) {
+                case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
+                    return atok_t_set_global_signal::NAME;
+                    break;
+                case onechar('t', 0, 32) | onechar('y', 8, 32) | onechar('p', 16, 32) | onechar('e', 24, 32):
+                    return atok_t_set_global_signal::TYPE;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 11:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('r', 0, 64) | onechar('o', 8, 64) | onechar('u', 16, 64) | onechar('t', 24, 64) | onechar('e', 32, 64) | onechar('_', 40, 64) | onechar('m', 48, 64) | onechar('o', 56, 64):
+                    switch (in[8]) {
+                        case onechar('d', 0, 8):
+                            switch (in[9]) {
+                                case onechar('e', 0, 8):
+                                    switch (in[10]) {
+                                        case onechar('l', 0, 8):
+                                            return atok_t_set_global_signal::ROUTE_MODEL;
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <set_global_signal>.").c_str());
+}
+
+inline gtok_t_global_route_constraints lex_node_t_global_route_constraints(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 17:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('s', 0, 64) | onechar('e', 8, 64) | onechar('t', 16, 64) | onechar('_', 24, 64) | onechar('g', 32, 64) | onechar('l', 40, 64) | onechar('o', 48, 64) | onechar('b', 56, 64):
+                    switch (*((triehash_uu64*)&in[8])) {
+                        case onechar('a', 0, 64) | onechar('l', 8, 64) | onechar('_', 16, 64) | onechar('s', 24, 64) | onechar('i', 32, 64) | onechar('g', 40, 64) | onechar('n', 48, 64) | onechar('a', 56, 64):
+                            switch (in[16]) {
+                                case onechar('l', 0, 8):
+                                    return gtok_t_global_route_constraints::SET_GLOBAL_SIGNAL;
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <global_route_constraints>.").c_str());
+}
+
 inline gtok_t_vpr_constraints lex_node_t_vpr_constraints(const char* in, const std::function<void(const char*)>* report_error) {
     unsigned int len = strlen(in);
     switch (len) {
@@ -365,6 +456,27 @@ inline gtok_t_vpr_constraints lex_node_t_vpr_constraints(const char* in, const s
                                         default:
                                             break;
                                     }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 24:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('g', 0, 64) | onechar('l', 8, 64) | onechar('o', 16, 64) | onechar('b', 24, 64) | onechar('a', 32, 64) | onechar('l', 40, 64) | onechar('_', 48, 64) | onechar('r', 56, 64):
+                    switch (*((triehash_uu64*)&in[8])) {
+                        case onechar('o', 0, 64) | onechar('u', 8, 64) | onechar('t', 16, 64) | onechar('e', 24, 64) | onechar('_', 32, 64) | onechar('c', 40, 64) | onechar('o', 48, 64) | onechar('n', 56, 64):
+                            switch (*((triehash_uu64*)&in[16])) {
+                                case onechar('s', 0, 64) | onechar('t', 8, 64) | onechar('r', 16, 64) | onechar('a', 24, 64) | onechar('i', 32, 64) | onechar('n', 40, 64) | onechar('t', 48, 64) | onechar('s', 56, 64):
+                                    return gtok_t_vpr_constraints::GLOBAL_ROUTE_CONSTRAINTS;
                                     break;
                                 default:
                                     break;
@@ -413,12 +525,6 @@ inline atok_t_vpr_constraints lex_attr_t_vpr_constraints(const char* in, const s
 [[noreturn]] inline void dfa_error(const char* wrong, const int* states, const char* const* lookup, int len, const std::function<void(const char*)>* report_error);
 
 /**
- * Internal error function for xs:all validators.
- */
-template<std::size_t N>
-[[noreturn]] inline void all_error(std::bitset<N> gstate, const char* const* lookup, const std::function<void(const char*)>* report_error);
-
-/**
  * Internal error function for attribute validators.
  */
 template<std::size_t N>
@@ -427,8 +533,6 @@ template<std::size_t N>
 /* Internal loading functions, which validate and load a PugiXML DOM tree into memory. */
 inline int load_int(const char* in, const std::function<void(const char*)>* report_error) {
     int out;
-    // global variable, must set to 0 before using it to avoid changed by other errors
-    errno = 0;
     out = std::strtol(in, NULL, 10);
     if (errno != 0)
         noreturn_report(report_error, ("Invalid value `" + std::string(in) + "` when loading into a int.").c_str());
@@ -675,6 +779,102 @@ inline void load_partition_list(const pugi::xml_node& root, T& out, Context& con
 }
 
 template<class T, typename Context>
+inline void load_set_global_signal(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
+    (void)root;
+    (void)out;
+    (void)context;
+    (void)report_error;
+    // Update current file offset in case an error is encountered.
+    *offset_debug = root.offset_debug();
+
+    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
+        atok_t_set_global_signal in = lex_attr_t_set_global_signal(attr.name(), report_error);
+        switch (in) {
+            case atok_t_set_global_signal::NAME:
+                out.set_set_global_signal_name(attr.value(), context);
+                break;
+            case atok_t_set_global_signal::ROUTE_MODEL:
+                out.set_set_global_signal_route_model(attr.value(), context);
+                break;
+            case atok_t_set_global_signal::TYPE:
+                out.set_set_global_signal_type(attr.value(), context);
+                break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+
+    if (root.first_child().type() == pugi::node_element)
+        noreturn_report(report_error, "Unexpected child element in <set_global_signal>.");
+}
+
+constexpr int NUM_T_GLOBAL_ROUTE_CONSTRAINTS_STATES = 2;
+constexpr const int NUM_T_GLOBAL_ROUTE_CONSTRAINTS_INPUTS = 1;
+constexpr int gstate_t_global_route_constraints[NUM_T_GLOBAL_ROUTE_CONSTRAINTS_STATES][NUM_T_GLOBAL_ROUTE_CONSTRAINTS_INPUTS] = {
+    {0},
+    {0},
+};
+template<class T, typename Context>
+inline void load_global_route_constraints(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
+    (void)root;
+    (void)out;
+    (void)context;
+    (void)report_error;
+    // Update current file offset in case an error is encountered.
+    *offset_debug = root.offset_debug();
+
+    if (root.first_attribute())
+        noreturn_report(report_error, "Unexpected attribute in <global_route_constraints>.");
+
+    // Preallocate arrays by counting child nodes (if any)
+    size_t set_global_signal_count = 0;
+    {
+        int next, state = 1;
+        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+            *offset_debug = node.offset_debug();
+            gtok_t_global_route_constraints in = lex_node_t_global_route_constraints(node.name(), report_error);
+            next = gstate_t_global_route_constraints[state][(int)in];
+            if (next == -1)
+                dfa_error(gtok_lookup_t_global_route_constraints[(int)in], gstate_t_global_route_constraints[state], gtok_lookup_t_global_route_constraints, 1, report_error);
+            state = next;
+            switch (in) {
+                case gtok_t_global_route_constraints::SET_GLOBAL_SIGNAL:
+                    set_global_signal_count += 1;
+                    break;
+                default:
+                    break; /* Not possible. */
+            }
+        }
+
+        out.preallocate_global_route_constraints_set_global_signal(context, set_global_signal_count);
+    }
+    int next, state = 1;
+    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+        *offset_debug = node.offset_debug();
+        gtok_t_global_route_constraints in = lex_node_t_global_route_constraints(node.name(), report_error);
+        next = gstate_t_global_route_constraints[state][(int)in];
+        if (next == -1)
+            dfa_error(gtok_lookup_t_global_route_constraints[(int)in], gstate_t_global_route_constraints[state], gtok_lookup_t_global_route_constraints, 1, report_error);
+        state = next;
+        switch (in) {
+            case gtok_t_global_route_constraints::SET_GLOBAL_SIGNAL: {
+                auto child_context = out.add_global_route_constraints_set_global_signal(context);
+                load_set_global_signal(node, out, child_context, report_error, offset_debug);
+                out.finish_global_route_constraints_set_global_signal(child_context);
+            } break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+    if (state != 0) dfa_error("end of input", gstate_t_global_route_constraints[state], gtok_lookup_t_global_route_constraints, 1, report_error);
+}
+
+constexpr int NUM_T_VPR_CONSTRAINTS_STATES = 1;
+constexpr const int NUM_T_VPR_CONSTRAINTS_INPUTS = 2;
+constexpr int gstate_t_vpr_constraints[NUM_T_VPR_CONSTRAINTS_STATES][NUM_T_VPR_CONSTRAINTS_INPUTS] = {
+    {0, 0},
+};
+template<class T, typename Context>
 inline void load_vpr_constraints(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
     (void)root;
     (void)out;
@@ -694,26 +894,57 @@ inline void load_vpr_constraints(const pugi::xml_node& root, T& out, Context& co
         }
     }
 
-    std::bitset<1> gstate = 0;
+    // Preallocate arrays by counting child nodes (if any)
+    size_t partition_list_count = 0;
+    size_t global_route_constraints_count = 0;
+    {
+        int next, state = 0;
+        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+            *offset_debug = node.offset_debug();
+            gtok_t_vpr_constraints in = lex_node_t_vpr_constraints(node.name(), report_error);
+            next = gstate_t_vpr_constraints[state][(int)in];
+            if (next == -1)
+                dfa_error(gtok_lookup_t_vpr_constraints[(int)in], gstate_t_vpr_constraints[state], gtok_lookup_t_vpr_constraints, 2, report_error);
+            state = next;
+            switch (in) {
+                case gtok_t_vpr_constraints::PARTITION_LIST:
+                    partition_list_count += 1;
+                    break;
+                case gtok_t_vpr_constraints::GLOBAL_ROUTE_CONSTRAINTS:
+                    global_route_constraints_count += 1;
+                    break;
+                default:
+                    break; /* Not possible. */
+            }
+        }
+
+        out.preallocate_vpr_constraints_partition_list(context, partition_list_count);
+        out.preallocate_vpr_constraints_global_route_constraints(context, global_route_constraints_count);
+    }
+    int next, state = 0;
     for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
         *offset_debug = node.offset_debug();
         gtok_t_vpr_constraints in = lex_node_t_vpr_constraints(node.name(), report_error);
-        if (gstate[(int)in] == 0)
-            gstate[(int)in] = 1;
-        else
-            noreturn_report(report_error, ("Duplicate element " + std::string(node.name()) + " in <vpr_constraints>.").c_str());
+        next = gstate_t_vpr_constraints[state][(int)in];
+        if (next == -1)
+            dfa_error(gtok_lookup_t_vpr_constraints[(int)in], gstate_t_vpr_constraints[state], gtok_lookup_t_vpr_constraints, 2, report_error);
+        state = next;
         switch (in) {
             case gtok_t_vpr_constraints::PARTITION_LIST: {
-                auto child_context = out.init_vpr_constraints_partition_list(context);
+                auto child_context = out.add_vpr_constraints_partition_list(context);
                 load_partition_list(node, out, child_context, report_error, offset_debug);
                 out.finish_vpr_constraints_partition_list(child_context);
+            } break;
+            case gtok_t_vpr_constraints::GLOBAL_ROUTE_CONSTRAINTS: {
+                auto child_context = out.add_vpr_constraints_global_route_constraints(context);
+                load_global_route_constraints(node, out, child_context, report_error, offset_debug);
+                out.finish_vpr_constraints_global_route_constraints(child_context);
             } break;
             default:
                 break; /* Not possible. */
         }
     }
-    std::bitset<1> test_gstate = gstate | std::bitset<1>(0b0);
-    if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_vpr_constraints, report_error);
+    if (state != 0) dfa_error("end of input", gstate_t_vpr_constraints[state], gtok_lookup_t_vpr_constraints, 2, report_error);
 }
 
 /* Internal writing functions, which uxsdcxx uses to write out a class. */
@@ -734,7 +965,7 @@ inline void write_partition(T& in, std::ostream& os, Context& context) {
         for (size_t i = 0, n = in.num_partition_add_region(context); i < n; i++) {
             auto child_context = in.get_partition_add_region(i, context);
             os << "<add_region";
-            if (in.get_add_region_subtile(child_context) != NO_SUBTILE)
+            if ((bool)in.get_add_region_subtile(child_context))
                 os << " subtile=\"" << in.get_add_region_subtile(child_context) << "\"";
             os << " x_high=\"" << in.get_add_region_x_high(child_context) << "\"";
             os << " x_low=\"" << in.get_add_region_x_low(child_context) << "\"";
@@ -763,15 +994,42 @@ inline void write_partition_list(T& in, std::ostream& os, Context& context) {
 }
 
 template<class T, typename Context>
+inline void write_global_route_constraints(T& in, std::ostream& os, Context& context) {
+    (void)in;
+    (void)os;
+    (void)context;
+    {
+        for (size_t i = 0, n = in.num_global_route_constraints_set_global_signal(context); i < n; i++) {
+            auto child_context = in.get_global_route_constraints_set_global_signal(i, context);
+            os << "<set_global_signal";
+            os << " name=\"" << in.get_set_global_signal_name(child_context) << "\"";
+            os << " route_model=\"" << in.get_set_global_signal_route_model(child_context) << "\"";
+            os << " type=\"" << in.get_set_global_signal_type(child_context) << "\"";
+            os << "/>\n";
+        }
+    }
+}
+
+template<class T, typename Context>
 inline void write_vpr_constraints(T& in, std::ostream& os, Context& context) {
     (void)in;
     (void)os;
     (void)context;
     {
-        auto child_context = in.get_vpr_constraints_partition_list(context);
-        os << "<partition_list>\n";
-        write_partition_list(in, os, child_context);
-        os << "</partition_list>\n";
+        for (size_t i = 0, n = in.num_vpr_constraints_partition_list(context); i < n; i++) {
+            auto child_context = in.get_vpr_constraints_partition_list(i, context);
+            os << "<partition_list>\n";
+            write_partition_list(in, os, child_context);
+            os << "</partition_list>\n";
+        }
+    }
+    {
+        for (size_t i = 0, n = in.num_vpr_constraints_global_route_constraints(context); i < n; i++) {
+            auto child_context = in.get_vpr_constraints_global_route_constraints(i, context);
+            os << "<global_route_constraints>\n";
+            write_global_route_constraints(in, os, child_context);
+            os << "</global_route_constraints>\n";
+        }
     }
 }
 
@@ -786,20 +1044,6 @@ inline void dfa_error(const char* wrong, const int* states, const char* const* l
         expected_or += std::string(" or ") + expected[i];
 
     noreturn_report(report_error, ("Expected " + expected_or + ", found " + std::string(wrong)).c_str());
-}
-
-template<std::size_t N>
-inline void all_error(std::bitset<N> gstate, const char* const* lookup, const std::function<void(const char*)>* report_error) {
-    std::vector<std::string> missing;
-    for (unsigned int i = 0; i < N; i++) {
-        if (gstate[i] == 0) missing.push_back(lookup[i]);
-    }
-
-    std::string missing_and = missing[0];
-    for (unsigned int i = 1; i < missing.size(); i++)
-        missing_and += std::string(", ") + missing[i];
-
-    noreturn_report(report_error, ("Didn't find required elements " + missing_and + ".").c_str());
 }
 
 template<std::size_t N>

--- a/vpr/src/base/gen/vpr_constraints_uxsdcxx_interface.h
+++ b/vpr/src/base/gen/vpr_constraints_uxsdcxx_interface.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx.py vpr_constraints.xsd
- * Input file: /home/khalid88/Documents/uxsdcxx/vpr_constraints.xsd
- * md5sum of input file: 6b6011a6e6446347b234da82e517422e
+ * Cmdline: uxsdcxx.py /home/tao/works/dev/clock/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * Input file: /home/tao/works/dev/clock/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * md5sum of input file: 2d6f442d8044f76e8f1b1d276b7358da
  */
 
 #include <functional>
@@ -24,11 +24,15 @@ struct DefaultVprConstraintsContextTypes {
     using AddRegionReadContext = void*;
     using PartitionReadContext = void*;
     using PartitionListReadContext = void*;
+    using SetGlobalSignalReadContext = void*;
+    using GlobalRouteConstraintsReadContext = void*;
     using VprConstraintsReadContext = void*;
     using AddAtomWriteContext = void*;
     using AddRegionWriteContext = void*;
     using PartitionWriteContext = void*;
     using PartitionListWriteContext = void*;
+    using SetGlobalSignalWriteContext = void*;
+    using GlobalRouteConstraintsWriteContext = void*;
     using VprConstraintsWriteContext = void*;
 };
 
@@ -92,7 +96,7 @@ class VprConstraintsBase {
     /** Generated for complex type "partition_list":
      * <xs:complexType name="partition_list">
      *   <xs:sequence>
-     *     <xs:element maxOccurs="unbounded" name="partition" type="partition" />
+     *     <xs:element name="partition" type="partition" maxOccurs="unbounded" />
      *   </xs:sequence>
      * </xs:complexType>
      */
@@ -102,19 +106,54 @@ class VprConstraintsBase {
     virtual inline size_t num_partition_list_partition(typename ContextTypes::PartitionListReadContext& ctx) = 0;
     virtual inline typename ContextTypes::PartitionReadContext get_partition_list_partition(int n, typename ContextTypes::PartitionListReadContext& ctx) = 0;
 
+    /** Generated for complex type "set_global_signal":
+     * <xs:complexType name="set_global_signal">
+     *   <xs:attribute name="name" type="xs:string" use="required" />
+     *   <xs:attribute name="type" type="xs:string" use="required" />
+     *   <xs:attribute name="route_model" type="xs:string" use="required" />
+     * </xs:complexType>
+     */
+    virtual inline const char* get_set_global_signal_name(typename ContextTypes::SetGlobalSignalReadContext& ctx) = 0;
+    virtual inline void set_set_global_signal_name(const char* name, typename ContextTypes::SetGlobalSignalWriteContext& ctx) = 0;
+    virtual inline const char* get_set_global_signal_route_model(typename ContextTypes::SetGlobalSignalReadContext& ctx) = 0;
+    virtual inline void set_set_global_signal_route_model(const char* route_model, typename ContextTypes::SetGlobalSignalWriteContext& ctx) = 0;
+    virtual inline const char* get_set_global_signal_type(typename ContextTypes::SetGlobalSignalReadContext& ctx) = 0;
+    virtual inline void set_set_global_signal_type(const char* type, typename ContextTypes::SetGlobalSignalWriteContext& ctx) = 0;
+
+    /** Generated for complex type "global_route_constraints":
+     * <xs:complexType name="global_route_constraints">
+     *   <xs:sequence>
+     *     <xs:element name="set_global_signal" type="set_global_signal" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     * </xs:complexType>
+     */
+    virtual inline void preallocate_global_route_constraints_set_global_signal(typename ContextTypes::GlobalRouteConstraintsWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::SetGlobalSignalWriteContext add_global_route_constraints_set_global_signal(typename ContextTypes::GlobalRouteConstraintsWriteContext& ctx) = 0;
+    virtual inline void finish_global_route_constraints_set_global_signal(typename ContextTypes::SetGlobalSignalWriteContext& ctx) = 0;
+    virtual inline size_t num_global_route_constraints_set_global_signal(typename ContextTypes::GlobalRouteConstraintsReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::SetGlobalSignalReadContext get_global_route_constraints_set_global_signal(int n, typename ContextTypes::GlobalRouteConstraintsReadContext& ctx) = 0;
+
     /** Generated for complex type "vpr_constraints":
      * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
-     *     <xs:all>
+     *     <xs:choice minOccurs="0" maxOccurs="unbounded">
      *       <xs:element name="partition_list" type="partition_list" />
-     *     </xs:all>
+     *       <xs:element name="global_route_constraints" type="global_route_constraints" />
+     *     </xs:choice>
      *     <xs:attribute name="tool_name" type="xs:string" />
      *   </xs:complexType>
      */
     virtual inline const char* get_vpr_constraints_tool_name(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
     virtual inline void set_vpr_constraints_tool_name(const char* tool_name, typename ContextTypes::VprConstraintsWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::PartitionListWriteContext init_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsWriteContext& ctx) = 0;
+    virtual inline void preallocate_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::PartitionListWriteContext add_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsWriteContext& ctx) = 0;
     virtual inline void finish_vpr_constraints_partition_list(typename ContextTypes::PartitionListWriteContext& ctx) = 0;
-    virtual inline typename ContextTypes::PartitionListReadContext get_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
+    virtual inline size_t num_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::PartitionListReadContext get_vpr_constraints_partition_list(int n, typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
+    virtual inline void preallocate_vpr_constraints_global_route_constraints(typename ContextTypes::VprConstraintsWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::GlobalRouteConstraintsWriteContext add_vpr_constraints_global_route_constraints(typename ContextTypes::VprConstraintsWriteContext& ctx) = 0;
+    virtual inline void finish_vpr_constraints_global_route_constraints(typename ContextTypes::GlobalRouteConstraintsWriteContext& ctx) = 0;
+    virtual inline size_t num_vpr_constraints_global_route_constraints(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::GlobalRouteConstraintsReadContext get_vpr_constraints_global_route_constraints(int n, typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
 };
 
 } /* namespace uxsd */

--- a/vpr/src/base/route_constraint.cpp
+++ b/vpr/src/base/route_constraint.cpp
@@ -1,0 +1,43 @@
+#include "route_constraint.h"
+
+RouteConstraint::RouteConstraint() {
+    net_name_ = std::string("");
+    net_type_ = std::string("");
+    route_method_ = std::string("");
+    is_valid_ = false;
+}
+
+void RouteConstraint::set_net_name(std::string name) {
+    net_name_ = name;
+    return;
+}
+
+std::string RouteConstraint::get_net_name() const {
+    return net_name_;
+}
+
+void RouteConstraint::set_net_type(std::string type) {
+    net_type_ = type;
+    return;
+}
+
+std::string RouteConstraint::get_net_type() const {
+    return net_type_;
+}
+
+void RouteConstraint::set_route_model(std::string route_method) {
+    route_method_ = route_method;
+    return;
+}
+
+std::string RouteConstraint::get_route_model() const {
+    return route_method_;
+}
+
+void RouteConstraint::set_is_valid(bool value) {
+    is_valid_ = value;
+}
+
+bool RouteConstraint::get_is_valid() const {
+    return is_valid_;
+}

--- a/vpr/src/base/route_constraint.h
+++ b/vpr/src/base/route_constraint.h
@@ -1,0 +1,65 @@
+#ifndef ROUTE_CONSTRAINT_H
+#define ROUTE_CONSTRAINT_H
+
+#include "vpr_types.h"
+
+/**
+ * @file
+ * @brief This file defines the RouteConstraint class.
+ */
+
+class RouteConstraint {
+  public:
+    /**
+     * @brief Constructor for the RouteConstraint class, sets member variables to invalid values
+     */
+    RouteConstraint();
+
+    /**
+     * @brief get net name
+     */
+    std::string get_net_name() const;
+
+    /**
+     * @brief set net name
+     */
+    void set_net_name(std::string);
+
+    /**
+     * @brief get net type
+     */
+    std::string get_net_type() const;
+
+    /**
+     * @brief set net type
+     */
+    void set_net_type(std::string);
+
+    /**
+     * @brief get route model
+     */
+    std::string get_route_model() const;
+
+    /**
+     * @brief set route model
+     */
+    void set_route_model(std::string);
+
+    /**
+     * @brief set is valid 
+     */
+    void set_is_valid(bool);
+
+    /**
+     * @brief get is valid 
+     */
+    bool get_is_valid() const;
+
+  private:
+    std::string net_name_;
+    std::string net_type_;
+    std::string route_method_;
+    bool is_valid_;
+};
+
+#endif /* ROUTE_CONSTRAINT_H */

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -346,10 +346,15 @@ void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_a
         }
     }
 
-    //Initialize vpr floorplanning constraints
+    //Initialize vpr floorplanning and routing constraints
     auto& filename_opts = vpr_setup->FileNameOpts;
     if (!filename_opts.read_vpr_constraints_file.empty()) {
-        load_vpr_constraints_file(filename_opts.read_vpr_constraints_file.c_str());
+        load_vpr_constraints_files(filename_opts.read_vpr_constraints_file.c_str());
+
+        // give a notificaiton on routing constraints overiding clock modeling
+        if (g_vpr_ctx.routing().constraints.get_route_constraint_num() && options->clock_modeling.provenance() == argparse::Provenance::SPECIFIED) {
+            VTR_LOG_WARN("Route constraint(s) detected and will override clock modeling setting.\n");
+        }
     }
 
     fflush(stdout);
@@ -696,7 +701,7 @@ bool vpr_place_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
 
     //Write out a vpr floorplanning constraints file if the option is specified
     if (!filename_opts.write_vpr_constraints_file.empty()) {
-        write_vpr_floorplan_constraints(filename_opts.write_vpr_constraints_file.c_str(), placer_opts.place_constraint_expand, placer_opts.place_constraint_subtile,
+        write_vpr_floorplan_constraints("vpr_floorplan_constraints.xml" /*filename_opts.write_vpr_constraints_file.c_str()*/, placer_opts.place_constraint_expand, placer_opts.place_constraint_subtile,
                                         placer_opts.floorplan_num_horizontal_partitions, placer_opts.floorplan_num_vertical_partitions);
     }
 
@@ -766,6 +771,11 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch, bool is_f
         //Assume successful
         route_status = RouteStatus(true, -1);
     } else { //Do or load
+
+        // apply route constraints
+        // use mutable routing context here to apply change on the constraints when binding the constraint to real net
+        apply_route_constraints(g_vpr_ctx.mutable_routing().constraints);
+
         int chan_width = router_opts.fixed_channel_width;
 
         auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -847,6 +857,11 @@ RouteStatus vpr_route_flow(t_vpr_setup& vpr_setup, const t_arch& arch, bool is_f
 
         //Update interactive graphics
         update_screen(ScreenUpdatePriority::MAJOR, graphics_msg.c_str(), ROUTING, timing_info);
+
+        //Write out a vpr floorplanning constraints file if the option is specified
+        if (!filename_opts.write_vpr_constraints_file.empty()) {
+            write_vpr_route_constraints(g_vpr_ctx.routing().constraints, "vpr_route_constraints.xml" /*filename_opts.write_vpr_constraints_file.c_str()*/);
+        }
     }
 
     return route_status;

--- a/vpr/src/base/vpr_constraints.h
+++ b/vpr/src/base/vpr_constraints.h
@@ -5,6 +5,7 @@
 #include "vpr_utils.h"
 #include "partition.h"
 #include "partition_region.h"
+#include "route_constraint.h"
 
 /**
  * @file
@@ -87,6 +88,34 @@ class VprConstraints {
      */
     PartitionRegion get_partition_pr(PartitionId part_id);
 
+    /**
+     * @brief add route constraint
+     *
+     *   @param net_name the route constraint 
+     */
+    void add_route_constraint(RouteConstraint rc);
+
+    /**
+     * @brief returns route constraint by index
+     *
+     *   @param index the constraint index 
+     */
+    RouteConstraint get_route_constraint_by_idx(std::size_t index) const;
+
+    /**
+     * @brief returns route constraint of a specific net
+     *
+     *   @param net_name the net name
+     */
+    RouteConstraint get_route_constraint_by_net_name(std::string net_name);
+
+    /**
+     * @brief returns number of route constraints
+     *
+     *   @param void
+     */
+    int get_route_constraint_num(void) const;
+
   private:
     /**
      * Store all constrained atoms
@@ -97,6 +126,11 @@ class VprConstraints {
      * Store all partitions
      */
     vtr::vector<PartitionId, Partition> partitions;
+
+    /**
+     * store all route constraints 
+     */
+    std::unordered_map<std::string, RouteConstraint> route_constraints_;
 };
 
 ///@brief used to print floorplanning constraints data from a VprConstraints object

--- a/vpr/src/base/vpr_constraints.xsd
+++ b/vpr/src/base/vpr_constraints.xsd
@@ -59,16 +59,36 @@
     </xs:sequence>
   </xs:complexType>
 
+
+
+  <!-- Add for global route constraint, an example
+    <global_route_constraints>
+      <set_global_signal name="clk0" type="clock" route_model="ideal"/> 
+      ...
+    </global_route_constraints>
+    -->
+  <xs:complexType name="set_global_signal">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="type" type="xs:string" use="required"/>
+    <xs:attribute name="route_model" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="global_route_constraints">
+    <xs:sequence>
+      <xs:element name="set_global_signal" type="set_global_signal" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
 <!-- This last definition is the root tag definition.  The name of the
        xs:element is the root tag, and the contents of the xs:complexType
        defines what attributes and subtags are expected.
     -->
   <xs:element name="vpr_constraints">
     <xs:complexType>
-      <xs:all>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="partition_list" type="partition_list"/>
-      </xs:all>
-
+        <xs:element name="global_route_constraints" type="global_route_constraints"/>
+      </xs:choice>
       <xs:attribute name="tool_name" type="xs:string"/>
     </xs:complexType>
   </xs:element>

--- a/vpr/src/base/vpr_constraints_reader.cpp
+++ b/vpr/src/base/vpr_constraints_reader.cpp
@@ -10,30 +10,58 @@
 
 #include <fstream>
 #include "vpr_constraints_reader.h"
+#include "vtr_token.h"
 
-void load_vpr_constraints_file(const char* read_vpr_constraints_name) {
-    vtr::ScopedStartFinishTimer timer("Loading VPR constraints file");
+void load_vpr_constraints_files(const char* read_vpr_constraints_name) {
+    vtr::ScopedStartFinishTimer timer("Loading VPR constraints file(s)");
 
     VprConstraintsSerializer reader;
 
-    if (vtr::check_file_name_extension(read_vpr_constraints_name, ".xml")) {
-        try {
-            std::ifstream file(read_vpr_constraints_name);
-            void* context;
-            uxsd::load_vpr_constraints_xml(reader, context, read_vpr_constraints_name, file);
-        } catch (pugiutil::XmlError& e) {
-            vpr_throw(VPR_ERROR_ROUTE, read_vpr_constraints_name, e.line(), "%s", e.what());
+    // file name from arguments could be a serial of files, seperated by colon ":"
+    // at this point, caller has already checked that the required constraint file name is not emtpy
+    int num_tokens = 0, num_file_read = 0;
+    bool found_file = false;
+    t_token* tokens = GetTokensFromString(read_vpr_constraints_name, &num_tokens);
+    std::string in_tokens("");
+    for (int i = 0; i < num_tokens; i++) {
+        if ((tokens[i].type == TOKEN_COLON)) { // end of one input file
+            found_file = true;
+        } else if (i == num_tokens - 1) { // end of inputs, append token anyway
+            in_tokens += std::string(tokens[i].data);
+            found_file = true;
+        } else {
+            in_tokens += std::string(tokens[i].data);
         }
-    } else {
-        VTR_LOG_WARN(
-            "VPR constraints file '%s' may be in incorrect format. "
-            "Expecting .xml format. Not reading file.\n",
-            read_vpr_constraints_name);
+        if (found_file) {
+            const char* file_name = in_tokens.c_str();
+            if (vtr::check_file_name_extension(file_name, ".xml")) {
+                try {
+                    std::ifstream file(file_name);
+                    void* context;
+                    uxsd::load_vpr_constraints_xml(reader, context, file_name, file);
+                } catch (pugiutil::XmlError& e) {
+                    vpr_throw(VPR_ERROR_ROUTE, file_name, e.line(), "%s", e.what());
+                }
+            } else {
+                VTR_LOG_WARN(
+                    "VPR constraints file '%s' may be in incorrect format. "
+                    "Expecting .xml format. Not reading file.\n",
+                    file_name);
+            }
+            in_tokens.clear();
+            num_file_read++;
+            found_file = false;
+        }
     }
+    VTR_LOG("Read in '%d' constraint file(s) successfully.\n", num_file_read);
 
     //Update the floorplanning constraints in the floorplanning constraints context
     auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
     floorplanning_ctx.constraints = reader.constraints_;
+
+    // update vpr constraints for routing
+    auto& routing_ctx = g_vpr_ctx.mutable_routing();
+    routing_ctx.constraints = reader.constraints_;
 
     VprConstraints ctx_constraints = floorplanning_ctx.constraints;
 

--- a/vpr/src/base/vpr_constraints_reader.h
+++ b/vpr/src/base/vpr_constraints_reader.h
@@ -5,6 +5,6 @@
 #ifndef VPR_CONSTRAINTS_READER_H_
 #define VPR_CONSTRAINTS_READER_H_
 
-void load_vpr_constraints_file(const char* read_vpr_constraints_name);
+void load_vpr_constraints_files(const char* read_vpr_constraints_name);
 
 #endif /* VPR_CONSTRAINTS_READER_H_ */

--- a/vpr/src/base/vpr_constraints_serializer.h
+++ b/vpr/src/base/vpr_constraints_serializer.h
@@ -2,6 +2,7 @@
 #define VPR_CONSTRAINTS_SERIALIZER_H_
 
 #include "region.h"
+#include "route_constraint.h"
 #include "vpr_constraints.h"
 #include "partition.h"
 #include "partition_region.h"
@@ -69,11 +70,15 @@ struct VprConstraintsContextTypes : public uxsd::DefaultVprConstraintsContextTyp
     using AddRegionReadContext = Region;
     using PartitionReadContext = partition_info;
     using PartitionListReadContext = void*;
+    using SetGlobalSignalReadContext = RouteConstraint;
+    using GlobalRouteConstraintsReadContext = void*;
     using VprConstraintsReadContext = void*;
     using AddAtomWriteContext = void*;
     using AddRegionWriteContext = void*;
     using PartitionWriteContext = void*;
     using PartitionListWriteContext = void*;
+    using SetGlobalSignalWriteContext = void*;
+    using GlobalRouteConstraintsWriteContext = void*;
     using VprConstraintsWriteContext = void*;
 };
 
@@ -300,11 +305,62 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
         return part_info;
     }
 
+    /** Generated for complex type "set_global_signal":
+     * <xs:complexType name="set_global_signal">
+     *   <xs:attribute name="name" type="xs:string" use="required" />
+     *   <xs:attribute name="type" type="xs:string" use="required" />
+     *   <xs:attribute name="route_model" type="xs:string" use="required" />
+     * </xs:complexType>
+     */
+    virtual inline const char* get_set_global_signal_name(RouteConstraint& rc) final {
+        return rc.get_net_name().c_str();
+    }
+    virtual inline void set_set_global_signal_name(const char* name, void*& /*ctx*/) final {
+        std::string net_name = std::string(name);
+        loaded_route_constraint.set_net_name(net_name);
+        return;
+    }
+    virtual inline const char* get_set_global_signal_route_model(RouteConstraint& rc) final {
+        return rc.get_route_model().c_str();
+    }
+    virtual inline void set_set_global_signal_route_model(const char* route_model, void*& /*ctx*/) final {
+        loaded_route_constraint.set_route_model(std::string(route_model));
+        loaded_route_constraint.set_is_valid(true);
+    }
+    virtual inline const char* get_set_global_signal_type(RouteConstraint& rc) final {
+        return rc.get_net_type().c_str();
+    }
+    virtual inline void set_set_global_signal_type(const char* type, void*& /*ctx*/) final {
+        loaded_route_constraint.set_net_type(std::string(type));
+    }
+
+    /** Generated for complex type "global_route_constraints":
+     * <xs:complexType name="global_route_constraints">
+     *   <xs:sequence>
+     *     <xs:element name="set_global_signal" type="set_global_signal" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     * </xs:complexType>
+     */
+    virtual inline void preallocate_global_route_constraints_set_global_signal(void*& /*ctx*/, size_t /*size*/) final {}
+    virtual inline void* add_global_route_constraints_set_global_signal(void*& /*ctx*/) final {
+        return nullptr;
+    }
+    virtual inline void finish_global_route_constraints_set_global_signal(void*& /*ctx*/) final {
+        constraints_.add_route_constraint(loaded_route_constraint);
+    }
+    virtual inline size_t num_global_route_constraints_set_global_signal(void*& /*ctx*/) final {
+        return constraints_.get_route_constraint_num();
+    }
+    virtual inline RouteConstraint get_global_route_constraints_set_global_signal(int n, void*& /*ctx*/) final {
+        return constraints_.get_route_constraint_by_idx((std::size_t)n);
+    }
+
     /** Generated for complex type "vpr_constraints":
      * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
-     *     <xs:all>
+     *     <xs:choice minOccurs="0" maxOccurs="unbounded">
      *       <xs:element name="partition_list" type="partition_list" />
-     *     </xs:all>
+     *       <xs:element name="global_route_constraints" type="global_route_constraints" />
+     *     </xs:choice>
      *     <xs:attribute name="tool_name" type="xs:string" />
      *   </xs:complexType>
      */
@@ -312,25 +368,54 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
         return temp_.c_str();
     }
 
-    virtual inline void set_vpr_constraints_tool_name(const char* /*tool_name*/, void*& /*ctx*/) final {}
+    virtual inline void set_vpr_constraints_tool_name(const char* /*tool_name*/, void*& /*ctx*/) final {
+    }
 
     virtual inline void set_vpr_constraints_constraints_comment(const char* /*constraints_comment*/, void*& /*ctx*/) final {}
 
     virtual inline const char* get_vpr_constraints_constraints_comment(void*& /*ctx*/) final {
         return temp_.c_str();
     }
-    virtual inline void* init_vpr_constraints_partition_list(void*& /*ctx*/) final {
+
+    virtual inline void preallocate_vpr_constraints_partition_list(void*& /*ctx*/, size_t) final {
+    }
+
+    virtual inline void* add_vpr_constraints_partition_list(void*& /*ctx*/) final {
         return nullptr;
     }
 
     virtual inline void finish_vpr_constraints_partition_list(void*& /*ctx*/) final {
+        return;
     }
 
-    virtual inline void* get_vpr_constraints_partition_list(void*& /*ctx*/) final {
+    virtual inline size_t num_vpr_constraints_partition_list(void*& /*ctx*/) final {
+        return 0;
+    }
+
+    virtual inline void* get_vpr_constraints_partition_list(int, void*& /*ctx*/) final {
+        return nullptr;
+    }
+
+    virtual inline void preallocate_vpr_constraints_global_route_constraints(void*& /*ctx*/, size_t) final {
+    }
+
+    virtual inline void* add_vpr_constraints_global_route_constraints(void*& /*ctx*/) final {
+        return nullptr;
+    }
+
+    virtual inline void finish_vpr_constraints_global_route_constraints(void*& /*ctx*/) final {
+        return;
+    }
+    virtual inline size_t num_vpr_constraints_global_route_constraints(void*& /*ctx*/) final {
+        return 0;
+    }
+
+    virtual inline void* get_vpr_constraints_global_route_constraints(int, void*& /*cts*/) final {
         return nullptr;
     }
 
     virtual void finish_load() final {
+        return;
     }
 
     //temp data for writes
@@ -350,6 +435,7 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     Region loaded_region;
     Partition loaded_partition;
     PartitionRegion loaded_part_region;
+    RouteConstraint loaded_route_constraint;
 
     //temp string used when a method must return a const char*
     std::string temp_ = "vpr";

--- a/vpr/src/base/vpr_constraints_writer.cpp
+++ b/vpr/src/base/vpr_constraints_writer.cpp
@@ -214,3 +214,29 @@ void create_partition(Partition& part, std::string part_name, int xmin, int ymin
     part_pr.set_partition_region(part_regions);
     part.set_part_region(part_pr);
 }
+
+void write_vpr_route_constraints(const VprConstraints& constraints, const char* file_name) {
+    VprConstraints write_constraints;
+    for (int i = 0; i < constraints.get_route_constraint_num(); i++) {
+        RouteConstraint rc = constraints.get_route_constraint_by_idx(i);
+        if (rc.get_is_valid()) {
+            write_constraints.add_route_constraint(rc);
+        }
+    }
+
+    VprConstraintsSerializer writer(write_constraints);
+
+    if (vtr::check_file_name_extension(file_name, ".xml")) {
+        std::fstream fp;
+        fp.open(file_name, std::fstream::out | std::fstream::trunc);
+        fp.precision(std::numeric_limits<float>::max_digits10);
+        void* context;
+        uxsd::write_vpr_constraints_xml(writer, context, fp);
+    } else {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
+                        "Unknown extension on output %s",
+                        file_name);
+    }
+
+    return;
+}

--- a/vpr/src/base/vpr_constraints_writer.h
+++ b/vpr/src/base/vpr_constraints_writer.h
@@ -47,4 +47,6 @@ void setup_vpr_floorplan_constraints_cutpoints(VprConstraints& constraints, int 
 
 void create_partition(Partition& part, std::string part_name, int xmin, int ymin, int xmax, int ymax);
 
+void write_vpr_route_constraints(const VprConstraints& constraints, const char* file_name);
+
 #endif /* VPR_SRC_BASE_VPR_CONSTRAINTS_WRITER_H_ */

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -438,6 +438,11 @@ struct RoutingContext : public Context {
     vtr::Cache<std::tuple<e_router_lookahead, std::string, std::vector<t_segment_inf>>,
                RouterLookahead>
         cached_router_lookahead_;
+
+    /**
+     * @brief Routing constraints, read only
+     */
+    VprConstraints constraints;
 };
 
 /**

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -191,4 +191,8 @@ bool is_node_on_tile(t_physical_tile_type_ptr physical_tile,
                      t_rr_type node_type,
                      int node_ptc);
 
+// apply route constraints for route flow
+class VprConstraints;
+void apply_route_constraints(VprConstraints& constraint);
+
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Allow router to route or skip specific signals.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Currently, VPR ignores or routes a global signal through clock modeling options; it does not allow a specific signal to be treated seperately as desired. See details in #2235 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Allow route constraints applied to specific signals.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed