### PR TITLE
Link stdc++fs for older gcc versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,6 +404,11 @@ jobs:
         submodules: 'true'
     - run: ./.github/scripts/install_dependencies.sh
 
+    - uses: egor-tensin/setup-gcc@v1
+      with:
+        version: 8
+        platform: x64
+
     - uses: hendrikmuhs/ccache-action@v1.2
 
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,11 +404,6 @@ jobs:
         submodules: 'true'
     - run: ./.github/scripts/install_dependencies.sh
 
-    - uses: egor-tensin/setup-gcc@v1
-      with:
-        version: 8
-        platform: x64
-
     - uses: hendrikmuhs/ccache-action@v1.2
 
     - name: Test
@@ -417,6 +412,17 @@ jobs:
         MATRIX_EVAL: ${{ matrix.eval }}
         BUILD_TYPE: release
       run: |
+        sudo apt update
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/gcc-8_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/g/gcc-8/gcc-8-base_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libgcc-8-dev_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/cpp-8_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libmpx2_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.kernel.org/ubuntu/pool/main/i/isl/libisl22_0.22.1-1_amd64.deb
+        sudo apt install ./libisl22_0.22.1-1_amd64.deb ./libmpx2_8.4.0-3ubuntu2_amd64.deb ./cpp-8_8.4.0-3ubuntu2_amd64.deb ./libgcc-8-dev_8.4.0-3ubuntu2_amd64.deb ./gcc-8-base_8.4.0-3ubuntu2_amd64.deb ./gcc-8_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb
+        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/g++-8_8.4.0-3ubuntu2_amd64.deb
+        sudo apt install ./libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb ./g++-8_8.4.0-3ubuntu2_amd64.deb
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         ./.github/scripts/build.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,12 +383,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { name: 'GCC 8 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-8 && CXX=g++-8',           }
         - { name: 'GCC 9 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           }
         - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         }
         - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-11 && CXX=g++-11',         }
         - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-12 && CXX=g++-12',         }
-        - { name: 'Clang 8 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-8 && CXX=clang++-8',   }
         - { name: 'Clang 11 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-11 && CXX=clang++-11',   }
         - { name: 'Clang 12 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-12 && CXX=clang++-12',   }
         - { name: 'Clang 13 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-13 && CXX=clang++-13',   }
@@ -412,17 +410,6 @@ jobs:
         MATRIX_EVAL: ${{ matrix.eval }}
         BUILD_TYPE: release
       run: |
-        sudo apt update
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/gcc-8_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/g/gcc-8/gcc-8-base_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libgcc-8-dev_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/cpp-8_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libmpx2_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.kernel.org/ubuntu/pool/main/i/isl/libisl22_0.22.1-1_amd64.deb
-        sudo apt install ./libisl22_0.22.1-1_amd64.deb ./libmpx2_8.4.0-3ubuntu2_amd64.deb ./cpp-8_8.4.0-3ubuntu2_amd64.deb ./libgcc-8-dev_8.4.0-3ubuntu2_amd64.deb ./gcc-8-base_8.4.0-3ubuntu2_amd64.deb ./gcc-8_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-8/g++-8_8.4.0-3ubuntu2_amd64.deb
-        sudo apt install ./libstdc++-8-dev_8.4.0-3ubuntu2_amd64.deb ./g++-8_8.4.0-3ubuntu2_amd64.deb
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         ./.github/scripts/build.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,10 +383,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - { name: 'GCC 8 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-8 && CXX=g++-8',           }
         - { name: 'GCC 9 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           }
         - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         }
         - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-11 && CXX=g++-11',         }
         - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-12 && CXX=g++-12',         }
+        - { name: 'Clang 8 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-8 && CXX=clang++-8',   }
         - { name: 'Clang 11 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-11 && CXX=clang++-11',   }
         - { name: 'Clang 12 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-12 && CXX=clang++-12',   }
         - { name: 'Clang 13 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-13 && CXX=clang++-13',   }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(VTR_IPO_BUILD "auto" CACHE STRING "Should VTR be compiled with interprocedur
 set_property(CACHE VTR_IPO_BUILD PROPERTY STRINGS auto on off)
 
 #Allow the user to configure how much assertion checking should occur
-set(VTR_ASSERT_LEVEL "2" CACHE STRING "VTR assertion checking level. 0: no assertions, 1: fast assertions, 2: regular assertions, 3: additional assertions with noticable run-time overhead, 4: all assertions (including those with significant run-time cost)")
+set(VTR_ASSERT_LEVEL "2" CACHE STRING "VTR assertion checking level. 0: no assertions, 1: fast assertions, 2: regular assertions, 3: additional assertions with noticeable run-time overhead, 4: all assertions (including those with significant run-time cost)")
 set_property(CACHE VTR_ASSERT_LEVEL PROPERTY STRINGS 0 1 2 3 4)
 
 option(VTR_ENABLE_STRICT_COMPILE "Specifies whether compiler warnings should be treated as errors (e.g. -Werror)" OFF)

--- a/libs/EXTERNAL/libargparse/README.md
+++ b/libs/EXTERNAL/libargparse/README.md
@@ -2,7 +2,7 @@ libargparse
 ===========
 This is (yet another) simple command-line parser for C++ applications, inspired by Python's agparse module.
 
-It requires only a C++11 compiler, and has no external dependancies.
+It requires only a C++11 compiler, and has no external dependencies.
 
 One of the advantages of libargparse is that all conversions from command-line strings to program types (bool, int etc.) are performed when the command line is parsed (and not when the options are accessed).
 This avoids command-line related errors from showing up deep in the program execution, which can be problematic for long-running programs.

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(libarchfpga PUBLIC ${LIB_INCLUDE_DIRS})
 
 set_target_properties(libarchfpga PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
-#Specify link-time dependancies
+#Specify link-time dependencies
 target_link_libraries(libarchfpga
                         libvtrutil
                         libpugixml

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -25,6 +25,26 @@ target_link_libraries(libarchfpga
                         libvtrcapnproto
 )
 
+# Using filesystem library requires additional compiler/linker options for GNU implementation prior to 9.1
+# and LLVM implementation prior to LLVM 9.0;
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    # Get the compiler version string
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE _gcc_output)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" _gcc_version ${_gcc_output})
+
+    if(_gcc_version VERSION_LESS "9.1")
+        target_link_libraries(libarchfpga stdc++fs)
+    endif()
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # Get the compiler version string
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE _clang_output)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" _clang_version ${_clang_output})
+
+    if(_clang_version VERSION_LESS "9.0")
+        target_link_libraries(libarchfpga c++fs)
+    endif()
+endif()
+
 target_compile_definitions(libarchfpga PUBLIC ${INTERCHANGE_SCHEMA_HEADERS})
 
 #Create the test executable

--- a/libs/librrgraph/CMakeLists.txt
+++ b/libs/librrgraph/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(librrgraph PUBLIC ${LIB_INCLUDE_DIRS})
 
 set_target_properties(librrgraph PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
-#Specify link-time dependancies
+#Specify link-time dependencies
 target_link_libraries(librrgraph
                       libvtrutil
                       libarchfpga

--- a/libs/libvtrutil/CMakeLists.txt
+++ b/libs/libvtrutil/CMakeLists.txt
@@ -100,7 +100,7 @@ set_target_properties(libvtrutil PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 #Ensure version is always up to date by requiring version to be run first
 add_dependencies(libvtrutil version)
 
-#Specify link-time dependancies
+#Specify link-time dependencies
 target_link_libraries(libvtrutil
                         liblog)
 

--- a/libs/libvtrutil/CMakeLists.txt
+++ b/libs/libvtrutil/CMakeLists.txt
@@ -104,6 +104,26 @@ add_dependencies(libvtrutil version)
 target_link_libraries(libvtrutil
                         liblog)
 
+# Using filesystem library requires additional compiler/linker options for GNU implementation prior to 9.1
+# and LLVM implementation prior to LLVM 9.0;
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    # Get the compiler version string
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE _gcc_output)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" _gcc_version ${_gcc_output})
+
+    if(_gcc_version VERSION_LESS "9.1")
+        target_link_libraries(libvtrutil stdc++fs)
+    endif()
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # Get the compiler version string
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE _clang_output)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" _clang_version ${_clang_output})
+
+    if(_clang_version VERSION_LESS "9.0")
+        target_link_libraries(libvtrutil c++fs)
+    endif()
+endif()
+
 install(TARGETS libvtrutil DESTINATION bin)
 install(FILES ${LIB_HEADERS} DESTINATION include/libvtrutil)
 

--- a/libs/libvtrutil/src/vtr_util.cpp
+++ b/libs/libvtrutil/src/vtr_util.cpp
@@ -26,12 +26,12 @@ static int cont;                 /* line continued? (used by strtok)*/
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const char* text, const std::string delims) {
+std::vector<std::string> split(const char* text, const std::string& delims) {
     if (text) {
         std::string text_str(text);
         return split(text_str, delims);
     }
-    return std::vector<std::string>();
+    return {};
 }
 
 /**
@@ -39,7 +39,7 @@ std::vector<std::string> split(const char* text, const std::string delims) {
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const std::string& text, const std::string delims) {
+std::vector<std::string> split(const std::string& text, const std::string& delims) {
     std::vector<std::string> tokens;
 
     std::string curr_tok;
@@ -102,7 +102,7 @@ std::string replace_all(const std::string& input, const std::string& search, con
 }
 
 ///@brief Retruns true if str starts with prefix
-bool starts_with(std::string str, std::string prefix) {
+bool starts_with(const std::string& str, const std::string& prefix) {
     return str.find(prefix) == 0;
 }
 
@@ -461,8 +461,8 @@ bool file_exists(const char* filename) {
  *
  * Returns true if the extension is correct, and false otherwise.
  */
-bool check_file_name_extension(std::string file_name,
-                               std::string file_extension) {
+bool check_file_name_extension(const std::string& file_name,
+                               const std::string& file_extension) {
     auto ext = std::filesystem::path(file_name).extension();
     return ext == file_extension;
 }

--- a/libs/libvtrutil/src/vtr_util.h
+++ b/libs/libvtrutil/src/vtr_util.h
@@ -14,8 +14,8 @@ namespace vtr {
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const char* text, const std::string delims = " \t\n");
-std::vector<std::string> split(const std::string& text, const std::string delims = " \t\n");
+std::vector<std::string> split(const char* text, const std::string& delims = " \t\n");
+std::vector<std::string> split(const std::string& text, const std::string& delims = " \t\n");
 
 ///@brief Returns 'input' with the first instance of 'search' replaced with 'replace'
 std::string replace_first(const std::string& input, const std::string& search, const std::string& replace);
@@ -24,7 +24,7 @@ std::string replace_first(const std::string& input, const std::string& search, c
 std::string replace_all(const std::string& input, const std::string& search, const std::string& replace);
 
 ///@brief Retruns true if str starts with prefix
-bool starts_with(std::string str, std::string prefix);
+bool starts_with(const std::string& str, const std::string& prefix);
 
 ///@brief Returns a std::string formatted using a printf-style format string
 std::string string_fmt(const char* fmt, ...);
@@ -69,7 +69,7 @@ double atod(const std::string& value);
  */
 int get_file_line_number_of_last_opened_file();
 bool file_exists(const char* filename);
-bool check_file_name_extension(std::string file_name, std::string file_extension);
+bool check_file_name_extension(const std::string& file_name, const std::string& file_extension);
 
 extern std::string out_file_prefix;
 

--- a/utils/fasm/CMakeLists.txt
+++ b/utils/fasm/CMakeLists.txt
@@ -33,7 +33,7 @@ if (GENFASM_USES_IPO)
     set_property(TARGET genfasm APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
-#Specify link-time dependancies
+#Specify link-time dependencies
 install(TARGETS genfasm DESTINATION bin)
 
 #
@@ -49,7 +49,7 @@ set(TEST_SOURCES
 add_executable(test_fasm ${TEST_SOURCES})
 target_link_libraries(test_fasm fasm Catch2::Catch2WithMain)
 
-#Supress IPO link warnings if IPO is enabled
+#Suppress IPO link warnings if IPO is enabled
 get_target_property(TEST_FASM_USES_IPO test_fasm INTERPROCEDURAL_OPTIMIZATION)
 if (TEST_FASM_USES_IPO)
     set_property(TARGET test_fasm APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})

--- a/utils/vqm2blif/CMakeLists.txt
+++ b/utils/vqm2blif/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(libvqm2blif STATIC
 target_include_directories(libvqm2blif PUBLIC ${LIB_INCLUDE_DIRS})
 set_target_properties(libvqm2blif PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
-#Specify link-time dependancies
+#Specify link-time dependencies
 target_link_libraries(libvqm2blif
                         libarchfpga
                         libvqm)

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(libvpr STATIC
 
 target_include_directories(libvpr PUBLIC ${LIB_INCLUDE_DIRS})
 
-#VPR_ANALYTIC_PLACE is inisitalized in the root CMakeLists
+#VPR_ANALYTIC_PLACE is initialized in the root CMakeLists
 #Check Eigen dependency
 if(${VPR_ANALYTIC_PLACE})
 	message(STATUS "VPR Analytic Placement: Requested")
@@ -79,7 +79,7 @@ endif()
 
 set_target_properties(libvpr PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
-#Specify link-time dependancies
+#Specify link-time dependencies
 target_link_libraries(libvpr
                         libvtrutil
                         libarchfpga
@@ -249,7 +249,7 @@ endif()
 # Signal handler configuration
 #
 if (VPR_USE_SIGNAL_HANDLER)
-    #Check wheter VPR can use sigaction to handle signals (only supported by POSIX)
+    #Check whether VPR can use sigaction to handle signals (only supported by POSIX)
     CHECK_CXX_SYMBOL_EXISTS(sigaction csignal HAVE_SIGACTION)
     if(HAVE_SIGACTION)
         target_compile_definitions(libvpr PRIVATE VPR_USE_SIGACTION)

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -171,21 +171,21 @@ void ClusteredNetlistStats::write(OutputFormat fmt, std::ostream& output) const 
     }
 }
 
-void writeClusteredNetlistStats(std::string block_usage_filename) {
+void writeClusteredNetlistStats(const std::string& block_usage_filename) {
     const auto stats = ClusteredNetlistStats();
 
     // Print out the human readable version to stdout
 
     stats.write(ClusteredNetlistStats::OutputFormat::HumanReadable, std::cout);
 
-    if (block_usage_filename.size() > 0) {
+    if (!block_usage_filename.empty()) {
         ClusteredNetlistStats::OutputFormat fmt;
 
-        if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".json")) {
+        if (vtr::check_file_name_extension(block_usage_filename, ".json")) {
             fmt = ClusteredNetlistStats::OutputFormat::JSON;
-        } else if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".xml")) {
+        } else if (vtr::check_file_name_extension(block_usage_filename, ".xml")) {
             fmt = ClusteredNetlistStats::OutputFormat::XML;
-        } else if (vtr::check_file_name_extension(block_usage_filename.c_str(), ".txt")) {
+        } else if (vtr::check_file_name_extension(block_usage_filename, ".txt")) {
             fmt = ClusteredNetlistStats::OutputFormat::HumanReadable;
         } else {
             VPR_FATAL_ERROR(VPR_ERROR_PACK, "Unknown extension on output %s", block_usage_filename.c_str());

--- a/vpr/src/base/ShowSetup.h
+++ b/vpr/src/base/ShowSetup.h
@@ -27,6 +27,6 @@ struct ClusteredNetlistStats {
 };
 
 void ShowSetup(const t_vpr_setup& vpr_setup);
-void writeClusteredNetlistStats(std::string block_usage_filename);
+void writeClusteredNetlistStats(const std::string& block_usage_filename);
 
 #endif


### PR DESCRIPTION
Fixes [this issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2507).

According to [filesystem library documentation](https://en.cppreference.com/w/cpp/filesystem), gcc versions older than 9.1 and clang prior to 9.0 need filesystem library to be explicitly linked. This PR adds the compiler option when it is necessary.

When trying to reproduce the compilation failure, I realized gcc-8.4 does not need the additional compiler option. However, to be consistent with the official documentation, I add the compiler flag for versions older than 9.1.


#### How Has This Been Tested?
Current Github Ubuntu images do not have gcc-8 installed by default. When I manually installed gcc-8.4, VTR was built without any problem. It seems that it is only gcc-8.3 and older version sthat need the link flag. I reproduced the compilation error on my local machine by building gcc-8.3 from source. Adding the compiler flag fixed the error. CI tests show that the flag is not applied for newer gcc versions.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
