### PR TITLE
generate_tech_xml_files.sh

### DIFF
--- a/vtr_flow/scripts/generate_tech_xml_files.sh
+++ b/vtr_flow/scripts/generate_tech_xml_files.sh
@@ -3,3 +3,8 @@
 ./generate_cmos_tech_data.pl ../tech/PTM_22nm/22nm.pm 22e-9 0.8 85 > ../tech/PTM_22nm/22nm.xml &
 ./generate_cmos_tech_data.pl ../tech/PTM_45nm/45nm.pm 45e-9 0.9 85 > ../tech/PTM_45nm/45nm.xml &
 ./generate_cmos_tech_data.pl ../tech/PTM_130nm/130nm.pm 130e-9 1.3 85 > ../tech/PTM_130nm/130nm.xml &
+
+# If you encounter a situation where the units in the generated numerical content 
+# have not been converted to exponential levels, you may try using the following code snippet.
+
+# python3 ./transform_the_content.py

--- a/vtr_flow/scripts/transform_the_content.py
+++ b/vtr_flow/scripts/transform_the_content.py
@@ -1,0 +1,30 @@
+import re
+def convert_suffix(match):
+    num = match.group(1)
+    suffix = match.group(2)
+    suffix_map = {
+        'a': 'E-18',
+        'f': 'E-15',
+        'u': 'E-6',
+        'n': 'E-9',
+        'p': 'E-12',
+        'm': 'E-3',
+        'e': 'E'
+    }
+    return num + suffix_map.get(suffix.lower(), '')
+
+# if you want to modify .xml files under other processes, you may need to modify the path below.
+xml_file = "~/vtr-verilog-to-routing/vtr_flow/tech/PTM_22nm/22nm.xml"
+
+# read .xml file
+with open(xml_file, 'r') as file:
+    lines = file.readlines()
+
+# Replace the units with the corresponding exponential level.
+for i in range(1,len(lines)):
+    lines[i] = re.sub(r'(\d+(?:\.\d*)?)([a-zA-Z])(?![a-zA-Z])', convert_suffix, lines[i])
+
+
+# write the content to the .xml file
+with open(xml_file, 'w') as file:
+    file.writelines(lines)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Completing the conversion from units to exponential scale.

#### Related Issue
When running generate_cmos_tech_data.pl with hspice 2017, you may come across an issue where the current values need to be converted into exponential notation with the "e" notation.(https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2424)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
