### PR TITLE
Routing Stats

### DIFF
--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -1104,7 +1104,7 @@ static inline bool relevant_node_to_target(const RRGraphView* rr_graph,
 static inline void update_router_stats(RouterStats* router_stats,
                                        bool is_push,
                                        RRNodeId rr_node_id,
-                                       const RRGraphView* rr_graph,) {
+                                       const RRGraphView* rr_graph) {
 #else
 static inline void update_router_stats(RouterStats* router_stats,
                                        bool is_push,

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -864,8 +864,7 @@ void ConnectionRouter<Heap>::add_route_tree_to_heap(
         }
         add_route_tree_node_to_heap(rt_node,
                                     target_node,
-                                    cost_params,
-                                    false);
+                                    cost_params);
     }
 
     for (const RouteTreeNode& child_node : rt_node.child_nodes()) {
@@ -893,8 +892,7 @@ template<typename Heap>
 void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
     const RouteTreeNode& rt_node,
     RRNodeId target_node,
-    const t_conn_cost_params cost_params,
-    bool is_high_fanout) {
+    const t_conn_cost_params cost_params) {
     const auto& device_ctx = g_vpr_ctx.device();
     const RRNodeId inode = rt_node.inode;
     float backward_path_cost = cost_params.criticality * rt_node.Tdel;
@@ -1021,7 +1019,7 @@ t_bb ConnectionRouter<Heap>::add_high_fanout_route_tree_to_heap(
                     continue;
                 }
                 // Put the node onto the heap
-                add_route_tree_node_to_heap(rt_node, target_node, cost_params, true);
+                add_route_tree_node_to_heap(rt_node, target_node, cost_params);
 
                 // Expand HF BB to include the node (clip by original BB)
                 expand_highfanout_bounding_box(highfanout_bb, net_bounding_box, rr_node_to_add, rr_graph_);

--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -26,15 +26,15 @@ static bool relevant_node_to_target(const RRGraphView* rr_graph,
                                     RRNodeId target_node);
 
 #ifdef VTR_ENABLE_DEBUG_LOGGING
-static void update_router_stats(const RRGraphView* rr_graph,
-                                       RouterStats* router_stats,
-                                       RRNodeId rr_node_id,
-                                       bool is_push);
+static void update_router_stats(RouterStats* router_stats,
+                                bool is_push,
+                                RRNodeId rr_node_id,
+                                const RRGraphView* rr_graph);
 #else
-static void update_router_stats(const RRGraphView* /*rr_graph*/,
-                                       RouterStats* router_stats,
-                                       RRNodeId /*rr_node_id*/,
-                                       bool is_push);
+static void update_router_stats(RouterStats* router_stats,
+                                bool is_push,
+                                RRNodeId /*rr_node_id*/,
+                                const RRGraphView* /*rr_graph*/);
 #endif
 
 /** return tuple <found_path, retry_with_full_bb, cheapest> */
@@ -220,10 +220,10 @@ t_heap* ConnectionRouter<Heap>::timing_driven_route_connection_from_heap(RRNodeI
     while (!heap_.is_empty_heap()) {
         // cheapest t_heap in current route tree to be expanded on
         cheapest = heap_.get_heap_head();
-        update_router_stats(rr_graph_,
-                            router_stats_,
+        update_router_stats(router_stats_,
+                            false,
                             cheapest->index,
-                            false);
+                            rr_graph_);
 
         RRNodeId inode = cheapest->index;
         VTR_LOGV_DEBUG(router_debug_, "  Popping node %d (cost: %g)\n",
@@ -309,10 +309,10 @@ vtr::vector<RRNodeId, t_heap> ConnectionRouter<Heap>::timing_driven_find_all_sho
     while (!heap_.is_empty_heap()) {
         // cheapest t_heap in current route tree to be expanded on
         t_heap* cheapest = heap_.get_heap_head();
-        update_router_stats(rr_graph_,
-                            router_stats_,
+        update_router_stats(router_stats_,
+                            false,
                             cheapest->index,
-                            false);
+                            rr_graph_);
 
         RRNodeId inode = cheapest->index;
         VTR_LOGV_DEBUG(router_debug_, "  Popping node %d (cost: %g)\n",
@@ -617,10 +617,10 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params 
         }
 
         heap_.add_to_heap(next_ptr);
-        update_router_stats(rr_graph_,
-                            router_stats_,
+        update_router_stats(router_stats_,
+                            true,
                             to_node,
-                            true);
+                            rr_graph_);
 
     } else {
         VTR_LOGV_DEBUG(router_debug_, "      Didn't expand to %d (%s)\n", to_node, describe_rr_node(device_ctx.rr_graph, device_ctx.grid, device_ctx.rr_indexed_data, to_node, is_flat_).c_str());
@@ -930,10 +930,10 @@ void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
                                  backward_path_cost, R_upstream, rt_node.Tdel, &rcv_path_manager);
     }
 
-    update_router_stats(rr_graph_,
-                        router_stats_,
+    update_router_stats(router_stats_,
+                        true,
                         inode,
-                        true);
+                        rr_graph_);
 
 #ifdef VTR_ENABLE_DEBUG_LOGGING
     router_stats_->rt_node_pushes[rr_graph_->node_type(inode)]++;
@@ -1101,15 +1101,15 @@ static inline bool relevant_node_to_target(const RRGraphView* rr_graph,
 }
 
 #ifdef VTR_ENABLE_DEBUG_LOGGING
-static inline void update_router_stats(const RRGraphView* rr_graph,
-                                       RouterStats* router_stats,
+static inline void update_router_stats(RouterStats* router_stats,
+                                       bool is_push,
                                        RRNodeId rr_node_id,
-                                       bool is_push) {
+                                       const RRGraphView* rr_graph,) {
 #else
-static inline void update_router_stats(const RRGraphView* /*rr_graph*/,
-                                       RouterStats* router_stats,
+static inline void update_router_stats(RouterStats* router_stats,
+                                       bool is_push,
                                        RRNodeId /*rr_node_id*/,
-                                       bool is_push) {
+                                       const RRGraphView* /*rr_graph*/) {
 #endif
     if (is_push) {
         router_stats->heap_pushes++;

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -239,8 +239,7 @@ class ConnectionRouter : public ConnectionRouterInterface {
     //used as branch-points for further routing.
     void add_route_tree_to_heap(const RouteTreeNode& rt_node,
                                 RRNodeId target_node,
-                                const t_conn_cost_params cost_params,
-                                bool from_high_fanout);
+                                const t_conn_cost_params cost_params);
 
     // Evaluate node costs using the RCV algorith
     float compute_node_cost_using_rcv(const t_conn_cost_params cost_params,

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -256,8 +256,7 @@ class ConnectionRouter : public ConnectionRouterInterface {
     void add_route_tree_node_to_heap(
         const RouteTreeNode& rt_node,
         RRNodeId target_node,
-        const t_conn_cost_params cost_params,
-        bool is_high_fanout);
+        const t_conn_cost_params cost_params);
 
     t_bb add_high_fanout_route_tree_to_heap(
         const RouteTreeNode& rt_root,

--- a/vpr/src/route/route.cpp
+++ b/vpr/src/route/route.cpp
@@ -614,13 +614,7 @@ bool route(const Netlist<>& net_list,
         VTR_LOG("total_internal_%s_pushes: %zu ", rr_node_typename[node_type_idx], router_stats.intra_cluster_node_type_cnt_pushes[node_type_idx]);
         VTR_LOG("total_internal_%s_pops: %zu ", rr_node_typename[node_type_idx], router_stats.intra_cluster_node_type_cnt_pops[node_type_idx]);
         VTR_LOG("rt_node_%s_pushes: %zu ", rr_node_typename[node_type_idx], router_stats.rt_node_pushes[node_type_idx]);
-        VTR_LOG("rt_node_%s_high_fanout_pushes: %zu ", rr_node_typename[node_type_idx], router_stats.rt_node_high_fanout_pushes[node_type_idx]);
-        VTR_LOG("rt_node_%s_entire_tree_pushes: %zu ", rr_node_typename[node_type_idx], router_stats.rt_node_entire_tree_pushes[node_type_idx]);
     }
-
-    VTR_LOG("total_number_of_adding_all_rt: %zu ", router_stats.add_all_rt);
-    VTR_LOG("total_number_of_adding_high_fanout_rt: %zu ", router_stats.add_high_fanout_rt);
-    VTR_LOG("total_number_of_adding_all_rt_from_calling_high_fanout_rt: %zu ", router_stats.add_all_rt_from_high_fanout);
 #endif
     VTR_LOG("\n");
 

--- a/vpr/src/route/route.cpp
+++ b/vpr/src/route/route.cpp
@@ -601,9 +601,11 @@ bool route(const Netlist<>& net_list,
     VTR_ASSERT(router_stats.heap_pushes >= router_stats.intra_cluster_node_pushes);
     VTR_ASSERT(router_stats.heap_pops >= router_stats.intra_cluster_node_pops);
     VTR_LOG(
-        "Router Stats: total_nets_routed: %zu total_connections_routed: %zu total_heap_pushes: %zu total_heap_pops: %zu "
+        "Router Stats: total_nets_routed: %zu total_connections_routed: %zu total_heap_pushes: %zu total_heap_pops: %zu ",
+        router_stats.nets_routed, router_stats.connections_routed, router_stats.heap_pushes, router_stats.heap_pops);
+#ifdef VTR_ENABLE_DEBUG_LOGGING
+    VTR_LOG(
         "total_internal_heap_pushes: %zu total_internal_heap_pops: %zu total_external_heap_pushes: %zu total_external_heap_pops: %zu ",
-        router_stats.nets_routed, router_stats.connections_routed, router_stats.heap_pushes, router_stats.heap_pops,
         router_stats.intra_cluster_node_pushes, router_stats.intra_cluster_node_pops,
         router_stats.inter_cluster_node_pushes, router_stats.inter_cluster_node_pops);
     for (int node_type_idx = 0; node_type_idx < t_rr_type::NUM_RR_TYPES; node_type_idx++) {
@@ -619,6 +621,7 @@ bool route(const Netlist<>& net_list,
     VTR_LOG("total_number_of_adding_all_rt: %zu ", router_stats.add_all_rt);
     VTR_LOG("total_number_of_adding_high_fanout_rt: %zu ", router_stats.add_high_fanout_rt);
     VTR_LOG("total_number_of_adding_all_rt_from_calling_high_fanout_rt: %zu ", router_stats.add_all_rt_from_high_fanout);
+#endif
     VTR_LOG("\n");
 
     return success;

--- a/vpr/src/route/router_stats.h
+++ b/vpr/src/route/router_stats.h
@@ -45,12 +45,6 @@ struct RouterStats {
 
     // For debugging purposes
     size_t rt_node_pushes[t_rr_type::NUM_RR_TYPES] = {0};
-    size_t rt_node_high_fanout_pushes[t_rr_type::NUM_RR_TYPES] = {0};
-    size_t rt_node_entire_tree_pushes[t_rr_type::NUM_RR_TYPES] = {0};
-
-    size_t add_all_rt_from_high_fanout = 0;
-    size_t add_high_fanout_rt = 0;
-    size_t add_all_rt = 0;
 
     /** Add rhs's stats to mine */
     void combine(RouterStats& rhs) {
@@ -68,12 +62,7 @@ struct RouterStats {
             intra_cluster_node_type_cnt_pushes[node_type_idx] += rhs.intra_cluster_node_type_cnt_pushes[node_type_idx];
             intra_cluster_node_type_cnt_pops[node_type_idx] += rhs.intra_cluster_node_type_cnt_pops[node_type_idx];
             rt_node_pushes[node_type_idx] += rhs.rt_node_pushes[node_type_idx];
-            rt_node_high_fanout_pushes[node_type_idx] += rhs.rt_node_high_fanout_pushes[node_type_idx];
-            rt_node_entire_tree_pushes[node_type_idx] += rhs.rt_node_entire_tree_pushes[node_type_idx];
         }
-        add_all_rt += rhs.add_all_rt;
-        add_all_rt_from_high_fanout += rhs.add_all_rt_from_high_fanout;
-        add_high_fanout_rt += rhs.add_high_fanout_rt;
     }
 };
 

--- a/vtr_flow/parse/parse_config/common/vpr.route_fixed_chan_width.txt
+++ b/vtr_flow/parse/parse_config/common/vpr.route_fixed_chan_width.txt
@@ -8,59 +8,6 @@ total_nets_routed;vpr.out;Router Stats: total_nets_routed: (\d+) .*
 total_connections_routed;vpr.out;Router Stats: .*total_connections_routed: (\d+) .*
 total_heap_pushes;vpr.out;Router Stats: .*total_heap_pushes: (\d+) .*
 total_heap_pops;vpr.out;Router Stats: .*total_heap_pops: (\d+)
-total_internal_heap_pushes;vpr.out;Router Stats: .*total_internal_heap_pushes: (\d+) .*
-total_internal_heap_pops;vpr.out;Router Stats: .*total_internal_heap_pops: (\d+) .*
-total_external_heap_pushes;vpr.out;Router Stats: .*total_external_heap_pushes: (\d+) .*
-total_external_heap_pops;vpr.out;Router Stats: .*total_external_heap_pops: (\d+) .*
-total_external_SOURCE_pushes;vpr.out;Router Stats: .*total_external_SOURCE_pushes: (\d+) .*
-total_external_SOURCE_pops;vpr.out;Router Stats: .*total_external_SOURCE_pops: (\d+) .*
-total_internal_SOURCE_pushes;vpr.out;Router Stats: .*total_internal_SOURCE_pushes: (\d+) .*
-total_internal_SOURCE_pops;vpr.out;Router Stats: .*total_internal_SOURCE_pops: (\d+) .*
-total_external_SINK_pushes;vpr.out;Router Stats: .*total_external_SINK_pushes: (\d+) .*
-total_external_SINK_pops;vpr.out;Router Stats: .*total_external_SINK_pops: (\d+) .*
-total_internal_SINK_pushes;vpr.out;Router Stats: .*total_internal_SINK_pushes: (\d+) .*
-total_internal_SINK_pops;vpr.out;Router Stats: .*total_internal_SINK_pops: (\d+) .*
-total_external_IPIN_pushes;vpr.out;Router Stats: .*total_external_IPIN_pushes: (\d+) .*
-total_external_IPIN_pops;vpr.out;Router Stats: .*total_external_IPIN_pops: (\d+) .*
-total_internal_IPIN_pushes;vpr.out;Router Stats: .*total_internal_IPIN_pushes: (\d+) .*
-total_internal_IPIN_pops;vpr.out;Router Stats: .*total_internal_IPIN_pops: (\d+) .*
-total_external_OPIN_pushes;vpr.out;Router Stats: .*total_external_OPIN_pushes: (\d+) .*
-total_external_OPIN_pops;vpr.out;Router Stats: .*total_external_OPIN_pops: (\d+) .*
-total_internal_OPIN_pushes;vpr.out;Router Stats: .*total_internal_OPIN_pushes: (\d+) .*
-total_internal_OPIN_pops;vpr.out;Router Stats: .*total_internal_OPIN_pops: (\d+) .*
-total_external_CHANX_pushes;vpr.out;Router Stats: .*total_external_CHANX_pushes: (\d+) .*
-total_external_CHANX_pops;vpr.out;Router Stats: .*total_external_CHANX_pops: (\d+) .*
-total_internal_CHANX_pushes;vpr.out;Router Stats: .*total_internal_CHANX_pushes: (\d+) .*
-total_internal_CHANX_pops;vpr.out;Router Stats: .*total_internal_CHANX_pops: (\d+) .*
-total_external_CHANY_pushes;vpr.out;Router Stats: .*total_external_CHANY_pushes: (\d+) .*
-total_external_CHANY_pops;vpr.out;Router Stats: .*total_external_CHANY_pops: (\d+) .*
-total_internal_CHANY_pushes;vpr.out;Router Stats: .*total_internal_CHANY_pushes: (\d+) .*
-total_internal_CHANY_pops;vpr.out;Router Stats: .*total_internal_CHANY_pops: (\d+) .*
-
-rt_node_SOURCE_pushes;vpr.out;Router Stats: .*rt_node_SOURCE_pushes: (\d+) .*
-rt_node_SINK_pushes;vpr.out;Router Stats: .*rt_node_SINK_pushes: (\d+) .*
-rt_node_IPIN_pushes;vpr.out;Router Stats: .*rt_node_IPIN_pushes: (\d+) .*
-rt_node_OPIN_pushes;vpr.out;Router Stats: .*rt_node_OPIN_pushes: (\d+) .*
-rt_node_CHANX_pushes;vpr.out;Router Stats: .*rt_node_CHANX_pushes: (\d+) .*
-rt_node_CHANY_pushes;vpr.out;Router Stats: .*rt_node_CHANY_pushes: (\d+) .*
-
-rt_node_SOURCE_high_fanout_pushes;vpr.out;Router Stats: .*rt_node_SOURCE_high_fanout_pushes: (\d+) .*
-rt_node_SINK_high_fanout_pushes;vpr.out;Router Stats: .*rt_node_SINK_high_fanout_pushes: (\d+) .*
-rt_node_IPIN_high_fanout_pushes;vpr.out;Router Stats: .*rt_node_IPIN_high_fanout_pushes: (\d+) .*
-rt_node_OPIN_high_fanout_pushes;vpr.out;Router Stats: .*rt_node_OPIN_high_fanout_pushes: (\d+) .*
-rt_node_CHANX_high_fanout_pushes;vpr.out;Router Stats: .*rt_node_CHANX_high_fanout_pushes: (\d+) .*
-rt_node_CHANY_high_fanout_pushes;vpr.out;Router Stats: .*rt_node_CHANY_high_fanout_pushes: (\d+) .*
-
-rt_node_SOURCE_entire_tree_pushes;vpr.out;Router Stats: .*rt_node_SOURCE_entire_tree_pushes: (\d+) .*
-rt_node_SINK_entire_tree_pushes;vpr.out;Router Stats: .*rt_node_SINK_entire_tree_pushes: (\d+) .*
-rt_node_IPIN_entire_tree_pushes;vpr.out;Router Stats: .*rt_node_IPIN_entire_tree_pushes: (\d+) .*
-rt_node_OPIN_entire_tree_pushes;vpr.out;Router Stats: .*rt_node_OPIN_entire_tree_pushes: (\d+) .*
-rt_node_CHANX_entire_tree_pushes;vpr.out;Router Stats: .*rt_node_CHANX_entire_tree_pushes: (\d+) .*
-rt_node_CHANY_entire_tree_pushes;vpr.out;Router Stats: .*rt_node_CHANY_entire_tree_pushes: (\d+) .*
-
-adding_all_rt;vpr.out;Router Stats: .*total_number_of_adding_all_rt: (\d+) .*
-adding_high_fanout_rt;vpr.out;Router Stats: .*total_number_of_adding_high_fanout_rt: (\d+) .*
-total_number_of_adding_all_rt_from_calling_high_fanout_rt;vpr.out;Router Stats: .*total_number_of_adding_all_rt_from_calling_high_fanout_rt: (\d+) .*
 
 #Area Metrics
 logic_block_area_total;vpr.out;\s*Total logic block area .*: (.*)

--- a/vtr_flow/parse/parse_config/timing/vpr.route_relaxed_chan_width.txt
+++ b/vtr_flow/parse/parse_config/timing/vpr.route_relaxed_chan_width.txt
@@ -11,45 +11,6 @@ crit_path_total_nets_routed;vpr.crit_path.out;.* total_nets_routed: (\d+)
 crit_path_total_connections_routed;vpr.crit_path.out;.* total_connections_routed: (\d+)
 crit_path_total_heap_pushes;vpr.crit_path.out;.* total_heap_pushes: (\d+)
 crit_path_total_heap_pops;vpr.crit_path.out;.* total_heap_pops: (\d+)
-crit_path_total_internal_heap_pushes;vpr.crit_path.out;Router Stats: .*total_internal_heap_pushes: (\d+) .*
-crit_path_total_internal_heap_pops;vpr.crit_path.out;Router Stats: .*total_internal_heap_pops: (\d+) .*
-crit_path_total_external_heap_pushes;vpr.crit_path.out;Router Stats: .*total_external_heap_pushes: (\d+) .*
-crit_path_total_external_heap_pops;vpr.crit_path.out;Router Stats: .*total_external_heap_pops: (\d+) .*
-crit_path_total_external_SOURCE_pushes;vpr.crit_path.out;Router Stats: .*total_external_SOURCE_pushes: (\d+) .*
-crit_path_total_external_SOURCE_pops;vpr.crit_path.out;Router Stats: .*total_external_SOURCE_pops: (\d+) .*
-crit_path_total_internal_SOURCE_pushes;vpr.crit_path.out;Router Stats: .*total_internal_SOURCE_pushes: (\d+) .*
-crit_path_total_internal_SOURCE_pops;vpr.crit_path.out;Router Stats: .*total_internal_SOURCE_pops: (\d+) .*
-crit_path_total_external_SINK_pushes;vpr.crit_path.out;Router Stats: .*total_external_SINK_pushes: (\d+) .*
-crit_path_total_external_SINK_pops;vpr.crit_path.out;Router Stats: .*total_external_SINK_pops: (\d+) .*
-crit_path_total_internal_SINK_pushes;vpr.crit_path.out;Router Stats: .*total_internal_SINK_pushes: (\d+) .*
-crit_path_total_internal_SINK_pops;vpr.crit_path.out;Router Stats: .*total_internal_SINK_pops: (\d+) .*
-crit_path_total_external_IPIN_pushes;vpr.crit_path.out;Router Stats: .*total_external_IPIN_pushes: (\d+) .*
-crit_path_total_external_IPIN_pops;vpr.crit_path.out;Router Stats: .*total_external_IPIN_pops: (\d+) .*
-crit_path_total_internal_IPIN_pushes;vpr.crit_path.out;Router Stats: .*total_internal_IPIN_pushes: (\d+) .*
-crit_path_total_internal_IPIN_pops;vpr.crit_path.out;Router Stats: .*total_internal_IPIN_pops: (\d+) .*
-crit_path_total_external_OPIN_pushes;vpr.crit_path.out;Router Stats: .*total_external_OPIN_pushes: (\d+) .*
-crit_path_total_external_OPIN_pops;vpr.crit_path.out;Router Stats: .*total_external_OPIN_pops: (\d+) .*
-crit_path_total_internal_OPIN_pushes;vpr.crit_path.out;Router Stats: .*total_internal_OPIN_pushes: (\d+) .*
-crit_path_total_internal_OPIN_pops;vpr.crit_path.out;Router Stats: .*total_internal_OPIN_pops: (\d+) .*
-crit_path_total_external_CHANX_pushes;vpr.crit_path.out;Router Stats: .*total_external_CHANX_pushes: (\d+) .*
-crit_path_total_external_CHANX_pops;vpr.crit_path.out;Router Stats: .*total_external_CHANX_pops: (\d+) .*
-crit_path_total_internal_CHANX_pushes;vpr.crit_path.out;Router Stats: .*total_internal_CHANX_pushes: (\d+) .*
-crit_path_total_internal_CHANX_pops;vpr.crit_path.out;Router Stats: .*total_internal_CHANX_pops: (\d+) .*
-crit_path_total_external_CHANY_pushes;vpr.crit_path.out;Router Stats: .*total_external_CHANY_pushes: (\d+) .*
-crit_path_total_external_CHANY_pops;vpr.crit_path.out;Router Stats: .*total_external_CHANY_pops: (\d+) .*
-crit_path_total_internal_CHANY_pushes;vpr.crit_path.out;Router Stats: .*total_internal_CHANY_pushes: (\d+) .*
-crit_path_total_internal_CHANY_pops;vpr.crit_path.out;Router Stats: .*total_internal_CHANY_pops: (\d+) .*
-
-crit_path_rt_node_SOURCE_pushes;vpr.crit_path.out;Router Stats: .*rt_node_SOURCE_pushes: (\d+) .*
-crit_path_rt_node_SINK_pushes;vpr.crit_path.out;Router Stats: .*rt_node_SINK_pushes: (\d+) .*
-crit_path_rt_node_IPIN_pushes;vpr.crit_path.out;Router Stats: .*rt_node_IPIN_pushes: (\d+) .*
-crit_path_rt_node_OPIN_pushes;vpr.crit_path.out;Router Stats: .*rt_node_OPIN_pushes: (\d+) .*
-crit_path_rt_node_CHANX_pushes;vpr.crit_path.out;Router Stats: .*rt_node_CHANX_pushes: (\d+) .*
-crit_path_rt_node_CHANY_pushes;vpr.crit_path.out;Router Stats: .*rt_node_CHANY_pushes: (\d+) .*
-
-crit_path_adding_all_rt;vpr.crit_path.out;Router Stats: .*total_number_of_adding_all_rt: (\d+) .*
-crit_path_adding_high_fanout_rt;vpr.crit_path.out;Router Stats: .*total_number_of_adding_high_fanout_rt: (\d+) .*
-crit_path_total_number_of_adding_all_rt_from_calling_high_fanout_rt;vpr.crit_path.out;Router Stats: .*total_number_of_adding_all_rt_from_calling_high_fanout_rt: (\d+)
 
 #VPR Analysis (final implementation) Metrics
 critical_path_delay;vpr.crit_path.out;Final critical path delay \(least slack\): (.*) ns


### PR DESCRIPTION
In this pull request, the routing status message has been modified. With this update, details such as the count of internal/external nodes pushed to/popped from the heap, breakdown of the node types pushed to/popped from the heap, and other extraneous messages will now be displayed only if `VTR_ENABLE_DEBUG_LOGGING` is defined. In case it is not defined, the output will be limited to the total number of routed nets and connections, along with the overall count of nodes pushed to and popped from the heap.

The PR would address the issue #2453 