### PR TITLE
Vb doc update - dusty annealing schedule link

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -784,7 +784,7 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
     **Default:** ``0.0``
 
 .. _dusty_sa_options:
-Setting any of the following options selects `Dusty's annealing schedule <dusty_sa.rst>`_.
+Setting any of the following 5 options selects `Dusty's annealing schedule :ref`dusty_sa`_.
 
 .. option:: --alpha_min <float>
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -784,7 +784,7 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
     **Default:** ``0.0``
 
 .. _dusty_sa_options:
-Setting any of the following 5 options selects :ref:`Dusty's annealing schedule <dusty_sa>`_.
+Setting any of the following 5 options selects :ref:`Dusty's annealing schedule <dusty_sa>`.
 
 .. option:: --alpha_min <float>
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -784,7 +784,7 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
     **Default:** ``0.0``
 
 .. _dusty_sa_options:
-Setting any of the following 5 options selects `Dusty's annealing schedule :ref`dusty_sa`_.
+Setting any of the following 5 options selects :ref:`Dusty's annealing schedule <dusty_sa>`_.
 
 .. option:: --alpha_min <float>
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -784,7 +784,7 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
     **Default:** ``0.0``
 
 .. _dusty_sa_options:
-Setting any of the following 5 options selects :ref:`Dusty's annealing schedule <dusty_sa>`.
+Setting any of the following 5 options selects :ref:`Dusty's annealing schedule <dusty_sa>` .
 
 .. option:: --alpha_min <float>
 

--- a/doc/src/vpr/dusty_sa.rst
+++ b/doc/src/vpr/dusty_sa.rst
@@ -1,3 +1,5 @@
+.. _dusty_sa:
+
 Dusty's Simulated Annealing Schedule
 ====================================
 


### PR DESCRIPTION
The vpr command line option description has some confusing text and a broken link to the Dusty annealing schedule. This fixes it.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
