### PR TITLE
Add 'not found' check for finding file extension of arch xml

### DIFF
--- a/.github/scripts/hostsetup.sh
+++ b/.github/scripts/hostsetup.sh
@@ -71,7 +71,7 @@ apt install -y \
   gcc-9 \
   wget \
   openssl \
-  libssl-dev
+  libssl-dev \
   libtbb-dev
 
 # installing the latest version of cmake

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -317,7 +317,7 @@ void XmlReadArch(const char* ArchFile,
     pugi::xml_node Next;
     ReqOpt POWER_REQD, SWITCHBLOCKLIST_REQD;
 
-    if ((vtr::check_file_name_extension(ArchFile, ".xml") == false) && (vtr::check_file_name_extension(ArchFile, ".xml") == false)) {
+    if ((vtr::check_file_name_extension(ArchFile, ".xml") == false) && (vtr::check_file_name_extension(ArchFile, ".xmle") == false)) {
         VTR_LOG_WARN(
             "Architecture file '%s' may be in incorrect format. "
             "Expecting .xml or .xmle format for architecture files.\n",

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -11,7 +11,7 @@ loc_data load_xml(pugi::xml_document& doc,      //Document object to be loaded w
     //store the position of last '.' in the file name
     size_t position = filename.find_last_of(".");
     std::string result = "";
-    if(position != std::string::npos) {
+    if (position != std::string::npos) {
         //store the characters after the '.' from the file_name string
         result = filename.substr(position);
     }

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -9,9 +9,12 @@ namespace pugiutil {
 loc_data load_xml(pugi::xml_document& doc,      //Document object to be loaded with file contents
                   const std::string filename) { //Filename to load from
     //store the position of last '.' in the file name
-    int position = filename.find_last_of(".");
-    //store the characters after the '.' from the file_name string
-    std::string result = filename.substr(position);
+    size_t position = filename.find_last_of(".");
+    std::string result = "";
+    if(position != std::string::npos) {
+        //store the characters after the '.' from the file_name string
+        result = filename.substr(position);
+    }
     if (result == ".xmle") {
         Decryption E1(filename);
         std::string fn_file = E1.getDecryptedContent();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
While checking for a file extension with `.find_last_of()` the 'not found' scenario also needs to be checked.
While using FOEDAG + VPR at Quicklogic, we already have an internal encryption-decryption mechanism which is in use and that uses different file extensions (neither `.xml` nor `.xmle`), and in many cases no extension at all.
These kind of XMLs with no extension, cause the check for finding the extension to throw `std::out_of_range` as the return value for `position` is actually `std::string::npos` which needs to be checked before using it in the the `substr()` call.

Additionally a typo fix while checking to warn users of unrecognized extension.

#### Related Issue
As this change is specific to `openfpga` branch, I have not raised an issue for this.
Please let me know if I need to raise the issue.

#### Motivation and Context
Fix file extension check process

#### How Has This Been Tested?
Regular testcases of VPR suite.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
