### PR TITLE
check libtbb-dev.

### DIFF
--- a/.github/scripts/install_dependencies.sh
+++ b/.github/scripts/install_dependencies.sh
@@ -56,7 +56,7 @@ sudo apt install -y \
   clang-13 \
   clang-14 \
   clang-format-14 \
-  libtbb12
+  libtbb-dev
 
 pip install -r requirements.txt
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update libtbb setting to libtbb-dev in build dependency.

#### Description
<!--- Describe your changes in detail -->
Update libtbb setting to libtbb-dev in build dependency.

#### Related Issue
Issue: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2269

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are seeing parallel timing analysis is not activated in Ubuntu 22.04 CI test, because the libtbb is not set properly. This change is grab it back.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI Test.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue) - Partially fix issue: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2269
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
