### PR TITLE
Expand build compatibility on GCC and Clang for Ubuntu 22.04

### DIFF
--- a/.github/workflows/build_dependency_ubuntu-22.04.sh
+++ b/.github/workflows/build_dependency_ubuntu-22.04.sh
@@ -53,7 +53,11 @@ apt-get install -y \
     gcc-10 \
     g++-11 \
     gcc-11 \
-    clang \
+    g++-12 \
+    gcc-12 \
+    clang-11 \
     clang-12 \
-    clang-format-12 \
+    clang-13 \
+    clang-14 \
+    clang-format-14 \
     libxml2-utils

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -363,7 +363,11 @@ jobs:
         - { name: 'GCC 9 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           }
         - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         }
         - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-11 && CXX=g++-11',         }
+        - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-12 && CXX=g++-12',         }
+        - { name: 'Clang 11 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-11 && CXX=clang++-11',   }
         - { name: 'Clang 12 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-12 && CXX=clang++-12',   }
+        - { name: 'Clang 13 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-13 && CXX=clang++-13',   }
+        - { name: 'Clang 14 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-14 && CXX=clang++-14',   }
     name: 'B: ${{ matrix.name }}'
     steps:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Due to the compiler version upgrades in Ubuntu 22.04, build compatibility should be restored. 
In this PR, the build compatibility is expanded to 

- gcc-12
- clang-11
- clang-12
- clang-13
- clang-14

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
