### PR TITLE
fix calculation of segment cap/utilization by adding all axes caps

### DIFF
--- a/vpr/src/route/segment_stats.cpp
+++ b/vpr/src/route/segment_stats.cpp
@@ -114,7 +114,7 @@ void get_segment_usage_stats(std::vector<t_segment_inf>& segment_inf) {
             int cap = 0;
             for (auto ax : {X_AXIS, Y_AXIS}) {
                 occ += directed_occ_by_length[ax][seg_length];
-                cap = directed_cap_by_length[ax][seg_length];
+                cap += directed_cap_by_length[ax][seg_length];
             }
             utilization = (float)occ / (float)cap;
             VTR_LOG("                               %s%s %4d %11.3g\n", std::string(std::max(4 - seg_name_size, (max_segment_name_length - seg_name_size)), ' ').c_str(), seg_name.c_str(), seg_type, utilization);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Fixes the calculation of segment capacity by adding capacities of all axes.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2309

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Segment Statistics is used for further calculations and power estimation - this fix will solve the incorrect calculation of the segment capacity while using it for utilization calculations.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
