### PR TITLE
Min Chan W Number of Router Iterations

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
+++ b/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
@@ -70,11 +70,11 @@ def run_relax_w(
 
     vpr_min_w_log = ".".join([logfile_base, "out"])
     vpr_relaxed_w_log = ".".join([logfile_base, "crit_path", "out"])
-    max_router_iterations = None
+    crit_path_router_iterations = None
 
-    if "max_router_iterations" in vpr_args:
-        max_router_iterations = vpr_args["max_router_iterations"]
-        del vpr_args["max_router_iterations"]
+    if "crit_path_router_iterations" in vpr_args:
+        crit_path_router_iterations = vpr_args["crit_path_router_iterations"]
+        del vpr_args["crit_path_router_iterations"]
 
     if "write_rr_graph" in vpr_args:
         del vpr_args["write_rr_graph"]
@@ -96,8 +96,8 @@ def run_relax_w(
     if explicit and "route" not in vpr_args:
         # Don't look for min W if routing was not run
         return
-    if max_router_iterations:
-        vpr_args["max_router_iterations"] = max_router_iterations
+    if crit_path_router_iterations:
+        vpr_args["max_router_iterations"] = crit_path_router_iterations
     min_w = determine_min_w(str(temp_dir / vpr_min_w_log))
 
     relaxed_w = relax_w(min_w, relax_w_factor)

--- a/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
+++ b/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py
@@ -165,6 +165,8 @@ def run(
 
 
     """
+    if "crit_path_router_iterations" in vpr_args:
+        del vpr_args["crit_path_router_iterations"]
 
     if vpr_args is None:
         vpr_args = OrderedDict()

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -704,8 +704,7 @@ def process_vpr_args(args, prog, temp_dir, vpr_args):
     Finds arguments needed in the VPR stage of the flow
     """
     if args.crit_path_router_iterations:
-        if "max_router_iterations" not in vpr_args:
-            vpr_args["max_router_iterations"] = args.crit_path_router_iterations
+        vpr_args["crit_path_router_iterations"] = args.crit_path_router_iterations
     if args.fix_pins:
         new_file = str(temp_dir / Path(args.fix_pins).name)
         shutil.copyfile(str((Path(prog).parent.parent / args.fix_pins)), new_file)


### PR DESCRIPTION
This pull request updates the behavior of the "run_vtr_flow.py" script to correctly handle the "max_router_iterations" argument. Currently, the script assumes that this argument is only for the router iterations on relaxed channel width. Thus, the VPR's default value of 50 iterations was used when attempting to find the minimum channel width. With this update, "max_router_iterations" determines the number of iterations for finding the minimum channel width, while "crit_path_router_iteration" is used for the relaxed channel width.

For example, running the script with the following command:

`run_vtr_flow.py ch_intrinsics.v k6_frac_N10_frac_chain_mem32K_40nm.xml -start odin -max_router_iterations 100 -crit_path_router_iteration 150`

Will set the maximum number of iterations for finding the minimum channel width to 100, and for the relaxed channel width to 150.

@vaughnbetz 
