### PR TITLE
Add documentation for Docker images of vtr8 and VTR master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,13 @@ _The following are changes which have been implemented in the VTR master branch 
 ### Deprecated
  * VPR's breadth-first router (use the timing-driven router, which provides supperiour QoR and Run-time)
 
+### Docker Image
+ * A docker image is available for VTR 8.0 release on mohamedelgammal/vtr8:latest. You can run it using the following commands:
+```
+$ sudo docker pull mohamedelgammal/vtr8:latest
+$ sudo docker run -it mohamedelgammal/vtr8:latest
+```
+ 
 ## v8.0.0-rc2 - 2019-08-01
 
 ### Changed

--- a/doc/src/vtr/get_vtr.rst
+++ b/doc/src/vtr/get_vtr.rst
@@ -31,6 +31,16 @@ The official VTR release is available from:
 
     https://verilogtorouting.org/download
 
+VTR Docker Image
+~~~~~~~~~~~~~~~~
+A docker image for VTR is available. This image provides all the required packages and python libraries required. However, this ease to compile and run comes at the cost of some runtime increase (<10%). To pull and run the docker image of latest VTR repository, you can run the following commands:
+
+.. code-block:: bash
+
+    > sudo docker pull mohamedelgammal/vtr-master:latest
+    > sudo docker run -it mohamedelgammal/vtr-master:latest
+
+
 Release
 ~~~~~~~
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
I have created a Docker image for VTR 8 and VTR master branch and highlighted how to run these images in the documentation