### PR TITLE
Flat Routing Online Document

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1120,6 +1120,13 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
 .. seealso:: :ref:`timing_driven_router_options`
 
+.. option:: --flat_routing {on | off}
+
+    If this option is enabled, the *run-flat* router is used instead of the *two-stage* router.
+    This means that during the routing stage, all nets, both intra- and inter-cluster, are routed directly from one primitive pin to another primitive pin.
+
+    **Default:** ``OFF`
+
 .. option:: --max_router_iterations <int>
 
     The number of iterations of a Pathfinder-based router that will be executed before a circuit is declared unrouteable (if it hasn’t routed successfully yet) at a given channel width.

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2441,9 +2441,9 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    route_grp.add_argument(args.flat_routing, "--flat_routing")
+    route_grp.add_argument<bool, ParseOnOff>(args.flat_routing, "--flat_routing")
         .help("Enable VPR's flat routing (routing the nets from the source primitive to the destination primitive)")
-        .default_value("false")
+        .default_value("OFF")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_grp.add_argument(args.has_choking_spot, "--has_choking_spot")

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/titan_other_run_flat/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/titan_other_run_flat/config/config.txt
@@ -41,5 +41,5 @@ qor_parse_file=qor_vpr_titan.txt
 # Pass requirements
 pass_requirements_file=pass_requirements_vpr_titan.txt
 
-script_params=-starting_stage vpr --route_chan_width 300 --max_router_iterations 400 --router_lookahead map --flat_routing true
+script_params=-starting_stage vpr --route_chan_width 300 --max_router_iterations 400 --router_lookahead map --flat_routing on
 

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/verify_router_lookahead_run_flat/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/verify_router_lookahead_run_flat/config/config.txt
@@ -27,4 +27,4 @@ qor_parse_file=qor_rr_graph.txt
 pass_requirements_file=pass_requirements_verify_rr_graph.txt
 
 # Script parameters
-script_params = -verify_inter_cluster_router_lookahead -verify_intra_cluster_router_lookahead --route_chan_width 130 --flat_routing true
+script_params = -verify_inter_cluster_router_lookahead -verify_intra_cluster_router_lookahead --route_chan_width 130 --flat_routing on

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/verify_rr_graph_run_flat/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/verify_rr_graph_run_flat/config/config.txt
@@ -27,4 +27,4 @@ qor_parse_file=qor_rr_graph.txt
 pass_requirements_file=pass_requirements_verify_rr_graph.txt
 
 # Script parameters
-script_params = -verify_rr_graph --route_chan_width 130 --flat_routing true
+script_params = -verify_rr_graph --route_chan_width 130 --flat_routing on

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/vtr_reg_qor_large_depop_run_flat/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/vtr_reg_qor_large_depop_run_flat/config/config.txt
@@ -29,4 +29,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage --max_router_iterations 300 --flat_routing true --has_choking_spot true
+script_params=-track_memory_usage --max_router_iterations 300 --flat_routing on --has_choking_spot true

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/vtr_reg_qor_large_run_flat/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/vtr_reg_qor_large_run_flat/config/config.txt
@@ -31,4 +31,4 @@ qor_parse_file=qor_large.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage -max_router_iterations 300 --flat_routing true
+script_params=-track_memory_usage -max_router_iterations 300 --flat_routing on

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_flat_router/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_flat_router/config/config.txt
@@ -24,6 +24,6 @@ qor_parse_file=qor_standard.txt
 # Pass requirements
 pass_requirements_file=pass_requirements.txt
 
-script_params_common=-track_memory_usage --route_chan_width 100 --max_router_iterations 100 --router_lookahead map --flat_routing true
+script_params_common=-track_memory_usage --route_chan_width 100 --max_router_iterations 100 --router_lookahead map --flat_routing on
 script_params_list_add =
 script_params_list_add = --router_algorithm parallel --num_workers 4


### PR DESCRIPTION
In this pull request, the flat router parameter has been updated from True/False to ON/OFF. Additionally, the parameter documentation has been added to the document page.

This addresses the issue [#2448](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2448).