### PR TITLE
[CAPNPROTO][CMake] Fixed Build When CAPNPROTO is Disabled

### DIFF
--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -22,8 +22,12 @@ target_link_libraries(libarchfpga
                         libvtrutil
                         libpugixml
                         libpugiutil
-                        libvtrcapnproto
 )
+
+if(${VTR_ENABLE_CAPNPROTO})
+    target_link_libraries(libarchfpga libvtrcapnproto)
+    target_compile_definitions(libarchfpga PRIVATE VTR_ENABLE_CAPNPROTO)
+endif()
 
 # Using filesystem library requires additional compiler/linker options for GNU implementation prior to 9.1
 # and LLVM implementation prior to LLVM 9.0;

--- a/libs/libarchfpga/src/read_fpga_interchange_arch.cpp
+++ b/libs/libarchfpga/src/read_fpga_interchange_arch.cpp
@@ -1,3 +1,10 @@
+
+
+#include "read_fpga_interchange_arch.h"
+#include "vtr_error.h"
+
+#ifdef VTR_ENABLE_CAPNPROTO
+
 #include <algorithm>
 #include <kj/std/iostream.h>
 #include <limits>
@@ -21,7 +28,6 @@
 #include "arch_util.h"
 #include "arch_types.h"
 
-#include "read_fpga_interchange_arch.h"
 
 /*
  * FPGA Interchange Device frontend
@@ -2497,11 +2503,14 @@ struct ArchReader {
     }
 };
 
+#endif  // VTR_ENABLE_CAPNPROTO
+
 void FPGAInterchangeReadArch(const char* FPGAInterchangeDeviceFile,
                              const bool /*timing_enabled*/,
                              t_arch* arch,
                              std::vector<t_physical_tile_type>& PhysicalTileTypes,
                              std::vector<t_logical_block_type>& LogicalBlockTypes) {
+#ifdef VTR_ENABLE_CAPNPROTO
     // Decompress GZipped capnproto device file
     gzFile file = gzopen(FPGAInterchangeDeviceFile, "r");
     VTR_ASSERT(file != Z_NULL);
@@ -2542,4 +2551,12 @@ void FPGAInterchangeReadArch(const char* FPGAInterchangeDeviceFile,
 
     ArchReader reader(arch, device_reader, FPGAInterchangeDeviceFile, PhysicalTileTypes, LogicalBlockTypes);
     reader.read_arch();
+#else   // VTR_ENABLE_CAPNPROTO
+    // If CAPNPROTO is disabled, throw an error.
+    (void)FPGAInterchangeDeviceFile;
+    (void)arch;
+    (void)PhysicalTileTypes;
+    (void)LogicalBlockTypes;
+    throw vtr::VtrError("Unable to read FPGA interchange if CAPNPROTO is not enabled", __FILE__, __LINE__);
+#endif  // VTR_ENABLE_CAPNPROTO
 }

--- a/libs/libarchfpga/src/read_fpga_interchange_arch.h
+++ b/libs/libarchfpga/src/read_fpga_interchange_arch.h
@@ -3,12 +3,16 @@
 
 #include "arch_types.h"
 
+#ifdef VTR_ENABLE_CAPNPROTO
+
 #include "DeviceResources.capnp.h"
 #include "LogicalNetlist.capnp.h"
 #include "capnp/serialize.h"
 #include "capnp/serialize-packed.h"
 #include <fcntl.h>
 #include <unistd.h>
+
+#endif  // VTR_ENABLE_CAPNPROTO
 
 #ifdef __cplusplus
 extern "C" {

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -43,10 +43,6 @@ file(GLOB_RECURSE LIB_SOURCES src/*/*.cpp)
 file(GLOB_RECURSE LIB_HEADERS src/*/*.h)
 files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
 
-if(${VTR_ENABLE_CAPNPROTO})
-    add_definitions("-DVTR_ENABLE_CAPNPROTO")
-endif()
-
 if(${VPR_DEBUG_PARTITION_TREE})
     message(STATUS "VPR: Partition tree debug logs: enabled")
     add_definitions("-DVPR_DEBUG_PARTITION_TREE")
@@ -131,6 +127,7 @@ target_compile_definitions(libvpr PUBLIC ${GRAPHICS_DEFINES})
 
 if(${VTR_ENABLE_CAPNPROTO})
     target_link_libraries(libvpr libvtrcapnproto)
+    target_compile_definitions(libvpr PRIVATE VTR_ENABLE_CAPNPROTO)
 endif()
 
 add_executable(vpr ${EXEC_SOURCES})

--- a/vpr/src/base/read_interchange_netlist.cpp
+++ b/vpr/src/base/read_interchange_netlist.cpp
@@ -6,6 +6,13 @@
  * hierarchical) netlist in FPGA Interchange Format file, and
  * builds a netlist data structure (AtomNetlist) from it.
  */
+
+#include "read_interchange_netlist.h"
+#include "atom_netlist.h"
+#include "vtr_error.h"
+
+#ifdef VTR_ENABLE_CAPNPROTO
+
 #include <cmath>
 #include <limits>
 #include <kj/std/iostream.h>
@@ -21,8 +28,6 @@
 #include "capnp/serialize.h"
 #include "capnp/serialize-packed.h"
 
-#include "atom_netlist.h"
-
 #include "vtr_assert.h"
 #include "vtr_hash.h"
 #include "vtr_util.h"
@@ -34,7 +39,6 @@
 #include "vpr_types.h"
 #include "vpr_error.h"
 #include "globals.h"
-#include "read_interchange_netlist.h"
 #include "arch_types.h"
 
 struct NetlistReader {
@@ -520,8 +524,11 @@ struct NetlistReader {
     }
 };
 
+#endif  // VTR_ENABLE_CAPNPROTO
+
 AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
                                      t_arch& arch) {
+#ifdef VTR_ENABLE_CAPNPROTO
     AtomNetlist netlist;
     std::string netlist_id = vtr::secure_digest_file(ic_netlist_file);
 
@@ -564,4 +571,13 @@ AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
     NetlistReader reader(netlist, netlist_reader, netlist_id, ic_netlist_file, arch);
 
     return netlist;
+
+#else   // VTR_ENABLE_CAPNPROTO
+
+    // If CAPNPROTO is not enabled, throw an error
+    (void)ic_netlist_file;
+    (void)arch;
+    throw vtr::VtrError("Unable to read interchange netlist with CAPNPROTO disabled", __FILE__, __LINE__);
+
+#endif  // VTR_ENABLE_CAPNPROTO
 }

--- a/vpr/src/route/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead_map.cpp
@@ -897,20 +897,20 @@ static void min_opin_distance_cost_map(const util::t_src_opin_delays& src_opin_d
         "Re-compile with CMake option VTR_ENABLE_CAPNPROTO=ON to enable."
 
 void read_router_lookahead(const std::string& /*file*/) {
-    VPR_THROW(VPR_ERROR_PLACE, "MapLookahead::read " DISABLE_ERROR);
+    VPR_THROW(VPR_ERROR_PLACE, "MapLookahead::read_router_lookahead " DISABLE_ERROR);
 }
 
-void write_router_lookahead(const std::string& file) {
-    VPR_THROW(VPR_ERROR_PLACE, "MapLookahead::write " DISABLE_ERROR);
+void write_router_lookahead(const std::string& /*file*/) {
+    VPR_THROW(VPR_ERROR_PLACE, "MapLookahead::write_router_lookahead " DISABLE_ERROR);
 }
 
-static void read_intra_cluster_router_lookahead(std::unordered_map<t_physical_tile_type_ptr, util::t_ipin_primitive_sink_delays>& /*intra_tile_pin_primitive_pin_delay*/,
+static void read_intra_cluster_router_lookahead(std::unordered_map<int, util::t_ipin_primitive_sink_delays>& /*intra_tile_pin_primitive_pin_delay*/,
                                                 const std::string& /*file*/) {
     VPR_THROW(VPR_ERROR_PLACE, "MapLookahead::read_intra_cluster_router_lookahead " DISABLE_ERROR);
 }
 
 static void write_intra_cluster_router_lookahead(const std::string& /*file*/,
-                                                 const std::unordered_map<t_physical_tile_type_ptr, util::t_ipin_primitive_sink_delays>& /*intra_tile_pin_primitive_pin_delay*/) {
+                                                 const std::unordered_map<int, util::t_ipin_primitive_sink_delays>& /*intra_tile_pin_primitive_pin_delay*/) {
     VPR_THROW(VPR_ERROR_PLACE, "MapLookahead::write_intra_cluster_router_lookahead " DISABLE_ERROR);
 }
 


### PR DESCRIPTION
There were many build errors that arose when CAPNPROTO was disabled. It looks like there was a dependency in libarchfpga on libvtrcapnproto even though the library is disabled if the user passes a flag to disable it. Removed this dependency when the flag is disabled.

VPR also had a similar issue. This appears to have been handled in the past, but has since regressed. We should consider adding this build to CI to prevent further regressions (if this feature is needed).

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
resolves #2510 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built using:
```
make CMAKE_PARAMS="-DVTR_ENABLE_CAPNPROTO=OFF"
```
and
```
make CMAKE_PARAMS="-DVTR_ENABLE_CAPNPROTO=ON"
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
