### PR TITLE
Architecture Seg Fault Issue

### DIFF
--- a/libs/libarchfpga/src/echo_arch.cpp
+++ b/libs/libarchfpga/src/echo_arch.cpp
@@ -13,6 +13,10 @@
 
 using vtr::t_linked_vptr;
 
+/// @brief indices to lookup IPIN connection block switch name
+constexpr int ipin_cblock_switch_index_within_die = 0;
+constexpr int ipin_cblock_switch_index_between_dice = 1;
+
 void PrintArchInfo(FILE* Echo, const t_arch* arch);
 static void PrintPb_types_rec(FILE* Echo, const t_pb_type* pb_type, int level);
 static void PrintPb_types_recPower(FILE* Echo,
@@ -231,13 +235,13 @@ void PrintArchInfo(FILE* Echo, const t_arch* arch) {
             break;
     }
 
-    fprintf(Echo, "\tInput Connect Block Switch Name Within a Same Die: %s\n", arch->ipin_cblock_switch_name[0].c_str());
+    fprintf(Echo, "\tInput Connect Block Switch Name Within a Same Die: %s\n", arch->ipin_cblock_switch_name[ipin_cblock_switch_index_within_die].c_str());
     
     //if there is more than one layer available, print the connection block switch name that is used for connection between two dice
     for(const auto& layout : arch->grid_layouts){
         int num_layers = (int)layout.layers.size();
         if(num_layers > 1){
-            fprintf(Echo, "\tInput Connect Block Switch Name Between Two Dice: %s\n", arch->ipin_cblock_switch_name[1].c_str());
+            fprintf(Echo, "\tInput Connect Block Switch Name Between Two Dice: %s\n", arch->ipin_cblock_switch_name[[ipin_cblock_switch_index_between_dice].c_str());
         }
     }
 

--- a/libs/libarchfpga/src/echo_arch.cpp
+++ b/libs/libarchfpga/src/echo_arch.cpp
@@ -232,9 +232,13 @@ void PrintArchInfo(FILE* Echo, const t_arch* arch) {
     }
 
     fprintf(Echo, "\tInput Connect Block Switch Name Within a Same Die: %s\n", arch->ipin_cblock_switch_name[0].c_str());
+    
     //if there is more than one layer available, print the connection block switch name that is used for connection between two dice
-    if (arch->grid_layouts.size() > 1) {
-        fprintf(Echo, "\tInput Connect Block Switch Name Between Two Dice: %s\n", arch->ipin_cblock_switch_name[1].c_str());
+    for(const auto& layout : arch->grid_layouts){
+        int num_layers = (int)layout.layers.size();
+        if(num_layers > 1){
+            fprintf(Echo, "\tInput Connect Block Switch Name Between Two Dice: %s\n", arch->ipin_cblock_switch_name[1].c_str());
+        }
     }
 
     fprintf(Echo, "*************************************************\n\n");
@@ -287,9 +291,12 @@ void PrintArchInfo(FILE* Echo, const t_arch* arch) {
             fprintf(Echo, "\t\t\t\ttype unidir mux_name for within die connections: %s\n",
                     arch->Switches[seg.arch_wire_switch].name.c_str());
             //if there is more than one layer available, print the segment switch name that is used for connection between two dice
-            if (arch->grid_layouts.size() > 1) {
-                fprintf(Echo, "\t\t\t\ttype unidir mux_name for between two dice connections: %s\n",
+            for(const auto& layout : arch->grid_layouts){
+                int num_layers = (int)layout.layers.size();
+                if(num_layers > 1){
+                    fprintf(Echo, "\t\t\t\ttype unidir mux_name for between two dice connections: %s\n",
                         arch->Switches[seg.arch_opin_between_dice_switch].name.c_str());
+                }
             }
         } else { //Should be bidir
             fprintf(Echo, "\t\t\t\ttype bidir wire_switch %s arch_opin_switch %s\n",

--- a/libs/libarchfpga/src/echo_arch.cpp
+++ b/libs/libarchfpga/src/echo_arch.cpp
@@ -241,7 +241,7 @@ void PrintArchInfo(FILE* Echo, const t_arch* arch) {
     for(const auto& layout : arch->grid_layouts){
         int num_layers = (int)layout.layers.size();
         if(num_layers > 1){
-            fprintf(Echo, "\tInput Connect Block Switch Name Between Two Dice: %s\n", arch->ipin_cblock_switch_name[[ipin_cblock_switch_index_between_dice].c_str());
+            fprintf(Echo, "\tInput Connect Block Switch Name Between Two Dice: %s\n", arch->ipin_cblock_switch_name[ipin_cblock_switch_index_between_dice].c_str());
         }
     }
 


### PR DESCRIPTION
In the current codebase, when we activate --echo_file, we might get a segmentation file while writing the architecture file. The reason is that we look at the number of layouts instead of layers. The architecture might have different layouts but still not be 3D using multiple <fixed_layout> options.  

This PR addresses the following issue:
[Segmentation Fault](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2449)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@vaughnbetz 