### PR TITLE
Fix fasm warnings

### DIFF
--- a/blifexplorer/CMakeLists.txt
+++ b/blifexplorer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project("blifexplorer")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/libs/libvtrutil/src/vtr_util.cpp
+++ b/libs/libvtrutil/src/vtr_util.cpp
@@ -26,7 +26,7 @@ static int cont;                 /* line continued? (used by strtok)*/
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const char* text, const std::string& delims) {
+std::vector<std::string> split(const char* text, std::string_view delims) {
     if (text) {
         std::string text_str(text);
         return split(text_str, delims);
@@ -39,13 +39,13 @@ std::vector<std::string> split(const char* text, const std::string& delims) {
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const std::string& text, const std::string& delims) {
+std::vector<std::string> split(std::string_view text, std::string_view delims) {
     std::vector<std::string> tokens;
 
     std::string curr_tok;
     for (char c : text) {
         if (delims.find(c) != std::string::npos) {
-            //Delimeter character
+            //Delimiter character
             if (!curr_tok.empty()) {
                 //At the end of the token
 
@@ -58,7 +58,7 @@ std::vector<std::string> split(const std::string& text, const std::string& delim
                 //Pass
             }
         } else {
-            //Non-delimeter append to token
+            //Non-delimiter append to token
             curr_tok += c;
         }
     }

--- a/libs/libvtrutil/src/vtr_util.cpp
+++ b/libs/libvtrutil/src/vtr_util.cpp
@@ -72,18 +72,18 @@ std::vector<std::string> split(std::string_view text, std::string_view delims) {
 }
 
 ///@brief Returns 'input' with the first instance of 'search' replaced with 'replace'
-std::string replace_first(const std::string& input, const std::string& search, const std::string& replace) {
+std::string replace_first(std::string_view input, std::string_view search, std::string_view replace) {
     auto pos = input.find(search);
 
     std::string output(input, 0, pos);
     output += replace;
-    output += std::string(input, pos + search.size());
+    output += input.substr(pos + search.size());
 
     return output;
 }
 
 ///@brief Returns 'input' with all instances of 'search' replaced with 'replace'
-std::string replace_all(const std::string& input, const std::string& search, const std::string& replace) {
+std::string replace_all(std::string_view input, std::string_view search, std::string_view replace) {
     std::string output;
 
     size_t last = 0;
@@ -101,8 +101,8 @@ std::string replace_all(const std::string& input, const std::string& search, con
     return output;
 }
 
-///@brief Retruns true if str starts with prefix
-bool starts_with(const std::string& str, const std::string& prefix) {
+///@brief Returns true if str starts with prefix
+bool starts_with(const std::string& str, std::string_view prefix) {
     return str.find(prefix) == 0;
 }
 
@@ -195,7 +195,7 @@ char* strdup(const char* str) {
  * and/or correct 'unexpected' behaviour of the standard c-functions
  */
 template<class T>
-T atoT(const std::string& value, const std::string& type_name) {
+T atoT(const std::string& value, std::string_view type_name) {
     //The c version of atof doesn't catch errors.
     //
     //This version uses stringstream to detect conversion errors
@@ -461,8 +461,8 @@ bool file_exists(const char* filename) {
  *
  * Returns true if the extension is correct, and false otherwise.
  */
-bool check_file_name_extension(const std::string& file_name,
-                               const std::string& file_extension) {
+bool check_file_name_extension(std::string_view file_name,
+                               std::string_view file_extension) {
     auto ext = std::filesystem::path(file_name).extension();
     return ext == file_extension;
 }

--- a/libs/libvtrutil/src/vtr_util.h
+++ b/libs/libvtrutil/src/vtr_util.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <cstdarg>
 #include <array>
 
@@ -14,8 +15,8 @@ namespace vtr {
  *
  * The split strings (excluding the delimiters) are returned
  */
-std::vector<std::string> split(const char* text, const std::string& delims = " \t\n");
-std::vector<std::string> split(const std::string& text, const std::string& delims = " \t\n");
+std::vector<std::string> split(const char* text, std::string_view string_view = " \t\n");
+std::vector<std::string> split(std::string_view text, std::string_view delims = " \t\n");
 
 ///@brief Returns 'input' with the first instance of 'search' replaced with 'replace'
 std::string replace_first(const std::string& input, const std::string& search, const std::string& replace);

--- a/libs/libvtrutil/src/vtr_util.h
+++ b/libs/libvtrutil/src/vtr_util.h
@@ -19,13 +19,13 @@ std::vector<std::string> split(const char* text, std::string_view string_view = 
 std::vector<std::string> split(std::string_view text, std::string_view delims = " \t\n");
 
 ///@brief Returns 'input' with the first instance of 'search' replaced with 'replace'
-std::string replace_first(const std::string& input, const std::string& search, const std::string& replace);
+std::string replace_first(std::string_view input, std::string_view search, std::string_view replace);
 
 ///@brief Returns 'input' with all instances of 'search' replaced with 'replace'
-std::string replace_all(const std::string& input, const std::string& search, const std::string& replace);
+std::string replace_all(std::string_view input, std::string_view search, std::string_view replace);
 
 ///@brief Retruns true if str starts with prefix
-bool starts_with(const std::string& str, const std::string& prefix);
+bool starts_with(const std::string& str, std::string_view prefix);
 
 ///@brief Returns a std::string formatted using a printf-style format string
 std::string string_fmt(const char* fmt, ...);
@@ -40,13 +40,13 @@ std::string vstring_fmt(const char* fmt, va_list args);
  *  would return "home/user/my_files/test.blif"
  */
 template<typename Iter>
-std::string join(Iter begin, Iter end, std::string delim);
+std::string join(Iter begin, Iter end, std::string_view delim);
 
 template<typename Container>
-std::string join(Container container, std::string delim);
+std::string join(Container container, std::string_view delim);
 
 template<typename T>
-std::string join(std::initializer_list<T> list, std::string delim);
+std::string join(std::initializer_list<T> list, std::string_view delim);
 
 template<typename Container>
 void uniquify(Container container);
@@ -70,7 +70,7 @@ double atod(const std::string& value);
  */
 int get_file_line_number_of_last_opened_file();
 bool file_exists(const char* filename);
-bool check_file_name_extension(const std::string& file_name, const std::string& file_extension);
+bool check_file_name_extension(std::string_view file_name, std::string_view file_extension);
 
 extern std::string out_file_prefix;
 
@@ -83,7 +83,7 @@ std::vector<std::string> ReadLineTokens(FILE* InFile, int* LineNum);
  * @brief Template join function implementation
  */
 template<typename Iter>
-std::string join(Iter begin, Iter end, std::string delim) {
+std::string join(Iter begin, Iter end, std::string_view delim) {
     std::string joined_str;
     for (auto iter = begin; iter != end; ++iter) {
         joined_str += *iter;
@@ -95,12 +95,12 @@ std::string join(Iter begin, Iter end, std::string delim) {
 }
 
 template<typename Container>
-std::string join(Container container, std::string delim) {
+std::string join(Container container, std::string_view delim) {
     return join(std::begin(container), std::end(container), delim);
 }
 
 template<typename T>
-std::string join(std::initializer_list<T> list, std::string delim) {
+std::string join(std::initializer_list<T> list, std::string_view delim) {
     return join(list.begin(), list.end(), delim);
 }
 

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -1,14 +1,10 @@
 #include "fasm.h"
 
 #include <algorithm>
-#include <fstream>
-#include <iomanip>
 #include <iostream>
-#include <iterator>
 #include <set>
 #include <sstream>
 #include <string>
-#include <unordered_map>
 
 #include "globals.h"
 
@@ -16,12 +12,9 @@
 
 #include "vtr_assert.h"
 #include "vtr_logic.h"
-#include "vtr_version.h"
 #include "vpr_error.h"
 
 #include "atom_netlist_utils.h"
-#include "netlist_writer.h"
-#include "vpr_utils.h"
 
 #include "fasm_utils.h"
 
@@ -77,7 +70,7 @@ void FasmWriterVisitor::visit_clb_impl(ClusterBlockId blk_id, const t_pb* clb) {
       std::vector<std::string> tag_defs = vtr::split(value->front().as_string().get(strings_), "\n");
       for (auto& tag_def: tag_defs) {
         auto parts = split_fasm_entry(tag_def, "=:", "\t ");
-        if (parts.size() == 0) {
+        if (parts.empty()) {
           continue;
         }
 
@@ -86,7 +79,7 @@ void FasmWriterVisitor::visit_clb_impl(ClusterBlockId blk_id, const t_pb* clb) {
         VTR_ASSERT(tags_.count(parts.at(0)) == 0);
 
         // When the value is "NULL" then substitute empty string
-        if (!parts.at(1).compare("NULL")) {
+        if (parts.at(1) == "NULL") {
             tags_[parts.at(0)] = "";
         }
         else {
@@ -179,7 +172,7 @@ std::string FasmWriterVisitor::handle_fasm_prefix(const t_metadata_dict *meta,
 }
 
 std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const {
-  std::string clb_prefix = "";
+  std::string clb_prefix;
 
   const t_pb *pb_for_graph_node = nullptr;
 
@@ -272,7 +265,7 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
   std::string clb_prefix = build_clb_prefix(pb, pb_graph_node, &is_parent_pb_null);
   clb_prefix_map_.insert(std::make_pair(pb_graph_node, clb_prefix));
   clb_prefix_ = clb_prefix;
-  if (is_parent_pb_null == true) {
+  if (is_parent_pb_null) {
     return;
   }
 
@@ -365,7 +358,7 @@ static LogicVec lut_outputs(const t_pb* atom_pb, size_t num_inputs, const t_pb_r
       if(truth_table.size() == 1) {
         VTR_ASSERT(truth_table[0].size() == 1);
         lut.SetConstant(truth_table[0][0]);
-      } else if(truth_table.size() == 0) {
+      } else if(truth_table.empty()) {
         lut.SetConstant(vtr::LogicValue::FALSE);
       } else {
         vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__, "LUT truth table unexpected size is %d", truth_table.size());
@@ -420,7 +413,7 @@ static LogicVec lut_outputs(const t_pb* atom_pb, size_t num_inputs, const t_pb_r
     return lut.table();
 }
 
-const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* pb_graph_node, std::string target_type) const {
+const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* pb_graph_node, const std::string& target_type) const {
   if(pb_graph_node == nullptr) {
     return nullptr;
   }
@@ -470,9 +463,8 @@ const LutOutputDefinition* FasmWriterVisitor::find_lut(const t_pb_graph_node* pb
         VTR_ASSERT(value != nullptr);
 
         std::vector<std::pair<std::string, LutOutputDefinition>> luts;
-        luts.push_back(std::make_pair(
-            vtr::string_fmt("%s[0]", pb_graph_node->pb_type->name),
-            LutOutputDefinition(value->as_string().get(strings_))));
+        luts.emplace_back(vtr::string_fmt("%s[0]", pb_graph_node->pb_type->name),
+                          LutOutputDefinition(value->as_string().get(strings_)));
 
         auto insert_result = lut_definitions_.insert(
             std::make_pair(pb_graph_node->pb_type, luts));
@@ -505,8 +497,7 @@ const LutOutputDefinition* FasmWriterVisitor::find_lut(const t_pb_graph_node* pb
                       fasm_lut_str.c_str());
           }
 
-          luts.push_back(std::make_pair(
-              parts[1], LutOutputDefinition(parts[0])));
+          luts.emplace_back(parts[1], LutOutputDefinition(parts[0]));
         }
 
         auto insert_result = lut_definitions_.insert(
@@ -569,9 +560,9 @@ void FasmWriterVisitor::check_for_param(const t_pb *atom) {
         VTR_ASSERT(value != nullptr);
 
         std::string fasm_params_str = value->as_string().get(strings_);
-        for(const auto param : vtr::split(fasm_params_str, "\n")) {
+        for(const auto& param : vtr::split(fasm_params_str, "\n")) {
           auto param_parts = split_fasm_entry(param, "=", "\t ");
-            if(param_parts.size() == 0) {
+            if(param_parts.empty()) {
                 continue;
             }
             VTR_ASSERT(param_parts.size() == 2);
@@ -589,10 +580,10 @@ void FasmWriterVisitor::check_for_param(const t_pb *atom) {
 
     auto &params = iter->second;
 
-    for(auto param : atom_ctx.nlist.block_params(atom_blk_id)) {
+    for(const auto& param : atom_ctx.nlist.block_params(atom_blk_id)) {
         auto feature = params.EmitFasmFeature(param.first, param.second);
 
-        if(feature.size() > 0) {
+        if(!feature.empty()) {
             output_fasm_features(feature);
         }
     }
@@ -668,7 +659,7 @@ void FasmWriterVisitor::find_clb_prefix(const t_pb_graph_node *node,
     }
 }
 
-void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux_str,
+void FasmWriterVisitor::output_fasm_mux(const std::string& fasm_mux_str,
                                         t_interconnect *interconnect,
                                         const t_pb_graph_pin *mux_input_pin) {
     auto *pb_name = mux_input_pin->parent_node->pb_type->name;
@@ -697,7 +688,7 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux_str,
     for(const auto &mux_input : mux_inputs) {
       auto mux_parts = split_fasm_entry(mux_input, "=:", "\t ");
 
-      if(mux_parts.size() == 0) {
+      if(mux_parts.empty()) {
         // Swallow whitespace.
         continue;
       }
@@ -753,11 +744,11 @@ void FasmWriterVisitor::output_fasm_mux(std::string fasm_mux_str,
         pb_name, pb_index, port_name, pin_index, fasm_mux_str.c_str());
 }
 
-void FasmWriterVisitor::output_fasm_features(const std::string features) const {
+void FasmWriterVisitor::output_fasm_features(const std::string& features) const {
   output_fasm_features(features, clb_prefix_, blk_prefix_);
 }
 
-void FasmWriterVisitor::output_fasm_features(const std::string features, const std::string clb_prefix, const std::string blk_prefix) const {
+void FasmWriterVisitor::output_fasm_features(const std::string& features, const std::string& clb_prefix, const std::string& blk_prefix) const {
   std::stringstream os(features);
 
   while(os) {

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -413,7 +413,7 @@ static LogicVec lut_outputs(const t_pb* atom_pb, size_t num_inputs, const t_pb_r
     return lut.table();
 }
 
-const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* pb_graph_node, const std::string& target_type) const {
+const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* pb_graph_node, std::string_view target_type) const {
   if(pb_graph_node == nullptr) {
     return nullptr;
   }
@@ -659,7 +659,7 @@ void FasmWriterVisitor::find_clb_prefix(const t_pb_graph_node *node,
     }
 }
 
-void FasmWriterVisitor::output_fasm_mux(const std::string& fasm_mux_str,
+void FasmWriterVisitor::output_fasm_mux(std::string_view fasm_mux_str,
                                         t_interconnect *interconnect,
                                         const t_pb_graph_pin *mux_input_pin) {
     auto *pb_name = mux_input_pin->parent_node->pb_type->name;
@@ -741,15 +741,15 @@ void FasmWriterVisitor::output_fasm_mux(const std::string& fasm_mux_str,
 
     vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
         "fasm_mux %s[%d].%s[%d] found no matches in:\n%s\n",
-        pb_name, pb_index, port_name, pin_index, fasm_mux_str.c_str());
+        pb_name, pb_index, port_name, pin_index, fasm_mux_str.data());
 }
 
 void FasmWriterVisitor::output_fasm_features(const std::string& features) const {
   output_fasm_features(features, clb_prefix_, blk_prefix_);
 }
 
-void FasmWriterVisitor::output_fasm_features(const std::string& features, const std::string& clb_prefix, const std::string& blk_prefix) const {
-  std::stringstream os(features);
+void FasmWriterVisitor::output_fasm_features(const std::string& features, std::string_view clb_prefix, std::string_view blk_prefix) const {
+  std::istringstream os(features);
 
   while(os) {
     std::string feature;

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -66,12 +66,12 @@ class FasmWriterVisitor : public NetlistVisitor {
       void finish_impl() override;
 
   private:
-      void output_fasm_features(const std::string features) const;
-      void output_fasm_features(const std::string features, const std::string clb_prefix, const std::string blk_prefix) const;
+      void output_fasm_features(const std::string& features) const;
+      void output_fasm_features(const std::string& features, const std::string& clb_prefix, const std::string& blk_prefix) const;
       void check_features(const t_metadata_dict *meta) const;
       void check_interconnect(const t_pb_routes &pb_route, int inode);
       void check_for_lut(const t_pb* atom);
-      void output_fasm_mux(std::string fasm_mux, t_interconnect *interconnect, const t_pb_graph_pin *mux_input_pin);
+      void output_fasm_mux(const std::string& fasm_mux, t_interconnect *interconnect, const t_pb_graph_pin *mux_input_pin);
       void walk_routing();
       void walk_route_tree(const RRGraphBuilder& rr_graph_builder, const RouteTreeNode& root);
       std::string build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const;
@@ -83,7 +83,7 @@ class FasmWriterVisitor : public NetlistVisitor {
         bool *have_prefix, std::string *clb_prefix) const;
       std::string handle_fasm_prefix(const t_metadata_dict *meta,
         const t_pb_graph_node *pb_graph_node, const t_pb_type *pb_type) const;
-      const t_metadata_dict *get_fasm_type(const t_pb_graph_node* pb_graph_node, std::string target_type) const;
+      const t_metadata_dict *get_fasm_type(const t_pb_graph_node* pb_graph_node, const std::string& target_type) const;
 
       vtr::string_internment *strings_;
       std::ostream& os_;

--- a/utils/fasm/src/fasm.h
+++ b/utils/fasm/src/fasm.h
@@ -15,6 +15,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -67,11 +68,11 @@ class FasmWriterVisitor : public NetlistVisitor {
 
   private:
       void output_fasm_features(const std::string& features) const;
-      void output_fasm_features(const std::string& features, const std::string& clb_prefix, const std::string& blk_prefix) const;
+      void output_fasm_features(const std::string& features, std::string_view clb_prefix, std::string_view blk_prefix) const;
       void check_features(const t_metadata_dict *meta) const;
       void check_interconnect(const t_pb_routes &pb_route, int inode);
       void check_for_lut(const t_pb* atom);
-      void output_fasm_mux(const std::string& fasm_mux, t_interconnect *interconnect, const t_pb_graph_pin *mux_input_pin);
+      void output_fasm_mux(std::string_view fasm_mux, t_interconnect *interconnect, const t_pb_graph_pin *mux_input_pin);
       void walk_routing();
       void walk_route_tree(const RRGraphBuilder& rr_graph_builder, const RouteTreeNode& root);
       std::string build_clb_prefix(const t_pb *pb, const t_pb_graph_node* pb_graph_node, bool* is_parent_pb_null) const;
@@ -83,7 +84,7 @@ class FasmWriterVisitor : public NetlistVisitor {
         bool *have_prefix, std::string *clb_prefix) const;
       std::string handle_fasm_prefix(const t_metadata_dict *meta,
         const t_pb_graph_node *pb_graph_node, const t_pb_type *pb_type) const;
-      const t_metadata_dict *get_fasm_type(const t_pb_graph_node* pb_graph_node, const std::string& target_type) const;
+      const t_metadata_dict *get_fasm_type(const t_pb_graph_node* pb_graph_node, std::string_view target_type) const;
 
       vtr::string_internment *strings_;
       std::ostream& os_;

--- a/utils/fasm/src/fasm_utils.cpp
+++ b/utils/fasm/src/fasm_utils.cpp
@@ -5,7 +5,7 @@
 
 namespace fasm {
 
-void parse_name_with_optional_index(const std::string in, std::string *name, int *index) {
+void parse_name_with_optional_index(std::string_view in, std::string *name, int *index) {
   auto in_parts = vtr::split(in, "[]");
 
   if(in_parts.size() == 1) {
@@ -16,13 +16,13 @@ void parse_name_with_optional_index(const std::string in, std::string *name, int
     *index = vtr::atoi(in_parts[1]);
   } else {
     vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
-              "Cannot parse %s.", in.c_str());
+              "Cannot parse %s.", in.data());
   }
 }
 
 std::vector<std::string> split_fasm_entry(std::string entry,
-                                                 std::string delims,
-                                                 std::string ignore) {
+                                          std::string_view delims,
+                                          std::string_view ignore) {
   for (size_t ii=0; ii<entry.length(); ii++) {
     while (ignore.find(entry[ii]) != std::string::npos) {
       entry.erase(ii, 1);
@@ -32,7 +32,7 @@ std::vector<std::string> split_fasm_entry(std::string entry,
   return vtr::split(entry, delims);
 }
 
-std::vector<std::string> find_tags_in_feature (const std::string& a_String) {
+std::vector<std::string> find_tags_in_feature (std::string_view a_String) {
     const std::regex regex ("(\\{[a-zA-Z0-9_]+\\})");
 
     std::vector<std::string> tags;
@@ -51,17 +51,17 @@ std::vector<std::string> find_tags_in_feature (const std::string& a_String) {
     return tags;
 }
 
-std::string substitute_tags (const std::string& a_Feature, const std::map<const std::string, std::string>& a_Tags) {
+std::string substitute_tags (std::string_view a_Feature, const std::map<const std::string, std::string>& a_Tags) {
 
     // First list tags that are given in the feature string
     auto tags = find_tags_in_feature(a_Feature);
     if (tags.empty()) {
-        return a_Feature;
+        return std::string{a_Feature};
     }
 
     // Check if those tags are defined, If not then throw an error
     bool have_errors = false;
-    for (auto tag: tags) {
+    for (const auto& tag: tags) {
         if (a_Tags.count(tag) == 0) {
             vtr::printf_error(__FILE__, __LINE__, "fasm placeholder '%s' not defined!", tag.c_str());
             have_errors = true;
@@ -71,13 +71,13 @@ std::string substitute_tags (const std::string& a_Feature, const std::map<const 
     if (have_errors) {
         vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
             "fasm feature '%s' contains placeholders that are not defined for the tile that it is used in!",
-            a_Feature.c_str()
+            a_Feature.data()
         );
     }
 
     // Substitute tags
     std::string feature(a_Feature);
-    for (auto tag: tags) {
+    for (const auto& tag: tags) {
         std::regex regex("\\{" + tag + "\\}");
         feature = std::regex_replace(feature, regex, a_Tags.at(tag));
     }

--- a/utils/fasm/src/fasm_utils.h
+++ b/utils/fasm/src/fasm_utils.h
@@ -2,6 +2,7 @@
 #define UTILS_FASM_FASM_UTILS_H_
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include <map>
 
@@ -13,27 +14,27 @@ namespace fasm {
 // in="A[5]" parts to *name="A", *index=5
 //
 // Throws vpr exception if parsing fails.
-void parse_name_with_optional_index(const std::string in, std::string *name, int *index);
+void parse_name_with_optional_index(std::string_view in, std::string *name, int *index);
 
 // Split FASM entry into parts.
 //
 // delims - Characters to split on.
 // ignore - Characters to ignore.
 std::vector<std::string> split_fasm_entry(std::string entry,
-                                                 std::string delims,
-                                                 std::string ignore);
+                                          std::string_view delims,
+                                          std::string_view ignore);
 
 // Searches for tags in given string, returns their names in a vector.
-std::vector<std::string> find_tags_in_feature (const std::string& a_String);
+std::vector<std::string> find_tags_in_feature(std::string_view a_String);
 
 // Substitutes tags found in a string with their values provided by the map.
-// Thorws an error if a tag is found in the string and its value is not present
+// Throws an error if a tag is found in the string and its value is not present
 // in the map.
 //
 // a_Feature - Fasm feature string (or any other string)
 // a_Tags    - Map with tags and their values
-std::string substitute_tags (const std::string& a_Feature,
-                             const std::map<const std::string, std::string>& a_Tags);
+std::string substitute_tags(std::string_view a_Feature,
+                            const std::map<const std::string, std::string>& a_Tags);
 
 } // namespace fasm
 

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -443,7 +443,7 @@ struct BlifAllocCallback : public blifparse::Callback {
     }
 
   private:
-    const t_model* find_model(std::string name) {
+    const t_model* find_model(std::string_view name) {
         const t_model* arch_model = nullptr;
         for (const t_model* arch_models : {user_arch_models_, library_arch_models_}) {
             arch_model = arch_models;
@@ -461,12 +461,12 @@ struct BlifAllocCallback : public blifparse::Callback {
         }
         if (!arch_model) {
             vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_, "Failed to find matching architecture model for '%s'\n",
-                      name.c_str());
+                      name.data());
         }
         return arch_model;
     }
 
-    const t_model_ports* find_model_port(const t_model* blk_model, std::string port_name) {
+    const t_model_ports* find_model_port(const t_model* blk_model, const std::string& port_name) {
         //We need to handle both single, and multi-bit port names
         //
         //By convention multi-bit port names have the bit index stored in square brackets
@@ -582,7 +582,7 @@ struct BlifAllocCallback : public blifparse::Callback {
             } else {
                 VTR_ASSERT(blif_model.block_type(blk_id) == AtomBlockType::OUTPAD);
 
-                auto raw_output_name = blif_model.block_name(blk_id);
+                const auto& raw_output_name = blif_model.block_name(blk_id);
 
                 std::string output_name = vtr::replace_first(raw_output_name, OUTPAD_NAME_PREFIX, "");
 
@@ -618,7 +618,7 @@ struct BlifAllocCallback : public blifparse::Callback {
      * @brief Merges all the recorded net pairs which need to be merged
      *
      * This should only be called at the end of a .model to ensure that
-     * all the associated driver/sink pins have been delcared and connected
+     * all the associated driver/sink pins have been declared and connected
      * to their nets
      */
     void merge_conn_nets() {
@@ -668,7 +668,7 @@ vtr::LogicValue to_vtr_logic_value(blifparse::LogicValue val) {
             new_val = vtr::LogicValue::UNKOWN;
             break;
         default:
-            VTR_ASSERT_OPT_MSG(false, "Unkown logic value");
+            VTR_ASSERT_OPT_MSG(false, "Unknown logic value");
     }
     return new_val;
 }

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -251,7 +251,7 @@ void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_a
      * Initialize the functions names for which VPR_ERRORs
      * are demoted to VTR_LOG_WARNs
      */
-    for (const std::string& func_name : vtr::split(options->disable_errors, std::string(":"))) {
+    for (const std::string& func_name : vtr::split(options->disable_errors.value(), ":")) {
         map_error_activation_status(func_name);
     }
 
@@ -259,7 +259,7 @@ void vpr_init_with_options(const t_options* options, t_vpr_setup* vpr_setup, t_a
      * Initialize the functions names for which
      * warnings are being suppressed
      */
-    std::vector<std::string> split_warning_option = vtr::split(options->suppress_warnings, std::string(","));
+    std::vector<std::string> split_warning_option = vtr::split(options->suppress_warnings.value(), ",");
     std::string warn_log_file;
     std::string warn_functions;
     // If no log file name is provided, the specified warning
@@ -507,7 +507,7 @@ void vpr_create_device_grid(const t_vpr_setup& vpr_setup, const t_arch& Arch) {
     if (!device_ctx.grid.limiting_resources().empty()) {
         std::vector<std::string> limiting_block_names;
         for (auto blk_type : device_ctx.grid.limiting_resources()) {
-            limiting_block_names.push_back(blk_type->name);
+            limiting_block_names.emplace_back(blk_type->name);
         }
         VTR_LOG("FPGA size limited by block type(s): %s\n", vtr::join(limiting_block_names, " ").c_str());
         VTR_LOG("\n");
@@ -565,7 +565,6 @@ void vpr_setup_noc_routing_algorithm(const std::string& noc_routing_algorithm_na
     auto& noc_ctx = g_vpr_ctx.mutable_noc();
 
     noc_ctx.noc_flows_router = NocRoutingAlgorithmCreator::create_routing_algorithm(noc_routing_algorithm_name);
-    return;
 }
 
 bool vpr_pack_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
@@ -598,7 +597,7 @@ bool vpr_pack_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
         check_netlist(packer_opts.pack_verbosity);
 
         /* Output the netlist stats to console and optionally to file. */
-        writeClusteredNetlistStats(vpr_setup.FileNameOpts.write_block_usage.c_str());
+        writeClusteredNetlistStats(vpr_setup.FileNameOpts.write_block_usage);
 
         // print the total number of used physical blocks for each
         // physical block type after finishing the packing stage


### PR DESCRIPTION
This PR fixes fasm warnings mentioned in [this issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2518). It also replaces some std::string and const std::string& arguments with std::string_view. When an rvalue char* is passed as an std:string& argument, an std::string object needs to be constructed, which involves memory allocation and copying. std::string_view doesn't need to allocate memory and copy the null terminated string because it directly points to rvalue char*.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
