### PR TITLE
Fix PR labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION


#### Description
If someone submits a PR from a forked repository, the labeler would not have write permission to the PR to add labels. As a result, PRs from forked repos are not labeled. This PR fixes this problem.

#### Related Issue
There is no open issue for this PR.


#### How Has This Been Tested?
It is not tested because I could not find a way to test this. The labeler reads labeler.yml on the master branch. So, we cannot test if this PR solves the issue until it is merged into master. However, [Github documentation](https://github.com/actions/labeler#permissions) is very clear on this problem. In worst case, if anything goes wrong, I can make another PR and revert this change.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
