### PR TITLE
Fixed a Couple Simple Warnings

### DIFF
--- a/libs/libvtrutil/cmake/modules/configure_version.cmake
+++ b/libs/libvtrutil/cmake/modules/configure_version.cmake
@@ -4,10 +4,11 @@
 #Figure out the git revision
 find_package(Git QUIET)
 if(GIT_FOUND)
-    exec_program(${GIT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}
-                 ARGS describe --always --long --dirty
-                 OUTPUT_VARIABLE VTR_VCS_REVISION
-                 RETURN_VALUE GIT_DESCRIBE_RETURN_VALUE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --long --dirty
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    OUTPUT_VARIABLE VTR_VCS_REVISION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    RESULT_VARIABLE GIT_DESCRIBE_RETURN_VALUE)
 
     if(NOT GIT_DESCRIBE_RETURN_VALUE EQUAL 0)
         #Git describe failed, usually this means we
@@ -18,10 +19,12 @@ if(GIT_FOUND)
 
     #Call again with exclude to get the revision excluding any tags
     #(i.e. just the commit ID and dirty flag)
-    exec_program(${GIT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}
-                 ARGS describe --always --long --dirty --exclude '*'
-                 OUTPUT_VARIABLE VTR_VCS_REVISION_SHORT
-                 RETURN_VALUE GIT_DESCRIBE_RETURN_VALUE)
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --long --dirty --exclude '*'
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    OUTPUT_VARIABLE VTR_VCS_REVISION_SHORT
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    RESULT_VARIABLE GIT_DESCRIBE_RETURN_VALUE)
+
     if(NOT GIT_DESCRIBE_RETURN_VALUE EQUAL 0)
         #Git describe failed, usually this means we
         #aren't in a git repo -- so don't set a VCS 

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -606,10 +606,10 @@ float ExtendedMapLookahead::get_expected_cost(
 
 #ifndef VTR_ENABLE_CAPNPROTO
 
-void ExtendedMapLookahead::read(const std::string& file) {
+void ExtendedMapLookahead::read(const std::string& /*file*/) {
     VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read not implemented");
 }
-void ExtendedMapLookahead::write(const std::string& file) const {
+void ExtendedMapLookahead::write(const std::string& /*file*/) const {
     VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write not implemented");
 }
 

--- a/vpr/src/route/router_lookahead_extended_map.cpp
+++ b/vpr/src/route/router_lookahead_extended_map.cpp
@@ -604,26 +604,25 @@ float ExtendedMapLookahead::get_expected_cost(
     }
 }
 
-#ifndef VTR_ENABLE_CAPNPROTO
-
-void ExtendedMapLookahead::read(const std::string& /*file*/) {
-    VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read not implemented");
-}
-void ExtendedMapLookahead::write(const std::string& /*file*/) const {
-    VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write not implemented");
-}
-
-#else
-
 void ExtendedMapLookahead::read(const std::string& file) {
+#ifndef VTR_ENABLE_CAPNPROTO
     cost_map_.read(file);
 
     this->src_opin_delays = util::compute_router_src_opin_lookahead(is_flat_);
 
     this->chan_ipins_delays = util::compute_router_chan_ipin_lookahead();
-}
-void ExtendedMapLookahead::write(const std::string& file) const {
-    cost_map_.write(file);
+#else   // VTR_ENABLE_CAPNPROTO
+    (void)file;
+    VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::read not implemented");
+#endif  // VTR_ENABLE_CAPNPROTO
 }
 
-#endif
+void ExtendedMapLookahead::write(const std::string& file) const {
+#ifndef VTR_ENABLE_CAPNPROTO
+    cost_map_.write(file);
+#else   // VTR_ENABLE_CAPNPROTO
+    (void)file;
+    VPR_THROW(VPR_ERROR_ROUTE, "MapLookahead::write not implemented");
+#endif  // VTR_ENABLE_CAPNPROTO
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

During the CI build process of the new "R: Basic with CAPNPROTO disabled" job, there were a couple of basic warnings that I thought I would resolve.

The first were some warnings directly caused by CAPNPROTO being disabled:
<img width="1024" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/8a613d18-38d7-49f9-998f-fd67c6669f10">
These were easy to fix by commenting out the unused variables.

Next were some CMake warnings which appear to be affecting all builds:
<img width="622" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/f8a03135-bed3-4e5d-be9c-740060bea1cd">
It looks like the [exec_program](https://cmake.org/cmake/help/latest/command/exec_program.html) command was deprecated and the suggested replacement was to use the [execute_process](https://cmake.org/cmake/help/latest/command/execute_process.html#command:execute_process) command instead. The syntax was similar, but required a few extra arguments in order to properly get the Git version.

#### Description
<!--- Describe your changes in detail -->

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some build warnings that showed up that caught my eye and I knew were simple to solve.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
