### PR TITLE
[Route][Types] Removed target_flag From rr_node_route_inf

### DIFF
--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1729,8 +1729,6 @@ constexpr bool is_src_sink(e_rr_type type) { return (type == SOURCE || type == S
  *                     is being used.
  *   @param backward_path_cost  Total cost of the path up to and including this
  *                     node.
- *   @param target_flag  Is this node a target (sink) for the current routing?
- *                     Number of times this node must be reached to fully route.
  *   @param occ        The current occupancy of the associated rr node
  */
 struct t_rr_node_route_inf {
@@ -1740,8 +1738,6 @@ struct t_rr_node_route_inf {
     float acc_cost;
     float path_cost;
     float backward_path_cost;
-
-    short target_flag;
 
   public: //Accessors
     short occ() const { return occ_; }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -315,34 +315,6 @@ float get_rr_cong_cost(RRNodeId inode, float pres_fac) {
     return (cost);
 }
 
-/* Mark all the SINKs of this net as targets by setting their target flags  *
- * to the number of times the net must connect to each SINK.  Note that     *
- * this number can occasionally be greater than 1 -- think of connecting   *
- * the same net to two inputs of an and-gate (and-gate inputs are logically *
- * equivalent, so both will connect to the same SINK).                      */
-void mark_ends(const Netlist<>& net_list, ParentNetId net_id) {
-    unsigned int ipin;
-    RRNodeId inode;
-
-    auto& route_ctx = g_vpr_ctx.mutable_routing();
-
-    for (ipin = 1; ipin < net_list.net_pins(net_id).size(); ipin++) {
-        inode = route_ctx.net_rr_terminals[net_id][ipin];
-        route_ctx.rr_node_route_inf[inode].target_flag++;
-    }
-}
-
-/** like mark_ends, but only performs it for the remaining sinks of a net */
-void mark_remaining_ends(ParentNetId net_id) {
-    auto& route_ctx = g_vpr_ctx.mutable_routing();
-    const auto& tree = route_ctx.route_trees[net_id].value();
-
-    for (int sink_pin : tree.get_remaining_isinks()) {
-        RRNodeId inode = route_ctx.net_rr_terminals[net_id][sink_pin];
-        ++route_ctx.rr_node_route_inf[inode].target_flag;
-    }
-}
-
 //Calculates how many (and allocates space for) OPINs which must be reserved to
 //respect 'instance' equivalence.
 //
@@ -453,7 +425,6 @@ void reset_rr_node_route_structs() {
         node_inf.acc_cost = 1.0;
         node_inf.path_cost = std::numeric_limits<float>::infinity();
         node_inf.backward_path_cost = std::numeric_limits<float>::infinity();
-        node_inf.target_flag = 0;
         node_inf.set_occ(0);
     }
 }

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -113,10 +113,6 @@ inline float get_single_rr_cong_cost(RRNodeId inode, float pres_fac) {
     return cost;
 }
 
-void mark_ends(const Netlist<>& net_list, ParentNetId net_id);
-
-void mark_remaining_ends(ParentNetId net_id);
-
 void add_to_mod_list(RRNodeId inode, std::vector<RRNodeId>& modified_rr_node_inf);
 
 void init_route_structs(const Netlist<>& net_list,

--- a/vpr/src/route/route_net.cpp
+++ b/vpr/src/route/route_net.cpp
@@ -42,11 +42,6 @@ void setup_net(int itry,
 
         // since all connections will be rerouted for this net, clear all of net's forced reroute flags
         connections_inf.clear_force_reroute_for_net(net_id);
-
-        // when we don't prune the tree, we also don't know the sink node indices
-        // thus we'll use functions that act on pin indices like mark_ends instead
-        // of their versions that act on node indices directly like mark_remaining_ends
-        mark_ends(net_list, net_id);
     } else {
         profiling::net_rebuild_start();
 
@@ -91,9 +86,6 @@ void setup_net(int itry,
 
         // congestion should've been pruned away
         VTR_ASSERT_SAFE(tree->is_uncongested());
-
-        // mark remaining ends
-        mark_remaining_ends(net_id);
 
         // mark the lookup (rr_node_route_inf) for existing tree elements as NO_PREVIOUS so add_to_path stops when it reaches one of them
         update_rr_route_inf_from_tree(tree->root());

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -448,9 +448,6 @@ inline NetResultFlags route_sink(ConnectionRouter& router,
 
     profiling::sink_criticality_end(cost_params.criticality);
 
-    RRNodeId inode(cheapest.index);
-    route_ctx.rr_node_route_inf[inode].target_flag--; /* Connected to this SINK. */
-
     vtr::optional<const RouteTreeNode&> new_branch, new_sink;
     std::tie(new_branch, new_sink) = tree.update_from_heap(&cheapest, target_pin, ((high_fanout) ? &spatial_rt_lookup : nullptr), is_flat);
 


### PR DESCRIPTION
The target_flag member used to be used by a different router; however, that router has since been removed. This data was still being collected and stored, but was going unused. Removed the member which would save space and should improve performance slightly.

See issue #2499

<!--- Provide a general summary of your changes in the Title above -->

#### Description
Removed all references to the target_flag member. This also removed the "mark_ends" and "mark_remaing_ends" methods which only existed to populate this member.

#### Related Issue
issue #2499 

#### Motivation and Context
This unused member was being instantiated for every node in the RR graph which is very wasteful. Also wasted some time populating this value.

#### How Has This Been Tested?
Compiled VPR to ensure it built without issue.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
