### PR TITLE
Fix a Typo in NoC Config File

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/task.py
+++ b/vtr_flow/scripts/python_libs/vtr/task.py
@@ -347,7 +347,10 @@ def create_jobs(args, configs, after_run=False):
                 work_dir = str(PurePath(arch).joinpath(circuit))
 
                 run_dir = (
-                    str(Path(get_latest_run_dir(find_task_dir(config, args.alt_tasks_dir))) / work_dir)
+                    str(
+                        Path(get_latest_run_dir(find_task_dir(config, args.alt_tasks_dir)))
+                        / work_dir
+                    )
                     if after_run
                     else str(
                         Path(get_next_run_dir(find_task_dir(config, args.alt_tasks_dir))) / work_dir
@@ -450,7 +453,10 @@ def create_jobs(args, configs, after_run=False):
                     cmd += ["-verbose"]
 
                 if noc_traffic:
-                    cmd += ["--noc_flows_file", resolve_vtr_source_file(config, noc_traffic, config.noc_traffic_dir)]
+                    cmd += [
+                        "--noc_flows_file",
+                        resolve_vtr_source_file(config, noc_traffic, config.noc_traffic_dir),
+                    ]
 
                 if config.script_params_list_add:
                     for value in config.script_params_list_add:

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_noc_nearest_neighbor_topology/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_noc_nearest_neighbor_topology/config/config.txt
@@ -18,7 +18,7 @@ circuit_list_add=complex_64_noc_nearest_neighbor.blif
 arch_list_add=stratixiv_arch.timing_with_a_embedded_10X10_mesh_noc_topology.xml
 
 # Add NoC Traffic Patterns to list to sweep
-noc_traffic_list_add=complex_64_noc_nearest_neighbor
+noc_traffic_list_add=complex_64_noc_nearest_neighbor.flows
 
 # Parse info and how to parse
 parse_file=vpr_noc.txt


### PR DESCRIPTION
There is a typo in the following file: `vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_noc_nearest_neighbor_topology/config/config.txt`. Specifically, when a NoC traffic flow file is specified, the suffix of the file (".flows") should also be included in the filename.

@vaughnbetz 