### PR TITLE
Update labeler.yml to v5 syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,126 +6,101 @@
 
 # Tools
 ABC:
-- changed-files:
-  - any-glob-to-any-file: abc_with_bb_support/*
-  - any-glob-to-any-file: abc_with_bb_support/**/*
-  - any-glob-to-any-file: abc/*
-  - any-glob-to-any-file: abc/**/*
+ - abc_with_bb_support/*
+ - abc_with_bb_support/**/*
+ - abc/*
+ - abc/**/*
 ACE2:
-- changed-files:
-  - any-glob-to-any-file: ace2/*
-  - any-glob-to-any-file: ace2/**/*
+ - ace2/*
+ - ace2/**/*
 blifexplorer:
-- changed-files:
-  - any-glob-to-any-file: blifexplorer/*
-  - any-glob-to-any-file: blifexplorer/**/*
+ - blifexplorer/*
+ - blifexplorer/**/*
 Odin:
-- changed-files:
-  - any-glob-to-any-file: odin_ii/*
-  - any-glob-to-any-file: odin_ii/**/*
-  - any-glob-to-any-file: odin2_helper/*
-  - any-glob-to-any-file: odin2_helper/**/*
+ - odin_ii/*
+ - odin_ii/**/*
+ - odin2_helper/*
+ - odin2_helper/**/*
 Parmys:
-- changed-files:
-  - any-glob-to-any-file: parmys/*
-  - any-glob-to-any-file: parmys/**/*
-  - any-glob-to-any-file: yosys/*
-  - any-glob-to-any-file: yosys/**/*
+ - parmys/*
+ - parmys/**/*
+ - yosys/*
+ - yosys/**/*
 VPR:
-- changed-files:
-  - any-glob-to-any-file: vpr/*
-  - any-glob-to-any-file: vpr/**/*
+ - vpr/*
+ - vpr/**/*
 
 # Libraries
 libarchfpga:
-- changed-files:
-  - any-glob-to-any-file: libs/libarchfpga/*
-  - any-glob-to-any-file: libs/libarchfpga/**/*
+ - libs/libarchfpga/*
+ - libs/libarchfpga/**/*
 libeasygl:
-- changed-files:
-  - any-glob-to-any-file: libs/libeasygl/*
-  - any-glob-to-any-file: libs/libeasygl/**/*
+ - libs/libeasygl/*
+ - libs/libeasygl/**/*
 liblog:
-- changed-files:
-  - any-glob-to-any-file: libs/liblog/*
-  - any-glob-to-any-file: libs/liblog/**/*
+ - libs/liblog/*
+ - libs/liblog/**/*
 libpugiutil:
-- changed-files:
-  - any-glob-to-any-file: libs/libpugiutil/*
-  - any-glob-to-any-file: libs/libpugiutil/**/*
+ - libs/libpugiutil/*
+ - libs/libpugiutil/**/*
 libvtrutil:
-- changed-files:
-  - any-glob-to-any-file: libs/libvtrutil/*
-  - any-glob-to-any-file: libs/libvtrutil/**/*
+ - libs/libvtrutil/*
+ - libs/libvtrutil/**/*
 external_libs:
-- changed-files:
-  - any-glob-to-any-file: libs/EXTERNAL/*
-  - any-glob-to-any-file: libs/EXTERNAL/**/*
+ - libs/EXTERNAL/*
+ - libs/EXTERNAL/**/*
 
 # General areas
 docs:
-- changed-files:
-  - any-glob-to-any-file: doc/*
-  - any-glob-to-any-file: doc/**/*
-  - any-glob-to-any-file: "*README*"
-  - any-glob-to-any-file: "*.md"
-  - any-glob-to-any-file: "*.rst"
+ - docs/*
+ - docs/**/*
+ - "*README*"
+ - "*.md"
+ - tutorial
+ - "*.rst"
 infra:
-- changed-files:
-  - any-glob-to-any-file: .github/*
-  - any-glob-to-any-file: .github/**/*
-  - any-glob-to-any-file: Dockerfile
-  - any-glob-to-any-file: "*docker*"
+ - .github/*
+ - .github/**/*
+ - Dockerfile
+ - "*docker*"
 build:
-- changed-files:
-  - any-glob-to-any-file: Makefile
-  - any-glob-to-any-file: "*.make"
-  - any-glob-to-any-file: CMakeLists.txt
-  - any-glob-to-any-file: cmake/*
-  - any-glob-to-any-file: cmake/**/*
+ - Makefile
+ - "*.make"
+ - CMakeLists.txt
+ - cmake
 tests:
-- changed-files:
-  - any-glob-to-any-file: "*_test.py"
-  - any-glob-to-any-file: "*test*"
-  - any-glob-to-any-file: "*TESTS*"
+ - "*_test.py"
+ - "*test*"
+ - "*TESTS*"
 scripts:
-- changed-files:
-  - any-glob-to-any-file: scripts
-  - any-glob-to-any-file: "*.pl"
-  - any-glob-to-any-file: "*.py"
-  - any-glob-to-any-file: "*.sh"
+ - scripts
+ - "*.pl"
+ - "*.py"
+ - "*.sh"
 VTR Flow:
-- changed-files:
-  - any-glob-to-any-file: vtr_flow
+ - vtr_flow
 
 # Tag pull requests with the languages used to make it easy to see what is
 # being used.
 lang-hdl:
-- changed-files:
-  - any-glob-to-any-file: "**/*.v"
-  - any-glob-to-any-file: "**/*.sv"
+ - "*.v"
+ - "*.sv"
 lang-cpp:
-- changed-files:
-  - any-glob-to-any-file: "**/*.c*"
-  - any-glob-to-any-file: "**/*.h"
+ - "*.c*"
+ - "*.h"
 lang-perl:
-- changed-files:
-  - any-glob-to-any-file: "**/*.pl"
-  - any-glob-to-any-file: "**/*perl*"
+ - "*.pl"
+ - "*perl*"
 lang-python:
-- changed-files:
-  - any-glob-to-any-file: "**/*.py"
+ - "*.py"
 lang-shell:
-- changed-files:
-  - any-glob-to-any-file: "**/*.sh"
+ - "*.sh"
 lang-netlist:
-- changed-files:
-  - any-glob-to-any-file: "**/*.blif"
-  - any-glob-to-any-file: "**/*.eblif"
-  - any-glob-to-any-file: "**/*.edif"
-  - any-glob-to-any-file: "**/*.vqm"
+ - "*.blif"
+ - "*.eblif"
+ - "*.edif"
+ - "*.vqm"
 lang-make:
-- changed-files:
-  - any-glob-to-any-file: "**/*.make"
-  - any-glob-to-any-file: "**/*Makefile"
-  - any-glob-to-any-file: "**/CMakeLists.txt"
+ - "*.make"
+ - Makefile
+ - CMakeLists.txt

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,101 +6,126 @@
 
 # Tools
 ABC:
- - abc_with_bb_support/*
- - abc_with_bb_support/**/*
- - abc/*
- - abc/**/*
+- changed-files:
+  - any-glob-to-any-file: abc_with_bb_support/*
+  - any-glob-to-any-file: abc_with_bb_support/**/*
+  - any-glob-to-any-file: abc/*
+  - any-glob-to-any-file: abc/**/*
 ACE2:
- - ace2/*
- - ace2/**/*
+- changed-files:
+  - any-glob-to-any-file: ace2/*
+  - any-glob-to-any-file: ace2/**/*
 blifexplorer:
- - blifexplorer/*
- - blifexplorer/**/*
+- changed-files:
+  - any-glob-to-any-file: blifexplorer/*
+  - any-glob-to-any-file: blifexplorer/**/*
 Odin:
- - odin_ii/*
- - odin_ii/**/*
- - odin2_helper/*
- - odin2_helper/**/*
+- changed-files:
+  - any-glob-to-any-file: odin_ii/*
+  - any-glob-to-any-file: odin_ii/**/*
+  - any-glob-to-any-file: odin2_helper/*
+  - any-glob-to-any-file: odin2_helper/**/*
 Parmys:
- - parmys/*
- - parmys/**/*
- - yosys/*
- - yosys/**/*
+- changed-files:
+  - any-glob-to-any-file: parmys/*
+  - any-glob-to-any-file: parmys/**/*
+  - any-glob-to-any-file: yosys/*
+  - any-glob-to-any-file: yosys/**/*
 VPR:
- - vpr/*
- - vpr/**/*
+- changed-files:
+  - any-glob-to-any-file: vpr/*
+  - any-glob-to-any-file: vpr/**/*
 
 # Libraries
 libarchfpga:
- - libs/libarchfpga/*
- - libs/libarchfpga/**/*
+- changed-files:
+  - any-glob-to-any-file: libs/libarchfpga/*
+  - any-glob-to-any-file: libs/libarchfpga/**/*
 libeasygl:
- - libs/libeasygl/*
- - libs/libeasygl/**/*
+- changed-files:
+  - any-glob-to-any-file: libs/libeasygl/*
+  - any-glob-to-any-file: libs/libeasygl/**/*
 liblog:
- - libs/liblog/*
- - libs/liblog/**/*
+- changed-files:
+  - any-glob-to-any-file: libs/liblog/*
+  - any-glob-to-any-file: libs/liblog/**/*
 libpugiutil:
- - libs/libpugiutil/*
- - libs/libpugiutil/**/*
+- changed-files:
+  - any-glob-to-any-file: libs/libpugiutil/*
+  - any-glob-to-any-file: libs/libpugiutil/**/*
 libvtrutil:
- - libs/libvtrutil/*
- - libs/libvtrutil/**/*
+- changed-files:
+  - any-glob-to-any-file: libs/libvtrutil/*
+  - any-glob-to-any-file: libs/libvtrutil/**/*
 external_libs:
- - libs/EXTERNAL/*
- - libs/EXTERNAL/**/*
+- changed-files:
+  - any-glob-to-any-file: libs/EXTERNAL/*
+  - any-glob-to-any-file: libs/EXTERNAL/**/*
 
 # General areas
 docs:
- - docs/*
- - docs/**/*
- - "*README*"
- - "*.md"
- - tutorial
- - "*.rst"
+- changed-files:
+  - any-glob-to-any-file: doc/*
+  - any-glob-to-any-file: doc/**/*
+  - any-glob-to-any-file: "*README*"
+  - any-glob-to-any-file: "*.md"
+  - any-glob-to-any-file: "*.rst"
 infra:
- - .github/*
- - .github/**/*
- - Dockerfile
- - "*docker*"
+- changed-files:
+  - any-glob-to-any-file: .github/*
+  - any-glob-to-any-file: .github/**/*
+  - any-glob-to-any-file: Dockerfile
+  - any-glob-to-any-file: "*docker*"
 build:
- - Makefile
- - "*.make"
- - CMakeLists.txt
- - cmake
+- changed-files:
+  - any-glob-to-any-file: Makefile
+  - any-glob-to-any-file: "*.make"
+  - any-glob-to-any-file: CMakeLists.txt
+  - any-glob-to-any-file: cmake/*
+  - any-glob-to-any-file: cmake/**/*
 tests:
- - "*_test.py"
- - "*test*"
- - "*TESTS*"
+- changed-files:
+  - any-glob-to-any-file: "*_test.py"
+  - any-glob-to-any-file: "*test*"
+  - any-glob-to-any-file: "*TESTS*"
 scripts:
- - scripts
- - "*.pl"
- - "*.py"
- - "*.sh"
+- changed-files:
+  - any-glob-to-any-file: scripts
+  - any-glob-to-any-file: "*.pl"
+  - any-glob-to-any-file: "*.py"
+  - any-glob-to-any-file: "*.sh"
 VTR Flow:
- - vtr_flow
+- changed-files:
+  - any-glob-to-any-file: vtr_flow
 
 # Tag pull requests with the languages used to make it easy to see what is
 # being used.
 lang-hdl:
- - "*.v"
- - "*.sv"
+- changed-files:
+  - any-glob-to-any-file: "**/*.v"
+  - any-glob-to-any-file: "**/*.sv"
 lang-cpp:
- - "*.c*"
- - "*.h"
+- changed-files:
+  - any-glob-to-any-file: "**/*.c*"
+  - any-glob-to-any-file: "**/*.h"
 lang-perl:
- - "*.pl"
- - "*perl*"
+- changed-files:
+  - any-glob-to-any-file: "**/*.pl"
+  - any-glob-to-any-file: "**/*perl*"
 lang-python:
- - "*.py"
+- changed-files:
+  - any-glob-to-any-file: "**/*.py"
 lang-shell:
- - "*.sh"
+- changed-files:
+  - any-glob-to-any-file: "**/*.sh"
 lang-netlist:
- - "*.blif"
- - "*.eblif"
- - "*.edif"
- - "*.vqm"
+- changed-files:
+  - any-glob-to-any-file: "**/*.blif"
+  - any-glob-to-any-file: "**/*.eblif"
+  - any-glob-to-any-file: "**/*.edif"
+  - any-glob-to-any-file: "**/*.vqm"
 lang-make:
- - "*.make"
- - Makefile
- - CMakeLists.txt
+- changed-files:
+  - any-glob-to-any-file: "**/*.make"
+  - any-glob-to-any-file: "**/*Makefile"
+  - any-glob-to-any-file: "**/CMakeLists.txt"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,3 +9,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        dot: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: fix_labeler_v5
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      with:
-        ref: fix_labeler_v5
     - uses: actions/labeler@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: fix_labeler_v5
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         dot: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,3 @@ jobs:
     - uses: actions/labeler@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        dot: false


### PR DESCRIPTION
#### Description
Pull Request Labeler v5 was released, introducing new syntax. Since the new syntax is not compatible with v4, triage job fails.

#### Motivation and Context
To prevent triage job from failing, we need to update labeler.yml file.

#### How Has This Been Tested?
"infra" label for this PR was automatically added after the bug was fixed.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
