### PR TITLE
[NO_GRAPHICS][Warnings] Resolved Unused Variables

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -204,6 +204,7 @@ void init_graphics_state(bool show_graphics_val,
     (void)route_type;
     (void)save_graphics;
     (void)graphics_commands;
+    (void)is_flat;
 #endif // NO_GRAPHICS
 }
 

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1711,6 +1711,9 @@ static e_move_result try_swap(const t_annealing_state* state,
     if (manual_move_enabled) {
 #ifndef NO_GRAPHICS
         create_move_outcome = manual_move_display_and_propose(manual_move_generator, blocks_affected, proposed_action.move_type, rlim, placer_opts, criticalities);
+#else //NO_GRAPHICS
+        // Cast to void to explicitly avoid warning.
+        (void)manual_move_generator;
 #endif //NO_GRAPHICS
     } else if (router_block_move) {
         // generate a move where two random router blocks are swapped

--- a/vpr/src/route/route_utilization.cpp
+++ b/vpr/src/route/route_utilization.cpp
@@ -36,6 +36,9 @@ vtr::Matrix<float> calculate_routing_usage(t_rr_type rr_type, bool is_flat, bool
             if (!draw_state->draw_layer_display[layer_num].visible)
                 continue; // don't count usage if layer is not visible
         }
+#else
+        // Cast to void to avoid warning.
+        (void)is_print;
 #endif
 
         if (rr_type == CHANX) {


### PR DESCRIPTION
There were some warnings of unused variables when NO_GRAPHICS was declared. Explicitly cast these variables to void to mark them as purposely unused.

This was one of the issues in issue #2518 
