### PR TITLE
Net max fanout issue in Net Settings graphics 

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -129,7 +129,7 @@ static void set_block_outline(GtkWidget* widget, gint /*response_id*/, gpointer 
 static void set_block_text(GtkWidget* widget, gint /*response_id*/, gpointer /*data*/);
 static void set_draw_partitions(GtkWidget* widget, gint /*response_id*/, gpointer /*data*/);
 static void clip_routing_util(GtkWidget* widget, gint /*response_id*/, gpointer /*data*/);
-static void run_graphics_commands(std::string commands);
+static void run_graphics_commands(const std::string& commands);
 
 /************************** File Scope Variables ****************************/
 
@@ -1245,7 +1245,7 @@ static void set_force_pause(GtkWidget* /*widget*/, gint /*response_id*/, gpointe
     draw_state->forced_pause = true;
 }
 
-static void run_graphics_commands(std::string commands) {
+static void run_graphics_commands(const std::string& commands) {
     //A very simmple command interpreter for scripting graphics
     t_draw_state* draw_state = get_draw_state_vars();
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -245,8 +245,13 @@ void drawnets(ezgl::renderer* g) {
      * blocks (or sub blocks in the case of IOs).                                */
 
     for (auto net_id : cluster_ctx.clb_nlist.nets()) {
-        if (cluster_ctx.clb_nlist.net_is_ignored(net_id))
+        if (cluster_ctx.clb_nlist.net_is_ignored(net_id)) {
             continue; /* Don't draw */
+        }
+
+        if ((int)cluster_ctx.clb_nlist.net_pins(net_id).size() > draw_state->draw_net_max_fanout) {
+            continue;
+        }
 
         b1 = cluster_ctx.clb_nlist.net_driver_block(net_id);
 
@@ -254,7 +259,7 @@ void drawnets(ezgl::renderer* g) {
         driver_block_layer_num = place_ctx.block_locs[b1].loc.layer;
 
         //To only show nets that are connected to currently active layers on the screen
-        if (draw_state->draw_layer_display[driver_block_layer_num].visible == false) {
+        if (!draw_state->draw_layer_display[driver_block_layer_num].visible) {
             continue; /* Don't draw */
         }
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -249,7 +249,7 @@ void drawnets(ezgl::renderer* g) {
             continue; /* Don't draw */
         }
 
-        if ((int)cluster_ctx.clb_nlist.net_pins(net_id).size() > draw_state->draw_net_max_fanout) {
+        if ((int)cluster_ctx.clb_nlist.net_pins(net_id).size() - 1 > draw_state->draw_net_max_fanout) {
             continue;
         }
 

--- a/vpr/src/draw/intra_logic_block.cpp
+++ b/vpr/src/draw/intra_logic_block.cpp
@@ -570,7 +570,7 @@ void draw_logical_connections(ezgl::renderer* g) {
 
     // iterate over all the atom nets
     for (auto net_id : atom_ctx.nlist.nets()) {
-        if ((int)atom_ctx.nlist.net_pins(net_id).size() > draw_state->draw_net_max_fanout) {
+        if ((int)atom_ctx.nlist.net_pins(net_id).size() - 1 > draw_state->draw_net_max_fanout) {
             continue;
         }
 

--- a/vpr/src/draw/intra_logic_block.cpp
+++ b/vpr/src/draw/intra_logic_block.cpp
@@ -919,7 +919,7 @@ bool t_selected_sub_block_info::gnode_clb_pair::operator==(const gnode_clb_pair&
  * @param pb current node to be examined
  * @return t_pb* t_pb ptr of block w. name "name". Returns nullptr if nothing found
  */
-t_pb* find_atom_block_in_pb(std::string name, t_pb* pb) {
+t_pb* find_atom_block_in_pb(const std::string& name, t_pb* pb) {
     //Checking if block is one being searched for
     std::string pbName(pb->name);
     if (pbName == name)

--- a/vpr/src/draw/intra_logic_block.h
+++ b/vpr/src/draw/intra_logic_block.h
@@ -138,7 +138,7 @@ void draw_logical_connections(ezgl::renderer* g);
 void find_pin_index_at_model_scope(const AtomPinId the_pin, const AtomBlockId lblk, int* pin_index, int* total_pins);
 
 //Returns pb ptr of given atom block name, given the pb of its containing block. Returns null if nothing found
-t_pb* find_atom_block_in_pb(std::string name, t_pb* pb);
+t_pb* find_atom_block_in_pb(const std::string& name, t_pb* pb);
 
 #endif /* NO_GRAPHICS */
 


### PR DESCRIPTION
#### Description
Net Max Fanout is now used to filter out both primitive nets and cluster nets.
Net Max Fanout was previsouly compared to the number of pins, not the number of sinks. This problem was also fixed in this PR.

#### Related Issue
[Issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2451) 


#### Motivation and Context
Net Max Fanout was not working for clustered nets. More specifically, when this setting was changed, nets with fanout higher that the specified value were not filtered out.

#### How Has This Been Tested?
Manually. I just ran vpr with --disp on and check if correct nets are shown.

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
