### PR TITLE
Fix Seg Fault error when reading in an RR Graph with different x-y segment types

### DIFF
--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -382,7 +382,12 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         side_map_[(1 << TOP) | (1 << RIGHT) | (1 << BOTTOM) | (1 << LEFT)] = uxsd::enum_loc_side::TOP_RIGHT_BOTTOM_LEFT;
     }
 
+    /**
+     * @brief This function separates the segments in segment_inf_ based on whether their parallel axis 
+     *        is X or Y, and it stores them in segment_inf_x_ and segment_inf_y_.
+     */
     void init_segment_inf_x_y(){
+
         /* Create a temp copy to convert from vtr::vector to std::vector
          * This is required because the ``alloc_and_load_rr_indexed_data()`` function supports only std::vector data
          * type for ``rr_segments``
@@ -401,7 +406,14 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
     }
 
-    int find_segment_index_along_axis(int seg_index, e_parallel_axis axis) const {
+    /**
+     * @brief Search for a segment with a matching segment ID and return its position index
+     *        in the list of segments along the corresponding axis (X or Y).
+     * @param segment_id The ID of the segment to search for.
+     * @param axis The axis along which to search for the segment (X or Y).
+     * @return int The position index of the matching segment.
+     */
+    int find_segment_index_along_axis(int segment_id, e_parallel_axis axis) const {
         const std::vector<t_segment_inf>* segment_inf_vec_ptr;
 
         if (axis == X_AXIS)
@@ -410,10 +422,16 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             segment_inf_vec_ptr = &segment_inf_y_;
 
         for(std::vector<t_segment_inf>::size_type i=0; i < (*segment_inf_vec_ptr).size(); i++){
-            if((*segment_inf_vec_ptr)[i].seg_index == seg_index)
+            if((*segment_inf_vec_ptr)[i].seg_index == segment_id)
                 return static_cast<int>(i);
         }
-        return 0;
+
+        if (axis == X_AXIS)
+            VTR_LOG_ERROR("Segment ID %d not found in the list of segments along X axis.\n", segment_id);
+        else
+            VTR_LOG_ERROR("Segment ID %d not found in the list of segments along Y axis.\n", segment_id);
+        
+        return -1;
     }
 
   public:
@@ -2000,8 +2018,8 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
      * the methods following routines:rr_graph_rr_nodes and init_node_segment according to the changes in 
      * rr_graph_indexed_data.cpp */
     const vtr::vector<RRSegmentId, t_segment_inf>& segment_inf_;
-    std::vector<t_segment_inf> segment_inf_x_;
-    std::vector<t_segment_inf> segment_inf_y_;
+    std::vector<t_segment_inf> segment_inf_x_; // [num_segs_along_x_axis-1:0] - vector of segment information for segments along the x-axis.
+    std::vector<t_segment_inf> segment_inf_y_; // [num_segs_along_y_axis-1:0] - vector of segment information for segments along the y-axis.
     const std::vector<t_physical_tile_type>& physical_tile_types_;
     const DeviceGrid& grid_;
     MetadataStorage<int>* rr_node_metadata_;

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -325,6 +325,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         , is_flat_(is_flat) {
         // Initialize internal data
         init_side_map();
+        init_segment_inf_x_y();
     }
 
     /* A truth table to help understand the conversion from VPR side mask to uxsd side code
@@ -379,6 +380,40 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         side_map_[(1 << TOP) | (1 << BOTTOM) | (1 << LEFT)] = uxsd::enum_loc_side::TOP_BOTTOM_LEFT;
         side_map_[(1 << RIGHT) | (1 << BOTTOM) | (1 << LEFT)] = uxsd::enum_loc_side::RIGHT_BOTTOM_LEFT;
         side_map_[(1 << TOP) | (1 << RIGHT) | (1 << BOTTOM) | (1 << LEFT)] = uxsd::enum_loc_side::TOP_RIGHT_BOTTOM_LEFT;
+    }
+
+    void init_segment_inf_x_y(){
+        /* Create a temp copy to convert from vtr::vector to std::vector
+         * This is required because the ``alloc_and_load_rr_indexed_data()`` function supports only std::vector data
+         * type for ``rr_segments``
+         * Note that this is a dirty fix (to avoid massive code changes)
+         * TODO: The ``alloc_and_load_rr_indexed_data()`` function should embrace ``vtr::vector`` for ``rr_segments``
+         */
+        std::vector<t_segment_inf> rr_segs;
+        rr_segs.reserve(segment_inf_.size());
+        for (auto& rr_seg : segment_inf_) {
+            rr_segs.push_back(rr_seg);
+        }
+
+        t_unified_to_parallel_seg_index seg_index_map;
+        segment_inf_x_ = get_parallel_segs(rr_segs, seg_index_map, X_AXIS);
+        segment_inf_y_ = get_parallel_segs(rr_segs, seg_index_map, Y_AXIS);
+
+    }
+
+    int find_segment_index_along_axis(int seg_index, e_parallel_axis axis) const {
+        const std::vector<t_segment_inf>* segment_inf_vec_ptr;
+
+        if (axis == X_AXIS)
+            segment_inf_vec_ptr = &segment_inf_x_;
+        else
+            segment_inf_vec_ptr = &segment_inf_y_;
+
+        for(std::vector<t_segment_inf>::size_type i=0; i < (*segment_inf_vec_ptr).size(); i++){
+            if((*segment_inf_vec_ptr)[i].seg_index == seg_index)
+                return static_cast<int>(i);
+        }
+        return 0;
     }
 
   public:
@@ -748,10 +783,12 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         if (GRAPH_GLOBAL == graph_type_) {
             rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(0));
         } else if (rr_graph.node_type(node.id()) == CHANX) {
-            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(CHANX_COST_INDEX_START + segment_id));
+            int seg_ind_x = find_segment_index_along_axis(segment_id, X_AXIS);
+            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(CHANX_COST_INDEX_START + seg_ind_x));
             seg_index_[rr_graph.node_cost_index(node.id())] = segment_id;
         } else if (rr_graph.node_type(node.id()) == CHANY) {
-            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(CHANX_COST_INDEX_START + segment_inf_.size() + segment_id));
+            int seg_ind_y = find_segment_index_along_axis(segment_id, Y_AXIS);
+            rr_graph_builder_->set_node_cost_index(node_id, RRIndexedDataId(CHANX_COST_INDEX_START + segment_inf_x_.size() + seg_ind_y));
             seg_index_[rr_graph.node_cost_index(node.id())] = segment_id;
         }
         return inode;
@@ -884,7 +921,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
     inline void* init_rr_graph_rr_nodes(void*& /*ctx*/) final {
         rr_nodes_->clear();
-        seg_index_.resize(CHANX_COST_INDEX_START + 2 * segment_inf_.size(), -1);
+        seg_index_.resize(CHANX_COST_INDEX_START + segment_inf_x_.size() + segment_inf_y_.size(), -1);
         return nullptr;
     }
     inline void finish_rr_graph_rr_nodes(void*& /*ctx*/) final {
@@ -1612,21 +1649,12 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         process_rr_node_indices();
 
         rr_graph_builder_->init_fan_in();
-        /* Create a temp copy to convert from vtr::vector to std::vector
-         * This is required because the ``alloc_and_load_rr_indexed_data()`` function supports only std::vector data
-         * type for ``rr_segments``
-         * Note that this is a dirty fix (to avoid massive code changes)
-         * TODO: The ``alloc_and_load_rr_indexed_data()`` function should embrace ``vtr::vector`` for ``rr_segments``
-         */
+        
         std::vector<t_segment_inf> temp_rr_segs;
         temp_rr_segs.reserve(segment_inf_.size());
         for (auto& rr_seg : segment_inf_) {
             temp_rr_segs.push_back(rr_seg);
         }
-
-        t_unified_to_parallel_seg_index seg_index_map;
-        auto segment_inf_x_ = get_parallel_segs(temp_rr_segs, seg_index_map, X_AXIS);
-        auto segment_inf_y_ = get_parallel_segs(temp_rr_segs, seg_index_map, Y_AXIS);
 
         alloc_and_load_rr_indexed_data(
             *rr_graph_,
@@ -1972,6 +2000,8 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
      * the methods following routines:rr_graph_rr_nodes and init_node_segment according to the changes in 
      * rr_graph_indexed_data.cpp */
     const vtr::vector<RRSegmentId, t_segment_inf>& segment_inf_;
+    std::vector<t_segment_inf> segment_inf_x_;
+    std::vector<t_segment_inf> segment_inf_y_;
     const std::vector<t_physical_tile_type>& physical_tile_types_;
     const DeviceGrid& grid_;
     MetadataStorage<int>* rr_node_metadata_;


### PR DESCRIPTION
Description
<!--- Describe your changes in detail -->
The pull request is to fix the segmentation fault that occurred when reading in the rr graph that had different segment types in the X and Y directions. The error was caused by some parts of the code that set the node cost index, which still relied on the assumption that the X and Y axes have the same segment types. The issue has been fixed by updating the relevant code.

How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes have been tested using the Stratix 10 architecture. Before the fix, the rr graph could not be read in properly, resulting in the segmentation fault. After applying the fix, the issue has been resolved, and the rr graph is now correctly processed without any errors.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
