### PR TITLE
[Route][Types] Clean Up rr_node_route_inf

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_storage.h
+++ b/libs/librrgraph/src/base/rr_graph_storage.h
@@ -336,6 +336,11 @@ class t_rr_graph_storage {
         return ret;
     }
 
+    /** @brief Get the source node for the specified edge. */
+    RRNodeId edge_src_node(const RREdgeId& edge) const {
+        return edge_src_node_[edge];
+    }
+
     /** @brief Get the destination node for the specified edge. */
     RRNodeId edge_sink_node(const RREdgeId& edge) const {
         return edge_dest_node_[edge];

--- a/libs/librrgraph/src/base/rr_graph_view.h
+++ b/libs/librrgraph/src/base/rr_graph_view.h
@@ -321,6 +321,12 @@ class RRGraphView {
     inline short edge_switch(RRNodeId id, t_edge_size iedge) const {
         return node_storage_.edge_switch(id, iedge);
     }
+
+    /** @brief Get the source node for the specified edge. */
+    inline RRNodeId edge_src_node(const RREdgeId edge_id) const {
+        return node_storage_.edge_src_node(edge_id);
+    }
+
     /** @brief Get the destination node for the iedge'th edge from specified RRNodeId.
      *  This method should generally not be used, and instead first_edge and
      *  last_edge should be used.*/

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1717,10 +1717,7 @@ constexpr bool is_src_sink(e_rr_type type) { return (type == SOURCE || type == S
  * @brief Extra information about each rr_node needed only during routing
  *        (i.e. during the maze expansion).
  *
- *   @param prev_node  Index of the previous node (on the lowest cost path known
- *                     to reach this node); used to generate the traceback.
- *                     If there is no predecessor, prev_node = NO_PREVIOUS.
- *   @param prev_edge  Index of the edge (from 0 to num_edges-1 of prev_node)
+ *   @param prev_edge  ID of the edge (globally unique edge ID in the RR Graph)
  *                     that was used to reach this node from the previous node.
  *                     If there is no predecessor, prev_edge = NO_PREVIOUS.
  *   @param acc_cost   Accumulated cost term from previous Pathfinder iterations.
@@ -1732,7 +1729,6 @@ constexpr bool is_src_sink(e_rr_type type) { return (type == SOURCE || type == S
  *   @param occ        The current occupancy of the associated rr node
  */
 struct t_rr_node_route_inf {
-    RRNodeId prev_node;
     RREdgeId prev_edge;
 
     float acc_cost;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1729,8 +1729,6 @@ constexpr bool is_src_sink(e_rr_type type) { return (type == SOURCE || type == S
  *                     is being used.
  *   @param backward_path_cost  Total cost of the path up to and including this
  *                     node.
- *   @param target_flag  Is this node a target (sink) for the current routing?
- *                     Number of times this node must be reached to fully route.
  *   @param occ        The current occupancy of the associated rr node
  */
 struct t_rr_node_route_inf {
@@ -1740,8 +1738,6 @@ struct t_rr_node_route_inf {
     float acc_cost;
     float path_cost;
     float backward_path_cost;
-
-    short target_flag;
 
   public: //Accessors
     short occ() const { return occ_; }

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -145,7 +145,6 @@ class ConnectionRouter : public ConnectionRouterInterface {
         //Record final link to target
         add_to_mod_list(cheapest->index);
 
-        route_inf->prev_node = cheapest->prev_node();
         route_inf->prev_edge = cheapest->prev_edge();
         route_inf->path_cost = cheapest->cost;
         route_inf->backward_path_cost = cheapest->backward_path_cost;

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -315,34 +315,6 @@ float get_rr_cong_cost(RRNodeId inode, float pres_fac) {
     return (cost);
 }
 
-/* Mark all the SINKs of this net as targets by setting their target flags  *
- * to the number of times the net must connect to each SINK.  Note that     *
- * this number can occasionally be greater than 1 -- think of connecting   *
- * the same net to two inputs of an and-gate (and-gate inputs are logically *
- * equivalent, so both will connect to the same SINK).                      */
-void mark_ends(const Netlist<>& net_list, ParentNetId net_id) {
-    unsigned int ipin;
-    RRNodeId inode;
-
-    auto& route_ctx = g_vpr_ctx.mutable_routing();
-
-    for (ipin = 1; ipin < net_list.net_pins(net_id).size(); ipin++) {
-        inode = route_ctx.net_rr_terminals[net_id][ipin];
-        route_ctx.rr_node_route_inf[inode].target_flag++;
-    }
-}
-
-/** like mark_ends, but only performs it for the remaining sinks of a net */
-void mark_remaining_ends(ParentNetId net_id) {
-    auto& route_ctx = g_vpr_ctx.mutable_routing();
-    const auto& tree = route_ctx.route_trees[net_id].value();
-
-    for (int sink_pin : tree.get_remaining_isinks()) {
-        RRNodeId inode = route_ctx.net_rr_terminals[net_id][sink_pin];
-        ++route_ctx.rr_node_route_inf[inode].target_flag;
-    }
-}
-
 //Calculates how many (and allocates space for) OPINs which must be reserved to
 //respect 'instance' equivalence.
 //
@@ -453,7 +425,6 @@ void reset_rr_node_route_structs() {
         node_inf.acc_cost = 1.0;
         node_inf.path_cost = std::numeric_limits<float>::infinity();
         node_inf.backward_path_cost = std::numeric_limits<float>::infinity();
-        node_inf.target_flag = 0;
         node_inf.set_occ(0);
     }
 }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -286,7 +286,6 @@ void reset_path_costs(const std::vector<RRNodeId>& visited_rr_nodes) {
     for (auto node : visited_rr_nodes) {
         route_ctx.rr_node_route_inf[node].path_cost = std::numeric_limits<float>::infinity();
         route_ctx.rr_node_route_inf[node].backward_path_cost = std::numeric_limits<float>::infinity();
-        route_ctx.rr_node_route_inf[node].prev_node = RRNodeId::INVALID();
         route_ctx.rr_node_route_inf[node].prev_edge = RREdgeId::INVALID();
     }
 }
@@ -420,7 +419,6 @@ void reset_rr_node_route_structs() {
     for (const RRNodeId& rr_id : device_ctx.rr_graph.nodes()) {
         auto& node_inf = route_ctx.rr_node_route_inf[rr_id];
 
-        node_inf.prev_node = RRNodeId::INVALID();
         node_inf.prev_edge = RREdgeId::INVALID();
         node_inf.acc_cost = 1.0;
         node_inf.path_cost = std::numeric_limits<float>::infinity();
@@ -908,8 +906,8 @@ void print_rr_node_route_inf() {
     for (size_t inode = 0; inode < route_ctx.rr_node_route_inf.size(); ++inode) {
         const auto& inf = route_ctx.rr_node_route_inf[RRNodeId(inode)];
         if (!std::isinf(inf.path_cost)) {
-            RRNodeId prev_node = inf.prev_node;
             RREdgeId prev_edge = inf.prev_edge;
+            RRNodeId prev_node = rr_graph.edge_src_node(prev_edge);
             auto switch_id = rr_graph.rr_nodes().edge_switch(prev_edge);
             VTR_LOG("rr_node: %d prev_node: %d prev_edge: %zu",
                     inode, prev_node, (size_t)prev_edge);
@@ -944,8 +942,8 @@ void print_rr_node_route_inf_dot() {
     for (size_t inode = 0; inode < route_ctx.rr_node_route_inf.size(); ++inode) {
         const auto& inf = route_ctx.rr_node_route_inf[RRNodeId(inode)];
         if (!std::isinf(inf.path_cost)) {
-            RRNodeId prev_node = inf.prev_node;
             RREdgeId prev_edge = inf.prev_edge;
+            RRNodeId prev_node = rr_graph.edge_src_node(prev_edge);
             auto switch_id = rr_graph.rr_nodes().edge_switch(prev_edge);
 
             if (prev_node.is_valid() && prev_edge.is_valid()) {

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -113,10 +113,6 @@ inline float get_single_rr_cong_cost(RRNodeId inode, float pres_fac) {
     return cost;
 }
 
-void mark_ends(const Netlist<>& net_list, ParentNetId net_id);
-
-void mark_remaining_ends(ParentNetId net_id);
-
 void add_to_mod_list(RRNodeId inode, std::vector<RRNodeId>& modified_rr_node_inf);
 
 void init_route_structs(const Netlist<>& net_list,

--- a/vpr/src/route/route_net.cpp
+++ b/vpr/src/route/route_net.cpp
@@ -117,7 +117,6 @@ void update_rr_route_inf_from_tree(const RouteTreeNode& rt_node) {
 
     for (auto& node : rt_node.all_nodes()) {
         RRNodeId inode = node.inode;
-        route_ctx.rr_node_route_inf[inode].prev_node = RRNodeId::INVALID();
         route_ctx.rr_node_route_inf[inode].prev_edge = RREdgeId::INVALID();
 
         // path cost should be unset

--- a/vpr/src/route/route_net.cpp
+++ b/vpr/src/route/route_net.cpp
@@ -42,11 +42,6 @@ void setup_net(int itry,
 
         // since all connections will be rerouted for this net, clear all of net's forced reroute flags
         connections_inf.clear_force_reroute_for_net(net_id);
-
-        // when we don't prune the tree, we also don't know the sink node indices
-        // thus we'll use functions that act on pin indices like mark_ends instead
-        // of their versions that act on node indices directly like mark_remaining_ends
-        mark_ends(net_list, net_id);
     } else {
         profiling::net_rebuild_start();
 
@@ -91,9 +86,6 @@ void setup_net(int itry,
 
         // congestion should've been pruned away
         VTR_ASSERT_SAFE(tree->is_uncongested());
-
-        // mark remaining ends
-        mark_remaining_ends(net_id);
 
         // mark the lookup (rr_node_route_inf) for existing tree elements as NO_PREVIOUS so add_to_path stops when it reaches one of them
         update_rr_route_inf_from_tree(tree->root());

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -448,9 +448,6 @@ inline NetResultFlags route_sink(ConnectionRouter& router,
 
     profiling::sink_criticality_end(cost_params.criticality);
 
-    RRNodeId inode(cheapest.index);
-    route_ctx.rr_node_route_inf[inode].target_flag--; /* Connected to this SINK. */
-
     vtr::optional<const RouteTreeNode&> new_branch, new_sink;
     std::tie(new_branch, new_sink) = tree.update_from_heap(&cheapest, target_pin, ((high_fanout) ? &spatial_rt_lookup : nullptr), is_flat);
 

--- a/vpr/src/route/route_path_manager.cpp
+++ b/vpr/src/route/route_path_manager.cpp
@@ -45,7 +45,6 @@ void PathManager::insert_backwards_path_into_traceback(t_heap_path* path_data, f
     for (unsigned i = 1; i < path_data->edge.size() - 1; i++) {
         RRNodeId node_2 = path_data->path_rr[i];
         RREdgeId edge = path_data->edge[i - 1];
-        route_ctx.rr_node_route_inf[node_2].prev_node = path_data->path_rr[i - 1];
         route_ctx.rr_node_route_inf[node_2].prev_edge = edge;
         route_ctx.rr_node_route_inf[node_2].path_cost = cost;
         route_ctx.rr_node_route_inf[node_2].backward_path_cost = backward_path_cost;

--- a/vpr/src/route/route_tree.cpp
+++ b/vpr/src/route/route_tree.cpp
@@ -532,7 +532,7 @@ RouteTree::add_subtree_from_heap(t_heap* hptr, int target_net_pin_index, bool is
      * new_branch_inodes: [sink, nodeN-1, nodeN-2, ... node 1] of length N
      * and new_branch_iswitches: [N-1->sink, N-2->N-1, ... 2->1, 1->found_node] of length N */
     RREdgeId edge = hptr->prev_edge();
-    RRNodeId new_inode = RRNodeId(hptr->prev_node());
+    RRNodeId new_inode = rr_graph.edge_src_node(edge);
     RRSwitchId new_iswitch = RRSwitchId(rr_graph.rr_nodes().edge_switch(edge));
 
     /* build a path, looking up rr nodes and switches from rr_node_route_inf */
@@ -541,7 +541,7 @@ RouteTree::add_subtree_from_heap(t_heap* hptr, int target_net_pin_index, bool is
         new_branch_inodes.push_back(new_inode);
         new_branch_iswitches.push_back(new_iswitch);
         edge = route_ctx.rr_node_route_inf[new_inode].prev_edge;
-        new_inode = RRNodeId(route_ctx.rr_node_route_inf[new_inode].prev_node);
+        new_inode = rr_graph.edge_src_node(edge);
         new_iswitch = RRSwitchId(rr_graph.rr_nodes().edge_switch(edge));
     }
     new_branch_iswitches.push_back(new_iswitch);


### PR DESCRIPTION
Cleaned up the rr_node_route_inf type as per issue #2499 

#### Description
Removed target_flag

Removed prev_node

Updated the comment for prev_edge

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

resolves issue #2499 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the Titan benchmarks on an unloaded machine and compared the results presently in Master with these changes:
![Screenshot from 2024-03-14 10-11-32](https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/03fdf8dc-8811-4042-b9c3-c87fff8b5bca)

As shown in the image above, there was no affect on QoR at all (which is to be expected since this MR does not change any functionality).

The max memory used by VPR reduced by 0.4%, which is in the order of 10 MB on the Titan benchmarks.

The runtime did not change. Although the results show a slight reduction in crit_path_route_time, both pack time and place time reduced by the same amount. Since this PR does not affect those two stages, it can be that the entire run was slightly faster due to testing conditions.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
