### PR TITLE
[Yosys][Warnings] Fixed Make Being Called With Multiple Threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,11 +418,13 @@ if(${WITH_PARMYS}) # define cmake params to compile Yosys
         set(MAKE_PROGRAM "make")
     endif()
 
-    if(NOT DEFINED "${CMAKE_BUILD_PARALLEL_LEVEL}")
-        set(CUSTOM_BUILD_PARALLEL_LEVEL 16)
-    else()
-        set(CUSTOM_BUILD_PARALLEL_LEVEL "${CMAKE_BUILD_PARALLEL_LEVEL}")
-    endif()
+    # Commented out since a make file should not call another make command with
+    # threads. It should pass this information from the parent automatically.
+    # if(NOT DEFINED "${CMAKE_BUILD_PARALLEL_LEVEL}")
+    #     set(CUSTOM_BUILD_PARALLEL_LEVEL 16)
+    # else()
+    #     set(CUSTOM_BUILD_PARALLEL_LEVEL "${CMAKE_BUILD_PARALLEL_LEVEL}")
+    # endif()
     add_subdirectory(yosys)
 endif()
 

--- a/yosys/CMakeLists.txt
+++ b/yosys/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_command(OUTPUT yosys-bin
 #            -C ${CMAKE_CURRENT_BINARY_DIR}
 #            -f ${CMAKE_CURRENT_SOURCE_DIR}/Makefile #(out-of-tree) build directory
             PREFIX=${CMAKE_BINARY_DIR}
-            -j${CUSTOM_BUILD_PARALLEL_LEVEL}
+#            -j${CUSTOM_BUILD_PARALLEL_LEVEL}
             > /dev/null
 
         COMMAND ${MAKE_PROGRAM} install ENABLE_ABC=0


### PR DESCRIPTION
CMake was calling another Make command, but was explicitly passing the number of threads to use. Make files should not pass the number of threads to use since it may cause more threads to be consumed than what the user intended.

For example, if the user used `make -j10`, the parent make would use 10 threads, and the child make would also use 10 threads (20 threads in total); but this is not what the user wanted. I think CMake recognized this and was suppressing this behaviour anyways. I believe that CMake will pass the number of threads for the child make to use anyways, but in a way that would prevent the above issue.

Removed the ability to set the number of threads for Yosys builds to handle the warning.

See issue #2518 
