### PR TITLE
Quickstart, requirements, and flow tutorial update

### DIFF
--- a/doc/src/quickstart/index.rst
+++ b/doc/src/quickstart/index.rst
@@ -48,6 +48,12 @@ On most unix-like systems you can run:
 
     > make
 
+The default front-end for VTR is :ref:`Parmys<parmys>`, but you can build with ODIN II instead using the command below. This is required to run :ref:`Synthesizing with ODIN II<synthesizing_with_odin_ii>`.
+
+.. code-block:: bash
+
+    > make CMAKE_PARAMS="-DWITH_ODIN=on"
+
 from the VTR root directory (hereafter referred to as :term:`$VTR_ROOT`) to build VTR.
 
 .. note:: 
@@ -62,6 +68,8 @@ from the VTR root directory (hereafter referred to as :term:`$VTR_ROOT`) to buil
 
     * define VTR_ROOT as a variable in your shell (e.g. if ``~/trees/vtr`` is the path to the VTR source tree on your machine, run the equivalent of ``VTR_ROOT=~/trees/vtr`` in BASH) which will allow you to run the commands as written in this guide, or
     * manually replace `$VTR_ROOT` in the example commands below with your path to the VTR source tree.
+
+
 
 For more details on building VTR on various operating systems/platforms see :doc:`Building VTR</BUILDING>`.
 
@@ -235,6 +243,7 @@ Next we need to run the three main sets of tools:
 * :ref:`ABC` performs 'logic optimization' which simplifies the circuit logic, and 'technology mapping' which converts logic equations into the Look-Up-Tables (LUTs) available on an FPGA, and
 * :ref:`VPR` which performs packing, placement and routing of the circuit to implement it on the targetted FPGA architecture.
 
+.. _synthesizing_with_odin_ii:
 Synthesizing with ODIN II
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/src/tutorials/flow/basic_flow.rst
+++ b/doc/src/tutorials/flow/basic_flow.rst
@@ -17,16 +17,9 @@ The following steps show you to run the VTR design flow to map a sample circuit 
 
         $VTR_ROOT/vtr_flow/scripts/run_vtr_task.py basic_no_timing 
         
-    The subdirectory ``regression_tests/vtr_reg_basic`` contains tests that are to be run before each commit. They check for basic functionallity to make sure nothing was           extremely out of order. This command runs the VTR flow on a set of circuits and a single architecture. 
+    The subdirectory ``regression_tests/vtr_reg_basic`` contains tests that are to be run before each commit. They check for basic functionality to make sure nothing was extremely out of order. This command runs the VTR flow on a set of circuits and a single architecture. 
     The files generated from the run are stored in ``basic_no_timing/run[#]`` where ``[#]`` is the number of runs you have done.
-    If this is your first time running the flow, the results will be stored in basic_no_timing/run001.
-    When the script completes, enter the following command:
-
-    .. code-block:: shell
-
-         ../../../scripts/python_libs/vtr/parse_vtr_task.py basic_no_timing/
-
-    This parses out the information of the VTR run and outputs the results in a text file called ``run[#]/parse_results.txt``.
+    If this is your first time running the flow, the results will be stored in basic_no_timing/run001. The command parses out the information of the VTR run and outputs the results in a text file called ``run[#]/parse_results.txt``.
 
     More info on how to run the flow on multiple circuits and architectures along with different options later.
     Before that, we need to ensure that the run that you have done works.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ psutil
 
 # Python linter and formatter
 click==8.0.2 # Our version of black needs an older version of click (https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click)
-black==20.8b1
+black==21.4b0
 pylint==2.7.4
 
 # Surelog


### PR DESCRIPTION
1. Quickstart now shows how to build for use with ODIN II
2. Updated basic design flow tutorial to remove redundant instructions to run ``parse_vtr_task.py``
3. Changed version of black in ``requirements.txt`` to 21.4b0 so that ``make env`` works

#### Motivation and Context
1. The quickstart guide did not tell users how to build to that ODIN II could be used for synthesis. They would have to go to the ODIN II page and see to navigate to the ``odin_ii`` directory and ``make build``. The new command in the quickstart guide allows them to build ODIN II when they build VTR.
2. There was an instruction to run ``parse_vtr_task.py`` in the Basic Design Flow Tutorial, the reason being it created a ``parse_results.txt`` file, but this is already created by the earlier ``run_vtr_task.py``
3. ``make env`` did not work with the previous version of black, 20.8b1

#### How Has This Been Tested?
3. I ran ``make env`` with the new version of black, and there are no errors.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
