### PR TITLE
[CI][XML] Added XMLLINT to CI Dependencies

### DIFF
--- a/.github/scripts/install_dependencies.sh
+++ b/.github/scripts/install_dependencies.sh
@@ -29,6 +29,7 @@ sudo apt install -y \
   libncurses5-dev \
   libx11-dev \
   libxft-dev \
+  libxml2-utils \
   libxml++2.6-dev \
   libreadline-dev \
   tcllib \


### PR DESCRIPTION
A warning was being generated by EZGL when pre-processing the resources for main.ui. This could not be removed since the library we use to preprocess always tries to use XMLLINT even when it is not used.

If the system does not have XMLLINT installed, it will always give a warning saying it is not installed.

As a quick fix, we can make it so the CI has it installed, since this is technically the use case we want tested.

See issue #2518 
