### PR TITLE
can read tileable rr_graph back into vpr

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_builder.h
+++ b/libs/librrgraph/src/base/rr_graph_builder.h
@@ -17,6 +17,7 @@
 #include "rr_spatial_lookup.h"
 #include "metadata_storage.h"
 #include "rr_edge.h"
+#include "rr_graph_type.h"
 
 class RRGraphBuilder {
     /* -- Constructors -- */
@@ -134,9 +135,12 @@ class RRGraphBuilder {
      *   - valid geometry information: xlow/ylow/xhigh/yhigh
      *   - a valid node type
      *   - a valid node ptc number
-     *   - a valid side (applicable to OPIN and IPIN nodes only
+     *   - a valid side (applicable to OPIN and IPIN nodes only)
+     * 
+     * In tileable rr-graph, ptc number is assigned differently for chanX and chanY. Hence, passing the graph 
+     * type will guide the function to add nodes with correct ptc number in all locations.
      */
-    void add_node_to_all_locs(RRNodeId node);
+    void add_node_to_all_locs(RRNodeId node, t_graph_type graph_type);
 
     /** @brief Clear all the underlying data storage */
     void clear();

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1643,7 +1643,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         /* Add the correct node into the vector */
         for (size_t inode = 0; inode < rr_nodes_->size(); inode++) {
             auto node = (*rr_nodes_)[inode];
-            rr_graph_builder.add_node_to_all_locs(node.id());
+            rr_graph_builder.add_node_to_all_locs(node.id(), graph_type_);
         }
     }
 


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Previously, when used tileable=true in architecture file, we couldn't read generated rr-graph back in since there was a node mismatch. The issue is because OpenFPGA assign ptc number to chanX and chanY different than what vpr does. This PR will make sure that in case of tileable architecture, reading rr-graph would use the same logic to assign ptc number and store nodes related to chanX and chanY.

@ganeshgore @tangxifan 


