### PR TITLE
Update benchmarks.rst to fix a typo where we said VTR instead of Koios

### DIFF
--- a/doc/src/vtr/benchmarks.rst
+++ b/doc/src/vtr/benchmarks.rst
@@ -102,7 +102,7 @@ These designs use many precisions including binary, different fixed point types 
     proxy               Proxy/synthetic benchmarks
     =================   ======================================
 
-The VTR benchmarks are provided as Verilog (enabling full flexibility to modify and change how the designs are implemented) under: ::
+The Koios benchmarks are provided as Verilog (enabling full flexibility to modify and change how the designs are implemented) under: ::
 
     $VTR_ROOT/vtr_flow/benchmarks/verilog/koios
 


### PR DESCRIPTION
Typo fix : should be Koios instead of VTR in one spot in the docs.
