### PR TITLE
Update CMake version in "CMakeLists.txt" files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 include(SupportCcache)

--- a/ace2/CMakeLists.txt
+++ b/ace2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("ace2")
 

--- a/blifexplorer/CMakeLists.txt
+++ b/blifexplorer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("blifexplorer")
 

--- a/doc/src/parmys/quickstart.rst
+++ b/doc/src/parmys/quickstart.rst
@@ -10,7 +10,7 @@ Prerequisites
 * bison
 * flex
 * g++ 9.x
-* cmake 3.9 (minimum version)
+* cmake 3.16 (minimum version)
 * time
 * cairo
 * build-essential

--- a/libs/EXTERNAL/libargparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libargparse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("libargparse")
 

--- a/libs/EXTERNAL/libblifparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libblifparse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 include(HeadersToIncludeDirs)
 

--- a/libs/EXTERNAL/libpugixml/CMakeLists.txt
+++ b/libs/EXTERNAL/libpugixml/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("libpugixml")
 

--- a/libs/EXTERNAL/libsdcparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libsdcparse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 include(HeadersToIncludeDirs)
 

--- a/libs/EXTERNAL/libtatum/CMakeLists.txt
+++ b/libs/EXTERNAL/libtatum/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("tatum")
 

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("libarchfpga")
 

--- a/libs/liblog/CMakeLists.txt
+++ b/libs/liblog/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("liblog")
 

--- a/libs/libpugiutil/CMakeLists.txt
+++ b/libs/libpugiutil/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("libpugiutil")
 

--- a/libs/librrgraph/CMakeLists.txt
+++ b/libs/librrgraph/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("librrgraph")
 

--- a/libs/librtlnumber/CMakeLists.txt
+++ b/libs/librtlnumber/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("librtlnumber")
 

--- a/libs/libvqm/CMakeLists.txt
+++ b/libs/libvqm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 project("libvqm")
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})

--- a/libs/libvtrutil/CMakeLists.txt
+++ b/libs/libvtrutil/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("libvtrutil")
 

--- a/odin_ii/CMakeLists.txt
+++ b/odin_ii/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("odin_ii")
 

--- a/parmys/CMakeLists.txt
+++ b/parmys/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("parmys")
 

--- a/utils/fasm/CMakeLists.txt
+++ b/utils/fasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("genfasm")
 

--- a/utils/route_diag/CMakeLists.txt
+++ b/utils/route_diag/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 cmake_policy(VERSION 3.9)
 
 project("route_diag")

--- a/utils/vqm2blif/CMakeLists.txt
+++ b/utils/vqm2blif/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("vqm2blif")
 

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("vpr")
 

--- a/yosys/CMakeLists.txt
+++ b/yosys/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project("yosys")
 


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This PR solves the [issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2271) . We need CMake version higher than 3.16 to be able to build the current master branach. Hence, I have updated the required version in all our CMakeLists.txt files in the repository and Documentation from 3.9 to 3.16 as a minimum version.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 2271](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2271)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
