### PR TITLE
[RR_GRAPH] Fixed Bug in LLVM17 Build

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_storage.cpp
+++ b/libs/librrgraph/src/base/rr_graph_storage.cpp
@@ -155,6 +155,13 @@ class edge_sort_iterator {
     using pointer = edge_swapper*;
     using difference_type = ssize_t;
 
+    // In order for this class to be used as an iterator within the std library,
+    // it needs to "act" like a pointer. One thing that it should do is that a
+    // const variable of this type should be de-referenceable. Therefore, this
+    // method should be const method; however, this requires modifying the class
+    // and may yield worst performance. For now the std::stable_sort allows this
+    // but in the future it may not. If this breaks, this is why.
+    // See issue #2517 and PR #2522
     edge_swapper& operator*() {
         return this->swapper_;
     }
@@ -419,7 +426,7 @@ size_t t_rr_graph_storage::count_rr_switches(
     // values.
     //
     // This sort is safe to do because partition_edges() has not been invoked yet.
-    std::sort(
+    std::stable_sort(
         edge_sort_iterator(this, 0),
         edge_sort_iterator(this, edge_dest_node_.size()),
         edge_compare_dest_node());
@@ -527,7 +534,7 @@ void t_rr_graph_storage::partition_edges(const vtr::vector<RRSwitchId, t_rr_swit
     //    by assign_first_edges()
     //  - Edges within a source node have the configurable edges before the
     //    non-configurable edges.
-    std::sort(
+    std::stable_sort(
         edge_sort_iterator(this, 0),
         edge_sort_iterator(this, edge_src_node_.size()),
         edge_compare_src_node_and_configurable_first(rr_switches));


### PR DESCRIPTION
The std::sort function requires operands to be "pointer-like", this requires that de-referencing a const pointer should be allowed.

This was not an issue in the past, but in LLVM17 this property is required. The edge_sort_iterator did not follow this property. This has been fixed.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
See issue #2517 

The LLVM17 build failed due to a const edge_sort_iterator unable to be de-referenced. This PR fixes that issue.

The problem is that this required the `swapper_` member to be a pointer to allow this to work. This means that the `swapper_` object needs to be declared on the heap. This may have affects on the performance of this implementation. To prevent regression in performance, this needs to be profiled to ensure we do not slow down the current high-priority builds for future builds.

#### Related Issue
issue #2517 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the quick and hard regression tests.

Still need to profile to ensure the performance does not regress.
