### PR TITLE
Fix CI failures in master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,6 +303,17 @@ jobs:
         # We skip QoR since we are only checking for errors in sanitizer runs
         ./run_reg_test.py ${{ matrix.suite }} -show_failures -j2 -skip_qor
 
+    - name: Upload regression run files
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{matrix.name}}_run_files
+        path: |
+          vtr_flow/**/*.out
+          vtr_flow/**/*.blif
+          vtr_flow/**/*.p
+          vtr_flow/**/*.net
+          vtr_flow/**/*.r
+
 
   Parmys:
     name: 'Parmys Basic Test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -350,6 +350,7 @@ jobs:
         CMAKE_PARAMS: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on -DWITH_PARMYS=OFF -DWITH_ODIN=on'
         BUILD_TYPE: debug
       run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         ./.github/scripts/build.sh
         ./run_reg_test.py odin_reg_basic -show_failures -j2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,6 +297,11 @@ jobs:
         CMAKE_PARAMS: ${{ matrix.params }}
         BUILD_TYPE: debug
         LSAN_OPTIONS: 'exitcode=42' #Use a non-standard exit code to ensure LSAN errors are detected
+        # In Ubuntu 20240310.1.0, the entropy of ASLR has increased (28 -> 32). LLVM 14 in this
+        # image is not compatible with this increased ASLR entropy. Apparently, memory sanitizer
+        # depends on LLVM and all CI tests where VTR_ENABLE_SANITIZE is enabled fail. For a temporary
+        # fix, we manually reduce the entropy. This quick fix should be removed in the future
+        # when github deploys a more stable Ubuntu image.
       run: |
         sudo sysctl -w vm.mmap_rnd_bits=28
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,21 +298,11 @@ jobs:
         BUILD_TYPE: debug
         LSAN_OPTIONS: 'exitcode=42' #Use a non-standard exit code to ensure LSAN errors are detected
       run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         ./.github/scripts/build.sh
         # We skip QoR since we are only checking for errors in sanitizer runs
         ./run_reg_test.py ${{ matrix.suite }} -show_failures -j2 -skip_qor
-
-    - name: Upload regression run files
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{matrix.name}}_run_files
-        path: |
-          vtr_flow/**/*.out
-          vtr_flow/**/*.blif
-          vtr_flow/**/*.p
-          vtr_flow/**/*.net
-          vtr_flow/**/*.r
 
 
   Parmys:


### PR DESCRIPTION
#### Description
CI  has been failing in master since two days ago. This PR fixes the problem. This is not the cleanest fix, but the alternative is to wait until next Friday when Github deploys the fix into their Ubuntu image.

#### Related Issue
[Issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2504)

#### Motivation and Context
Preventing CI test from failing in master.

#### How Has This Been Tested?
Two CI tests fail in the master branch, but not in this one.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
