### PR TITLE
Function Argument Mismatch in RRGraph reader/writer

### DIFF
--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcxx.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: cf10a1fa99fdfc7a455393a2a3cd1426
  */
 
 #include <functional>
@@ -82,7 +82,7 @@ template <class T, typename Context>
 inline void load_block_types(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 template <class T, typename Context>
 inline void load_grid_loc(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
-inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, int* layer, const std::function<void(const char*)> * report_error);
+inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * layer, int * width_offset, int * x, int * y, const std::function<void(const char*)> * report_error);
 template <class T, typename Context>
 inline void load_grid_locs(const pugi::xml_node &root, T &out, Context &context, const std::function<void(const char*)> *report_error, ptrdiff_t *offset_debug);
 template <class T, typename Context>
@@ -269,8 +269,8 @@ constexpr const char *atok_lookup_t_block_type[] = {"height", "id", "name", "wid
 enum class gtok_t_block_types {BLOCK_TYPE};
 constexpr const char *gtok_lookup_t_block_types[] = {"block_type"};
 
-enum class atok_t_grid_loc {BLOCK_TYPE_ID, HEIGHT_OFFSET, WIDTH_OFFSET, X, Y, LAYER};
-constexpr const char *atok_lookup_t_grid_loc[] = {"block_type_id", "height_offset", "width_offset", "x", "y", "layer"};
+enum class atok_t_grid_loc {BLOCK_TYPE_ID, HEIGHT_OFFSET, LAYER, WIDTH_OFFSET, X, Y};
+constexpr const char *atok_lookup_t_grid_loc[] = {"block_type_id", "height_offset", "layer", "width_offset", "x", "y"};
 
 enum class gtok_t_grid_locs {GRID_LOC};
 constexpr const char *gtok_lookup_t_grid_locs[] = {"grid_loc"};
@@ -1015,21 +1015,19 @@ inline atok_t_grid_loc lex_attr_t_grid_loc(const char *in, const std::function<v
 		default: break;
 		}
 		break;
-
 	case 5:
 		switch(*((triehash_uu32*)&in[0])){
-			case onechar('l', 0, 32) | onechar('a', 8, 32) | onechar('y', 16, 32) | onechar('e', 24, 32):
-				switch(in[4]){
-					case onechar('r', 0, 8):
-						return atok_t_grid_loc::LAYER;
-					break;
-					default: break;
-				}
+		case onechar('l', 0, 32) | onechar('a', 8, 32) | onechar('y', 16, 32) | onechar('e', 24, 32):
+			switch(in[4]){
+			case onechar('r', 0, 8):
+				return atok_t_grid_loc::LAYER;
 			break;
-			default:break;
+			default: break;
+			}
+		break;
+		default: break;
 		}
 		break;
-
 	case 12:
 		switch(*((triehash_uu64*)&in[0])){
 		case onechar('w', 0, 64) | onechar('i', 8, 64) | onechar('d', 16, 64) | onechar('t', 24, 64) | onechar('h', 32, 64) | onechar('_', 40, 64) | onechar('o', 48, 64) | onechar('f', 56, 64):
@@ -2308,18 +2306,21 @@ inline void load_block_type_required_attributes(const pugi::xml_node &root, int 
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_block_type, report_error);
 }
 
-inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * width_offset, int * x, int * y, int* layer, const std::function<void(const char *)> * report_error){
+inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * block_type_id, int * height_offset, int * layer, int * width_offset, int * x, int * y, const std::function<void(const char *)> * report_error){
 	std::bitset<6> astate = 0;
 	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
 		atok_t_grid_loc in = lex_attr_t_grid_loc(attr.name(), report_error);
 		if(astate[(int)in] == 0) astate[(int)in] = 1;
 		else noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <grid_loc>.").c_str());
 		switch(in){
-        case atok_t_grid_loc::BLOCK_TYPE_ID:
+		case atok_t_grid_loc::BLOCK_TYPE_ID:
 			*block_type_id = load_int(attr.value(), report_error);
 			break;
 		case atok_t_grid_loc::HEIGHT_OFFSET:
 			*height_offset = load_int(attr.value(), report_error);
+			break;
+		case atok_t_grid_loc::LAYER:
+			*layer = load_int(attr.value(), report_error);
 			break;
 		case atok_t_grid_loc::WIDTH_OFFSET:
 			*width_offset = load_int(attr.value(), report_error);
@@ -2330,8 +2331,6 @@ inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * 
 		case atok_t_grid_loc::Y:
 			*y = load_int(attr.value(), report_error);
 			break;
-        case atok_t_grid_loc::LAYER:
-            *layer=load_int(attr.value(), report_error);
 		default: break; /* Not possible. */
 		}
 	}
@@ -3218,16 +3217,16 @@ inline void load_grid_locs(const pugi::xml_node &root, T &out, Context &context,
 				memset(&grid_loc_block_type_id, 0, sizeof(grid_loc_block_type_id));
 				int grid_loc_height_offset;
 				memset(&grid_loc_height_offset, 0, sizeof(grid_loc_height_offset));
+				int grid_loc_layer;
+				memset(&grid_loc_layer, 0, sizeof(grid_loc_layer));
 				int grid_loc_width_offset;
 				memset(&grid_loc_width_offset, 0, sizeof(grid_loc_width_offset));
 				int grid_loc_x;
 				memset(&grid_loc_x, 0, sizeof(grid_loc_x));
 				int grid_loc_y;
 				memset(&grid_loc_y, 0, sizeof(grid_loc_y));
-                int grid_loc_layer;
-                memset(&grid_loc_layer,0,sizeof(grid_loc_layer));
-				load_grid_loc_required_attributes(node, &grid_loc_block_type_id, &grid_loc_height_offset, &grid_loc_width_offset, &grid_loc_x, &grid_loc_y, &grid_loc_layer, report_error);
-				auto child_context = out.add_grid_locs_grid_loc(context, grid_loc_block_type_id, grid_loc_height_offset, grid_loc_width_offset, grid_loc_x, grid_loc_y, grid_loc_layer);
+				load_grid_loc_required_attributes(node, &grid_loc_block_type_id, &grid_loc_height_offset, &grid_loc_layer, &grid_loc_width_offset, &grid_loc_x, &grid_loc_y, report_error);
+				auto child_context = out.add_grid_locs_grid_loc(context, grid_loc_block_type_id, grid_loc_height_offset, grid_loc_layer, grid_loc_width_offset, grid_loc_x, grid_loc_y);
 				load_grid_loc(node, out, child_context, report_error, offset_debug);
 				out.finish_grid_locs_grid_loc(child_context);
 			}
@@ -3946,11 +3945,10 @@ inline void write_grid_locs(T &in, std::ostream &os, Context &context){
 			os << "<grid_loc";
 			os << " block_type_id=\"" << in.get_grid_loc_block_type_id(child_context) << "\"";
 			os << " height_offset=\"" << in.get_grid_loc_height_offset(child_context) << "\"";
+			os << " layer=\"" << in.get_grid_loc_layer(child_context) << "\"";
 			os << " width_offset=\"" << in.get_grid_loc_width_offset(child_context) << "\"";
 			os << " x=\"" << in.get_grid_loc_x(child_context) << "\"";
 			os << " y=\"" << in.get_grid_loc_y(child_context) << "\"";
-			os << " layer=\"" << in.get_grid_loc_layer(child_context) << "\"";
-
 			os << "/>\n";
 		}
 	}

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcap.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+ * Cmdline: uxsdcxx/uxsdcap.py /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: cf10a1fa99fdfc7a455393a2a3cd1426
  */
 
 #include <functional>
@@ -687,7 +687,7 @@ inline void load_grid_locs_capnp_type(const ucap::GridLocs::Reader &root, T &out
 		auto data = root.getGridLocs();
 		out.preallocate_grid_locs_grid_loc(context, data.size());
 		for(const auto & el : data) {
-			auto child_context = out.add_grid_locs_grid_loc(context, el.getBlockTypeId(), el.getHeightOffset(), el.getWidthOffset(), el.getX(), el.getY(), el.getLayer());
+			auto child_context = out.add_grid_locs_grid_loc(context, el.getBlockTypeId(), el.getHeightOffset(), el.getLayer(), el.getWidthOffset(), el.getX(), el.getY());
 			load_grid_loc_capnp_type(el, out, child_context, report_error, stack);
 			out.finish_grid_locs_grid_loc(child_context);
 			stack->back().second += 1;
@@ -1117,6 +1117,7 @@ inline void write_grid_locs_capnp_type(T &in, ucap::GridLocs::Builder &root, Con
 		auto child_context = in.get_grid_locs_grid_loc(i, context);
 		grid_locs_grid_loc.setBlockTypeId(in.get_grid_loc_block_type_id(child_context));
 		grid_locs_grid_loc.setHeightOffset(in.get_grid_loc_height_offset(child_context));
+		grid_locs_grid_loc.setLayer(in.get_grid_loc_layer(child_context));
 		grid_locs_grid_loc.setWidthOffset(in.get_grid_loc_width_offset(child_context));
 		grid_locs_grid_loc.setX(in.get_grid_loc_x(child_context));
 		grid_locs_grid_loc.setY(in.get_grid_loc_y(child_context));

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcxx.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: cf10a1fa99fdfc7a455393a2a3cd1426
  */
 
 #include <functional>
@@ -330,9 +330,9 @@ public:
 
 	/** Generated for complex type "grid_loc":
 	 * <xs:complexType name="grid_loc">
+	 *   <xs:attribute name="layer" type="xs:int" use="required" />
 	 *   <xs:attribute name="x" type="xs:int" use="required" />
 	 *   <xs:attribute name="y" type="xs:int" use="required" />
-	 *   <xs:attribute name="layer" type="xs:int" use=:"required" />
 	 *   <xs:attribute name="block_type_id" type="xs:int" use="required" />
 	 *   <xs:attribute name="width_offset" type="xs:int" use="required" />
 	 *   <xs:attribute name="height_offset" type="xs:int" use="required" />
@@ -340,10 +340,10 @@ public:
 	*/
 	virtual inline int get_grid_loc_block_type_id(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_height_offset(typename ContextTypes::GridLocReadContext &ctx) = 0;
+	virtual inline int get_grid_loc_layer(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_width_offset(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_x(typename ContextTypes::GridLocReadContext &ctx) = 0;
 	virtual inline int get_grid_loc_y(typename ContextTypes::GridLocReadContext &ctx) = 0;
-	virtual inline int get_grid_loc_layer(typename ContextTypes::GridLocReadContext &ctx) =0;
 
 	/** Generated for complex type "grid_locs":
 	 * <xs:complexType name="grid_locs">
@@ -353,7 +353,7 @@ public:
 	 * </xs:complexType>
 	*/
 	virtual inline void preallocate_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, size_t size) = 0;
-	virtual inline typename ContextTypes::GridLocWriteContext add_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, int block_type_id, int height_offset, int width_offset, int x, int y, int layer) = 0;
+	virtual inline typename ContextTypes::GridLocWriteContext add_grid_locs_grid_loc(typename ContextTypes::GridLocsWriteContext &ctx, int block_type_id, int height_offset, int layer, int width_offset, int x, int y) = 0;
 	virtual inline void finish_grid_locs_grid_loc(typename ContextTypes::GridLocWriteContext &ctx) = 0;
 	virtual inline size_t num_grid_locs_grid_loc(typename ContextTypes::GridLocsReadContext &ctx) = 0;
 	virtual inline typename ContextTypes::GridLocReadContext get_grid_locs_grid_loc(int n, typename ContextTypes::GridLocsReadContext &ctx) = 0;

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1538,7 +1538,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 grid_.grid_size(), size);
         }
     }
-    inline void* add_grid_locs_grid_loc(void*& /*ctx*/, int block_type_id, int height_offset, int width_offset, int x, int y, int layer) final {
+    inline void* add_grid_locs_grid_loc(void*& /*ctx*/, int block_type_id, int height_offset, int layer, int width_offset, int x, int y) final {
         const auto& type = grid_.get_physical_type({x, y, layer});
         int grid_width_offset = grid_.get_width_offset({x, y, layer});
         int grid_height_offset = grid_.get_height_offset({x, y, layer});

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -2,11 +2,11 @@
 # https://github.com/duck2/uxsdcxx
 # Modify only if your build process doesn't involve regenerating this file.
 #
-# Cmdline: uxsdcxx/uxsdcap.py /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# Input file: /home/amin/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# md5sum of input file: 8672cb3951993f7e0ea3433a02507672
+# Cmdline: uxsdcxx/uxsdcap.py /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# Input file: /home/sara/Desktop/RLPLACE_LOCAL/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# md5sum of input file: cf10a1fa99fdfc7a455393a2a3cd1426
 
-@0xe9a519eb0e454dd4;
+@0xe180df9b6ce517f5;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -151,10 +151,10 @@ struct BlockTypes {
 struct GridLoc {
 	blockTypeId @0 :Int32;
 	heightOffset @1 :Int32;
-	widthOffset @2 :Int32;
-	x @3 :Int32;
-	y @4 :Int32;
-	layer @5 : Int32;
+	layer @2 :Int32;
+	widthOffset @3 :Int32;
+	x @4 :Int32;
+	y @5 :Int32;
 }
 
 struct GridLocs {


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
While adding a layer in to grid in rr graph specification, a bug has been merged with master branch causing the reading rr graph to crash because of a function argument mismatch. I generated the files again and fixed the interface to run correctly.  

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
