### PR TITLE
Astar Profiler Document

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1299,7 +1299,7 @@ The following options are only valid when the router is in timing-driven mode (t
     **Default:** ``1.2``
 
 .. option:: --router_profiler_astar_fac <float>
-    Controls the directedness of the timing-driven router's exploration when doing router delay profiling. 
+    Controls the directedness of the timing-driven router's exploration when doing router delay profiling of an architecture.
     The router delay profiling step is currently used to calculate the place delay matrix lookup.
     Values between 1 and 2 are resonable; higher values trade some quality for reduced run-time.
 

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1298,6 +1298,13 @@ The following options are only valid when the router is in timing-driven mode (t
 
     **Default:** ``1.2``
 
+.. option:: --router_profiler_astar_fac <float>
+    Controls the directedness of the timing-driven router's exploration when doing router delay profiling. 
+    The router delay profiling step is currently used to calculate the place delay matrix lookup.
+    Values between 1 and 2 are resonable; higher values trade some quality for reduced run-time.
+
+    **Default:** ``1.2``
+
 .. option:: --max_criticality <float>
 
     Sets the maximum fraction of routing cost that can come from delay (vs. coming from routability) for any net.

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1889,7 +1889,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
             "What algorithm should be used to compute the place delta matrix.\n"
             "\n"
             " * astar : Find delta delays between OPIN's and IPIN's using\n"
-            "           the router with the current --astar_fac.\n"
+            "           the router with the current --router_profiler_astar_fac.\n"
             " * dijkstra : Use Dijkstra's algorithm to find all shortest paths \n"
             "              from sampled OPIN's to all IPIN's.\n")
         .default_value("astar")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2479,7 +2479,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
     route_timing_grp.add_argument(args.router_profiler_astar_fac, "--router_profiler_astar_fac")
         .help(
             "Controls the directedness of the timing-driven router's exploration"
-            " when doing router delay profiling."
+            " when doing router delay profiling of an architecture."
             " The router delay profiling step is currently used to calculate the place delay matrix lookup."
             " Values between 1 and 2 are resonable; higher values trade some quality for reduced run-time")
         .default_value("1.2")


### PR DESCRIPTION
This pull request adds documentation related to `router_profiler_astar_fac` to the VTR documentation. (issue [#2536](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2536))
@vaughnbetz 