### PR TITLE
[Yosys][Warnings] Fixed Fatal Not Git Repo Warning

### DIFF
--- a/yosys/Makefile
+++ b/yosys/Makefile
@@ -149,7 +149,8 @@ YOSYS_VER := 0.32
 # back to calling git directly.
 TARBALL_GIT_REV := $(shell cat $(YOSYS_SRC)/.gitcommit)
 ifeq ($(TARBALL_GIT_REV),$$Format:%h$$)
-GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)
+#GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)
+GIT_REV := $(shell echo UNKNOWN)
 else
 GIT_REV := $(TARBALL_GIT_REV)
 endif


### PR DESCRIPTION
Fixed a warning where "fatal: not a git repository: './/.git' was being printed during builds of VPR.

This is caused by Yosys being included as a subtree instead of a git submodule. The Makefile in Yosys is trying to get the current version of git for Yosys but it cannot do it since it is not a git repo.

Just commented out the line causing the warning for now.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This was actually a very interesting warning to debug.

I started by debugging the make command without using multiple threads to see what CMake command was causing this warning:
```
make -d &> temp.dump
```

Looking into the temp.dump file, I found that the warning was being printed when generating "yosys-bin":
<img width="400" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/79803a27-a494-45f9-b11d-b79e9ded2109">
Not only that, but it was being printed twice.

I then opened up yosys' CMakeList to find this beauty:
<img width="604" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/752a9b4f-ce65-45b4-a026-6d4142d2c56c">
It looks like all this CMake is doing is running another Makefile, twice. I should note that the "-f" argument should be set here since this is, in-fact, an "out-of-tree" build.

Looking into Yosys' Makefile, we find the culprit:
<img width="658" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/e16ecdeb-df23-48a4-8c41-1bb46c3e74d9">
`YOSYS_SRC` is a variable that should point to the directory of the current Makefile as defined here:
<img width="363" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/431c293f-90f0-4cfa-b269-12eaf73e4a5d">
However, since the "-f" argument was not set before, this gets initialized to "./"; hence the warning. Setting the "-f" argument does not fix the warning however, it just makes it better:
<img width="590" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/218700dc-bbc0-4749-81d3-001a18470c48">
Obviously, we still get the same warning since this is not a git repository, since it was included into VTR as a git subtree. To fix this issue I just commented out the line causing this issue since all it was doing was failing to find the git version. Perhaps the Yosys infrastructure should be revisited if we plan to support this long term.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See issue #2518 
