### PR TITLE
RR Graph Reader - Backward Compatiblity

### DIFF
--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
  * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+ * md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
  */
 
 #include <functional>
@@ -82,12 +82,12 @@ template <class T, typename Context>
 inline void load_block_types(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 template <class T, typename Context>
 inline void load_grid_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
-inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, int* layer, const std::function<void(const char*)> * report_error);
+inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, const std::function<void(const char*)> * report_error);
 template <class T, typename Context>
 inline void load_grid_locs(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 template <class T, typename Context>
 inline void load_node_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
-inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * layer, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char*)> * report_error);
+inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char*)> * report_error);
 template <class T, typename Context>
 inline void load_node_timing(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 inline void load_node_timing_required_attributes(const pugi::xml_node &root, float * C, float * R, const std::function<void(const char*)> * report_error);
@@ -269,8 +269,8 @@ constexpr const char *atok_lookup_t_block_type[] = {"height", "id", "name", "wid
 enum class gtok_t_block_types {BLOCK_TYPE};
 constexpr const char *gtok_lookup_t_block_types[] = {"block_type"};
 
-enum class atok_t_grid_loc {BLOCK_TYPE_ID, HEIGHT_OFFSET, WIDTH_OFFSET, X, Y, LAYER};
-constexpr const char *atok_lookup_t_grid_loc[] = {"block_type_id", "height_offset", "width_offset", "x", "y", "layer"};
+enum class atok_t_grid_loc {BLOCK_TYPE_ID, HEIGHT_OFFSET, LAYER, WIDTH_OFFSET, X, Y};
+constexpr const char *atok_lookup_t_grid_loc[] = {"block_type_id", "height_offset", "layer", "width_offset", "x", "y"};
 
 enum class gtok_t_grid_locs {GRID_LOC};
 constexpr const char *gtok_lookup_t_grid_locs[] = {"grid_loc"};
@@ -1015,21 +1015,19 @@ inline atok_t_grid_loc lex_attr_t_grid_loc(const char *in, const std::function<v
 		default: break;
 		}
 		break;
-
 	case 5:
 		switch(*((triehash_uu32*)&in[0])){
-			case onechar('l', 0, 32) | onechar('a', 8, 32) | onechar('y', 16, 32) | onechar('e', 24, 32):
-				switch(in[4]){
-					case onechar('r', 0, 8):
-						return atok_t_grid_loc::LAYER;
-					break;
-					default: break;
-				}
+		case onechar('l', 0, 32) | onechar('a', 8, 32) | onechar('y', 16, 32) | onechar('e', 24, 32):
+			switch(in[4]){
+			case onechar('r', 0, 8):
+				return atok_t_grid_loc::LAYER;
 			break;
-			default:break;
+			default: break;
+			}
+		break;
+		default: break;
 		}
 		break;
-
 	case 12:
 		switch(*((triehash_uu64*)&in[0])){
 		case onechar('w', 0, 64) | onechar('i', 8, 64) | onechar('d', 16, 64) | onechar('t', 24, 64) | onechar('h', 32, 64) | onechar('_', 40, 64) | onechar('o', 48, 64) | onechar('f', 56, 64):
@@ -2308,18 +2306,21 @@ inline void load_block_type_required_attributes(const pugi::xml_node &root, int 
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_block_type, report_error);
 }
 
-inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, int* layer, const std::function<void(const char *)> * report_error){
+inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, const std::function<void(const char *)> * report_error){
 	std::bitset<6> astate = 0;
 	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
 		atok_t_grid_loc in = lex_attr_t_grid_loc(attr.name(), report_error);
 		if(astate[(int)in] == 0) astate[(int)in] = 1;
 		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <grid_loc>.").c_str());
 		switch(in){
-        case atok_t_grid_loc::BLOCK_TYPE_ID:
+		case atok_t_grid_loc::BLOCK_TYPE_ID:
 			*block_type_id = load_int(attr.value(), report_error);
 			break;
 		case atok_t_grid_loc::HEIGHT_OFFSET:
 			*height_offset = load_int(attr.value(), report_error);
+			break;
+		case atok_t_grid_loc::LAYER:
+			/* Attribute layer set after element init */
 			break;
 		case atok_t_grid_loc::WIDTH_OFFSET:
 			*width_offset = load_int(attr.value(), report_error);
@@ -2330,16 +2331,14 @@ inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * 
 		case atok_t_grid_loc::Y:
 			*y = load_int(attr.value(), report_error);
 			break;
-        case atok_t_grid_loc::LAYER:
-            *layer=load_int(attr.value(), report_error);
 		default: break; /* Not possible. */
 		}
 	}
-	std::bitset<6> test_astate = astate | std::bitset<6>(0b000000);
+	std::bitset<6> test_astate = astate | std::bitset<6>(0b000100);
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_grid_loc, report_error);
 }
 
-inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * layer, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char *)> * report_error){
+inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char *)> * report_error){
 	std::bitset<7> astate = 0;
 	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
 		atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
@@ -2347,7 +2346,7 @@ inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * 
 		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <node_loc>.").c_str());
 		switch(in){
 		case atok_t_node_loc::LAYER:
-			*layer = load_int(attr.value(), report_error);
+			/* Attribute layer set after element init */
 			break;
 		case atok_t_node_loc::PTC:
 			*ptc = load_int(attr.value(), report_error);
@@ -2370,7 +2369,7 @@ inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * 
 		default: break; /* Not possible. */
 		}
 	}
-	std::bitset<7> test_astate = astate | std::bitset<7>(0b0000100);
+	std::bitset<7> test_astate = astate | std::bitset<7>(0b0000101);
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_loc, report_error);
 }
 
@@ -3158,6 +3157,30 @@ inline void load_grid_loc(const pugi::xml_node &root, T &out, Context &context, 
 	// Update current file offset in case an error is encountered.
 	*offset_debug = root.offset_debug();
 
+	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
+		atok_t_grid_loc in = lex_attr_t_grid_loc(attr.name(), report_error);
+		switch(in){
+		case atok_t_grid_loc::BLOCK_TYPE_ID:
+			/* Attribute block_type_id is already set */
+			break;
+		case atok_t_grid_loc::HEIGHT_OFFSET:
+			/* Attribute height_offset is already set */
+			break;
+		case atok_t_grid_loc::LAYER:
+			out.set_grid_loc_layer(load_int(attr.value(), report_error), context);
+			break;
+		case atok_t_grid_loc::WIDTH_OFFSET:
+			/* Attribute width_offset is already set */
+			break;
+		case atok_t_grid_loc::X:
+			/* Attribute x is already set */
+			break;
+		case atok_t_grid_loc::Y:
+			/* Attribute y is already set */
+			break;
+		default: break; /* Not possible. */
+		}
+	}
 
 	if(root.first_child().type() == pugi::node_element)
 		noreturn_report(report_error, "Unexpected child element in <grid_loc>.");
@@ -3224,10 +3247,8 @@ inline void load_grid_locs(const pugi::xml_node &root, T &out, Context &context,
 				memset(&grid_loc_x, 0, sizeof(grid_loc_x));
 				int grid_loc_y;
 				memset(&grid_loc_y, 0, sizeof(grid_loc_y));
-                int grid_loc_layer;
-                memset(&grid_loc_layer,0,sizeof(grid_loc_layer));
-				load_grid_loc_required_attributes(node, &grid_loc_block_type_id, &grid_loc_height_offset, &grid_loc_width_offset, &grid_loc_x, &grid_loc_y, &grid_loc_layer, report_error);
-				auto child_context = out.add_grid_locs_grid_loc(context, grid_loc_block_type_id, grid_loc_height_offset, grid_loc_width_offset, grid_loc_x, grid_loc_y, grid_loc_layer);
+				load_grid_loc_required_attributes(node, &grid_loc_block_type_id, &grid_loc_height_offset, &grid_loc_width_offset, &grid_loc_x, &grid_loc_y, report_error);
+				auto child_context = out.add_grid_locs_grid_loc(context, grid_loc_block_type_id, grid_loc_height_offset, grid_loc_width_offset, grid_loc_x, grid_loc_y);
 				load_grid_loc(node, out, child_context, report_error, offset_debug);
 				out.finish_grid_locs_grid_loc(child_context);
 			}
@@ -3252,7 +3273,7 @@ inline void load_node_loc(const pugi::xml_node &root, T &out, Context &context, 
 		atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
 		switch(in){
 		case atok_t_node_loc::LAYER:
-			/* Attribute layer is already set */
+			out.set_node_loc_layer(load_int(attr.value(), report_error), context);
 			break;
 		case atok_t_node_loc::PTC:
 			/* Attribute ptc is already set */
@@ -3435,8 +3456,6 @@ inline void load_node(const pugi::xml_node &root, T &out, Context &context, cons
 		switch(in){
 		case gtok_t_node::LOC:
 			{
-				int node_loc_layer;
-				memset(&node_loc_layer, 0, sizeof(node_loc_layer));
 				int node_loc_ptc;
 				memset(&node_loc_ptc, 0, sizeof(node_loc_ptc));
 				int node_loc_xhigh;
@@ -3447,8 +3466,8 @@ inline void load_node(const pugi::xml_node &root, T &out, Context &context, cons
 				memset(&node_loc_yhigh, 0, sizeof(node_loc_yhigh));
 				int node_loc_ylow;
 				memset(&node_loc_ylow, 0, sizeof(node_loc_ylow));
-				load_node_loc_required_attributes(node, &node_loc_layer, &node_loc_ptc, &node_loc_xhigh, &node_loc_xlow, &node_loc_yhigh, &node_loc_ylow, report_error);
-				auto child_context = out.init_node_loc(context, node_loc_layer, node_loc_ptc, node_loc_xhigh, node_loc_xlow, node_loc_yhigh, node_loc_ylow);
+				load_node_loc_required_attributes(node, &node_loc_ptc, &node_loc_xhigh, &node_loc_xlow, &node_loc_yhigh, &node_loc_ylow, report_error);
+				auto child_context = out.init_node_loc(context, node_loc_ptc, node_loc_xhigh, node_loc_xlow, node_loc_yhigh, node_loc_ylow);
 				load_node_loc(node, out, child_context, report_error, offset_debug);
 				out.finish_node_loc(child_context);
 			}
@@ -3946,11 +3965,11 @@ inline void write_grid_locs(T &in, std::ostream &os, Context &context){
 			os << "<grid_loc";
 			os << " block_type_id=\"" << in.get_grid_loc_block_type_id(child_context) << "\"";
 			os << " height_offset=\"" << in.get_grid_loc_height_offset(child_context) << "\"";
+			if((bool)in.get_grid_loc_layer(child_context))
+				os << " layer=\"" << in.get_grid_loc_layer(child_context) << "\"";
 			os << " width_offset=\"" << in.get_grid_loc_width_offset(child_context) << "\"";
 			os << " x=\"" << in.get_grid_loc_x(child_context) << "\"";
 			os << " y=\"" << in.get_grid_loc_y(child_context) << "\"";
-			os << " layer=\"" << in.get_grid_loc_layer(child_context) << "\"";
-
 			os << "/>\n";
 		}
 	}
@@ -3989,7 +4008,8 @@ inline void write_node(T &in, std::ostream &os, Context &context){
 	{
 		auto child_context = in.get_node_loc(context);
 		os << "<loc";
-		os << " layer=\"" << in.get_node_loc_layer(child_context) << "\"";
+		if((bool)in.get_node_loc_layer(child_context))
+			os << " layer=\"" << in.get_node_loc_layer(child_context) << "\"";
 		os << " ptc=\"" << in.get_node_loc_ptc(child_context) << "\"";
 		if((bool)in.get_node_loc_side(child_context))
 			os << " side=\"" << lookup_loc_side[(int)in.get_node_loc_side(child_context)] << "\"";

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
  * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
+ * md5sum of input file: 38649d034e0edccbcb511ddb8915cdff
  */
 
 #include <functional>
@@ -3965,8 +3965,7 @@ inline void write_grid_locs(T &in, std::ostream &os, Context &context){
 			os << "<grid_loc";
 			os << " block_type_id=\"" << in.get_grid_loc_block_type_id(child_context) << "\"";
 			os << " height_offset=\"" << in.get_grid_loc_height_offset(child_context) << "\"";
-			if((bool)in.get_grid_loc_layer(child_context))
-				os << " layer=\"" << in.get_grid_loc_layer(child_context) << "\"";
+			os << " layer=\"" << in.get_grid_loc_layer(child_context) << "\"";
 			os << " width_offset=\"" << in.get_grid_loc_width_offset(child_context) << "\"";
 			os << " x=\"" << in.get_grid_loc_x(child_context) << "\"";
 			os << " y=\"" << in.get_grid_loc_y(child_context) << "\"";
@@ -4008,8 +4007,7 @@ inline void write_node(T &in, std::ostream &os, Context &context){
 	{
 		auto child_context = in.get_node_loc(context);
 		os << "<loc";
-		if((bool)in.get_node_loc_layer(child_context))
-			os << " layer=\"" << in.get_node_loc_layer(child_context) << "\"";
+		os << " layer=\"" << in.get_node_loc_layer(child_context) << "\"";
 		os << " ptc=\"" << in.get_node_loc_ptc(child_context) << "\"";
 		if((bool)in.get_node_loc_side(child_context))
 			os << " side=\"" << lookup_loc_side[(int)in.get_node_loc_side(child_context)] << "\"";

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcap.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
  * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+ * md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
  */
 
 #include <functional>
@@ -672,6 +672,7 @@ inline void load_grid_loc_capnp_type(const ucap::GridLoc::Reader &root, T &out, 
 	(void)report_error;
 	(void)stack;
 
+	out.set_grid_loc_layer(root.getLayer(), context);
 }
 
 template<class T, typename Context>
@@ -687,7 +688,7 @@ inline void load_grid_locs_capnp_type(const ucap::GridLocs::Reader &root, T &out
 		auto data = root.getGridLocs();
 		out.preallocate_grid_locs_grid_loc(context, data.size());
 		for(const auto & el : data) {
-			auto child_context = out.add_grid_locs_grid_loc(context, el.getBlockTypeId(), el.getHeightOffset(), el.getWidthOffset(), el.getX(), el.getY(), el.getLayer());
+			auto child_context = out.add_grid_locs_grid_loc(context, el.getBlockTypeId(), el.getHeightOffset(), el.getWidthOffset(), el.getX(), el.getY());
 			load_grid_loc_capnp_type(el, out, child_context, report_error, stack);
 			out.finish_grid_locs_grid_loc(child_context);
 			stack->back().second += 1;
@@ -704,6 +705,7 @@ inline void load_node_loc_capnp_type(const ucap::NodeLoc::Reader &root, T &out, 
 	(void)report_error;
 	(void)stack;
 
+	out.set_node_loc_layer(root.getLayer(), context);
 	out.set_node_loc_side(conv_enum_loc_side(root.getSide(), report_error), context);
 }
 
@@ -775,7 +777,7 @@ inline void load_node_capnp_type(const ucap::Node::Reader &root, T &out, Context
 	stack->push_back(std::make_pair("getLoc", 0));
 	if (root.hasLoc()) {
 		auto child_el = root.getLoc();
-		auto child_context = out.init_node_loc(context, child_el.getLayer(), child_el.getPtc(), child_el.getXhigh(), child_el.getXlow(), child_el.getYhigh(), child_el.getYlow());
+		auto child_context = out.init_node_loc(context, child_el.getPtc(), child_el.getXhigh(), child_el.getXlow(), child_el.getYhigh(), child_el.getYlow());
 		load_node_loc_capnp_type(child_el, out, child_context, report_error, stack);
 		out.finish_node_loc(child_context);
 	}
@@ -1117,6 +1119,8 @@ inline void write_grid_locs_capnp_type(T &in, ucap::GridLocs::Builder &root, Con
 		auto child_context = in.get_grid_locs_grid_loc(i, context);
 		grid_locs_grid_loc.setBlockTypeId(in.get_grid_loc_block_type_id(child_context));
 		grid_locs_grid_loc.setHeightOffset(in.get_grid_loc_height_offset(child_context));
+		if((bool)in.get_grid_loc_layer(child_context))
+			grid_locs_grid_loc.setLayer(in.get_grid_loc_layer(child_context));
 		grid_locs_grid_loc.setWidthOffset(in.get_grid_loc_width_offset(child_context));
 		grid_locs_grid_loc.setX(in.get_grid_loc_x(child_context));
 		grid_locs_grid_loc.setY(in.get_grid_loc_y(child_context));
@@ -1153,7 +1157,8 @@ inline void write_node_capnp_type(T &in, ucap::Node::Builder &root, Context &con
 	{
 		auto child_context = in.get_node_loc(context);
 		auto node_loc = root.initLoc();
-		node_loc.setLayer(in.get_node_loc_layer(child_context));
+		if((bool)in.get_node_loc_layer(child_context))
+			node_loc.setLayer(in.get_node_loc_layer(child_context));
 		node_loc.setPtc(in.get_node_loc_ptc(child_context));
 		if((bool)in.get_node_loc_side(child_context))
 			node_loc.setSide(conv_to_enum_loc_side(in.get_node_loc_side(child_context)));

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcap.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
  * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
+ * md5sum of input file: 38649d034e0edccbcb511ddb8915cdff
  */
 
 #include <functional>
@@ -1119,8 +1119,7 @@ inline void write_grid_locs_capnp_type(T &in, ucap::GridLocs::Builder &root, Con
 		auto child_context = in.get_grid_locs_grid_loc(i, context);
 		grid_locs_grid_loc.setBlockTypeId(in.get_grid_loc_block_type_id(child_context));
 		grid_locs_grid_loc.setHeightOffset(in.get_grid_loc_height_offset(child_context));
-		if((bool)in.get_grid_loc_layer(child_context))
-			grid_locs_grid_loc.setLayer(in.get_grid_loc_layer(child_context));
+		grid_locs_grid_loc.setLayer(in.get_grid_loc_layer(child_context));
 		grid_locs_grid_loc.setWidthOffset(in.get_grid_loc_width_offset(child_context));
 		grid_locs_grid_loc.setX(in.get_grid_loc_x(child_context));
 		grid_locs_grid_loc.setY(in.get_grid_loc_y(child_context));
@@ -1157,8 +1156,7 @@ inline void write_node_capnp_type(T &in, ucap::Node::Builder &root, Context &con
 	{
 		auto child_context = in.get_node_loc(context);
 		auto node_loc = root.initLoc();
-		if((bool)in.get_node_loc_layer(child_context))
-			node_loc.setLayer(in.get_node_loc_layer(child_context));
+		node_loc.setLayer(in.get_node_loc_layer(child_context));
 		node_loc.setPtc(in.get_node_loc_ptc(child_context));
 		if((bool)in.get_node_loc_side(child_context))
 			node_loc.setSide(conv_to_enum_loc_side(in.get_node_loc_side(child_context)));

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
  * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+ * md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
  */
 
 #include <functional>
@@ -330,9 +330,9 @@ public:
 
 	/** Generated for complex type "grid_loc":
 	 * <xs:complexType name="grid_loc">
+	 *   <xs:attribute name="layer" type="xs:int" />
 	 *   <xs:attribute name="x" type="xs:int" use="required" />
 	 *   <xs:attribute name="y" type="xs:int" use="required" />
-	 *   <xs:attribute name="layer" type="xs:int" use=:"required" />
 	 *   <xs:attribute name="block_type_id" type="xs:int" use="required" />
 	 *   <xs:attribute name="width_offset" type="xs:int" use="required" />
 	 *   <xs:attribute name="height_offset" type="xs:int" use="required" />
@@ -340,10 +340,11 @@ public:
 	*/
 	virtual inline int get_grid_loc_block_type_id(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_height_offset(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline int get_grid_loc_layer(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline void set_grid_loc_layer(int layer, typename ContextTypes::GridLocWriteContext &ctx) = 0;
 	virtual inline int get_grid_loc_width_offset(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_x(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_y(typename ContextTypes::GridLocReadContext &ctx) = 0;
-	virtual inline int get_grid_loc_layer(typename ContextTypes::GridLocReadContext &ctx) =0;
 
 	/** Generated for complex type "grid_locs":
 	 * <xs:complexType name="grid_locs">
@@ -353,14 +354,14 @@ public:
 	 * </xs:complexType>
 	*/
 	virtual inline void preallocate_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, size_t size) = 0;
-	virtual inline typename ContextTypes::GridLocWriteContext add_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, int block_type_id, int height_offset, int width_offset, int x, int y, int layer) = 0;
+	virtual inline typename ContextTypes::GridLocWriteContext add_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, int block_type_id, int height_offset, int width_offset, int x, int y) = 0;
 	virtual inline void finish_grid_locs_grid_loc(typename ContextTypes::GridLocWriteContext &ctx) = 0;
 	virtual inline size_t num_grid_locs_grid_loc(typename ContextTypes::GridLocsReadContext &ctx) = 0;
 	virtual inline typename ContextTypes::GridLocReadContext get_grid_locs_grid_loc(int n, typename ContextTypes::GridLocsReadContext &ctx) = 0;
 
 	/** Generated for complex type "node_loc":
 	 * <xs:complexType name="node_loc">
-	 *   <xs:attribute name="layer" type="xs:int" use="required" />
+	 *   <xs:attribute name="layer" type="xs:int" />
 	 *   <xs:attribute name="xlow" type="xs:int" use="required" />
 	 *   <xs:attribute name="ylow" type="xs:int" use="required" />
 	 *   <xs:attribute name="xhigh" type="xs:int" use="required" />
@@ -370,6 +371,7 @@ public:
 	 * </xs:complexType>
 	*/
 	virtual inline int get_node_loc_layer(typename ContextTypes::NodeLocReadContext &ctx) = 0;
+	virtual inline void set_node_loc_layer(int layer, typename ContextTypes::NodeLocWriteContext &ctx) = 0;
 	virtual inline int get_node_loc_ptc(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 	virtual inline enum_loc_side get_node_loc_side(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 	virtual inline void set_node_loc_side(enum_loc_side side, typename ContextTypes::NodeLocWriteContext &ctx) = 0;
@@ -440,7 +442,7 @@ public:
 	virtual inline void set_node_direction(enum_node_direction direction, typename ContextTypes::NodeWriteContext &ctx) = 0;
 	virtual inline unsigned int get_node_id(typename ContextTypes::NodeReadContext &ctx) = 0;
 	virtual inline enum_node_type get_node_type(typename ContextTypes::NodeReadContext &ctx) = 0;
-	virtual inline typename ContextTypes::NodeLocWriteContext init_node_loc(typename ContextTypes::NodeWriteContext &ctx, int layer, int ptc, int xhigh, int xlow, int yhigh, int ylow) = 0;
+	virtual inline typename ContextTypes::NodeLocWriteContext init_node_loc(typename ContextTypes::NodeWriteContext &ctx, int ptc, int xhigh, int xlow, int yhigh, int ylow) = 0;
 	virtual inline void finish_node_loc(typename ContextTypes::NodeLocWriteContext &ctx) = 0;
 	virtual inline typename ContextTypes::NodeLocReadContext get_node_loc(typename ContextTypes::NodeReadContext &ctx) = 0;
 	virtual inline typename ContextTypes::NodeTimingWriteContext init_node_timing(typename ContextTypes::NodeWriteContext &ctx, float C, float R) = 0;

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
@@ -6,7 +6,7 @@
  *
  * Cmdline: uxsdcxx/uxsdcxx.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
  * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
+ * md5sum of input file: 38649d034e0edccbcb511ddb8915cdff
  */
 
 #include <functional>
@@ -330,7 +330,7 @@ public:
 
 	/** Generated for complex type "grid_loc":
 	 * <xs:complexType name="grid_loc">
-	 *   <xs:attribute name="layer" type="xs:int" />
+	 *   <xs:attribute name="layer" type="xs:int" default="0" />
 	 *   <xs:attribute name="x" type="xs:int" use="required" />
 	 *   <xs:attribute name="y" type="xs:int" use="required" />
 	 *   <xs:attribute name="block_type_id" type="xs:int" use="required" />
@@ -361,7 +361,7 @@ public:
 
 	/** Generated for complex type "node_loc":
 	 * <xs:complexType name="node_loc">
-	 *   <xs:attribute name="layer" type="xs:int" />
+	 *   <xs:attribute name="layer" type="xs:int" default="0" />
 	 *   <xs:attribute name="xlow" type="xs:int" use="required" />
 	 *   <xs:attribute name="ylow" type="xs:int" use="required" />
 	 *   <xs:attribute name="xhigh" type="xs:int" use="required" />

--- a/libs/librrgraph/src/io/rr_graph.xsd
+++ b/libs/librrgraph/src/io/rr_graph.xsd
@@ -208,7 +208,7 @@
   </xs:simpleType>
 
   <xs:complexType name="grid_loc">
-    <xs:attribute name="layer" type="xs:int" use="required"/>
+    <xs:attribute name="layer" type="xs:int"/>
     <xs:attribute name="x" type="xs:int" use="required"/>
     <xs:attribute name="y" type="xs:int" use="required"/>
     <xs:attribute name="block_type_id" type="xs:int" use="required"/>
@@ -259,7 +259,7 @@
   </xs:simpleType>
 
   <xs:complexType name="node_loc">
-    <xs:attribute name="layer" type="xs:int" use="required"/>
+    <xs:attribute name="layer" type="xs:int"/>
     <xs:attribute name="xlow" type="xs:int" use="required"/>
     <xs:attribute name="ylow" type="xs:int" use="required"/>
     <xs:attribute name="xhigh" type="xs:int" use="required"/>

--- a/libs/librrgraph/src/io/rr_graph.xsd
+++ b/libs/librrgraph/src/io/rr_graph.xsd
@@ -208,7 +208,7 @@
   </xs:simpleType>
 
   <xs:complexType name="grid_loc">
-    <xs:attribute name="layer" type="xs:int"/>
+    <xs:attribute name="layer" type="xs:int" default="0"/>
     <xs:attribute name="x" type="xs:int" use="required"/>
     <xs:attribute name="y" type="xs:int" use="required"/>
     <xs:attribute name="block_type_id" type="xs:int" use="required"/>
@@ -259,7 +259,7 @@
   </xs:simpleType>
 
   <xs:complexType name="node_loc">
-    <xs:attribute name="layer" type="xs:int"/>
+    <xs:attribute name="layer" type="xs:int" default="0"/>
     <xs:attribute name="xlow" type="xs:int" use="required"/>
     <xs:attribute name="ylow" type="xs:int" use="required"/>
     <xs:attribute name="xhigh" type="xs:int" use="required"/>

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1554,19 +1554,12 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 grid_.grid_size(), size);
         }
     }
-<<<<<<< HEAD
     inline void* add_grid_locs_grid_loc(void*& /*ctx*/, int block_type_id, int height_offset, int width_offset, int x, int y) final {
         curr_tmp_block_type_id = block_type_id;
         curr_tmp_height_offset = height_offset;
         curr_tmp_width_offset = width_offset;
         curr_tmp_x = x;
         curr_tmp_y = y;
-=======
-    inline void* add_grid_locs_grid_loc(void*& /*ctx*/, int block_type_id, int height_offset, int layer, int width_offset, int x, int y) final {
-        const auto& type = grid_.get_physical_type({x, y, layer});
-        int grid_width_offset = grid_.get_width_offset({x, y, layer});
-        int grid_height_offset = grid_.get_height_offset({x, y, layer});
->>>>>>> ef5f993959c6b6896f6821b14b361d581ebf46fe
 
         return nullptr;
     }

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -325,6 +325,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         , is_flat_(is_flat) {
         // Initialize internal data
         init_side_map();
+        init_segment_inf_x_y();
         curr_tmp_block_type_id = -1;
         curr_tmp_height_offset = -1;
         curr_tmp_width_offset = -1;

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -670,7 +670,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     inline void set_node_loc_layer(int layer_num, int& inode) final {
         auto node = (*rr_nodes_)[inode];
         RRNodeId node_id = node.id();
-        const auto& rr_graph = (*rr_graph_);
+
 
         VTR_ASSERT(layer_num >= 0);
         rr_graph_builder_->set_node_layer(node_id, layer_num);

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -633,12 +633,13 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
      * </xs:complexType>
      */
 
-    inline int init_node_loc(int& inode, int layer, int ptc, int xhigh, int xlow, int yhigh, int ylow) final {
+    inline int init_node_loc(int& inode, int ptc, int xhigh, int xlow, int yhigh, int ylow) final {
         auto node = (*rr_nodes_)[inode];
         RRNodeId node_id = node.id();
 
         rr_graph_builder_->set_node_coordinates(node_id, xlow, ylow, xhigh, yhigh);
-        rr_graph_builder_->set_node_layer(node_id, layer);
+        // We set the layer num 0 - If it is specified in the XML, it will be overwritten
+        rr_graph_builder_->set_node_layer(node_id, 0);
         rr_graph_builder_->set_node_ptc_num(node_id, ptc);
         return inode;
     }
@@ -664,6 +665,15 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     }
     inline int get_node_loc_ylow(const t_rr_node& node) final {
         return rr_graph_->node_ylow(node.id());
+    }
+
+    inline void set_node_loc_layer(int layer_num, int& inode) final {
+        auto node = (*rr_nodes_)[inode];
+        RRNodeId node_id = node.id();
+        const auto& rr_graph = (*rr_graph_);
+
+        VTR_ASSERT(layer_num >= 0);
+        rr_graph_builder_->set_node_layer(node_id, layer_num);
     }
 
     inline void set_node_loc_side(uxsd::enum_loc_side side, int& inode) final {

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1493,28 +1493,58 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 grid_.grid_size(), size);
         }
     }
-    inline void* add_grid_locs_grid_loc(void*& /*ctx*/, int block_type_id, int height_offset, int width_offset, int x, int y, int layer) final {
-        const auto& type = grid_.get_physical_type({x, y, layer});
-        int grid_width_offset = grid_.get_width_offset({x, y, layer});
-        int grid_height_offset = grid_.get_height_offset({x, y, layer});
+    inline void* add_grid_locs_grid_loc(void*& /*ctx*/, int block_type_id, int height_offset, int width_offset, int x, int y) final {
+        curr_tmp_block_type_id = block_type_id;
+        curr_tmp_height_offset = height_offset;
+        curr_tmp_width_offset = width_offset;
+        curr_tmp_x = x;
+        curr_tmp_y = y;
 
-        if (type->index != block_type_id) {
-            report_error(
-                "Architecture file does not match RR graph's block_type_id at (%d, %d): arch used ID %d, RR graph used ID %d.", x, y,
-                (type->index), block_type_id);
-        }
-        if (grid_width_offset != width_offset) {
-            report_error(
-                "Architecture file does not match RR graph's width_offset at (%d, %d)", x, y);
-        }
-
-        if (grid_height_offset != height_offset) {
-            report_error(
-                "Architecture file does not match RR graph's height_offset at (%d, %d)", x, y);
-        }
         return nullptr;
     }
-    inline void finish_grid_locs_grid_loc(void*& /*ctx*/) final {}
+    inline void finish_grid_locs_grid_loc(void*& /*ctx*/) final {
+        VTR_ASSERT(curr_tmp_block_type_id >= 0);
+        VTR_ASSERT(curr_tmp_height_offset >= 0);
+        VTR_ASSERT(curr_tmp_width_offset >= 0);
+        VTR_ASSERT(curr_tmp_layer >= 0);
+        VTR_ASSERT(curr_tmp_x >= 0);
+        VTR_ASSERT(curr_tmp_y >= 0);
+        const auto& type = grid_.get_physical_type({curr_tmp_x, curr_tmp_y, curr_tmp_layer});
+        int grid_width_offset = grid_.get_width_offset({curr_tmp_x, curr_tmp_y, curr_tmp_layer});
+        int grid_height_offset = grid_.get_height_offset({curr_tmp_x, curr_tmp_y, curr_tmp_layer});
+
+        if (type->index != curr_tmp_block_type_id) {
+            report_error(
+                "Architecture file does not match RR graph's block_type_id at (%d, %d): arch used ID %d, RR graph used ID %d.",
+                curr_tmp_layer,
+                curr_tmp_x,
+                curr_tmp_y,
+                (type->index),
+                curr_tmp_block_type_id);
+        }
+        if (grid_width_offset != curr_tmp_width_offset) {
+            report_error(
+                "Architecture file does not match RR graph's width_offset at (%d, %d)",
+                curr_tmp_layer,
+                curr_tmp_x,
+                curr_tmp_y);
+        }
+
+        if (grid_height_offset != curr_tmp_height_offset) {
+            report_error(
+                "Architecture file does not match RR graph's height_offset at (%d, %d)",
+                curr_tmp_layer,
+                curr_tmp_x,
+                curr_tmp_y);
+        }
+
+        curr_tmp_block_type_id = -1;
+        curr_tmp_height_offset = -1;
+        curr_tmp_width_offset = -1;
+        curr_tmp_layer = 0;
+        curr_tmp_x = -1;
+        curr_tmp_y = -1;
+    }
 
     inline void* init_rr_graph_grid(void*& /*ct*/) final {
         return nullptr;
@@ -1547,6 +1577,10 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     }
     inline const t_grid_tile* get_grid_locs_grid_loc(int n, void*& /*ctx*/) final {
         return grid_.get_grid_locs_grid_loc(n);
+    }
+
+    inline void set_grid_loc_layer(int layer_num, void*& /*ctx*/) final {
+        curr_tmp_layer = layer_num;
     }
 
 
@@ -1990,4 +2024,12 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     vtr::interned_string empty_;
     const std::function<void(const char*)>* report_error_;
     bool is_flat_;
+
+    // Temporary data to check grid block types
+    int curr_tmp_block_type_id;
+    int curr_tmp_height_offset;
+    int curr_tmp_width_offset;
+    int curr_tmp_layer;
+    int curr_tmp_x;
+    int curr_tmp_y;
 };

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -325,6 +325,12 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         , is_flat_(is_flat) {
         // Initialize internal data
         init_side_map();
+        curr_tmp_block_type_id = -1;
+        curr_tmp_height_offset = -1;
+        curr_tmp_width_offset = -1;
+        curr_tmp_layer = 0;
+        curr_tmp_x = -1;
+        curr_tmp_y = -1;
     }
 
     /* A truth table to help understand the conversion from VPR side mask to uxsd side code

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -4,9 +4,9 @@
 #
 # Cmdline: uxsdcxx/uxsdcap.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
 # Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+# md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
 
-@0xe9a519eb0e454dd4;
+@0xe05e6a59b7f502a0;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -151,10 +151,10 @@ struct BlockTypes {
 struct GridLoc {
 	blockTypeId @0 :Int32;
 	heightOffset @1 :Int32;
-	widthOffset @2 :Int32;
-	x @3 :Int32;
-	y @4 :Int32;
-	layer @5 : Int32;
+	layer @2 :Int32;
+	widthOffset @3 :Int32;
+	x @4 :Int32;
+	y @5 :Int32;
 }
 
 struct GridLocs {

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -4,9 +4,9 @@
 #
 # Cmdline: uxsdcxx/uxsdcap.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
 # Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# md5sum of input file: 8a13fa50b87a91c2baab7c6ced02f573
+# md5sum of input file: 38649d034e0edccbcb511ddb8915cdff
 
-@0xe05e6a59b7f502a0;
+@0xf8328695afe65adc;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -151,7 +151,7 @@ struct BlockTypes {
 struct GridLoc {
 	blockTypeId @0 :Int32;
 	heightOffset @1 :Int32;
-	layer @2 :Int32;
+	layer @2 :Int32 = 0;
 	widthOffset @3 :Int32;
 	x @4 :Int32;
 	y @5 :Int32;
@@ -162,7 +162,7 @@ struct GridLocs {
 }
 
 struct NodeLoc {
-	layer @0 :Int32;
+	layer @0 :Int32 = 0;
 	ptc @1 :Int32;
 	side @2 :LocSide;
 	xhigh @3 :Int32;


### PR DESCRIPTION
In this pull request, I have made changes to the RR Graph reader to enable it to read RR graph files that do not specify the layer number of nodes and grid.

After updating VPR to support 3D architecture, the layer number is now included in both the RR node description and the grid description of the XML file. However, some RR graph files generated by older runs may not have this information. As a result, if the reader cannot find the layer number, it would raise an error, causing issues for users using these older RR graph files.

With the updated RR Graph reader, we ensure that it can handle both cases seamlessly, allowing users to work with RR graph files from both older and newer runs without encountering any errors. 