### PR TITLE
Added --quench_recompute_divider documentation

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -938,6 +938,13 @@ The following options are only valid when the placement engine is in timing-driv
 
     **Default:** ``0``
 
+.. option:: --quench_recompute_divider <int>
+
+    Controls how many times the placer performs a timing analysis to update its criticality estimates during a quench. 
+    If unspecified, uses the value from --inner_loop_recompute_divider.
+
+    **Default:** ``0``
+
 .. option:: --td_place_exp_first <float>
 
     Controls how critical a connection is considered as a function of its slack, at the start of the anneal.


### PR DESCRIPTION
We are missing documentation for this command line option; this PR adds it.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
