### PR TITLE
Removed Less-Simple Uses of STD Iterator

### DIFF
--- a/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <iterator>
 #include <memory>
 
@@ -104,15 +105,15 @@ class TimingTags {
 
         //Iterator definition
         template<class T>
-        class Iterator : public std::iterator<std::random_access_iterator_tag, T> {
+        class Iterator {
             friend TimingTags;
             public:
-                using value_type = typename std::iterator<std::random_access_iterator_tag, T>::value_type;
-                using difference_type = typename std::iterator<std::random_access_iterator_tag, T>::difference_type;
-                using pointer = typename std::iterator<std::random_access_iterator_tag, T>::pointer;
-                using reference = typename std::iterator<std::random_access_iterator_tag, T>::reference;
-                using iterator_category = typename std::iterator<std::random_access_iterator_tag, T>::iterator_category;
-            public:
+                using iterator_category = std::random_access_iterator_tag;
+                using difference_type = std::ptrdiff_t;
+                using value_type = T;
+                using pointer = T*;
+                using reference = T&;
+
                 Iterator(): p_(nullptr) {}
                 Iterator(pointer p): p_(p) {}
                 Iterator(const Iterator& other): p_(other.p_) {}
@@ -143,7 +144,7 @@ class TimingTags {
                 friend bool operator>=(Iterator lhs, Iterator rhs) { return lhs.p_ >= rhs.p_; }
                 friend void swap(Iterator lhs, Iterator rhs) { std::swap(lhs.p_, rhs.p_); }
             private:
-                T* p_ = nullptr;
+                pointer p_ = nullptr;
         };
 
     private:

--- a/libs/libvtrutil/src/vtr_array_view.h
+++ b/libs/libvtrutil/src/vtr_array_view.h
@@ -207,21 +207,15 @@ class array_view_id : private array_view<V> {
      * to iterate through the keys with a range-based for loop
      *
      */
-    class key_iterator : public std::iterator<std::bidirectional_iterator_tag, key_type> {
+    class key_iterator {
       public:
-        /**
-         * @brief Intermediate type my_iter
-         *
-         * We use the intermediate type my_iter to avoid a potential ambiguity for which
-         * clang generates errors and warnings
-         */
-        using my_iter = typename std::iterator<std::bidirectional_iterator_tag, K>;
-        using typename my_iter::iterator;
-        using typename my_iter::pointer;
-        using typename my_iter::reference;
-        using typename my_iter::value_type;
+        using iterator_category = std::bidirectional_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = key_type;
+        using pointer = key_type*;
+        using reference = key_type&;
 
-        key_iterator(key_iterator::value_type init)
+        key_iterator(value_type init)
             : value_(init) {}
 
         /**
@@ -233,13 +227,13 @@ class array_view_id : private array_view<V> {
          */
 
         ///@brief increment the iterator
-        key_iterator operator++() {
+        key_iterator& operator++() {
             value_ = value_type(size_t(value_) + 1);
             return *this;
         }
 
         ///@brief decrement the iterator
-        key_iterator operator--() {
+        key_iterator& operator--() {
             value_ = value_type(size_t(value_) - 1);
             return *this;
         }
@@ -250,8 +244,8 @@ class array_view_id : private array_view<V> {
         ///@brief -> operator
         pointer operator->() { return &value_; }
 
-        friend bool operator==(const key_iterator lhs, const key_iterator rhs) { return lhs.value_ == rhs.value_; }
-        friend bool operator!=(const key_iterator lhs, const key_iterator rhs) { return !(lhs == rhs); }
+        friend bool operator==(const key_iterator& lhs, const key_iterator& rhs) { return lhs.value_ == rhs.value_; }
+        friend bool operator!=(const key_iterator& lhs, const key_iterator& rhs) { return !(lhs == rhs); }
 
       private:
         value_type value_;

--- a/libs/libvtrutil/src/vtr_vector.h
+++ b/libs/libvtrutil/src/vtr_vector.h
@@ -160,17 +160,16 @@ class vector : private std::vector<V, Allocator> {
      * This allows end-users to call the parent class's keys() member
      * to iterate through the keys with a range-based for loop
      */
-    class key_iterator : public std::iterator<std::bidirectional_iterator_tag, key_type> {
+    class key_iterator {
       public:
-        ///@brief We use the intermediate type my_iter to avoid a potential ambiguity for which clang generates errors and warnings
-        using my_iter = typename std::iterator<std::bidirectional_iterator_tag, K>;
-        using typename my_iter::iterator;
-        using typename my_iter::pointer;
-        using typename my_iter::reference;
-        using typename my_iter::value_type;
+        using iterator_category = std::bidirectional_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = key_type;
+        using pointer = key_type*;
+        using reference = key_type&;
 
         ///@brief constructor
-        key_iterator(key_iterator::value_type init)
+        key_iterator(value_type init)
             : value_(init) {}
 
         /*
@@ -180,12 +179,12 @@ class vector : private std::vector<V, Allocator> {
          * we can just increment the underlying Id to build the next key.
          */
         ///@brief ++ operator
-        key_iterator operator++() {
+        key_iterator& operator++() {
             value_ = value_type(size_t(value_) + 1);
             return *this;
         }
         ///@brief decrement operator
-        key_iterator operator--() {
+        key_iterator& operator--() {
             value_ = value_type(size_t(value_) - 1);
             return *this;
         }
@@ -195,9 +194,9 @@ class vector : private std::vector<V, Allocator> {
         pointer operator->() { return &value_; }
 
         ///@brief == operator
-        friend bool operator==(const key_iterator lhs, const key_iterator rhs) { return lhs.value_ == rhs.value_; }
+        friend bool operator==(const key_iterator& lhs, const key_iterator& rhs) { return lhs.value_ == rhs.value_; }
         ///@brief != operator
-        friend bool operator!=(const key_iterator lhs, const key_iterator rhs) { return !(lhs == rhs); }
+        friend bool operator!=(const key_iterator& lhs, const key_iterator& rhs) { return !(lhs == rhs); }
 
       private:
         value_type value_;


### PR DESCRIPTION
See issue #2557 for context.

As with PR #2558 , removed slightly more complicated uses of std::iterator after discussing this more.

This PR modifies Tatum, I will upstream these changes back to the Tatum library after the PR is merged.

After this PR, the only use of std::iterator would be in the Capnproto library, which may be quite a bit more complicated to resolve.