### PR TITLE
Placement move type and block type print information

### DIFF
--- a/vpr/src/place/RL_agent_util.cpp
+++ b/vpr/src/place/RL_agent_util.cpp
@@ -2,6 +2,9 @@
 #include "manual_move_generator.h"
 
 void create_move_generators(std::unique_ptr<MoveGenerator>& move_generator, std::unique_ptr<MoveGenerator>& move_generator2, const t_placer_opts& placer_opts, int move_lim) {
+    //extract available physical block types in the netlist
+    determine_agent_block_types();
+
     if (placer_opts.RL_agent_placement == false) {
         if (placer_opts.place_algorithm.is_timing_driven()) {
             VTR_LOG("Using static probabilities for choosing each move type\n");
@@ -41,9 +44,6 @@ void create_move_generators(std::unique_ptr<MoveGenerator>& move_generator, std:
          *      2nd state agent Q-table size is always 7 and always proposes   *
          *      only move type.                                                *
          *      This state is activated late in the anneal and in the Quench   */
-
-        //extract available physical block types in the netlist
-        determine_agent_block_types();
 
         auto& place_ctx = g_vpr_ctx.placement();
         int num_1st_state_avail_moves = placer_opts.place_algorithm.is_timing_driven() ? NUM_PL_1ST_STATE_MOVE_TYPES : NUM_PL_NONTIMING_MOVE_TYPES;

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -10,10 +10,6 @@ static vtr::vector<NocTrafficFlowId, double> traffic_flow_aggregate_bandwidth_co
 static std::vector<NocTrafficFlowId> affected_traffic_flows;
 /*********************************************************** *****************************/
 
-/*********** NoC Placement Stats ***********/
-static NocPlaceStats noc_place_stats;
-/*******************************************/
-
 void initial_noc_placement(void) {
     // need to get placement information about where the router cluster blocks are palced on the device
     const auto& place_ctx = g_vpr_ctx.placement();
@@ -545,42 +541,9 @@ e_create_move propose_router_swap(t_pl_blocks_to_be_moved& blocks_affected, floa
     return create_move;
 }
 
-/* Below are functions related to modifying and printing the NoC placement
- * statistical data */
-void initialize_noc_placement_stats(const t_placer_opts& placer_opts) {
-    // initially there are no router blocks moved
-    noc_place_stats.number_of_noc_router_moves = 0;
-
-    // allocate the space to keep track of how many of each move type caused a router block to move
-    noc_place_stats.number_of_noc_router_moves_per_move_type.resize(placer_opts.place_static_move_prob.size() + 1, 0);
-
-    return;
-}
-
 void update_noc_placement_stats(int move_type) {
     noc_place_stats.number_of_noc_router_moves++;
     noc_place_stats.number_of_noc_router_moves_per_move_type[move_type]++;
-
-    return;
-}
-
-void print_noc_placement_stats(void) {
-    float moves;
-    std::string move_name;
-
-    VTR_LOG("\n\nTotal number of NoC router block moves: %d\n", noc_place_stats.number_of_noc_router_moves);
-    VTR_LOG("\nPercentage of different move types that cause NoC router block moves:\n");
-
-    for (size_t i = 0; i < noc_place_stats.number_of_noc_router_moves_per_move_type.size(); i++) {
-        moves = noc_place_stats.number_of_noc_router_moves_per_move_type[i];
-        if (moves != 0) {
-            move_name = move_type_to_string(e_move_type(i));
-            VTR_LOG(
-                "\t%.17s move: %2.2f %%\n",
-                move_name.c_str(), 100 * moves / noc_place_stats.number_of_noc_router_moves);
-        }
-    }
-    VTR_LOG("\n");
 
     return;
 }

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -541,13 +541,6 @@ e_create_move propose_router_swap(t_pl_blocks_to_be_moved& blocks_affected, floa
     return create_move;
 }
 
-void update_noc_placement_stats(int move_type) {
-    noc_place_stats.number_of_noc_router_moves++;
-    noc_place_stats.number_of_noc_router_moves_per_move_type[move_type]++;
-
-    return;
-}
-
 void write_noc_placement_file(std::string file_name) {
     // we need the clustered netlist to get the names of all the NoC router cluster blocks
     auto& cluster_ctx = g_vpr_ctx.clustering();

--- a/vpr/src/place/noc_place_utils.h
+++ b/vpr/src/place/noc_place_utils.h
@@ -24,13 +24,6 @@ constexpr double MAX_INV_NOC_LATENCY_COST = 1.e12;
 // So this value represents the lowest possible latency cost.
 constexpr double MIN_EXPECTED_NOC_LATENCY_COST = 1.e-12;
 
-/* Stores statistical data about how the NoC blocks were moved during placement
- */
-struct NocPlaceStats {
-    int number_of_noc_router_moves;
-    std::vector<int> number_of_noc_router_moves_per_move_type;
-};
-
 /* Defines how the links found in a traffic flow are updated in terms
  * of their bandwidth usage.
  */

--- a/vpr/src/place/noc_place_utils.h
+++ b/vpr/src/place/noc_place_utils.h
@@ -437,36 +437,6 @@ bool check_for_router_swap(int user_supplied_noc_router_swap_percentage);
  */
 e_create_move propose_router_swap(t_pl_blocks_to_be_moved& blocks_affected, float rlim);
 
-/* Below are functions related to modifying and retreiving the NoC placement stats dastructure*/
-
-/**
- * @brief Initializes all the stat values to 0 and allocates space for the
- * number of possible move types offered by the placer. This is needed as
- * the stats datastructure for the NoC keeps track of which moves caused
- * a router block to move.
- * 
- * @param placer_opts Contains information about all the possible move
- * types in the placer.
- */
-void initialize_noc_placement_stats(const t_placer_opts& placer_opts);
-
-/**
- * @brief Increments the count of total number of router block moves during
- * placement. Also increments the move type that caused the router block to
- * move. This function should be called whenever a noc router block is moved
- * during placement.
- * 
- * @param move_type The type of move in the placer which caused a router block
- * to move.
- */
-void update_noc_placement_stats(int move_type);
-
-/**
- * @brief Displays the NoC placement statistical data.
- * 
- */
-void print_noc_placement_stats(void);
-
 /**
  * @brief Writes out the locations of the router cluster blocks in the
  * final placement. This file contains only NoC routers and the 

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -753,11 +753,6 @@ void try_place(const Netlist<>& net_list,
     move_type_stat.accepted_moves.resize((get_num_agent_types()) * (placer_opts.place_static_move_prob.size()), 0);
     move_type_stat.rejected_moves.resize((get_num_agent_types()) * (placer_opts.place_static_move_prob.size()), 0);
 
-    // if the noc option was turned on then setup the noc placement stats datastructure
-    if (noc_opts.noc) {
-        initialize_noc_placement_stats(placer_opts);
-    }
-
     /* Get the first range limiter */
     first_rlim = (float)max(device_ctx.grid.width() - 1,
                             device_ctx.grid.height() - 1);
@@ -1621,11 +1616,6 @@ static e_move_result try_swap(const t_annealing_state* state,
 
                 costs->noc_aggregate_bandwidth_cost += noc_aggregate_bandwidth_delta_c;
                 costs->noc_latency_cost += noc_latency_delta_c;
-
-                // if a noc router block was moved, update the NoC related stats
-                if (number_of_affected_noc_traffic_flows != 0) {
-                    update_noc_placement_stats((int)move_type);
-                }
             }
 
             //Highlights the new block when manual move is selected.

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1025,8 +1025,8 @@ void try_place(const Netlist<>& net_list,
     print_placement_swaps_stats(state);
 
     print_placement_move_types_stats(move_type_stat);
+
     if (noc_opts.noc) {
-        print_noc_placement_stats();
         write_noc_placement_file(noc_opts.noc_placement_file_name);
     }
 


### PR DESCRIPTION
#### Description
After combining RLPlace 2.0 and NoC placement, details about placement statistics (which block has been moved, how many moves were accepted/rejected, ..) was printed twice for NoCs. Since RLPlace 2.0 code was general and contained all block types, I have removed noc code related to printing information about moves to avoid duplication. 

In addition to that, we needed block type information regardless of using RL agent as placement algorithm. Hence, I have moved the block type extraction function to execute regardless of the placer algorithm, so we can have information printed even if we are using StaticMoveGenerator. 

@vaughnbetz 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
