### PR TITLE
congestion aware placement in the master branch

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -629,6 +629,7 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
     PlacerOpts->recompute_crit_iter = Options.RecomputeCritIter;
 
     PlacerOpts->timing_tradeoff = Options.PlaceTimingTradeoff;
+    PlacerOpts->congestion_tradeoff = Options.CongestionTradeoff;
 
     /* Depends on PlacerOpts->place_algorithm */
     PlacerOpts->delay_offset = Options.place_delay_offset;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -158,6 +158,7 @@ struct t_options {
 
     /* Timing-driven placement options only */
     argparse::ArgValue<float> PlaceTimingTradeoff;
+    argparse::ArgValue<float> CongestionTradeoff;
     argparse::ArgValue<int> RecomputeCritIter;
     argparse::ArgValue<int> inner_loop_recompute_divider;
     argparse::ArgValue<int> quench_recompute_divider;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -971,7 +971,8 @@ struct t_annealing_sched {
 enum e_place_algorithm {
     BOUNDING_BOX_PLACE,
     CRITICALITY_TIMING_PLACE,
-    SLACK_TIMING_PLACE
+    SLACK_TIMING_PLACE,
+    CONGESTION_AWARE_PLACE
 };
 
 /**
@@ -1015,7 +1016,7 @@ class t_place_algorithm {
 
     ///@brief Check if the algorithm belongs to the timing driven category.
     inline bool is_timing_driven() const {
-        return algo == CRITICALITY_TIMING_PLACE || algo == SLACK_TIMING_PLACE;
+        return algo == CRITICALITY_TIMING_PLACE || algo == SLACK_TIMING_PLACE || algo== CONGESTION_AWARE_PLACE;
     }
 
     ///@brief Accessor: returns the underlying e_place_algorithm enum value.
@@ -1147,6 +1148,7 @@ struct t_placer_opts {
     t_place_algorithm place_algorithm;
     t_place_algorithm place_quench_algorithm;
     float timing_tradeoff;
+    float congestion_tradeoff;
     float place_cost_exp;
     int place_chan_width;
     enum e_pad_loc_type pad_loc_type;

--- a/vpr/src/place/move_generator.h
+++ b/vpr/src/place/move_generator.h
@@ -12,9 +12,11 @@ struct MoveOutcomeStats {
     float delta_cost_norm = std::numeric_limits<float>::quiet_NaN();
     float delta_bb_cost_norm = std::numeric_limits<float>::quiet_NaN();
     float delta_timing_cost_norm = std::numeric_limits<float>::quiet_NaN();
+    float delta_cong_cost_norm = std::numeric_limits<float>::quiet_NaN();
 
     float delta_bb_cost_abs = std::numeric_limits<float>::quiet_NaN();
     float delta_timing_cost_abs = std::numeric_limits<float>::quiet_NaN();
+    float delta_cong_cost_abs = std::numeric_limits<float>::quiet_NaN();
 
     e_move_result outcome = ABORTED;
     float elapsed_time = std::numeric_limits<float>::quiet_NaN();

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -65,6 +65,7 @@ static GridBlock init_grid_blocks() {
 void t_placer_costs::update_norm_factors() {
     if (place_algorithm.is_timing_driven()) {
         bb_cost_norm = 1 / bb_cost;
+        cong_cost_norm = 1/ cong_cost;
         //Prevent the norm factor from going to infinity
         timing_cost_norm = std::min(1 / timing_cost, MAX_INV_TIMING_COST);
     } else {
@@ -289,6 +290,7 @@ void t_placer_statistics::reset() {
     av_cost = 0.;
     av_bb_cost = 0.;
     av_timing_cost = 0.;
+    av_cong_cost = 0.;
     sum_of_squares = 0.;
     success_sum = 0;
     success_rate = 0.;
@@ -301,6 +303,7 @@ void t_placer_statistics::single_swap_update(const t_placer_costs& costs) {
     av_cost += costs.cost;
     av_bb_cost += costs.bb_cost;
     av_timing_cost += costs.timing_cost;
+    av_cong_cost += costs.cong_cost;
     sum_of_squares += (costs.cost) * (costs.cost);
 }
 
@@ -310,10 +313,12 @@ void t_placer_statistics::calc_iteration_stats(const t_placer_costs& costs, int 
         av_cost = costs.cost;
         av_bb_cost = costs.bb_cost;
         av_timing_cost = costs.timing_cost;
+        av_cong_cost = costs.cong_cost;
     } else {
         av_cost /= success_sum;
         av_bb_cost /= success_sum;
         av_timing_cost /= success_sum;
+        av_cong_cost /= success_sum;
     }
     success_rate = success_sum / float(move_lim);
     std_dev = get_std_dev(success_sum, sum_of_squares, av_cost);

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -51,6 +51,8 @@ class t_placer_costs {
     double timing_cost = 0.;
     double bb_cost_norm = 0.;
     double timing_cost_norm = 0.;
+    double cong_cost = 0.;
+    double cong_cost_norm = 0.;
     double noc_aggregate_bandwidth_cost = 0.;
     double noc_aggregate_bandwidth_cost_norm = 0.;
     double noc_latency_cost = 0.;
@@ -190,6 +192,7 @@ class t_placer_statistics {
     double av_cost;
     double av_bb_cost;
     double av_timing_cost;
+    double av_cong_cost;
     double sum_of_squares;
     int success_sum;
     float success_rate;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
This is the same pull requestion from before. I added your suggestions and moved it to the master branch



#### How Has This Been Tested?
Here is a simple example in the first case which uses the VTR default placer the minimum routing channel width is 48 however in the second case the routing channel width is 34. This exmaple shows how this congestion aware placement helps VPR routability.
vpr/vpr /media/mohammad/Elements/ubuntu/fpga_dnn/vtr-verilog-to-routing/vtr_flow/arch/custom_grid/fixed_grid.xml /media/mohammad/Elements/ubuntu/fpga_dnn/vtr-verilog-to-routing/vtr_flow/benchmarks/blif/alu4.blif --suppress_warnings check_rr_node_warnings.log,check_rr_node --clock_modeling ideal --absorb_buffer_luts off --constant_net_method route --allow_unrelated_clustering off --allow_dangling_combinational_nodes on --place_delta_delay_matrix_calculation_method dijkstra --gen_post_synthesis_netlist on --post_synth_netlist_unconn_inputs gnd --inner_loop_recompute_divider 1 --max_router_iterations 100 --timing_report_detail detailed --timing_report_npaths 100 --route --place --pack --device 25x25
vpr/vpr /media/mohammad/Elements/ubuntu/fpga_dnn/vtr-verilog-to-routing/vtr_flow/arch/custom_grid/fixed_grid.xml /media/mohammad/Elements/ubuntu/fpga_dnn/vtr-verilog-to-routing/vtr_flow/benchmarks/blif/alu4.blif --suppress_warnings check_rr_node_warnings.log,check_rr_node --clock_modeling ideal --absorb_buffer_luts off --constant_net_method route --allow_unrelated_clustering off --allow_dangling_combinational_nodes on --place_delta_delay_matrix_calculation_method dijkstra --gen_post_synthesis_netlist on --post_synth_netlist_unconn_inputs gnd --inner_loop_recompute_divider 1 --max_router_iterations 100 --timing_report_detail detailed --timing_report_npaths 100 --route --place --pack --place_algorithm congestion_aware --congest_tradeoff 28 --device 25x25


