### PR TITLE
StrongIdIterator Operator Overloading

### DIFF
--- a/libs/libvtrutil/src/vtr_strong_id_range.h
+++ b/libs/libvtrutil/src/vtr_strong_id_range.h
@@ -90,7 +90,7 @@ class StrongIdIterator {
 
     ///@brief ~ operator
     template<typename IdType>
-    ssize_t operator-(const StrongIdIterator<IdType>& other) {
+    ssize_t operator-(const StrongIdIterator<IdType>& other) const {
         VTR_ASSERT_SAFE(bool(id_));
         VTR_ASSERT_SAFE(bool(other.id_));
 
@@ -101,19 +101,19 @@ class StrongIdIterator {
 
     ///@brief == operator
     template<typename IdType>
-    bool operator==(const StrongIdIterator<IdType>& other) {
+    bool operator==(const StrongIdIterator<IdType>& other) const {
         return id_ == other.id_;
     }
 
     ///@brief != operator
     template<typename IdType>
-    bool operator!=(const StrongIdIterator<IdType>& other) {
+    bool operator!=(const StrongIdIterator<IdType>& other) const {
         return id_ != other.id_;
     }
 
     ///@brief < operator
     template<typename IdType>
-    bool operator<(const StrongIdIterator<IdType>& other) {
+    bool operator<(const StrongIdIterator<IdType>& other) const {
         return id_ < other.id_;
     }
 

--- a/libs/libvtrutil/src/vtr_strong_id_range.h
+++ b/libs/libvtrutil/src/vtr_strong_id_range.h
@@ -88,26 +88,6 @@ class StrongIdIterator {
         return StrongId(size_t(id_) + offset);
     }
 
-    ///@brief + operator
-    template<typename IdType>
-    friend StrongIdIterator<IdType> operator+(
-        const StrongIdIterator<IdType>& lhs,
-        ssize_t n) {
-        StrongIdIterator ret = lhs;
-        ret += n;
-        return ret;
-    }
-
-    ///@brief - operator
-    template<typename IdType>
-    friend StrongIdIterator<IdType> operator-(
-        const StrongIdIterator<IdType>& lhs,
-        ssize_t n) {
-        StrongIdIterator ret = lhs;
-        ret -= n;
-        return ret;
-    }
-
     ///@brief ~ operator
     template<typename IdType>
     friend ssize_t operator-(
@@ -123,25 +103,45 @@ class StrongIdIterator {
 
     ///@brief == operator
     template<typename IdType>
-    friend bool operator==(const StrongIdIterator<IdType>& lhs, const StrongIdIterator<IdType>& rhs) {
-        return lhs.id_ == rhs.id_;
+    bool operator==(const StrongIdIterator<IdType>& other) {
+        return id_ == other.id_;
     }
 
     ///@brief != operator
     template<typename IdType>
-    friend bool operator!=(const StrongIdIterator<IdType>& lhs, const StrongIdIterator<IdType>& rhs) {
-        return lhs.id_ != rhs.id_;
+    bool operator!=(const StrongIdIterator<IdType>& other) {
+        return id_ != other.id_;
     }
 
     ///@brief < operator
     template<typename IdType>
-    friend bool operator<(const StrongIdIterator<IdType>& lhs, const StrongIdIterator<IdType>& rhs) {
-        return lhs.id_ < rhs.id_;
+    bool operator<(const StrongIdIterator<IdType>& other) {
+        return id_ < other.id_;
     }
 
   private:
     StrongId id_;
 };
+
+///@brief + operator
+template<typename IdType>
+inline StrongIdIterator<IdType> operator+(
+    const StrongIdIterator<IdType>& lhs,
+    ssize_t n) {
+    StrongIdIterator ret = lhs;
+    ret += n;
+    return ret;
+}
+
+///@brief - operator
+template<typename IdType>
+inline StrongIdIterator<IdType> operator-(
+    const StrongIdIterator<IdType>& lhs,
+    ssize_t n) {
+    StrongIdIterator ret = lhs;
+    ret -= n;
+    return ret;
+}
 
 /**
  * @brief StrongIdRange class

--- a/libs/libvtrutil/src/vtr_strong_id_range.h
+++ b/libs/libvtrutil/src/vtr_strong_id_range.h
@@ -90,14 +90,12 @@ class StrongIdIterator {
 
     ///@brief ~ operator
     template<typename IdType>
-    friend ssize_t operator-(
-        const StrongIdIterator<IdType>& lhs,
-        const StrongIdIterator<IdType>& rhs) {
-        VTR_ASSERT_SAFE(bool(lhs.id_));
-        VTR_ASSERT_SAFE(bool(rhs.id_));
+    ssize_t operator-(const StrongIdIterator<IdType>& other) {
+        VTR_ASSERT_SAFE(bool(id_));
+        VTR_ASSERT_SAFE(bool(other.id_));
 
-        ssize_t ret = size_t(lhs.id_);
-        ret -= size_t(rhs.id_);
+        ssize_t ret = size_t(id_);
+        ret -= size_t(other.id_);
         return ret;
     }
 

--- a/libs/libvtrutil/test/test_strong_id.cpp
+++ b/libs/libvtrutil/test/test_strong_id.cpp
@@ -82,7 +82,7 @@ TEST_CASE("StrongIdIterator", "[StrongId/StrongIdIterator]") {
     REQUIRE(c_iter[-4] == b);
     REQUIRE(c_iter[-5] == a);
 
-    REQUIRE((a_iter + 5) == c_iter);
+    REQUIRE(c_iter == (a_iter + 5));
     REQUIRE(a_iter == (c_iter - 5));
     a_iter += 5;
     REQUIRE(a_iter == c_iter);

--- a/libs/libvtrutil/test/test_strong_id.cpp
+++ b/libs/libvtrutil/test/test_strong_id.cpp
@@ -82,7 +82,7 @@ TEST_CASE("StrongIdIterator", "[StrongId/StrongIdIterator]") {
     REQUIRE(c_iter[-4] == b);
     REQUIRE(c_iter[-5] == a);
 
-    REQUIRE(c_iter == (a_iter + 5));
+    REQUIRE((a_iter + 5) == c_iter);
     REQUIRE(a_iter == (c_iter - 5));
     a_iter += 5;
     REQUIRE(a_iter == c_iter);


### PR DESCRIPTION
In this PR, the operators that don't use private methods are moved outside of StrongIdIterator class. The "friend" identifier of other operators inside of the class is removed to avoid redefinition of them when an operator is used.