### PR TITLE
[Route][Heap] Removed prev_node From t_heap

### DIFF
--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -374,8 +374,8 @@ void ConnectionRouter<Heap>::timing_driven_expand_cheapest(t_heap* cheapest,
         VTR_LOGV_DEBUG(router_debug_, "    New back cost: %g\n", new_back_cost);
         VTR_LOGV_DEBUG(router_debug_, "      Setting path costs for associated node %d (from %d edge %zu)\n",
                        cheapest->index,
-                       cheapest->prev_node(),
-                       size_t(cheapest->prev_edge()));
+                       static_cast<size_t>(rr_graph_->edge_src_node(cheapest->prev_edge())),
+                       static_cast<size_t>(cheapest->prev_edge()));
 
         update_cheapest(cheapest, route_inf);
 
@@ -601,7 +601,6 @@ void ConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_params&
         next_ptr->backward_path_cost = next.backward_path_cost;
         next_ptr->index = to_node;
         next_ptr->set_prev_edge(from_edge);
-        next_ptr->set_prev_node(from_node);
 
         if (rcv_path_manager.is_enabled() && current->path_data) {
             next_ptr->path_data->path_rr = current->path_data->path_rr;
@@ -924,7 +923,7 @@ void ConnectionRouter<Heap>::add_route_tree_node_to_heap(
                        describe_rr_node(device_ctx.rr_graph, device_ctx.grid, device_ctx.rr_indexed_data, inode, is_flat_).c_str());
 
         push_back_node(&heap_, rr_node_route_inf_,
-                       inode, tot_cost, RRNodeId::INVALID(), RREdgeId::INVALID(),
+                       inode, tot_cost, RREdgeId::INVALID(),
                        backward_path_cost, R_upstream);
     } else {
         float expected_total_cost = compute_node_cost_using_rcv(cost_params, inode, target_node, rt_node.Tdel, 0, R_upstream);

--- a/vpr/src/route/heap_type.cpp
+++ b/vpr/src/route/heap_type.cpp
@@ -29,7 +29,6 @@ HeapStorage::alloc() {
     temp_ptr->R_upstream = 0.;
     temp_ptr->index = RRNodeId::INVALID();
     temp_ptr->path_data = nullptr;
-    temp_ptr->set_prev_node(RRNodeId::INVALID());
     temp_ptr->set_prev_edge(RREdgeId::INVALID());
     return (temp_ptr);
 }

--- a/vpr/src/route/heap_type.h
+++ b/vpr/src/route/heap_type.h
@@ -45,15 +45,6 @@ struct t_heap {
     // Managed by PathManager class
     t_heap_path* path_data;
 
-    /** Previous node and edge IDs. These are not StrongIds for performance & brevity
-     * reasons: StrongIds can't be trivially placed into an anonymous union (see below) */
-    struct t_prev {
-        uint32_t node;
-        uint32_t edge;
-        static_assert(sizeof(uint32_t) == sizeof(RRNodeId));
-        static_assert(sizeof(uint32_t) == sizeof(RREdgeId));
-    };
-
     t_heap* next_heap_item() const {
         return u.next;
     }
@@ -62,30 +53,25 @@ struct t_heap {
         u.next = next;
     }
 
-    /** Get prev_node.
-     * Be careful: will return 0 (a valid id!) if uninitialized. */
-    constexpr RRNodeId prev_node() const {
-        return RRNodeId(u.prev.node);
-    }
-
-    inline void set_prev_node(RRNodeId node) {
-        u.prev.node = size_t(node);
-    }
-
     /** Get prev_edge.
      * Be careful: will return 0 (a valid id!) if uninitialized. */
     constexpr RREdgeId prev_edge() const {
-        return RREdgeId(u.prev.edge);
+        static_assert(sizeof(uint32_t) == sizeof(RREdgeId));
+        return RREdgeId(u.prev_edge);
     }
 
     inline void set_prev_edge(RREdgeId edge) {
-        u.prev.edge = size_t(edge);
+        static_assert(sizeof(uint32_t) == sizeof(RREdgeId));
+        u.prev_edge = size_t(edge);
     }
 
   private:
     union {
         t_heap* next = nullptr;
-        t_prev prev;
+        // The previous edge is not a StrongId for performance & brevity
+        // reasons: StrongIds can't be trivially placed into an anonymous
+        // union.
+        uint32_t prev_edge;
     } u;
 };
 

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -810,7 +810,7 @@ void reserve_locally_used_opins(HeapInterface* heap, float pres_fac, float acc_f
                 //Add the OPIN to the heap according to it's congestion cost
                 cost = get_rr_cong_cost(to_node, pres_fac);
                 add_node_to_heap(heap, route_ctx.rr_node_route_inf,
-                                 to_node, cost, RRNodeId::INVALID(), RREdgeId::INVALID(),
+                                 to_node, cost, RREdgeId::INVALID(),
                                  0., 0.);
             }
 

--- a/vpr/src/route/route_common.h
+++ b/vpr/src/route/route_common.h
@@ -159,7 +159,6 @@ t_heap* prepare_to_add_node_to_heap(
     const RouteInf& rr_node_route_inf,
     RRNodeId inode,
     float total_cost,
-    RRNodeId prev_node,
     RREdgeId prev_edge,
     float backward_path_cost,
     float R_upstream) {
@@ -170,7 +169,6 @@ t_heap* prepare_to_add_node_to_heap(
 
     hptr->index = inode;
     hptr->cost = total_cost;
-    hptr->set_prev_node(prev_node);
     hptr->set_prev_edge(prev_edge);
     hptr->backward_path_cost = backward_path_cost;
     hptr->R_upstream = R_upstream;
@@ -184,13 +182,12 @@ void add_node_to_heap(
     const RouteInf& rr_node_route_inf,
     RRNodeId inode,
     float total_cost,
-    RRNodeId prev_node,
     RREdgeId prev_edge,
     float backward_path_cost,
     float R_upstream) {
     t_heap* hptr = prepare_to_add_node_to_heap(
         heap,
-        rr_node_route_inf, inode, total_cost, prev_node,
+        rr_node_route_inf, inode, total_cost,
         prev_edge, backward_path_cost, R_upstream);
     if (hptr) {
         heap->add_to_heap(hptr);
@@ -206,13 +203,12 @@ void push_back_node(
     const RouteInf& rr_node_route_inf,
     RRNodeId inode,
     float total_cost,
-    RRNodeId prev_node,
     RREdgeId prev_edge,
     float backward_path_cost,
     float R_upstream) {
     t_heap* hptr = prepare_to_add_node_to_heap(
         heap,
-        rr_node_route_inf, inode, total_cost, prev_node, prev_edge,
+        rr_node_route_inf, inode, total_cost, prev_edge,
         backward_path_cost, R_upstream);
     if (hptr) {
         heap->push_back(hptr);


### PR DESCRIPTION
A previous commit removed prev_node from t_rr_node_route_inf. This was because the prev_node can be uniquely identified by the prev_edge (but not the other way around).

The same methedology can be applied to the t_heap type. This was only being set, but it was never being used (with the exception of one debug message). Therefore this is only good for performance and memory overhead.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

issue #2499 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This cleans up the t_heap struct some, which reduces memory overhead. This makes it easier to work with the heap and also may improve performance slightly.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
