### PR TITLE
[vqm2blif][Warnings] Removed std::regex and strncpy Warnings

### DIFF
--- a/utils/vqm2blif/src/base/hard_block_recog.cpp
+++ b/utils/vqm2blif/src/base/hard_block_recog.cpp
@@ -1735,7 +1735,7 @@ static std::string construct_hard_block_name(std::vector<std::string>*node_name_
 static void identify_hard_block_port_name_and_index (t_parsed_hard_block_port_info* curr_hard_block_port, std::string curr_node_name_component)
 {   
     // identifer to check whether the port defined in the current node name is a bus (ex. payload[1]~QIC_DANGLING_PORT_I)
-    std::regex port_is_a_bus ("(.*)[[]([0-9]*)\]~(?:.*)");
+    std::regex port_is_a_bus ("(.*)[[]([0-9]*)\\]~(?:.*)");
 
     // identifier to check whether the current port defined in the current node name isn't a bus (ex. value~9490_I)
     std::regex port_is_not_a_bus ("(.*)~(?:.*)");

--- a/utils/vqm2blif/src/base/preprocess.cpp
+++ b/utils/vqm2blif/src/base/preprocess.cpp
@@ -1914,8 +1914,9 @@ void duplicate_and_split_multiclock_blocks(t_module* module, vector<t_node*>& mu
 
         char buf[50];
         snprintf(buf, sizeof(char)*50, DUMMY_NET_NAME_FORMAT, dummy_net_count);
-        new_net->name = (char*) vtr::malloc(strlen(buf)+1);
-        strncpy(new_net->name, buf, strlen(buf)+1);
+        size_t new_net_name_length = strlen(buf) + 1;
+        new_net->name = (char*) vtr::malloc(new_net_name_length * sizeof(char));
+        strncpy(new_net->name, buf, new_net_name_length);
         new_net->left = 0;
         new_net->right = 0;
         new_net->indexed = T_FALSE;

--- a/utils/vqm2blif/src/base/vqm2blif_util.cpp
+++ b/utils/vqm2blif/src/base/vqm2blif_util.cpp
@@ -61,7 +61,7 @@ void verify_hard_block_type_name(string curr_hard_block_type_name){
     // Condition 1: the first charatcer must be a lowercase/uppercase alphabetical character. Or the first character can be a underscore.
     // Condition 2: The remaning characters must be a lowercase/uppercase alphabetical character, or a underscore, or a single digit number or the '$' character
     // the rules above are checked with the identifier below 
-    std::regex verilog_VHDL_naming_rules_one ("^[a-zA-Z_][a-zA-Z_\$0-9]*[a-zA-Z_\$0-9]$");
+    std::regex verilog_VHDL_naming_rules_one ("^[a-zA-Z_][a-zA-Z_\\$0-9]*[a-zA-Z_\\$0-9]$");
 
     // verilog names can also contain any characters, as long as they are escaped with a '\' at the start of the identifer. For example, \reset-
     // we check this using the identifier below


### PR DESCRIPTION
Cleaned up a few warnings that were simply resolved.

See issue #2518 

This also resolves one of the warnings in issue #2294 
