### PR TITLE
add top module and search path for parmys

### DIFF
--- a/vtr_flow/misc/yosys/synthesis.tcl
+++ b/vtr_flow/misc/yosys/synthesis.tcl
@@ -20,10 +20,10 @@ if {$env(PARSER) == "surelog" } {
 	puts "Using Yosys read_systemverilog command"
 	plugin -i systemverilog
 	yosys -import
-	read_systemverilog -debug XXX
+	read_systemverilog -I"SEARCHPATH" -debug XXX
 } elseif {$env(PARSER) == "default" } {
 	puts "Using Yosys read_verilog command"
-	read_verilog -sv -nolatches XXX
+	read_verilog -I"SEARCHPATH" -sv -nolatches XXX
 } else {
 	error "Invalid PARSER"
 }
@@ -33,7 +33,7 @@ scc -select
 select -assert-none %
 select -clear
 
-hierarchy -check -auto-top -purge_lib
+hierarchy -check TOPMODULE -purge_lib
 
 opt_expr
 opt_clean
@@ -76,6 +76,6 @@ opt -fast -noff
 
 tee -o /dev/stdout stat
 
-hierarchy -check -auto-top -purge_lib
+hierarchy -check TOPMODULE -purge_lib
 
 write_blif -true + vcc -false + gnd -undef + unconn -blackbox ZZZ

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -52,6 +52,8 @@ def init_script_file(
     circuit_list,
     output_netlist,
     architecture_file_path,
+    include_dir='.',
+    top_module='-auto-top'
 ):
     """initializing the raw yosys script file"""
     # specify the input files type
@@ -68,6 +70,8 @@ def init_script_file(
             "TTT": str(vtr.paths.yosys_tcl_path),
             "ZZZ": output_netlist,
             "QQQ": architecture_file_path,
+            "SEARCHPATH": include_dir,
+            "TOPMODULE": top_module,
         },
     )
 
@@ -205,11 +209,30 @@ def run(
     # Create a list showing all (.v) and (.vh) files
     circuit_list = create_circuits_list(circuit_file, include_files)
 
+    # parse search directory
+    if ('searchpath' in parmys_args):
+        if (parmys_args['searchpath'] is not None) and (parmys_args['searchpath'] != ''):
+            include_dir = parmys_args['searchpath']
+        del parmys_args['searchpath']
+    else:
+        include_dir = '.'
+
+    # parse top module
+    # NOTE: the default value is '-auto-top'
+    if ('topmodule' in parmys_args):
+        if (parmys_args['topmodule'] is not None) and (parmys_args['topmodule'] != ''):
+            top_module = '-top ' + parmys_args['topmodule']
+        del parmys_args['topmodule']
+    else:
+        top_module = '-auto-top'
+
     init_script_file(
         yosys_script_full_path,
         circuit_list,
         output_netlist.name,
         architecture_file_path,
+        include_dir,
+        top_module
     )
 
     odin_base_config = str(vtr.paths.odin_cfg_path)

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -10,7 +10,7 @@ import textwrap
 import socket
 from datetime import datetime
 from collections import OrderedDict
-
+import os
 # pylint: disable=wrong-import-position, import-error
 sys.path.insert(0, str(Path(__file__).resolve().parent / "python_libs"))
 import vtr
@@ -186,7 +186,7 @@ def vtr_command_argparser(prog=None):
 
     house_keeping.add_argument(
         "-temp_dir",
-        default=None,
+        default=os.getcwd() + "/temp",
         help="Directory to run the flow in (will be created if non-existant).",
     )
 
@@ -368,6 +368,18 @@ def vtr_command_argparser(prog=None):
         help="Specify a parser for the Yosys synthesizer [default (Verilog-2005), surelog (UHDM), "
         + "system-verilog]. The script used the Yosys conventional Verilog"
         + " parser if this argument is not specified.",
+    )
+    parmys.add_argument(
+        "-top",
+        default=None,
+        dest="topmodule",
+        help="Specify the name of the module in the design that should be considered as top",
+    )
+    parmys.add_argument(
+        '-search',
+        default=os.getcwd(),
+        dest='searchpath',
+        help='search path for verilog files'
     )
     #
     # VPR arguments
@@ -725,7 +737,8 @@ def process_parmys_args(args):
     """
     parmys_args = OrderedDict()
     parmys_args["parser"] = args.parser
-
+    parmys_args["topmodule"] = args.topmodule
+    parmys_args['searchpath'] = args.searchpath
     return parmys_args
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix temp_dir parse error and add features for Yosys+Parmys
#### Description
<!--- Describe your changes in detail -->
This PR fixed the issue for #2347, which may cause Parmys+Yosys synthesize failure.
This PR also adds two features for #2351 
Since the VTR project moves to Parmys+Yosys front end, more people are likely to write projects using SystemVerilog and use the `include` syntax to organize projects, so I added the command line support for letting Yosys search for the `include` directory.
In addition, I added support for manually specifying the top module for Yosys, in case sometimes Yosys find the wrong top module hierarchy.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2347 
#2351 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I am doing my project with VTR and using SystemVerilog as my main language, so I added the two features to support wider use.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Ubuntu 22.04 LTS.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
The `-top` seems to exist in the document https://docs.verilogtorouting.org/en/latest/parmys/parmys_plugin/, but was not supported in the command line, so I added this.
The include dir needs a documentation change to let people know this feature.