### PR TITLE
Removed Simple Uses of STD Iterator

### DIFF
--- a/libs/librrgraph/src/base/rr_node_impl.h
+++ b/libs/librrgraph/src/base/rr_node_impl.h
@@ -3,28 +3,35 @@
 // This file provides the inline proxy implemenation for t_rr_node.
 // See the t_rr_node class comment for additional details.
 
-#include "rr_node_types.h"
+#include <cstddef>
+#include <iterator>
 #include "rr_node.h"
 #include "rr_graph_storage.h"
 
-class node_idx_iterator : public std::iterator<std::bidirectional_iterator_tag, const t_rr_node> {
+class node_idx_iterator {
   public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = const t_rr_node;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     node_idx_iterator(t_rr_node value)
         : value_(value) {}
 
-    iterator operator++() {
+    node_idx_iterator& operator++() {
         value_.next_node();
         return *this;
     }
-    iterator operator--() {
+    node_idx_iterator& operator--() {
         value_.prev_node();
         return *this;
     }
     reference operator*() const { return value_; }
     pointer operator->() const { return &value_; }
 
-    friend bool operator==(const node_idx_iterator lhs, const node_idx_iterator rhs) { return lhs.value_.id() == rhs.value_.id(); }
-    friend bool operator!=(const node_idx_iterator lhs, const node_idx_iterator rhs) { return !(lhs == rhs); }
+    friend bool operator==(const node_idx_iterator& lhs, const node_idx_iterator& rhs) { return lhs.value_.id() == rhs.value_.id(); }
+    friend bool operator!=(const node_idx_iterator& lhs, const node_idx_iterator& rhs) { return !(lhs == rhs); }
 
   private:
     t_rr_node value_;

--- a/libs/librrgraph/src/base/rr_node_types.h
+++ b/libs/librrgraph/src/base/rr_node_types.h
@@ -1,6 +1,8 @@
 #ifndef RR_NODE_TYPES_H
 #define RR_NODE_TYPES_H
 
+#include <cstddef>
+#include <iterator>
 #include <string>
 #include <vector>
 #include <array>
@@ -64,23 +66,29 @@ typedef uint16_t t_edge_size;
  *
  * Used inconjunction with vtr::Range to return ranges of edge indices
  */
-class edge_idx_iterator : public std::iterator<std::bidirectional_iterator_tag, t_edge_size> {
+class edge_idx_iterator {
   public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = t_edge_size;
+    using pointer = t_edge_size*;
+    using reference = t_edge_size&;
+
     edge_idx_iterator(value_type init)
         : value_(init) {}
-    iterator operator++() {
+    edge_idx_iterator& operator++() {
         value_ += 1;
         return *this;
     }
-    iterator operator--() {
+    edge_idx_iterator& operator--() {
         value_ -= 1;
         return *this;
     }
     reference operator*() { return value_; }
     pointer operator->() { return &value_; }
 
-    friend bool operator==(const edge_idx_iterator lhs, const edge_idx_iterator rhs) { return lhs.value_ == rhs.value_; }
-    friend bool operator!=(const edge_idx_iterator lhs, const edge_idx_iterator rhs) { return !(lhs == rhs); }
+    friend bool operator==(const edge_idx_iterator& lhs, const edge_idx_iterator& rhs) { return lhs.value_ == rhs.value_; }
+    friend bool operator!=(const edge_idx_iterator& lhs, const edge_idx_iterator& rhs) { return !(lhs == rhs); }
 
   private:
     value_type value_;

--- a/libs/libvtrutil/src/vtr_ragged_matrix.h
+++ b/libs/libvtrutil/src/vtr_ragged_matrix.h
@@ -1,5 +1,6 @@
 #ifndef VTR_RAGGED_MATRIX_H
 #define VTR_RAGGED_MATRIX_H
+#include <cstddef>
 #include <vector>
 #include <iterator>
 
@@ -212,8 +213,14 @@ class FlatRaggedMatrix {
      * uses a callback to determine row lengths.
      */
     template<class Callback>
-    class RowLengthIterator : public std::iterator<std::random_access_iterator_tag, size_t> {
+    class RowLengthIterator {
       public:
+        using iterator_category = std::random_access_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = size_t;
+        using pointer = size_t*;
+        using reference = size_t&;
+
         RowLengthIterator(size_t irow, Callback& callback)
             : irow_(irow)
             , callback_(callback) {}


### PR DESCRIPTION
See issue #2557 for more context.

Removed the uses of std::iterator that were very simple to remove. These just required declaring some types that the users of the iterators expect and removing the inheritance on the std::iterator.

The other cases in VTR which use std::iterator are a bit more complicated and may require some work to remove correctly.