### PR TITLE
Cpp format Fix-up

### DIFF
--- a/cmake/modules/AutoClangFormat.cmake
+++ b/cmake/modules/AutoClangFormat.cmake
@@ -21,11 +21,11 @@ add_custom_target(format-cpp-files
     COMMAND find ${DIRS_TO_FORMAT_CPP} ${FIND_TO_FORMAT_CPP})
 
 #
-# Use clang-format-12 for code format
+# Use clang-format-14 for code format
 #
 add_custom_target(format-cpp
     COMMAND find ${DIRS_TO_FORMAT_CPP} ${FIND_TO_FORMAT_CPP} |
-    xargs -P ${CPU_COUNT} clang-format-12 -style=file -i)
+    xargs -P ${CPU_COUNT} clang-format-14 -style=file -i)
 
 #
 # Use simple python script for fixing C like boxed comments

--- a/libs/librtlnumber/src/include/internal_bits.hpp
+++ b/libs/librtlnumber/src/include/internal_bits.hpp
@@ -383,7 +383,9 @@ class BitFields {
   public:
     BitFields(bit_value_t init_v) {
         this->bits = static_cast<T>(
-            (_0 == init_v) ? _All_0 : (_1 == init_v) ? _All_1 : (_z == init_v) ? _All_z : _All_x);
+            (_0 == init_v) ? _All_0 : (_1 == init_v) ? _All_1
+                                  : (_z == init_v)   ? _All_z
+                                                     : _All_x);
     }
 
     template<typename Addr_t>

--- a/libs/librtlnumber/src/rtl_int.cpp
+++ b/libs/librtlnumber/src/rtl_int.cpp
@@ -418,42 +418,48 @@ VNumber V_LOGICAL_OR(VNumber& a, VNumber& b) {
 
 VNumber V_LT(VNumber& a, VNumber& b) {
     compare_bit cmp = eval_op(a, b);
-    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_lt() ? BitSpace::_1 : BitSpace::_0;
+    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_lt() ? BitSpace::_1
+                                                                             : BitSpace::_0;
     VNumber to_return(1, result, false, true);
     return to_return;
 }
 
 VNumber V_GT(VNumber& a, VNumber& b) {
     compare_bit cmp = eval_op(a, b);
-    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_gt() ? BitSpace::_1 : BitSpace::_0;
+    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_gt() ? BitSpace::_1
+                                                                             : BitSpace::_0;
     VNumber to_return(1, result, false, true);
     return to_return;
 }
 
 VNumber V_EQUAL(VNumber& a, VNumber& b) {
     compare_bit cmp = eval_op(a, b);
-    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_eq() ? BitSpace::_1 : BitSpace::_0;
+    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_eq() ? BitSpace::_1
+                                                                             : BitSpace::_0;
     VNumber to_return(1, result, false, true);
     return to_return;
 }
 
 VNumber V_GE(VNumber& a, VNumber& b) {
     compare_bit cmp = eval_op(a, b);
-    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_ge() ? BitSpace::_1 : BitSpace::_0;
+    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_ge() ? BitSpace::_1
+                                                                             : BitSpace::_0;
     VNumber to_return(1, result, false, true);
     return to_return;
 }
 
 VNumber V_LE(VNumber& a, VNumber& b) {
     compare_bit cmp = eval_op(a, b);
-    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_le() ? BitSpace::_1 : BitSpace::_0;
+    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_le() ? BitSpace::_1
+                                                                             : BitSpace::_0;
     VNumber to_return(1, result, false, true);
     return to_return;
 }
 
 VNumber V_NOT_EQUAL(VNumber& a, VNumber& b) {
     compare_bit cmp = eval_op(a, b);
-    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_ne() ? BitSpace::_1 : BitSpace::_0;
+    BitSpace::bit_value_t result = cmp.is_unk() ? BitSpace::_x : cmp.is_ne() ? BitSpace::_1
+                                                                             : BitSpace::_0;
     VNumber to_return(1, result, false, true);
     return to_return;
 }
@@ -603,11 +609,14 @@ VNumber V_POWER(VNumber& a, VNumber& b) {
     }
 
     compare_bit res_a = eval_op(a, 0);
-    short val_a = (res_a.is_eq()) ? 0 : (res_a.is_lt()) ? (eval_op(a, -1).is_lt()) ? -2 : -1 :
-                                                        /* GREATHER_THAN */ (eval_op(a, 1).is_gt()) ? 2 : 1;
+    short val_a = (res_a.is_eq()) ? 0 : (res_a.is_lt()) ? (eval_op(a, -1).is_lt()) ? -2 : -1
+                                    :
+                                    /* GREATHER_THAN */ (eval_op(a, 1).is_gt()) ? 2
+                                                                                : 1;
 
     compare_bit res_b = eval_op(b, 0);
-    short val_b = (res_b.is_eq()) ? 0 : (res_b.is_lt()) ? -1 :
+    short val_b = (res_b.is_eq()) ? 0 : (res_b.is_lt()) ? -1
+                                                        :
                                                         /* GREATHER_THAN */ 1;
 
     // Compute: Case Where 'val_a <= -2' or 'val_a >= 2'; As-Per the Spec:
@@ -742,5 +751,6 @@ VNumber V_TERNARY(VNumber& a_in, VNumber& b_in, VNumber& c_in) {
     /*	if a evaluates properly	*/
     compare_bit eval = eval_op(V_LOGICAL_NOT(a_in), 0);
 
-    return (eval.is_unk()) ? b_in.bitwise(c_in, l_ternary) : (eval.is_eq()) ? VNumber(b_in) : VNumber(c_in);
+    return (eval.is_unk()) ? b_in.bitwise(c_in, l_ternary) : (eval.is_eq()) ? VNumber(b_in)
+                                                                            : VNumber(c_in);
 }

--- a/libs/libvtrutil/src/vtr_geometry.h
+++ b/libs/libvtrutil/src/vtr_geometry.h
@@ -71,13 +71,13 @@ class Point {
     T y() const;
 
     ///@brief == operator
-    friend bool operator== <>(Point<T> lhs, Point<T> rhs);
+    friend bool operator==<>(Point<T> lhs, Point<T> rhs);
 
     ///@brief != operator
-    friend bool operator!= <>(Point<T> lhs, Point<T> rhs);
+    friend bool operator!=<>(Point<T> lhs, Point<T> rhs);
 
     ///@brief < operator
-    friend bool operator< <>(Point<T> lhs, Point<T> rhs);
+    friend bool operator<<>(Point<T> lhs, Point<T> rhs);
 
   public: //Mutators
     ///@brief Set x and y values
@@ -172,10 +172,10 @@ class Rect {
     bool empty() const;
 
     ///@brief == operator
-    friend bool operator== <>(const Rect<T>& lhs, const Rect<T>& rhs);
+    friend bool operator==<>(const Rect<T>& lhs, const Rect<T>& rhs);
 
     ///@brief != operator
-    friend bool operator!= <>(const Rect<T>& lhs, const Rect<T>& rhs);
+    friend bool operator!=<>(const Rect<T>& lhs, const Rect<T>& rhs);
 
   public: //Mutators
     ///@brief set xmin to a point
@@ -296,10 +296,10 @@ class RectUnion {
      *
      * Note: does not check whether the representations they are equivalent
      */
-    friend bool operator== <>(const RectUnion<T>& lhs, const RectUnion<T>& rhs);
+    friend bool operator==<>(const RectUnion<T>& lhs, const RectUnion<T>& rhs);
 
     ///@brief != operator
-    friend bool operator!= <>(const RectUnion<T>& lhs, const RectUnion<T>& rhs);
+    friend bool operator!=<>(const RectUnion<T>& lhs, const RectUnion<T>& rhs);
 
   private:
     // Note that a union of rectanges may have holes and may not be contiguous

--- a/libs/libvtrutil/src/vtr_geometry.h
+++ b/libs/libvtrutil/src/vtr_geometry.h
@@ -77,7 +77,7 @@ class Point {
     friend bool operator!=<>(Point<T> lhs, Point<T> rhs);
 
     ///@brief < operator
-    friend bool operator<<>(Point<T> lhs, Point<T> rhs);
+    friend bool operator< <>(Point<T> lhs, Point<T> rhs);
 
   public: //Mutators
     ///@brief Set x and y values

--- a/libs/libvtrutil/src/vtr_pair_util.h
+++ b/libs/libvtrutil/src/vtr_pair_util.h
@@ -36,7 +36,7 @@ class pair_first_iter {
     auto operator*() { return iter_->first; }
 
     ///@brief -> operator
-    auto operator-> () { return &iter_->first; }
+    auto operator->() { return &iter_->first; }
 
     ///@brief == operator
     friend bool operator==(const pair_first_iter lhs, const pair_first_iter rhs) { return lhs.iter_ == rhs.iter_; }
@@ -80,7 +80,7 @@ class pair_second_iter {
     auto operator*() { return iter_->second; }
 
     ///@brief -> operator
-    auto operator-> () { return &iter_->second; }
+    auto operator->() { return &iter_->second; }
 
     ///@brief == operator
     friend bool operator==(const pair_second_iter lhs, const pair_second_iter rhs) { return lhs.iter_ == rhs.iter_; }

--- a/libs/libvtrutil/src/vtr_strong_id.h
+++ b/libs/libvtrutil/src/vtr_strong_id.h
@@ -202,11 +202,11 @@ class StrongId {
      * Note that since these are templated functions we provide an empty set of template parameters
      * after the function name (i.e. <>)
      */
-    friend bool operator== <>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
+    friend bool operator==<>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
     ///@brief != operator
-    friend bool operator!= <>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
+    friend bool operator!=<>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
     ///@brief < operator
-    friend bool operator< <>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
+    friend bool operator<<>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
 
   private:
     T id_;

--- a/libs/libvtrutil/src/vtr_strong_id.h
+++ b/libs/libvtrutil/src/vtr_strong_id.h
@@ -206,7 +206,7 @@ class StrongId {
     ///@brief != operator
     friend bool operator!=<>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
     ///@brief < operator
-    friend bool operator<<>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
+    friend bool operator< <>(const StrongId<tag, T, sentinel>& lhs, const StrongId<tag, T, sentinel>& rhs);
 
   private:
     T id_;

--- a/odin_ii/src/core/adders.cpp
+++ b/odin_ii/src/core/adders.cpp
@@ -1131,7 +1131,8 @@ static void connect_output_pin_to_node(int* width, int current_pin, int output_p
     if (subtraction) {
         remap_pin_to_new_node(node->output_pins[current_pin], current_adder, output_pin_id);
     } else {
-        npin_t* node_pin_select = node->output_pins[(node->num_input_port_sizes == 2) ? current_pin : (current_pin < width[output_pin_id] - 1) ? current_pin + 1 : 0];
+        npin_t* node_pin_select = node->output_pins[(node->num_input_port_sizes == 2) ? current_pin : (current_pin < width[output_pin_id] - 1) ? current_pin + 1
+                                                                                                                                               : 0];
         if (node_pin_select) {
             if (node_pin_select->type != NO_ID || (node->num_input_port_sizes == 2)) {
                 remap_pin_to_new_node(node_pin_select, current_adder, output_pin_id);

--- a/odin_ii/src/simulate/simulate_blif.cpp
+++ b/odin_ii/src/simulate/simulate_blif.cpp
@@ -1850,7 +1850,10 @@ static void instantiate_memory(nnode_t* node, long data_width, long addr_width) 
 }
 
 static int parse_mif_radix(std::string radix) {
-    return (radix == "HEX") ? 16 : (radix == "DEC") ? 10 : (radix == "OCT") ? 8 : (radix == "BIN") ? 2 : 0;
+    return (radix == "HEX") ? 16 : (radix == "DEC") ? 10
+                               : (radix == "OCT")   ? 8
+                               : (radix == "BIN")   ? 2
+                                                    : 0;
 }
 
 static void assign_memory_from_mif_file(nnode_t* node, const char* filename, int width, long address_width) {

--- a/odin_ii/src/utils/atomic_buffer.h
+++ b/odin_ii/src/utils/atomic_buffer.h
@@ -115,7 +115,8 @@ class atomic_buffer {
     void print() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
             uint8_t value = get_bits(i);
-            printf("%s", (value == 0) ? "0" : (value == 1) ? "1" : "x");
+            printf("%s", (value == 0) ? "0" : (value == 1) ? "1"
+                                                           : "x");
         }
         printf("\n");
     }

--- a/vpr/src/power/power_sizing.cpp
+++ b/vpr/src/power/power_sizing.cpp
@@ -98,8 +98,8 @@ static double power_count_transistors_connectionbox() {
         /* Muxes to IPINs */
         transistor_cnt += inputs
                           * power_count_transistors_mux(
-                                power_get_mux_arch(power_ctx.commonly_used->max_IPIN_fanin,
-                                                   power_ctx.arch->mux_transistor_size));
+                              power_get_mux_arch(power_ctx.commonly_used->max_IPIN_fanin,
+                                                 power_ctx.arch->mux_transistor_size));
     }
     return transistor_cnt;
 }
@@ -234,9 +234,9 @@ static double power_count_transistors_interc(t_interconnect* interc) {
             transistor_cnt += interc->interconnect_power->num_output_ports
                               * interc->interconnect_power->num_pins_per_port
                               * power_count_transistors_mux(
-                                    power_get_mux_arch(
-                                        interc->interconnect_power->num_input_ports,
-                                        power_ctx.arch->mux_transistor_size));
+                                  power_get_mux_arch(
+                                      interc->interconnect_power->num_input_ports,
+                                      power_ctx.arch->mux_transistor_size));
             break;
         }
         default:

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -870,7 +870,7 @@ int get_max_primitives_in_pb_type(t_pb_type* pb_type) {
             for (j = 0; j < pb_type->modes[i].num_pb_type_children; j++) {
                 temp_size += pb_type->modes[i].pb_type_children[j].num_pb
                              * get_max_primitives_in_pb_type(
-                                   &pb_type->modes[i].pb_type_children[j]);
+                                 &pb_type->modes[i].pb_type_children[j]);
             }
             if (temp_size > max_size) {
                 max_size = temp_size;
@@ -893,7 +893,7 @@ int get_max_nets_in_pb_type(const t_pb_type* pb_type) {
             for (j = 0; j < pb_type->modes[i].num_pb_type_children; j++) {
                 temp_nets += pb_type->modes[i].pb_type_children[j].num_pb
                              * get_max_nets_in_pb_type(
-                                   &pb_type->modes[i].pb_type_children[j]);
+                                 &pb_type->modes[i].pb_type_children[j]);
             }
             if (temp_nets > max_nets) {
                 max_nets = temp_nets;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Run 

```
make format-cpp
```

to format all the C++ codes using clang-format-14. 


#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
To resolve the issue #2268 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As stated in #2268 already, clang-format-14 (used in Ubuntu 22.04) apply code formatting in a slight different way than clang-format-7 (used in Ubuntu 18.04)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
