### PR TITLE
Removed Warnings in libvtrutil and vqm2blif

### DIFF
--- a/libs/libvtrutil/test/test_array_view.cpp
+++ b/libs/libvtrutil/test/test_array_view.cpp
@@ -8,7 +8,7 @@ struct test_tag;
 using TestStrongId = vtr::StrongId<test_tag>;
 
 TEST_CASE("Array view", "[array_view/array_view]") {
-    std::array<uint16_t, 10> arr;
+    std::array<uint16_t, 10> arr = {0};
     vtr::array_view<uint16_t> arr_view(arr.data(), arr.size());
 
     const vtr::array_view<uint16_t>& carr_view = arr_view;
@@ -56,7 +56,7 @@ TEST_CASE("Array view", "[array_view/array_view]") {
 }
 
 TEST_CASE("Array view id", "[array_view/array_view_id]") {
-    std::array<uint16_t, 10> arr;
+    std::array<uint16_t, 10> arr = {0};
     vtr::array_view_id<TestStrongId, uint16_t> arr_view(arr.data(), arr.size());
 
     const vtr::array_view_id<TestStrongId, uint16_t>& carr_view = arr_view;

--- a/utils/vqm2blif/src/base/cleanup.cpp
+++ b/utils/vqm2blif/src/base/cleanup.cpp
@@ -297,7 +297,7 @@ void remove_one_lut_nodes ( busvec* buses, std::unordered_map<std::string, int> 
 	t_node_port_association* source_port;
 	t_node_port_association* prev_port;
 	netvec* prev_bus;
-	t_net* prev_net;
+	t_net* prev_net = nullptr;
 
 	netvec* vcc_bus = get_bus_from_hash (hash_table, const_cast<char*>("vcc"), buses);
 	VTR_ASSERT(vcc_bus != NULL);
@@ -658,7 +658,7 @@ void verify_netlist ( t_node** nodes, int num_nodes, busvec* buses, std::unorder
 		auto hash_entry = hash_table.find(ref_pin->name);
 
 		VTR_ASSERT(hash_entry != hash_table.end());
-		VTR_ASSERT((unsigned int)hash_entry->second == i);
+		VTR_ASSERT((unsigned int)hash_entry->second == (unsigned int)i);
 
 		for (int j = 0; (unsigned int)j < temp_bus->size(); j++){
 			temp_net = &(temp_bus->at(j));


### PR DESCRIPTION
Fixed a couple of warnings in libvtrutil and vqm2blif

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See issue #2518