### PR TITLE
[Warnings] Suppressed Bison Deprecation Warnings

### DIFF
--- a/libs/EXTERNAL/libblifparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libblifparse/CMakeLists.txt
@@ -27,7 +27,9 @@ file(GLOB_RECURSE PARSER_SOURCES src/blif*.y)
 #Make the flex and bison targets
 flex_target(BlifLexer ${LEXER_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/blif_lexer.gen.cpp
         COMPILE_FLAGS --header-file=${CMAKE_CURRENT_BINARY_DIR}/blif_lexer.gen.hpp)
-bison_target(BlifParser ${PARSER_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/blif_parser.gen.cpp)
+# Suppress deprecation warnings. See PR #2529
+bison_target(BlifParser ${PARSER_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/blif_parser.gen.cpp
+        COMPILE_FLAGS -Wno-deprecated)
 add_flex_bison_dependency(BlifLexer BlifParser)
 
 #Suppress warnings in Flex/Bison generated files

--- a/libs/EXTERNAL/libsdcparse/CMakeLists.txt
+++ b/libs/EXTERNAL/libsdcparse/CMakeLists.txt
@@ -27,7 +27,9 @@ file(GLOB_RECURSE PARSER_SOURCES src/sdc*.y)
 #Make the flex and bison targets
 flex_target(SdcLexer ${LEXER_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/sdc_lexer.gen.cpp
         COMPILE_FLAGS --header-file=${CMAKE_CURRENT_BINARY_DIR}/sdc_lexer.gen.hpp)
-bison_target(SdcParser ${PARSER_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/sdc_parser.gen.cpp)
+# Suppress deprecation warnings. See PR #2529
+bison_target(SdcParser ${PARSER_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/sdc_parser.gen.cpp
+        COMPILE_FLAGS -Wno-deprecated)
 add_flex_bison_dependency(SdcLexer SdcParser)
 
 


### PR DESCRIPTION
Suppressed the Bison deprecation warnings for SDCParse and BlifParse since the fix for the deprecation requires Bison 3.3, but the current minimum version of Bison is 3.0

Some development machines using VPR cannot be upgraded to Bison 3.3 easily, so for now the deprecation warnings are just being suppressed until all machines are on Bison 3.3

PR #2529 tracks this issue and contains the code to fix the deprecations.

This represents the last warnings in the CI detailed in issue #2518 
