### PR TITLE
Allow -j argument to quick test

### DIFF
--- a/run_quick_test.py
+++ b/run_quick_test.py
@@ -2,6 +2,11 @@
 
 """  Run the vtr_reg_basic regression test """
 
+import argparse
 import subprocess
 
-subprocess.run(["./run_reg_test.py", "vtr_reg_basic"], check=True)
+parser = argparse.ArgumentParser()
+parser.add_argument("-j", "--jobs", type=int, default=1, help="Number of processes to use")
+args = parser.parse_args()
+
+subprocess.run( ["./run_reg_test.py", "vtr_reg_basic", "-j", str(args.jobs)], check=True)

--- a/run_quick_test.py
+++ b/run_quick_test.py
@@ -9,4 +9,4 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-j", "--jobs", type=int, default=1, help="Number of processes to use")
 args = parser.parse_args()
 
-subprocess.run( ["./run_reg_test.py", "vtr_reg_basic", "-j", str(args.jobs)], check=True)
+subprocess.run(["./run_reg_test.py", "vtr_reg_basic", "-j", str(args.jobs)], check=True)


### PR DESCRIPTION
#### Description
Allow -j argument to quick test

#### Related Issue
None

#### Motivation and Context
Currently quick test can only be run j=1 

#### How Has This Been Tested?
Test providing various j values (and no j argument).  Correct value is passed on to subsequent script.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
