### PR TITLE
Net decomposition: tuning and polishing

### DIFF
--- a/vpr/src/route/DecompNetlistRouter.h
+++ b/vpr/src/route/DecompNetlistRouter.h
@@ -2,7 +2,8 @@
 
 /** @file Parallel and net-decomposing case for NetlistRouter. Works like
  * \see ParallelNetlistRouter, but tries to "decompose" nets and assign them to
- * the next level of the partition tree where possible. */
+ * the next level of the partition tree where possible.
+ * See "Parallel FPGA Routing with On-the-Fly Net Decomposition", FPT'24 */
 #include "netlist_routers.h"
 
 #include <tbb/task_group.h>
@@ -57,6 +58,8 @@ class DecompNetlistRouter : public NetlistRouter {
      * \ref route_net for each net, which will handle other global updates.
      * \return RouteIterResults for this iteration. */
     RouteIterResults route_netlist(int itry, float pres_fac, float worst_neg_slack);
+    /** Inform the PartitionTree of the nets with updated bounding boxes */
+    void handle_bb_updated_nets(const std::vector<ParentNetId>& nets);
     /** Set RCV enable flag for all routers managed by this netlist router.
      * Net decomposition does not work with RCV, so calling this fn with x=true is a fatal error. */
     void set_rcv_enabled(bool x);
@@ -65,10 +68,14 @@ class DecompNetlistRouter : public NetlistRouter {
   private:
     /** Should we decompose this net? */
     bool should_decompose_net(ParentNetId net_id, const PartitionTreeNode& node);
-    /** Get a bitset with sinks to route before net decomposition */
+    /** Get a bitset of sinks to route before net decomposition. Output bitset is 
+     * [1..num_sinks] where the corresponding index is set to 1 if the sink needs to
+     * be routed */
     vtr::dynamic_bitset<> get_decomposition_mask(ParentNetId net_id, const PartitionTreeNode& node);
-    /** Get a bitset with sinks to route before virtual net decomposition */
-    vtr::dynamic_bitset<> get_vnet_decomposition_mask(const VirtualNet& vnet, const PartitionTreeNode& node);
+    /** Get a bitset of sinks to route before virtual net decomposition. Output bitset is 
+     * [1..num_sinks] where the corresponding index is set to 1 if the sink needs to
+     * be routed */
+    vtr::dynamic_bitset<> get_decomposition_mask_vnet(const VirtualNet& vnet, const PartitionTreeNode& node);
     /** Decompose and route a regular net. Output the resulting vnets to \p left and \p right.
      * \return Success status: true if routing is successful and left and right now contain valid virtual nets: false otherwise. */
     bool decompose_and_route_net(ParentNetId net_id, const PartitionTreeNode& node, VirtualNet& left, VirtualNet& right);
@@ -114,6 +121,9 @@ class DecompNetlistRouter : public NetlistRouter {
     int _itry;
     float _pres_fac;
     float _worst_neg_slack;
+
+    /** The partition tree. Holds the groups of nets for each partition */
+    vtr::optional<PartitionTree> _tree;
 
     /** Sinks to be always sampled for decomposition for each net: [0.._net_list.size()-1]
      * (i.e. when routing fails after decomposition for a sink, sample it on next iteration) */

--- a/vpr/src/route/DecompNetlistRouter.tpp
+++ b/vpr/src/route/DecompNetlistRouter.tpp
@@ -3,6 +3,7 @@
 /** @file Impls for DecompNetlistRouter */
 
 #include "DecompNetlistRouter.h"
+#include "globals.h"
 #include "netlist_routers.h"
 #include "route_net.h"
 #include "sink_sampling.h"
@@ -21,23 +22,42 @@ inline RouteIterResults DecompNetlistRouter<HeapType>::route_netlist(int itry, f
     _pres_fac = pres_fac;
     _worst_neg_slack = worst_neg_slack;
 
+    vtr::Timer timer;
+
     /* Organize netlist into a PartitionTree.
      * Nets in a given level of nodes are guaranteed to not have any overlapping bounding boxes, so they can be routed in parallel. */
-    PartitionTree tree(_net_list);
+    if(!_tree){
+        _tree = PartitionTree(_net_list);
+        PartitionTreeDebug::log("Iteration " + std::to_string(itry) + ": built partition tree in " + std::to_string(timer.elapsed_sec()) + " s");
+    }
+
+    /* Remove all virtual nets: we will create them for each iteration.
+     * This needs to be done because the partition tree can change between iterations 
+     * due to bounding box updates, which invalidates virtual nets */
+    _tree->clear_vnets();
 
     /* Put the root node on the task queue, which will add its child nodes when it's finished. Wait until the entire tree gets routed. */
-    tbb::task_group g;
-    route_partition_tree_node(g, tree.root());
-    g.wait();
+    tbb::task_group group;
+    route_partition_tree_node(group, _tree->root());
+    group.wait();
+    PartitionTreeDebug::log("Routing all nets took " + std::to_string(timer.elapsed_sec()) + " s");
 
     /* Combine results from threads */
     RouteIterResults out;
     for (auto& results : _results_th) {
         out.stats.combine(results.stats);
         out.rerouted_nets.insert(out.rerouted_nets.end(), results.rerouted_nets.begin(), results.rerouted_nets.end());
+        out.bb_updated_nets.insert(out.bb_updated_nets.end(), results.bb_updated_nets.begin(), results.bb_updated_nets.end());
         out.is_routable &= results.is_routable;
     }
+
     return out;
+}
+
+template<typename HeapType>
+void DecompNetlistRouter<HeapType>::handle_bb_updated_nets(const std::vector<ParentNetId>& nets) {
+    VTR_ASSERT(_tree);
+    _tree->update_nets(nets);
 }
 
 template<typename HeapType>
@@ -120,6 +140,10 @@ inline bool should_decompose_vnet(const VirtualNet& vnet, const PartitionTreeNod
 template<typename HeapType>
 void DecompNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group& g, PartitionTreeNode& node) {
     auto& route_ctx = g_vpr_ctx.mutable_routing();
+    vtr::Timer timer;
+
+    /* node.nets is an unordered set, copy into vector to sort */
+    std::vector<ParentNetId> nets(node.nets.begin(), node.nets.end());
 
     /* Sort so that nets with the most sinks are routed first.
      * We want to interleave virtual nets with regular ones, so sort an "index vector"
@@ -129,15 +153,14 @@ void DecompNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group& g
     std::vector<size_t> order(node.nets.size() + node.vnets.size());
     std::iota(order.begin(), order.end(), 0);
     std::stable_sort(order.begin(), order.end(), [&](size_t i, size_t j) -> bool {
-        ParentNetId id1 = i < node.nets.size() ? node.nets[i] : node.vnets[i - node.nets.size()].net_id;
-        ParentNetId id2 = j < node.nets.size() ? node.nets[j] : node.vnets[j - node.nets.size()].net_id;
+        ParentNetId id1 = i < node.nets.size() ? nets[i] : node.vnets[i - nets.size()].net_id;
+        ParentNetId id2 = j < node.nets.size() ? nets[j] : node.vnets[j - nets.size()].net_id;
         return _net_list.net_sinks(id1).size() > _net_list.net_sinks(id2).size();
     });
 
-    vtr::Timer t;
     for (size_t i : order) {
-        if (i < node.nets.size()) { /* Regular net (not decomposed) */
-            ParentNetId net_id = node.nets[i];
+        if (i < nets.size()) { /* Regular net (not decomposed) */
+            ParentNetId net_id = nets[i];
             if (!should_route_net(_net_list, net_id, _connections_inf, _budgeting_inf, _worst_neg_slack, true))
                 continue;
             /* Setup the net (reset or prune) only once here in the flow. Then all calls to route_net turn off auto-setup */
@@ -188,6 +211,7 @@ void DecompNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group& g
             if (flags.retry_with_full_bb) {
                 /* ConnectionRouter thinks we should grow the BB. Do that and leave this net unrouted for now */
                 route_ctx.route_bb[net_id] = full_device_bb();
+                _results_th.local().bb_updated_nets.push_back(net_id);
                 /* Disable decomposition for nets like this: they're already problematic */
                 _is_decomp_disabled[net_id] = true;
                 continue;
@@ -206,7 +230,7 @@ void DecompNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group& g
                     continue;
                 }
             }
-            /* Route the full vnet. Again we don't care about the flags, they should be handled by the regular path */
+            /* Route the full vnet. We don't care about the flags, they should be handled by the regular path */
             auto sink_mask = get_vnet_sink_mask(vnet);
             route_net(
                 _routers_th.local(),
@@ -234,7 +258,7 @@ void DecompNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group& g
 
     PartitionTreeDebug::log("Node with " + std::to_string(node.nets.size())
                             + " nets and " + std::to_string(node.vnets.size())
-                            + " virtual nets routed in " + std::to_string(t.elapsed_sec())
+                            + " virtual nets routed in " + std::to_string(timer.elapsed_sec())
                             + " s");
 
     /* This node is finished: add left & right branches to the task queue */
@@ -277,7 +301,7 @@ inline void make_vnet_pair(ParentNetId net_id, const t_bb& bb, Axis cutline_axis
 
 template<typename HeapType>
 bool DecompNetlistRouter<HeapType>::decompose_and_route_net(ParentNetId net_id, const PartitionTreeNode& node, VirtualNet& left, VirtualNet& right) {
-    auto& route_ctx = g_vpr_ctx.routing();
+    auto& route_ctx = g_vpr_ctx.mutable_routing();
     auto& net_bb = route_ctx.route_bb[net_id];
 
     /* Sample enough sinks to provide branch-off points to the virtual nets we create */
@@ -382,7 +406,7 @@ inline std::string describe_vnet(const VirtualNet& vnet) {
 template<typename HeapType>
 bool DecompNetlistRouter<HeapType>::decompose_and_route_vnet(VirtualNet& vnet, const PartitionTreeNode& node, VirtualNet& left, VirtualNet& right) {
     /* Sample enough sinks to provide branch-off points to the virtual nets we create */
-    auto sink_mask = get_vnet_decomposition_mask(vnet, node);
+    auto sink_mask = get_decomposition_mask_vnet(vnet, node);
 
     /* Route the *parent* net with the given mask: only the sinks we ask for will be routed */
     auto flags = route_net(
@@ -499,6 +523,7 @@ inline bool get_reduction_mask(ParentNetId net_id, Axis cutline_axis, int cutlin
 template<typename HeapType>
 vtr::dynamic_bitset<> DecompNetlistRouter<HeapType>::get_decomposition_mask(ParentNetId net_id, const PartitionTreeNode& node) {
     const auto& route_ctx = g_vpr_ctx.routing();
+
     const RouteTree& tree = route_ctx.route_trees[net_id].value();
     size_t num_sinks = tree.num_sinks();
 
@@ -512,6 +537,7 @@ vtr::dynamic_bitset<> DecompNetlistRouter<HeapType>::get_decomposition_mask(Pare
     bool is_reduced = get_reduction_mask(net_id, node.cutline_axis, node.cutline_pos, out);
 
     bool source_on_cutline = is_close_to_cutline(tree.root().inode, node.cutline_axis, node.cutline_pos, 1);
+
     if (!is_reduced || source_on_cutline)
         convex_hull_downsample(net_id, route_ctx.route_bb[net_id], out);
 
@@ -638,7 +664,7 @@ inline bool get_reduction_mask_vnet_with_source(const VirtualNet& vnet, Axis cut
 }
 
 template<typename HeapType>
-vtr::dynamic_bitset<> DecompNetlistRouter<HeapType>::get_vnet_decomposition_mask(const VirtualNet& vnet, const PartitionTreeNode& node) {
+vtr::dynamic_bitset<> DecompNetlistRouter<HeapType>::get_decomposition_mask_vnet(const VirtualNet& vnet, const PartitionTreeNode& node) {
     const auto& route_ctx = g_vpr_ctx.routing();
     const RouteTree& tree = route_ctx.route_trees[vnet.net_id].value();
     int num_sinks = tree.num_sinks();
@@ -652,8 +678,9 @@ vtr::dynamic_bitset<> DecompNetlistRouter<HeapType>::get_vnet_decomposition_mask
     if (inside_bb(tree.root().inode, vnet.clipped_bb)) { /* We have source, no need to sample after reduction in most cases */
         bool is_reduced = get_reduction_mask_vnet_with_source(vnet, node.cutline_axis, node.cutline_pos, out);
         bool source_on_cutline = is_close_to_cutline(tree.root().inode, node.cutline_axis, node.cutline_pos, 1);
-        if (!is_reduced || source_on_cutline)
+        if (!is_reduced || source_on_cutline){
             convex_hull_downsample(vnet.net_id, vnet.clipped_bb, out);
+        }    
     } else {
         int reduced_sides = get_reduction_mask_vnet_no_source(vnet, node.cutline_axis, node.cutline_pos, out);
         if (reduced_sides < 2) {
@@ -666,9 +693,11 @@ vtr::dynamic_bitset<> DecompNetlistRouter<HeapType>::get_vnet_decomposition_mask
     /* Sample if a sink is too close to the cutline (and unreached).
      * Those sinks are likely to fail routing */
     for (size_t isink : isinks) {
+        RRNodeId rr_sink = route_ctx.net_rr_terminals[vnet.net_id][isink];
+        if (!inside_bb(rr_sink, vnet.clipped_bb))
+            continue;
         if (is_isink_reached.get(isink))
             continue;
-        RRNodeId rr_sink = route_ctx.net_rr_terminals[vnet.net_id][isink];
         if (is_close_to_cutline(rr_sink, node.cutline_axis, node.cutline_pos, 1)) {
             out.set(isink, true);
             continue;

--- a/vpr/src/route/ParallelNetlistRouter.h
+++ b/vpr/src/route/ParallelNetlistRouter.h
@@ -8,8 +8,9 @@
  *
  * Note that the parallel router does not support graphical router breakpoints.
  *
- * [0]: F. Koşar, "A net-decomposing parallel FPGA router", MS thesis, UofT ECE, 2023 */
+ * [0]: "Parallel FPGA Routing with On-the-Fly Net Decomposition", FPT'24 */
 #include "netlist_routers.h"
+#include "vtr_optional.h"
 
 #include <tbb/task_group.h>
 
@@ -52,6 +53,8 @@ class ParallelNetlistRouter : public NetlistRouter {
      * \ref route_net for each net, which will handle other global updates.
      * \return RouteIterResults for this iteration. */
     RouteIterResults route_netlist(int itry, float pres_fac, float worst_neg_slack);
+    /** Inform the PartitionTree of the nets with updated bounding boxes */
+    void handle_bb_updated_nets(const std::vector<ParentNetId>& nets);
     void set_rcv_enabled(bool x);
     void set_timing_info(std::shared_ptr<SetupHoldTimingInfo> timing_info);
 
@@ -95,6 +98,9 @@ class ParallelNetlistRouter : public NetlistRouter {
     int _itry;
     float _pres_fac;
     float _worst_neg_slack;
+
+    /** The partition tree. Holds the groups of nets for each partition */
+    vtr::optional<PartitionTree> _tree;
 };
 
 #include "ParallelNetlistRouter.tpp"

--- a/vpr/src/route/ParallelNetlistRouter.tpp
+++ b/vpr/src/route/ParallelNetlistRouter.tpp
@@ -2,6 +2,7 @@
 
 /** @file Impls for ParallelNetlistRouter */
 
+#include <string>
 #include "netlist_routers.h"
 #include "route_net.h"
 #include "vtr_time.h"
@@ -20,18 +21,24 @@ inline RouteIterResults ParallelNetlistRouter<HeapType>::route_netlist(int itry,
 
     /* Organize netlist into a PartitionTree.
      * Nets in a given level of nodes are guaranteed to not have any overlapping bounding boxes, so they can be routed in parallel. */
-    PartitionTree tree(_net_list);
+    vtr::Timer timer;
+    if(!_tree){
+        _tree = PartitionTree(_net_list);
+        PartitionTreeDebug::log("Iteration " + std::to_string(itry) + ": built partition tree in " + std::to_string(timer.elapsed_sec()) + " s");
+    }
 
     /* Put the root node on the task queue, which will add its child nodes when it's finished. Wait until the entire tree gets routed. */
-    tbb::task_group g;
-    route_partition_tree_node(g, tree.root());
-    g.wait();
+    tbb::task_group group;
+    route_partition_tree_node(group, _tree->root());
+    group.wait();
+    PartitionTreeDebug::log("Routing all nets took " + std::to_string(timer.elapsed_sec()) + " s");
 
     /* Combine results from threads */
     RouteIterResults out;
     for (auto& results : _results_th) {
         out.stats.combine(results.stats);
         out.rerouted_nets.insert(out.rerouted_nets.end(), results.rerouted_nets.begin(), results.rerouted_nets.end());
+        out.bb_updated_nets.insert(out.bb_updated_nets.end(), results.bb_updated_nets.begin(), results.bb_updated_nets.end());
         out.is_routable &= results.is_routable;
     }
     return out;
@@ -41,13 +48,16 @@ template<typename HeapType>
 void ParallelNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group& g, PartitionTreeNode& node) {
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
+    /* node.nets is an unordered set, copy into vector to sort */
+    std::vector<ParentNetId> nets(node.nets.begin(), node.nets.end());
+
     /* Sort so net with most sinks is routed first. */
-    std::stable_sort(node.nets.begin(), node.nets.end(), [&](ParentNetId id1, ParentNetId id2) -> bool {
+    std::stable_sort(nets.begin(), nets.end(), [&](ParentNetId id1, ParentNetId id2) -> bool {
         return _net_list.net_sinks(id1).size() > _net_list.net_sinks(id2).size();
     });
 
-    vtr::Timer t;
-    for (auto net_id : node.nets) {
+    vtr::Timer timer;
+    for (auto net_id : nets) {
         auto flags = route_net(
             _routers_th.local(),
             _net_list,
@@ -76,13 +86,18 @@ void ParallelNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group&
         if (flags.retry_with_full_bb) {
             /* ConnectionRouter thinks we should grow the BB. Do that and leave this net unrouted for now */
             route_ctx.route_bb[net_id] = full_device_bb();
+            _results_th.local().bb_updated_nets.push_back(net_id);
             continue;
         }
         if (flags.was_rerouted) {
             _results_th.local().rerouted_nets.push_back(net_id);
         }
     }
-    PartitionTreeDebug::log("Node with " + std::to_string(node.nets.size()) + " nets routed in " + std::to_string(t.elapsed_sec()) + " s");
+
+    PartitionTreeDebug::log("Node with " + std::to_string(node.nets.size())
+                            + " nets and " + std::to_string(node.vnets.size())
+                            + " virtual nets routed in " + std::to_string(timer.elapsed_sec())
+                            + " s");
 
     /* This node is finished: add left & right branches to the task queue */
     if (node.left && node.right) {
@@ -95,6 +110,12 @@ void ParallelNetlistRouter<HeapType>::route_partition_tree_node(tbb::task_group&
     } else {
         VTR_ASSERT(!node.left && !node.right); // there shouldn't be a node with a single branch
     }
+}
+
+template<typename HeapType>
+void ParallelNetlistRouter<HeapType>::handle_bb_updated_nets(const std::vector<ParentNetId>& nets) {
+    VTR_ASSERT(_tree);
+    _tree->update_nets(nets);
 }
 
 template<typename HeapType>

--- a/vpr/src/route/SerialNetlistRouter.h
+++ b/vpr/src/route/SerialNetlistRouter.h
@@ -35,6 +35,7 @@ class SerialNetlistRouter : public NetlistRouter {
     ~SerialNetlistRouter() {}
 
     RouteIterResults route_netlist(int itry, float pres_fac, float worst_neg_slack);
+    void handle_bb_updated_nets(const std::vector<ParentNetId>& nets);
     void set_rcv_enabled(bool x);
     void set_timing_info(std::shared_ptr<SetupHoldTimingInfo> timing_info);
 

--- a/vpr/src/route/SerialNetlistRouter.tpp
+++ b/vpr/src/route/SerialNetlistRouter.tpp
@@ -4,11 +4,14 @@
 
 #include "SerialNetlistRouter.h"
 #include "route_net.h"
+#include "vtr_time.h"
 
 template<typename HeapType>
 inline RouteIterResults SerialNetlistRouter<HeapType>::route_netlist(int itry, float pres_fac, float worst_neg_slack) {
     auto& route_ctx = g_vpr_ctx.mutable_routing();
     RouteIterResults out;
+
+    vtr::Timer timer;
 
     /* Sort so net with most sinks is routed first */
     auto sorted_nets = std::vector<ParentNetId>(_net_list.nets().begin(), _net_list.nets().end());
@@ -45,7 +48,9 @@ inline RouteIterResults SerialNetlistRouter<HeapType>::route_netlist(int itry, f
         }
 
         if (flags.retry_with_full_bb) {
-            /* Grow the BB and retry this net right away. */
+            /* Grow the BB and retry this net right away.
+             * We don't populate out.bb_updated_nets for the serial router, since
+             * there is no partition tree to update. */
             route_ctx.route_bb[net_id] = full_device_bb();
             inet--;
             continue;
@@ -59,7 +64,12 @@ inline RouteIterResults SerialNetlistRouter<HeapType>::route_netlist(int itry, f
         }
     }
 
+    PartitionTreeDebug::log("Routing all nets took " + std::to_string(timer.elapsed_sec()) + " s");
     return out;
+}
+
+template<typename HeapType>
+void SerialNetlistRouter<HeapType>::handle_bb_updated_nets(const std::vector<ParentNetId>& /* nets */) {
 }
 
 template<typename HeapType>

--- a/vpr/src/route/netlist_routers.h
+++ b/vpr/src/route/netlist_routers.h
@@ -15,6 +15,7 @@
  * NetlistRouter-derived class is still a NetlistRouter, so that is transparent to the user
  * of this interface. */
 
+#include <vector>
 #include "NetPinTimingInvalidator.h"
 #include "clustered_netlist_utils.h"
 #include "connection_based_routing_fwd.h"
@@ -37,6 +38,9 @@ struct RouteIterResults {
     bool is_routable = true;
     /** Net IDs with changed routing */
     std::vector<ParentNetId> rerouted_nets;
+    /** Net IDs with changed bounding box for this iteration.
+     * Used by the parallel router to update the \ref PartitionTree */
+    std::vector<ParentNetId> bb_updated_nets;
     /** RouterStats for this iteration */
     RouterStats stats;
 };
@@ -52,6 +56,10 @@ class NetlistRouter {
      * route_net for each net, which will handle other global updates.
      * \return RouteIterResults for this iteration. */
     virtual RouteIterResults route_netlist(int itry, float pres_fac, float worst_neg_slack) = 0;
+
+    /** Handle net bounding box updates by passing them to the PartitionTree.
+     * No-op for the serial router */
+    virtual void handle_bb_updated_nets(const std::vector<ParentNetId>& nets) = 0;
 
     /** Enable RCV for each of the ConnectionRouters this NetlistRouter manages.*/
     virtual void set_rcv_enabled(bool x) = 0;

--- a/vpr/src/route/route.cpp
+++ b/vpr/src/route/route.cpp
@@ -308,6 +308,8 @@ bool route(const Netlist<>& net_list,
         float iter_cumm_time = iteration_timer.elapsed_sec();
         float iter_elapsed_time = iter_cumm_time - prev_iter_cumm_time;
 
+        PartitionTreeDebug::log("Iteration " + std::to_string(itry) + " took " +  std::to_string(iter_elapsed_time) + " s");
+
         //Output progress
         print_route_status(itry, iter_elapsed_time, pres_fac, num_net_bounding_boxes_updated, iter_results.stats, overuse_info, wirelength_info, timing_info, est_success_iteration);
 
@@ -424,10 +426,12 @@ bool route(const Netlist<>& net_list,
         /*
          * Prepare for the next iteration
          */
-
         if (router_opts.route_bb_update == e_route_bb_update::DYNAMIC) {
-            num_net_bounding_boxes_updated = dynamic_update_bounding_boxes(iter_results.rerouted_nets);
+            dynamic_update_bounding_boxes(iter_results.rerouted_nets, iter_results.bb_updated_nets);
         }
+
+        num_net_bounding_boxes_updated = iter_results.bb_updated_nets.size();
+        netlist_router->handle_bb_updated_nets(iter_results.bb_updated_nets);
 
         if (itry >= high_effort_congestion_mode_iteration_threshold) {
             //We are approaching the maximum number of routing iterations,

--- a/vpr/src/route/route_utils.cpp
+++ b/vpr/src/route/route_utils.cpp
@@ -8,6 +8,7 @@
 #include "draw_global.h"
 #include "draw_types.h"
 #include "net_delay.h"
+#include "netlist_fwd.h"
 #include "overuse_report.h"
 #include "place_and_route.h"
 #include "route_debug.h"
@@ -68,7 +69,7 @@ bool check_net_delays(const Netlist<>& net_list, NetPinsMatrix<float>& net_delay
 //
 // Typically, only a small minority of nets (typically > 10%) have their BBs updated
 // each routing iteration.
-size_t dynamic_update_bounding_boxes(const std::vector<ParentNetId>& updated_nets) {
+void dynamic_update_bounding_boxes(const std::vector<ParentNetId>& rerouted_nets, std::vector<ParentNetId> out_bb_updated_nets) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& route_ctx = g_vpr_ctx.mutable_routing();
 
@@ -87,9 +88,7 @@ size_t dynamic_update_bounding_boxes(const std::vector<ParentNetId>& updated_net
     int grid_xmax = grid.width() - 1;
     int grid_ymax = grid.height() - 1;
 
-    size_t num_bb_updated = 0;
-
-    for (ParentNetId net : updated_nets) {
+    for (ParentNetId net : rerouted_nets) {
         if (!route_ctx.route_trees[net])
             continue; // Skip if no routing
         if (!route_ctx.net_status.is_routed(net))
@@ -133,13 +132,12 @@ size_t dynamic_update_bounding_boxes(const std::vector<ParentNetId>& updated_net
         }
 
         if (updated_bb) {
-            ++num_bb_updated;
+            out_bb_updated_nets.push_back(net);
             //VTR_LOG("Expanded net %6zu router BB to (%d,%d)x(%d,%d) based on net RR node BB (%d,%d)x(%d,%d)\n", size_t(net),
             //router_bb.xmin, router_bb.ymin, router_bb.xmax, router_bb.ymax,
             //curr_bb.xmin, curr_bb.ymin, curr_bb.xmax, curr_bb.ymax);
         }
     }
-    return num_bb_updated;
 }
 
 bool early_reconvergence_exit_heuristic(const t_router_opts& router_opts,

--- a/vpr/src/route/route_utils.h
+++ b/vpr/src/route/route_utils.h
@@ -2,6 +2,7 @@
 
 /** @file Utility functions used in the top-level router (route.cpp). */
 
+#include "netlist_fwd.h"
 #include "router_stats.h"
 #include "timing_info.h"
 #include "vpr_net_pins_matrix.h"
@@ -47,7 +48,7 @@ WirelengthInfo calculate_wirelength_info(const Netlist<>& net_list, size_t avail
 bool check_net_delays(const Netlist<>& net_list, NetPinsMatrix<float>& net_delay);
 
 /** Update bounding box for net if existing routing is close to boundary */
-size_t dynamic_update_bounding_boxes(const std::vector<ParentNetId>& updated_nets);
+void dynamic_update_bounding_boxes(const std::vector<ParentNetId>& rerouted_nets, std::vector<ParentNetId> out_bb_updated_nets);
 
 /** Early exit code for cases where it is obvious that a successful route will not be found
  * Heuristic: If total wirelength used in first routing iteration is X% of total available wirelength, exit */

--- a/vpr/src/route/spatial_route_tree_lookup.cpp
+++ b/vpr/src/route/spatial_route_tree_lookup.cpp
@@ -17,7 +17,11 @@ SpatialRouteTreeLookup build_route_tree_spatial_lookup(const Netlist<>& net_list
     float bb_area_per_sink = bb_area / fanout;
     float bin_area = BIN_AREA_PER_SINK_FACTOR * bb_area_per_sink;
 
-    float bin_dim = std::ceil(std::sqrt(bin_area));
+    /* Set a minimum bin dimension so that we don't get minuscule bin sizes
+     * when flat routing is enabled and every LUT input becomes a sink.
+     * (P.S. This took some time to debug.) */
+    constexpr float MIN_BIN_DIM = 3;
+    float bin_dim = std::max(MIN_BIN_DIM, std::ceil(std::sqrt(bin_area)));
 
     size_t bins_x = std::ceil(device_ctx.grid.width() / bin_dim);
     size_t bins_y = std::ceil(device_ctx.grid.height() / bin_dim);


### PR DESCRIPTION
Paper version of the net decomposing router. Major fixes are:

1. Don't count pruned sinks towards high fanout case's chan_nodes_added
2. Add a minimum bin size for the HF case to prevent minuscule bins when flat routing is enabled
3. Incrementally update the PartitionTree instead of rebuilding on every iteration