### PR TITLE
Support for link/router specific bandwidth/latency in architecture file

### DIFF
--- a/libs/libarchfpga/src/arch_check.cpp
+++ b/libs/libarchfpga/src/arch_check.cpp
@@ -86,7 +86,7 @@ void warn_model_missing_timing(const t_model* model, const char* file, uint32_t 
 
     for (t_model_ports* port = model->outputs; port != nullptr; port = port->next) {
         if (port->clock.empty()                          //Not sequential
-            && !comb_connected_outputs.count(port->name) //Not combinationally drivven
+            && !comb_connected_outputs.count(port->name) //Not combinationally driven
             && !port->is_clock                           //Not an output clock
         ) {
             VTR_LOGF_WARN(file, line,

--- a/libs/libarchfpga/src/arch_types.h
+++ b/libs/libarchfpga/src/arch_types.h
@@ -18,6 +18,8 @@
 /* Value for UNDEFINED data */
 constexpr int UNDEFINED = -1;
 
+constexpr int NUM_MODELS_IN_LIBRARY = 4;
+
 /* Maximum value for mininum channel width to avoid overflows of short data type.               */
 constexpr int MAX_CHANNEL_WIDTH = 8000;
 

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -520,7 +520,7 @@ t_port* findPortByName(const char* name, t_pb_type* pb_type, int* high_index, in
     return port;
 }
 
-t_physical_tile_type get_empty_physical_type(const char* name) {
+t_physical_tile_type get_empty_physical_type(const char* name /*= EMPTY_BLOCK_NAME*/) {
     t_physical_tile_type type;
     type.name = vtr::strdup(name);
     type.num_pins = 0;

--- a/libs/libarchfpga/src/arch_util.cpp
+++ b/libs/libarchfpga/src/arch_util.cpp
@@ -538,7 +538,7 @@ t_physical_tile_type get_empty_physical_type(const char* name) {
     return type;
 }
 
-t_logical_block_type get_empty_logical_type(const char* name) {
+t_logical_block_type get_empty_logical_type(const char* name /*=EMPTY_BLOCK_NAME*/) {
     t_logical_block_type type;
     type.name = vtr::strdup(name);
     type.pb_type = nullptr;

--- a/libs/libarchfpga/src/main.cpp
+++ b/libs/libarchfpga/src/main.cpp
@@ -5,12 +5,11 @@
  * Author: Jason Luu
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 #include "vtr_error.h"
-#include "vtr_memory.h"
 
 #include "arch_util.h"
 #include "read_xml_arch_file.h"

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -28,6 +28,7 @@
 #define PHYSICAL_TYPES_H
 
 #include <functional>
+#include <utility>
 #include <vector>
 #include <unordered_map>
 #include <string>
@@ -146,7 +147,7 @@ struct t_metadata_dict : vtr::flat_map<
     void add(vtr::interned_string key, vtr::interned_string value) {
         // Get the iterator to the key, which may already have elements if
         // add was called with this key in the past.
-        (*this)[key].emplace_back(t_metadata_value(value));
+        (*this)[key].emplace_back(value);
     }
 };
 
@@ -263,10 +264,10 @@ enum e_sb_location {
  */
 struct t_grid_loc_spec {
     t_grid_loc_spec(std::string start, std::string end, std::string repeat, std::string incr)
-        : start_expr(start)
-        , end_expr(end)
-        , repeat_expr(repeat)
-        , incr_expr(incr) {}
+        : start_expr(std::move(start))
+        , end_expr(std::move(end))
+        , repeat_expr(std::move(repeat))
+        , incr_expr(std::move(incr)) {}
 
     std::string start_expr; //Starting position (inclusive)
     std::string end_expr;   //Ending position (inclusive)
@@ -280,7 +281,7 @@ struct t_grid_loc_spec {
 
 /* Definition of how to place physical logic block in the grid.
  *  This defines a region of the grid to be set to a specific type
- *  (provided it's priority is high enough to override other blocks).
+ *  (provided its priority is high enough to override other blocks).
  *
  *  The diagram below illustrates the layout specification.
  *
@@ -345,7 +346,7 @@ struct t_grid_loc_spec {
  */
 struct t_grid_loc_def {
     t_grid_loc_def(std::string block_type_val, int priority_val)
-        : block_type(block_type_val)
+        : block_type(std::move(block_type_val))
         , priority(priority_val)
         , x("0", "W-1", "max(w+1,W)", "w") //Fill in x direction, no repeat, incr by block width
         , y("0", "H-1", "max(h+1,H)", "h") //Fill in y direction, no repeat, incr by block height
@@ -358,7 +359,7 @@ struct t_grid_loc_def {
                       // the largest priority wins.
 
     t_grid_loc_spec x; //Horizontal location specification
-    t_grid_loc_spec y; //Veritcal location specification
+    t_grid_loc_spec y; //Vertical location specification
 
     // When 1 metadata tag is split among multiple t_grid_loc_def, one
     // t_grid_loc_def is arbitrarily chosen to own the metadata, and the other
@@ -1601,7 +1602,7 @@ struct t_hash_segment_inf {
 enum class SwitchType {
     MUX = 0,   //A configurable (buffered) mux (single-driver)
     TRISTATE,  //A configurable tristate-able buffer (multi-driver)
-    PASS_GATE, //A configurable pass transitor switch (multi-driver)
+    PASS_GATE, //A configurable pass transistor switch (multi-driver)
     SHORT,     //A non-configurable electrically shorted connection (multi-driver)
     BUFFER,    //A non-configurable non-tristate-able buffer (uni-driver)
     INVALID,   //Unspecified, usually an error
@@ -1992,7 +1993,7 @@ struct t_arch {
     // nets from the circuit netlist are belonging to the constant network,
     // and assigned to it accordingly.
     //
-    // NOTE: At the moment, the constant cells and nets are primarly used
+    // NOTE: At the moment, the constant cells and nets are primarily used
     // for the interchange netlist format, to determine which are the constants
     // net names and which virtual cell is responsible to generate them.
     // The information is present in the device database.

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -182,11 +182,11 @@ constexpr std::array<e_side, NUM_SIDES> SIDES = {{TOP, RIGHT, BOTTOM, LEFT}};   
 constexpr std::array<const char*, NUM_SIDES> SIDE_STRING = {{"TOP", "RIGHT", "BOTTOM", "LEFT"}}; //String versions of side orientations
 
 /* pin location distributions */
-enum e_pin_location_distr {
-    E_SPREAD_PIN_DISTR,
-    E_PERIMETER_PIN_DISTR,
-    E_SPREAD_INPUTS_PERIMETER_OUTPUTS_PIN_DISTR,
-    E_CUSTOM_PIN_DISTR
+enum class e_pin_location_distr {
+    SPREAD,
+    PERIMETER,
+    SPREAD_INPUTS_PERIMETER_OUTPUTS,
+    CUSTOM
 };
 
 /* pb_type class */
@@ -649,7 +649,7 @@ struct t_physical_tile_type {
 
     std::vector<t_class> class_inf; /* [0..num_class-1] */
 
-    // Primitive class is refered to a classes that are in the primitive blocks. These classes are
+    // Primitive class is referred to a classes that are in the primitive blocks. These classes are
     // used during flat-routing to route the nets.
     // The starting number of primitive classes
     int primitive_class_starting_idx = -1;
@@ -756,7 +756,7 @@ struct t_capacity_range {
 struct t_sub_tile {
     char* name = nullptr;
 
-    // Mapping between the sub tile's pins and the physical pins corresponding
+    // Mapping between the subtile's pins and the physical pins corresponding
     // to the physical tile type.
     std::vector<int> sub_tile_to_tile_pin_indices;
 

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -130,7 +130,7 @@ struct t_metadata_dict : vtr::flat_map<
 
     // Get metadata values matching key.
     //
-    // Returns nullptr if key is not found or if multiple values are prsent
+    // Returns nullptr if key is not found or if multiple values are present
     // per key.
     inline const t_metadata_value* one(vtr::interned_string key) const {
         auto values = get(key);
@@ -1954,6 +1954,7 @@ struct t_noc_inf {
 
 /*   Detailed routing architecture */
 struct t_arch {
+    /** Stores unique strings used as key and values in <metadata> tags*/
     mutable vtr::string_internment strings;
     std::vector<vtr::interned_string> interned_strings;
 

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1947,6 +1947,10 @@ struct t_noc_inf {
     /** A list of all routers in the NoC*/
     std::vector<t_router> router_list;
 
+    std::map<int, double> router_latency_overrides;
+    std::map<std::pair<int, int>, double> link_latency_overrides;
+    std::map<std::pair<int, int>, double> link_bandwidth_overrides;
+
     /** Represents the name of a router tile on the FPGA device. This should match the name used in the arch file when
      * describing a NoC router tile within the FPGA device*/
     std::string noc_router_tile_name;

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1845,7 +1845,7 @@ static void ProcessMode(pugi::xml_node Parent,
                 ProcessPb_Type(Cur, &mode->pb_type_children[pb_type_child_idx], mode, timing_enabled, arch, loc_data, parent_pb_idx);
 
                 auto [_, success] = pb_type_names.insert(mode->pb_type_children[pb_type_child_idx].name);
-                if (success) {
+                if (!success) {
                     archfpga_throw(loc_data.filename_c_str(), loc_data.line(Cur),
                                    "Duplicate pb_type name: '%s' in mode: '%s'.\n",
                                    mode->pb_type_children[pb_type_child_idx].name, mode->name);

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -143,7 +143,6 @@ static void ProcessTileProps(pugi::xml_node Node,
 
 static t_pin_counts ProcessSubTilePorts(pugi::xml_node Parent,
                                         t_sub_tile* SubTile,
-                                        std::unordered_map<std::string, t_physical_tile_port>& tile_port_names,
                                         const pugiutil::loc_data& loc_data);
 
 static void ProcessTilePort(pugi::xml_node Node,
@@ -3011,7 +3010,6 @@ static void ProcessTileProps(pugi::xml_node Node,
 
 static t_pin_counts ProcessSubTilePorts(pugi::xml_node Parent,
                                         t_sub_tile* SubTile,
-                                        std::unordered_map<std::string, t_physical_tile_port>& tile_port_names,
                                         const pugiutil::loc_data& loc_data) {
     pugi::xml_node Cur;
 
@@ -3043,17 +3041,6 @@ static t_pin_counts ProcessSubTilePorts(pugi::xml_node Parent,
                 archfpga_throw(loc_data.filename_c_str(), loc_data.line(Cur),
                                "Duplicate port names in subtile '%s': port '%s'\n",
                                SubTile->name, port.name);
-            }
-
-            //Check port name duplicates
-            auto [added_entry, tile_success] = tile_port_names.insert({port.name, port});
-            if (!tile_success) {
-                if (added_entry->second.num_pins != port.num_pins || added_entry->second.equivalent != port.equivalent) {
-                    archfpga_throw(loc_data.filename_c_str(), loc_data.line(Cur),
-                                   "Another port found with the same name in other sub tiles "
-                                   "that did not match the current port settings. '%s': port '%s'\n",
-                                   SubTile->name, port.name);
-                }
             }
 
             //Push port
@@ -3540,7 +3527,7 @@ static void ProcessSubTiles(pugi::xml_node Node,
         PhysicalTileType->capacity += capacity;
 
         /* Process sub tile port definitions */
-        const auto pin_counts = ProcessSubTilePorts(CurSubTile, &SubTile, tile_port_names, loc_data);
+        const auto pin_counts = ProcessSubTilePorts(CurSubTile, &SubTile, loc_data);
 
         /* Map Sub Tile physical pins with the Physical Tile Type physical pins.
          * This takes into account the capacity of each sub tiles to add the correct offset.

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -3,7 +3,7 @@
  * <a> <b/> </a> will generate two pugi::xml_nodes.  One called "a" and its
  * child "b".  Each pugi::xml_node can contain various XML data such as attribute
  * information and text content.  The XML parser provides several functions to
- * help the developer build, and traverse tree (this is also somtime referred to
+ * help the developer build, and traverse tree (this is also sometimes referred to
  * as the Document Object Model or DOM).
  *
  * For convenience, it often makes sense to use some wraper functions (provided in
@@ -64,6 +64,8 @@
 #include "parse_switchblocks.h"
 
 #include "physical_types_util.h"
+
+#include "read_xml_arch_file_noc_tag.h"
 
 using namespace std::string_literals;
 using pugiutil::ReqOpt;
@@ -356,24 +358,6 @@ static void ProcessPower(pugi::xml_node parent,
 
 static void ProcessClocks(pugi::xml_node Parent, t_clock_arch* clocks, const pugiutil::loc_data& loc_data);
 
-/**
- * @brief Parses NoC-related information under <noc> tag.
- * @param noc_tag An XML node pointing to <noc> tag.
- * @param arch High-level architecture information. This function fills
- * arch->noc with NoC-related information.
- * @param loc_data Points to the location in the xml file where the parser is reading.
- */
-static void ProcessNoc(pugi::xml_node noc_tag,
-                       t_arch* arch,
-                       const pugiutil::loc_data& loc_data);
-
-static void processTopology(pugi::xml_node topology_tag,
-                            const pugiutil::loc_data& loc_data,
-                            t_noc_inf* noc_ref);
-
-static void processMeshTopology(pugi::xml_node mesh_topology_tag, const pugiutil::loc_data& loc_data, t_noc_inf* noc_ref);
-
-static void processRouter(pugi::xml_node router_tag, const pugiutil::loc_data& loc_data, t_noc_inf* noc_ref, std::map<int, std::pair<int, int>>& routers_info_in_arch);
 
 static void ProcessPb_TypePowerEstMethod(pugi::xml_node Parent, t_pb_type* pb_type, const pugiutil::loc_data& loc_data);
 static void ProcessPb_TypePort_Power(pugi::xml_node Parent, t_port* port, e_power_estimation_method power_method, const pugiutil::loc_data& loc_data);
@@ -386,69 +370,10 @@ static bool attribute_to_bool(const pugi::xml_node node,
 
 static int find_switch_by_name(const t_arch& arch, const std::string& switch_name);
 
-e_side string_to_side(std::string side_str);
+e_side string_to_side(const std::string& side_str);
 
 template<typename T>
 static T* get_type_by_name(const char* type_name, std::vector<T>& types);
-
-static void generate_noc_mesh(pugi::xml_node mesh_topology_tag, const pugiutil::loc_data& loc_data, t_noc_inf* noc_ref, double mesh_region_start_x, double mesh_region_end_x, double mesh_region_start_y, double mesh_region_end_y, int mesh_size);
-
-/**
- * @brief Parses the connections field in <router> tag under <topology> tag.
- * The user provides the list of routers any given router is connected to
- * by the router ids seperated by spaces. For example:
- * connections="1 2 3 4 5"
- * Go through the connections here and store them. Also make sure the list is legal.
- *
- * @param router_tag An XML node referring to a <router> tag.
- * @param loc_data Points to the location in the xml file where the parser is reading.
- * @param router_id The id field of the given <router> tag.
- * @param connection_list Parsed connections of the given <router>. To be filled by this
- * function.
- * @param connection_list_attribute_value Raw connections field of the given <router>.
- * @param routers_in_arch_info Stores router information that includes the number of connections
- * a router has within a given topology and also the number of times a router was declared
- * in the arch file using the <router> tag. [router_id, [n_declarations, n_connections]]
- *
- * @return True if parsing the connection list was successful.
- */
-static bool parse_noc_router_connection_list(pugi::xml_node router_tag,
-                                             const pugiutil::loc_data& loc_data,
-                                             int router_id,
-                                             std::vector<int>& connection_list,
-                                             const std::string& connection_list_attribute_value,
-                                             std::map<int, std::pair<int, int>>& routers_in_arch_info);
-
-/**
- * @brief Each router needs a separate <router> tag in the architecture description file
- * to declare it. The number of declarations for each router in the
- * architecture file is updated here. Additionally, for any given topology,
- * a router can connect to other routers. The number of connections for each router
- * is also updated here.
- *
- * @param router_id The identifier of the router whose information needs to be updated.
- * @param router_updated_as_a_connection Indicated whether the router id was seen in the
- * connections field of a <router> tag.
- * @param routers_in_arch_info Stores router information that includes the number of connections
- * a router has within a given topology and also the number of times a router was declared
- * in the arch file using the <router> tag. [router_id, [n_declarations, n_connections]]
- */
-static void update_router_info_in_arch(int router_id,
-                                       bool router_updated_as_a_connection,
-                                       std::map<int, std::pair<int, int>>& routers_in_arch_info);
-
-
-/**
- * @brief Verify each router in the noc by checking whether they satisfy the following conditions:
- * - The router has only one declaration in the arch file
- * - The router has at least one connection to another router
- * If any of the conditions above are not met, then an error is thrown.
- *
- * @param routers_in_arch_info Stores router information that includes the number of connections
- * a router has within a given topology and also the number of times a router was declared
- * in the arch file using the <router> tag. [router_id, [n_declarations, n_connections]]
- */
-static void verify_noc_topology(const std::map<int, std::pair<int, int>>& routers_in_arch_info);
 
 /*
  *
@@ -617,7 +542,7 @@ void XmlReadArch(const char* ArchFile,
         // process NoC (optional)
         Next = get_single_child(architecture, "noc", loc_data, pugiutil::OPTIONAL);
         if (Next) {
-            ProcessNoc(Next, arch, loc_data);
+            process_noc_tag(Next, arch, loc_data);
         }
 
         SyncModelsPbTypes(arch, LogicalBlockTypes);
@@ -4759,227 +4684,6 @@ static void ProcessClocks(pugi::xml_node Parent, t_clock_arch* clocks, const pug
     }
 }
 
-static void ProcessNoc(pugi::xml_node noc_tag,
-                       t_arch* arch,
-                       const pugiutil::loc_data& loc_data) {
-    // a vector representing all the possible attributes within the noc tag
-    std::vector<std::string> expected_noc_attributes = {"link_bandwidth", "link_latency", "router_latency", "noc_router_tile_name"};
-
-    std::vector<std::string> expected_noc_children_tags = {"mesh", "topology"};
-
-    pugi::xml_node noc_topology;
-    pugi::xml_node noc_mesh_topology;
-
-    // identifier that lets us know when we could not properly convert a string conversion value
-    std::string attribute_conversion_failure_string;
-
-    // if we are here, then the user has a NoC in their architecture, so need to add it
-    arch->noc = new t_noc_inf;
-    t_noc_inf* noc_ref = arch->noc;
-
-    /* process the noc attributes first */
-
-    // quick error check to make sure that we don't have unexpected attributes
-    pugiutil::expect_only_attributes(noc_tag, expected_noc_attributes, loc_data);
-
-    // now go through and parse the required attributes for noc tag
-
-    // variables below temporarily store the attribute values as string
-    // this is so that scientific notation can be used for these attributes
-
-    auto link_bandwidth_intermediate_val = pugiutil::get_attribute(noc_tag, "link_bandwidth", loc_data, pugiutil::REQUIRED).as_string();
-    noc_ref->link_bandwidth = std::atof(link_bandwidth_intermediate_val);
-
-    auto link_latency_intermediate_val = pugiutil::get_attribute(noc_tag, "link_latency", loc_data, pugiutil::REQUIRED).as_string();
-    noc_ref->link_latency = std::atof(link_latency_intermediate_val);
-
-    auto router_latency_intermediate_val = pugiutil::get_attribute(noc_tag, "router_latency", loc_data, pugiutil::REQUIRED).as_string();
-    noc_ref->router_latency = std::atof(router_latency_intermediate_val);
-
-    noc_ref->noc_router_tile_name = pugiutil::get_attribute(noc_tag, "noc_router_tile_name", loc_data, pugiutil::REQUIRED).as_string();
-
-    // the noc parameters can only be non-zero positive values
-    if ((noc_ref->link_bandwidth <= 0.) || (noc_ref->link_latency <= 0.) || (noc_ref->router_latency <= 0.)) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(noc_tag),
-                       "The link bandwidth, link latency and router latency for the NoC must be a positive non-zero value.");
-    }
-
-    // check that the router tile name was supplied properly
-    if (!(noc_ref->noc_router_tile_name.compare(attribute_conversion_failure_string))) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(noc_tag),
-                       "The noc router tile name must be a string.");
-    }
-
-    /* We processed the NoC node, so now process the topology*/
-
-    // make sure that only the topology tag is found under NoC
-    pugiutil::expect_only_children(noc_tag, expected_noc_children_tags, loc_data);
-
-    noc_mesh_topology = pugiutil::get_single_child(noc_tag, "mesh", loc_data, pugiutil::OPTIONAL);
-
-    // we cannot check for errors related to number of routers and as well as whether a router is out of bounds (this will be done later)
-    // the chip still needs to be sized
-
-    if (noc_mesh_topology) {
-        processMeshTopology(noc_mesh_topology, loc_data, noc_ref);
-    } else {
-        noc_topology = pugiutil::get_single_child(noc_tag, "topology", loc_data, pugiutil::REQUIRED);
-
-        processTopology(noc_topology, loc_data, noc_ref);
-    }
-}
-
-/*
- * A NoC mesh is created based on the user supplied size and region location.
- */
-static void processMeshTopology(pugi::xml_node mesh_topology_tag, const pugiutil::loc_data& loc_data, t_noc_inf* noc_ref) {
-    // noc mesh topology properties
-    double mesh_region_start_x = 0;
-    double mesh_region_end_x = 0;
-    double mesh_region_start_y = 0;
-    double mesh_region_end_y = 0;
-    int mesh_size = 0;
-
-    // identifier that lets us know when we could not properly convert an attribute value to a integer
-    int attribute_conversion_failure = -1;
-
-    // a list of attrbutes that should be found for the mesh tag
-    std::vector<std::string> expected_router_attributes = {"startx", "endx", "starty", "endy", "size"};
-
-    // verify that only the acceptable attributes were supplied
-    pugiutil::expect_only_attributes(mesh_topology_tag, expected_router_attributes, loc_data);
-
-    // go through the attributes and store their values
-    mesh_region_start_x = pugiutil::get_attribute(mesh_topology_tag, "startx", loc_data, pugiutil::REQUIRED).as_double(attribute_conversion_failure);
-
-    mesh_region_end_x = pugiutil::get_attribute(mesh_topology_tag, "endx", loc_data, pugiutil::REQUIRED).as_double(attribute_conversion_failure);
-
-    mesh_region_start_y = pugiutil::get_attribute(mesh_topology_tag, "starty", loc_data, pugiutil::REQUIRED).as_double(attribute_conversion_failure);
-
-    mesh_region_end_y = pugiutil::get_attribute(mesh_topology_tag, "endy", loc_data, pugiutil::REQUIRED).as_double(attribute_conversion_failure);
-
-    mesh_size = pugiutil::get_attribute(mesh_topology_tag, "size", loc_data, pugiutil::REQUIRED).as_int(attribute_conversion_failure);
-
-    // verify that the attrbiutes provided were legal
-    if ((mesh_region_start_x < 0) || (mesh_region_end_x < 0) || (mesh_region_start_y < 0) || (mesh_region_end_y < 0) || (mesh_size < 0)) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(mesh_topology_tag),
-                       "The parameters for the mesh topology have to be positive values.");
-    }
-
-    // now create the mesh topology for the noc
-    // create routers, make connections and detertmine positions
-    generate_noc_mesh(mesh_topology_tag, loc_data, noc_ref, mesh_region_start_x, mesh_region_end_x, mesh_region_start_y, mesh_region_end_y, mesh_size);
-
-    return;
-}
-
-/*
- * Go through each router in the NoC and store the list of routers that connect to it.
- */
-static void processTopology(pugi::xml_node topology_tag,
-                            const pugiutil::loc_data& loc_data,
-                            t_noc_inf* noc_ref) {
-    // The topology tag should have no attributes, check that
-    pugiutil::expect_only_attributes(topology_tag, {}, loc_data);
-
-    /**
-     * Stores router information that includes the number of connections a router
-     * has within a given topology and also the number of times a router was declared
-     * in the arch file using the <router> tag.
-     * key --> router id
-     * value.first  --> the number of router declarations
-     * value.second --> the number of router connections
-     * This is used only for error checking.
-     */
-    std::map<int, std::pair<int, int>> routers_in_arch_info;
-
-    /* Now go through the children tags of topology, which is basically
-     * each router found within the NoC 
-     */
-    for (pugi::xml_node router : topology_tag.children()) {
-        // we can only have router tags within the topology
-        if (router.name() != std::string("router")) {
-            bad_tag(router, loc_data, topology_tag, {"router"});
-        } else {
-            // current tag is a valid router, so process it
-            processRouter(router, loc_data, noc_ref, routers_in_arch_info);
-        }
-    }
-
-    // check whether any routers were supplied
-    if (noc_ref->router_list.empty()) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(topology_tag),
-                       "No routers were supplied for the NoC.");
-    }
-
-    // check that the topology of the noc was correctly described in the arch file
-    verify_noc_topology(routers_in_arch_info);
-}
-
-/*
- * Store the properties of a single router and then store the list of routers that connect to it.
- */
-static void processRouter(pugi::xml_node router_tag,
-                          const pugiutil::loc_data& loc_data,
-                          t_noc_inf* noc_ref,
-                          std::map<int, std::pair<int, int>>& routers_in_arch_info) {
-    // identifier that lets us know when we could not properly convert an attribute value to an integer
-    constexpr int ATTRIBUTE_CONVERSION_FAILURE = -1;
-
-    // an accepted list of attributes for the router tag
-    std::vector<std::string> expected_router_attributes = {"id", "positionx", "positiony", "connections"};
-
-    // check that only the accepted router attributes are found in the tag
-    pugiutil::expect_only_attributes(router_tag, expected_router_attributes, loc_data);
-
-    // variable to store current router info
-    t_router router_info;
-
-    // store the router information from the attributes
-    router_info.id = pugiutil::get_attribute(router_tag, "id", loc_data, pugiutil::REQUIRED).as_int(ATTRIBUTE_CONVERSION_FAILURE);
-
-    router_info.device_x_position = pugiutil::get_attribute(router_tag, "positionx", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
-
-    router_info.device_y_position = pugiutil::get_attribute(router_tag, "positiony", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
-
-    // verify whether the attribute information was legal
-    if ((router_info.id < 0) || (router_info.device_x_position < 0) || (router_info.device_y_position < 0)) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
-                       "The router id, and position (x & y) for the router must be a positive number.");
-    }
-
-    // get the current router connection list
-     std::string router_connection_list_attribute_value = pugiutil::get_attribute(router_tag, "connections", loc_data, pugiutil::REQUIRED).as_string();
-
-    // if the connections attribute was not provided, or it was empty, then we don't process it and throw a warning
-    if (!router_connection_list_attribute_value.empty()) {
-        // process the router connection list
-        bool router_connection_list_result = parse_noc_router_connection_list(router_tag, loc_data, router_info.id,
-                                                                              router_info.connection_list,
-                                                                              router_connection_list_attribute_value,
-                                                                              routers_in_arch_info);
-
-        // check if the user provided a legal router connection list
-        if (!router_connection_list_result) {
-            archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
-                           "The 'connections' attribute for the router must be a list of integers seperated by spaces, "
-                           "where each integer represents a router id that the current router is connected to.");
-        }
-
-    } else {
-        VTR_LOGF_WARN(loc_data.filename_c_str(), loc_data.line(router_tag),
-                      "The router with id:%d either has an empty 'connections' attribute "
-                      "or does not have any associated connections to other routers in the NoC.\n",
-                      router_info.id);
-    }
-
-    // at this point the current router information was completely legal, so we store the newly created router within the noc
-    noc_ref->router_list.push_back(router_info);
-
-    // update the number of declarations info for the current router (since we just finished processing one <router> tag)
-    update_router_info_in_arch(router_info.id, false, routers_in_arch_info);
-}
-
 std::string inst_port_to_port_name(std::string inst_port) {
     auto pos = inst_port.find('.');
     if (pos != std::string::npos) {
@@ -5013,7 +4717,7 @@ static int find_switch_by_name(const t_arch& arch, const std::string& switch_nam
     return OPEN;
 }
 
-e_side string_to_side(std::string side_str) {
+e_side string_to_side(const std::string& side_str) {
     e_side side = NUM_SIDES;
     if (side_str.empty()) {
         side = NUM_SIDES;
@@ -5042,201 +4746,4 @@ static T* get_type_by_name(const char* type_name, std::vector<T>& types) {
 
     archfpga_throw(__FILE__, __LINE__,
                    "Could not find type: %s\n", type_name);
-}
-
-/*
- * Create routers and set their properties so that a mesh grid of routers is created. Then connect the routers together so that a mesh topology is created.
- */
-static void generate_noc_mesh(pugi::xml_node mesh_topology_tag, const pugiutil::loc_data& loc_data, t_noc_inf* noc_ref, double mesh_region_start_x, double mesh_region_end_x, double mesh_region_start_y, double mesh_region_end_y, int mesh_size) {
-    // check that the mesh size of the router is not 0
-    if (mesh_size == 0) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(mesh_topology_tag),
-                       "The NoC mesh size cannot be 0.");
-    }
-
-    // calculating the vertical horizontal distances between routers in the supplied region
-    // we decrease the mesh size by 1 when calculating the spacing so that the first and last routers of each row or column are positioned on the mesh boundary
-    /*
-     * For example:
-     * - If we had a mesh size of 3, then using 3 would result in a spacing that would result in one router positions being placed in either the start of the reigion or end of the region. This is because the distance calculation resulted in having 3 spaces between the ends of the region 
-     *
-     * start              end
-     ***   ***   ***   ***
-     *
-     * - if we instead used 2 in the distance calculation, the the resulting positions would result in having 2 routers positioned on the start and end of the region. This is beacuse we now specified 2 spaces between the region and this allows us to place 2 routers on the regions edges and one router in the center.
-     *
-     * start        end
-     ***   ***   ***
-     *
-     * THe reasoning for this is to reduce the number of calculated router positions.
-     */
-    double vertical_router_separation = (mesh_region_end_y - mesh_region_start_y) / (mesh_size - 1);
-    double horizontal_router_separation = (mesh_region_end_x - mesh_region_start_x) / (mesh_size - 1);
-
-    t_router temp_router;
-
-    // improper region check
-    if ((vertical_router_separation <= 0) || (horizontal_router_separation <= 0)) {
-        archfpga_throw(loc_data.filename_c_str(), loc_data.line(mesh_topology_tag),
-                       "The NoC region is invalid.");
-    }
-
-    // create routers and their connections
-    // start with router id 0 (bottom left of the chip) to the maximum router id (top right of the chip)
-    for (int j = 0; j < mesh_size; j++) {
-        for (int i = 0; i < mesh_size; i++) {
-            // assign router id
-            temp_router.id = (mesh_size * j) + i;
-
-            // calculate router position
-            /* The first and last router of each column or row will be located on the mesh region boundary, the remaining routers will be placed within the region and seperated from other routers using the distance calculated previously.
-             */
-            temp_router.device_x_position = (i * horizontal_router_separation) + mesh_region_start_x;
-            temp_router.device_y_position = (j * vertical_router_separation) + mesh_region_start_y;
-
-            // assign connections
-            // check if there is a router to the left
-            if ((i - 1) >= 0) {
-                // add the left router as a connection
-                temp_router.connection_list.push_back((mesh_size * j) + i - 1);
-            }
-
-            // check if there is a router to the top
-            if ((j + 1) <= (mesh_size - 1)) {
-                // add the top router as a connection
-                temp_router.connection_list.push_back((mesh_size * (j + 1)) + i);
-            }
-
-            // check if there is a router to the right
-            if ((i + 1) <= (mesh_size - 1)) {
-                // add the router located to the right
-                temp_router.connection_list.push_back((mesh_size * j) + i + 1);
-            }
-
-            // check of there is a router below
-            if ((j - 1) >= (0)) {
-                // add the bottom router as a connection
-                temp_router.connection_list.push_back((mesh_size * (j - 1)) + i);
-            }
-
-            // add the router to the list
-            noc_ref->router_list.push_back(temp_router);
-
-            // clear the current router information for the next router
-            temp_router.connection_list.clear();
-        }
-    }
-
-    return;
-}
-
-static bool parse_noc_router_connection_list(pugi::xml_node router_tag,
-                                             const pugiutil::loc_data& loc_data,
-                                             int router_id,
-                                             std::vector<int>& connection_list,
-                                             const std::string& connection_list_attribute_value,
-                                             std::map<int, std::pair<int, int>>& routers_in_arch_info) {
-    // we wil be modifying the string so store it in a temporary variable
-    // additionally, we process substrings seperated by spaces,
-    // so we add a space at the end of the string to be able to process the last sub-string
-    std::string modified_attribute_value = connection_list_attribute_value + " ";
-    const std::string delimiter = " ";
-    std::stringstream single_connection;
-    int converted_connection;
-
-    size_t position = 0;
-
-    bool result = true;
-
-    // find the position of the first space in the connection list string
-    while ((position = modified_attribute_value.find(delimiter)) != std::string::npos) {
-        // the string upto the space represent a single connection, so grab the substring
-        single_connection << modified_attribute_value.substr(0, position);
-
-        // convert the connection to an integer
-        single_connection >> converted_connection;
-
-        /* we expect the connection list to be a string of integers seperated by spaces,
-         * where each integer represents a router id that the current router is connected to.
-         * So we make sure that the router id was an integer.
-         */
-        if (single_connection.fail()) {
-            // if we are here, then an integer was not supplied
-            result = false;
-            break;
-        }
-
-        // check the case where a duplicate connection was provided
-        if (std::find(connection_list.begin(), connection_list.end(), converted_connection) != connection_list.end()) {
-            archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
-                           "The router with id:'%d' was included multiple times in the connection list for another router.", converted_connection);
-        }
-
-        // make sure that the current router isn't connected to itself
-        if (router_id == converted_connection) {
-            archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
-                           "The router with id:%d was added to its own connection list. A router cannot connect to itself.", router_id);
-        }
-
-        // if we are here then a legal router id was supplied, so store it
-        connection_list.push_back(converted_connection);
-        // update the connection information for the current router in the connection list
-        update_router_info_in_arch(converted_connection, true, routers_in_arch_info);
-
-        // before we process the next router connection, we need to delete the substring (current router connection)
-        modified_attribute_value.erase(0, position + delimiter.length());
-        // clear the buffer that stores the router connection in a string format for the next iteration
-         single_connection.clear();
-    }
-
-    return result;
-}
-
-static void update_router_info_in_arch(int router_id,
-                                       bool router_updated_as_a_connection,
-                                       std::map<int, std::pair<int, int>>& routers_in_arch_info) {
-    // try to add the router
-    // if it was already added, get the existing one
-    auto [curr_router_info, _] = routers_in_arch_info.insert({router_id, {0, 0}});
-
-    auto& [n_declarations, n_connections] = curr_router_info->second;
-
-    // case where the current router was provided while parsing the connections of another router
-    if (router_updated_as_a_connection) {
-        // since we are within the case where the current router is being processed as
-        // a connection to another router we just increment its number of connections
-        n_connections++;
-
-    } else {
-        // since we are within the case where the current router is processed from a <router> tag,
-        // we just increment its number of declarations
-        n_declarations++;
-    }
-}
-
-static void verify_noc_topology(const std::map<int, std::pair<int, int>>& routers_in_arch_info) {
-
-    for (const auto& [router_id, router_info] : routers_in_arch_info) {
-        const auto [n_declarations, n_connections] = router_info;
-        // case where the router was included in the architecture and had no connections to other routers
-        if (n_declarations == 1 && n_connections == 0) {
-            archfpga_throw("", -1,
-                           "The router with id:'%d' is not connected to any other router in the NoC.",
-                           router_id);
-
-        } // case where a router was found to be connected to another router but not declared using the <router> tag in the arch file (i.e. missing)
-        else if (n_declarations == 0 && n_connections > 0) {
-            archfpga_throw("", -1,
-                           "The router with id:'%d' was found to be connected to another router "
-                           "but missing in the architecture file. Add the router using the <router> tag.",
-                           router_id);
-
-        } // case where the router was declared multiple times in the architecture file (multiple <router> tags for the same router)
-        else if (n_declarations > 1) {
-            archfpga_throw("", -1,
-                           "The router with id:'%d' was included more than once in the architecture file. "
-                           "Routers should only be declared once.",
-                           router_id);
-        }
-    }
 }

--- a/libs/libarchfpga/src/read_xml_arch_file.h
+++ b/libs/libarchfpga/src/read_xml_arch_file.h
@@ -9,8 +9,6 @@ extern "C" {
 
 /* special type indexes, necessary for initialization, everything afterwards
  * should use the pointers to these type indices*/
-
-#define NUM_MODELS_IN_LIBRARY 4
 #define EMPTY_TYPE_INDEX 0
 
 /* function declarations */

--- a/libs/libarchfpga/src/read_xml_arch_file_noc_tag.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file_noc_tag.cpp
@@ -618,5 +618,4 @@ static void process_noc_overrides(pugi::xml_node noc_overrides_tag,
             bad_tag(override_tag, loc_data, noc_overrides_tag, {"router", "link"});
         }
     }
-
 }

--- a/libs/libarchfpga/src/read_xml_arch_file_noc_tag.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file_noc_tag.cpp
@@ -15,8 +15,8 @@ static void process_mesh_topology(pugi::xml_node mesh_topology_tag,
 
 static void process_router(pugi::xml_node router_tag,
                            const pugiutil::loc_data& loc_data,
-                            t_noc_inf* noc_ref,
-                            std::map<int, std::pair<int, int>>& routers_info_in_arch);
+                           t_noc_inf* noc_ref,
+                           std::map<int, std::pair<int, int>>& routers_info_in_arch);
 
 static void generate_noc_mesh(pugi::xml_node mesh_topology_tag,
                               const pugiutil::loc_data& loc_data,

--- a/libs/libarchfpga/src/read_xml_arch_file_noc_tag.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file_noc_tag.cpp
@@ -1,0 +1,507 @@
+
+#include "read_xml_arch_file_noc_tag.h"
+
+#include "read_xml_util.h"
+#include "pugixml_util.hpp"
+#include "vtr_log.h"
+#include "arch_error.h"
+
+static void process_topology(pugi::xml_node topology_tag,
+                            const pugiutil::loc_data& loc_data,
+                            t_noc_inf* noc_ref);
+
+static void process_mesh_topology(pugi::xml_node mesh_topology_tag,
+                                  const pugiutil::loc_data& loc_data, t_noc_inf* noc_ref);
+
+static void process_router(pugi::xml_node router_tag,
+                           const pugiutil::loc_data& loc_data,
+                            t_noc_inf* noc_ref,
+                            std::map<int, std::pair<int, int>>& routers_info_in_arch);
+
+static void generate_noc_mesh(pugi::xml_node mesh_topology_tag,
+                              const pugiutil::loc_data& loc_data,
+                              t_noc_inf* noc_ref,
+                              double mesh_region_start_x, double mesh_region_end_x,
+                              double mesh_region_start_y, double mesh_region_end_y,
+                              int mesh_size);
+
+/**
+ * @brief Verify each router in the noc by checking whether they satisfy the following conditions:
+ * - The router has only one declaration in the arch file
+ * - The router has at least one connection to another router
+ * If any of the conditions above are not met, then an error is thrown.
+ *
+ * @param routers_in_arch_info Stores router information that includes the number of connections
+ * a router has within a given topology and also the number of times a router was declared
+ * in the arch file using the <router> tag. [router_id, [n_declarations, n_connections]]
+ */
+static void verify_noc_topology(const std::map<int, std::pair<int, int>>& routers_in_arch_info);
+
+/**
+ * @brief Parses the connections field in <router> tag under <topology> tag.
+ * The user provides the list of routers any given router is connected to
+ * by the router ids seperated by spaces. For example:
+ * connections="1 2 3 4 5"
+ * Go through the connections here and store them. Also make sure the list is legal.
+ *
+ * @param router_tag An XML node referring to a <router> tag.
+ * @param loc_data Points to the location in the xml file where the parser is reading.
+ * @param router_id The id field of the given <router> tag.
+ * @param connection_list Parsed connections of the given <router>. To be filled by this
+ * function.
+ * @param connection_list_attribute_value Raw connections field of the given <router>.
+ * @param routers_in_arch_info Stores router information that includes the number of connections
+ * a router has within a given topology and also the number of times a router was declared
+ * in the arch file using the <router> tag. [router_id, [n_declarations, n_connections]]
+ *
+ * @return True if parsing the connection list was successful.
+ */
+static bool parse_noc_router_connection_list(pugi::xml_node router_tag,
+                                             const pugiutil::loc_data& loc_data,
+                                             int router_id,
+                                             std::vector<int>& connection_list,
+                                             const std::string& connection_list_attribute_value,
+                                             std::map<int, std::pair<int, int>>& routers_in_arch_info);
+
+/**
+ * @brief Each router needs a separate <router> tag in the architecture description file
+ * to declare it. The number of declarations for each router in the
+ * architecture file is updated here. Additionally, for any given topology,
+ * a router can connect to other routers. The number of connections for each router
+ * is also updated here.
+ *
+ * @param router_id The identifier of the router whose information needs to be updated.
+ * @param router_updated_as_a_connection Indicated whether the router id was seen in the
+ * connections field of a <router> tag.
+ * @param routers_in_arch_info Stores router information that includes the number of connections
+ * a router has within a given topology and also the number of times a router was declared
+ * in the arch file using the <router> tag. [router_id, [n_declarations, n_connections]]
+ */
+static void update_router_info_in_arch(int router_id,
+                                       bool router_updated_as_a_connection,
+                                       std::map<int, std::pair<int, int>>& routers_in_arch_info);
+
+
+void process_noc_tag(pugi::xml_node noc_tag,
+                     t_arch* arch,
+                     const pugiutil::loc_data& loc_data) {
+    // a vector representing all the possible attributes within the noc tag
+    std::vector<std::string> expected_noc_attributes = {"link_bandwidth", "link_latency", "router_latency", "noc_router_tile_name"};
+
+    std::vector<std::string> expected_noc_children_tags = {"mesh", "topology"};
+
+
+    // identifier that lets us know when we could not properly convert a string conversion value
+    std::string attribute_conversion_failure_string;
+
+    // if we are here, then the user has a NoC in their architecture, so need to add it
+    arch->noc = new t_noc_inf;
+    t_noc_inf* noc_ref = arch->noc;
+
+    /* process the noc attributes first */
+
+    // quick error check to make sure that we don't have unexpected attributes
+    pugiutil::expect_only_attributes(noc_tag, expected_noc_attributes, loc_data);
+
+    // now go through and parse the required attributes for noc tag
+
+    // variables below temporarily store the attribute values as string
+    // this is so that scientific notation can be used for these attributes
+
+    auto link_bandwidth_intermediate_val = pugiutil::get_attribute(noc_tag, "link_bandwidth", loc_data, pugiutil::REQUIRED).as_string();
+    noc_ref->link_bandwidth = std::atof(link_bandwidth_intermediate_val);
+
+    auto link_latency_intermediate_val = pugiutil::get_attribute(noc_tag, "link_latency", loc_data, pugiutil::REQUIRED).as_string();
+    noc_ref->link_latency = std::atof(link_latency_intermediate_val);
+
+    auto router_latency_intermediate_val = pugiutil::get_attribute(noc_tag, "router_latency", loc_data, pugiutil::REQUIRED).as_string();
+    noc_ref->router_latency = std::atof(router_latency_intermediate_val);
+
+    noc_ref->noc_router_tile_name = pugiutil::get_attribute(noc_tag, "noc_router_tile_name", loc_data, pugiutil::REQUIRED).as_string();
+
+    // the noc parameters can only be non-zero positive values
+    if ((noc_ref->link_bandwidth <= 0.) || (noc_ref->link_latency <= 0.) || (noc_ref->router_latency <= 0.)) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(noc_tag),
+                       "The link bandwidth, link latency and router latency for the NoC must be a positive non-zero value.");
+    }
+
+    // check that the router tile name was supplied properly
+    if (!(noc_ref->noc_router_tile_name.compare(attribute_conversion_failure_string))) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(noc_tag),
+                       "The noc router tile name must be a string.");
+    }
+
+    /* We processed the NoC node, so now process the topology*/
+
+    // make sure that only the topology tag is found under NoC
+    pugiutil::expect_only_children(noc_tag, expected_noc_children_tags, loc_data);
+
+    pugi::xml_node noc_mesh_topology = pugiutil::get_single_child(noc_tag, "mesh", loc_data, pugiutil::OPTIONAL);
+
+    // we cannot check for errors related to number of routers and as well as whether a router is out of bounds (this will be done later)
+    // the chip still needs to be sized
+
+    if (noc_mesh_topology) {
+        process_mesh_topology(noc_mesh_topology, loc_data, noc_ref);
+    } else {
+        pugi::xml_node noc_topology = pugiutil::get_single_child(noc_tag, "topology", loc_data, pugiutil::REQUIRED);
+
+        process_topology(noc_topology, loc_data, noc_ref);
+    }
+
+    //    pugi::xml_node noc_overrides = pugiutil::get_single_child(noc_tag, "overrides", loc_data, pugiutil::OPTIONAL);
+    //    if (noc_overrides) {
+    //
+    //    }
+}
+
+/*
+ * A NoC mesh is created based on the user supplied size and region location.
+ */
+static void process_mesh_topology(pugi::xml_node mesh_topology_tag,
+                                  const pugiutil::loc_data& loc_data,
+                                  t_noc_inf* noc_ref) {
+
+    // identifier that lets us know when we could not properly convert an attribute value to a number
+    constexpr int ATTRIBUTE_CONVERSION_FAILURE = -1;
+
+    // a list of attributes that should be found for the mesh tag
+    std::vector<std::string> expected_router_attributes = {"startx", "endx", "starty", "endy", "size"};
+
+    // verify that only the acceptable attributes were supplied
+    pugiutil::expect_only_attributes(mesh_topology_tag, expected_router_attributes, loc_data);
+
+    // go through the attributes and store their values
+    double mesh_region_start_x = pugiutil::get_attribute(mesh_topology_tag, "startx", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
+    double mesh_region_end_x = pugiutil::get_attribute(mesh_topology_tag, "endx", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
+    double mesh_region_start_y = pugiutil::get_attribute(mesh_topology_tag, "starty", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
+    double mesh_region_end_y = pugiutil::get_attribute(mesh_topology_tag, "endy", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
+
+    int mesh_size = pugiutil::get_attribute(mesh_topology_tag, "size", loc_data, pugiutil::REQUIRED).as_int(ATTRIBUTE_CONVERSION_FAILURE);
+
+    // verify that the attributes provided were legal
+    if ((mesh_region_start_x < 0) || (mesh_region_end_x < 0) || (mesh_region_start_y < 0) || (mesh_region_end_y < 0) || (mesh_size < 0)) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(mesh_topology_tag),
+                       "The parameters for the mesh topology have to be positive values.");
+    }
+
+    // now create the mesh topology for the noc
+    // create routers, make connections and determine positions
+    generate_noc_mesh(mesh_topology_tag, loc_data, noc_ref, mesh_region_start_x, mesh_region_end_x, mesh_region_start_y, mesh_region_end_y, mesh_size);
+}
+
+/*
+ * Create routers and set their properties so that a mesh grid of routers is created.
+ * Then connect the routers together so that a mesh topology is created.
+ */
+static void generate_noc_mesh(pugi::xml_node mesh_topology_tag,
+                              const pugiutil::loc_data& loc_data,
+                              t_noc_inf* noc_ref,
+                              double mesh_region_start_x, double mesh_region_end_x,
+                              double mesh_region_start_y, double mesh_region_end_y,
+                              int mesh_size) {
+    // check that the mesh size of the router is not 0
+    if (mesh_size == 0) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(mesh_topology_tag),
+                       "The NoC mesh size cannot be 0.");
+    }
+
+    // calculating the vertical and horizontal distances between routers in the supplied region
+    // we decrease the mesh size by 1 when calculating the spacing so that the first and
+    // last routers of each row or column are positioned on the mesh boundary
+    /*
+     * For example:
+     * - If we had a mesh size of 3, then using 3 would result in a spacing that would result in
+     * one router positions being placed in either the start of the region or end of the region.
+     * This is because the distance calculation resulted in having 3 spaces between the ends of the region
+     *
+     * start              end
+     ***   ***   ***   ***
+     *
+     * - if we instead used 2 in the distance calculation, the resulting positions would result in
+     * having 2 routers positioned on the start and end of the region.
+     * This is beacuse we now specified 2 spaces between the region and this allows us to place 2 routers
+     * on the regions edges and one router in the center.
+     *
+     * start        end
+     ***   ***   ***
+     *
+     * THe reasoning for this is to reduce the number of calculated router positions.
+     */
+    double vertical_router_separation = (mesh_region_end_y - mesh_region_start_y) / (mesh_size - 1);
+    double horizontal_router_separation = (mesh_region_end_x - mesh_region_start_x) / (mesh_size - 1);
+
+    t_router temp_router;
+
+    // improper region check
+    if ((vertical_router_separation <= 0) || (horizontal_router_separation <= 0)) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(mesh_topology_tag),
+                       "The NoC region is invalid.");
+    }
+
+    // create routers and their connections
+    // start with router id 0 (bottom left of the chip) to the maximum router id (top right of the chip)
+    for (int j = 0; j < mesh_size; j++) {
+        for (int i = 0; i < mesh_size; i++) {
+            // assign router id
+            temp_router.id = (mesh_size * j) + i;
+
+            // calculate router position
+            /* The first and last router of each column or row will be located on the mesh region boundary,
+             * the remaining routers will be placed within the region and seperated from other routers
+             * using the distance calculated previously.
+             */
+            temp_router.device_x_position = (i * horizontal_router_separation) + mesh_region_start_x;
+            temp_router.device_y_position = (j * vertical_router_separation) + mesh_region_start_y;
+
+            // assign connections
+            // check if there is a router to the left
+            if ((i - 1) >= 0) {
+                // add the left router as a connection
+                temp_router.connection_list.push_back((mesh_size * j) + i - 1);
+            }
+
+            // check if there is a router to the top
+            if ((j + 1) <= (mesh_size - 1)) {
+                // add the top router as a connection
+                temp_router.connection_list.push_back((mesh_size * (j + 1)) + i);
+            }
+
+            // check if there is a router to the right
+            if ((i + 1) <= (mesh_size - 1)) {
+                // add the router located to the right
+                temp_router.connection_list.push_back((mesh_size * j) + i + 1);
+            }
+
+            // check of there is a router below
+            if ((j - 1) >= (0)) {
+                // add the bottom router as a connection
+                temp_router.connection_list.push_back((mesh_size * (j - 1)) + i);
+            }
+
+            // add the router to the list
+            noc_ref->router_list.push_back(temp_router);
+
+            // clear the current router information for the next router
+            temp_router.connection_list.clear();
+        }
+    }
+}
+
+/*
+ * Go through each router in the NoC and store the list of routers that connect to it.
+ */
+static void process_topology(pugi::xml_node topology_tag,
+                            const pugiutil::loc_data& loc_data,
+                            t_noc_inf* noc_ref) {
+    // The topology tag should have no attributes, check that
+    pugiutil::expect_only_attributes(topology_tag, {}, loc_data);
+
+    /**
+     * Stores router information that includes the number of connections a router
+     * has within a given topology and also the number of times a router was declared
+     * in the arch file using the <router> tag.
+     * key --> router id
+     * value.first  --> the number of router declarations
+     * value.second --> the number of router connections
+     * This is used only for error checking.
+     */
+    std::map<int, std::pair<int, int>> routers_in_arch_info;
+
+    /* Now go through the children tags of topology, which is basically
+     * each router found within the NoC
+     */
+    for (pugi::xml_node router : topology_tag.children()) {
+        // we can only have router tags within the topology
+        if (router.name() != std::string("router")) {
+            bad_tag(router, loc_data, topology_tag, {"router"});
+        } else {
+            // current tag is a valid router, so process it
+            process_router(router, loc_data, noc_ref, routers_in_arch_info);
+        }
+    }
+
+    // check whether any routers were supplied
+    if (noc_ref->router_list.empty()) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(topology_tag),
+                       "No routers were supplied for the NoC.");
+    }
+
+    // check that the topology of the noc was correctly described in the arch file
+    verify_noc_topology(routers_in_arch_info);
+}
+
+/*
+ * Store the properties of a single router and then store the list of routers that connect to it.
+ */
+static void process_router(pugi::xml_node router_tag,
+                           const pugiutil::loc_data& loc_data,
+                           t_noc_inf* noc_ref,
+                           std::map<int, std::pair<int, int>>& routers_in_arch_info) {
+    // identifier that lets us know when we could not properly convert an attribute value to an integer
+    constexpr int ATTRIBUTE_CONVERSION_FAILURE = -1;
+
+    // an accepted list of attributes for the router tag
+    std::vector<std::string> expected_router_attributes = {"id", "positionx", "positiony", "connections"};
+
+    // check that only the accepted router attributes are found in the tag
+    pugiutil::expect_only_attributes(router_tag, expected_router_attributes, loc_data);
+
+    // variable to store current router info
+    t_router router_info;
+
+    // store the router information from the attributes
+    router_info.id = pugiutil::get_attribute(router_tag, "id", loc_data, pugiutil::REQUIRED).as_int(ATTRIBUTE_CONVERSION_FAILURE);
+
+    router_info.device_x_position = pugiutil::get_attribute(router_tag, "positionx", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
+
+    router_info.device_y_position = pugiutil::get_attribute(router_tag, "positiony", loc_data, pugiutil::REQUIRED).as_double(ATTRIBUTE_CONVERSION_FAILURE);
+
+    // verify whether the attribute information was legal
+    if ((router_info.id < 0) || (router_info.device_x_position < 0) || (router_info.device_y_position < 0)) {
+        archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
+                       "The router id, and position (x & y) for the router must be a positive number.");
+    }
+
+    // get the current router connection list
+    std::string router_connection_list_attribute_value = pugiutil::get_attribute(router_tag, "connections", loc_data, pugiutil::REQUIRED).as_string();
+
+    // if the connections attribute was not provided, or it was empty, then we don't process it and throw a warning
+    if (!router_connection_list_attribute_value.empty()) {
+        // process the router connection list
+        bool router_connection_list_result = parse_noc_router_connection_list(router_tag, loc_data, router_info.id,
+                                                                              router_info.connection_list,
+                                                                              router_connection_list_attribute_value,
+                                                                              routers_in_arch_info);
+
+        // check if the user provided a legal router connection list
+        if (!router_connection_list_result) {
+            archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
+                           "The 'connections' attribute for the router must be a list of integers seperated by spaces, "
+                           "where each integer represents a router id that the current router is connected to.");
+        }
+
+    } else {
+        VTR_LOGF_WARN(loc_data.filename_c_str(), loc_data.line(router_tag),
+                      "The router with id:%d either has an empty 'connections' attribute "
+                      "or does not have any associated connections to other routers in the NoC.\n",
+                      router_info.id);
+    }
+
+    // at this point the current router information was completely legal, so we store the newly created router within the noc
+    noc_ref->router_list.push_back(router_info);
+
+    // update the number of declarations info for the current router (since we just finished processing one <router> tag)
+    update_router_info_in_arch(router_info.id, false, routers_in_arch_info);
+}
+
+static void verify_noc_topology(const std::map<int, std::pair<int, int>>& routers_in_arch_info) {
+
+    for (const auto& [router_id, router_info] : routers_in_arch_info) {
+        const auto [n_declarations, n_connections] = router_info;
+        // case where the router was included in the architecture and had no connections to other routers
+        if (n_declarations == 1 && n_connections == 0) {
+            archfpga_throw("", -1,
+                           "The router with id:'%d' is not connected to any other router in the NoC.",
+                           router_id);
+
+        } // case where a router was found to be connected to another router but not declared using the <router> tag in the arch file (i.e. missing)
+        else if (n_declarations == 0 && n_connections > 0) {
+            archfpga_throw("", -1,
+                           "The router with id:'%d' was found to be connected to another router "
+                           "but missing in the architecture file. Add the router using the <router> tag.",
+                           router_id);
+
+        } // case where the router was declared multiple times in the architecture file (multiple <router> tags for the same router)
+        else if (n_declarations > 1) {
+            archfpga_throw("", -1,
+                           "The router with id:'%d' was included more than once in the architecture file. "
+                           "Routers should only be declared once.",
+                           router_id);
+        }
+    }
+}
+
+static bool parse_noc_router_connection_list(pugi::xml_node router_tag,
+                                             const pugiutil::loc_data& loc_data,
+                                             int router_id,
+                                             std::vector<int>& connection_list,
+                                             const std::string& connection_list_attribute_value,
+                                             std::map<int, std::pair<int, int>>& routers_in_arch_info) {
+    // we wil be modifying the string so store it in a temporary variable
+    // additionally, we process substrings seperated by spaces,
+    // so we add a space at the end of the string to be able to process the last sub-string
+    std::string modified_attribute_value = connection_list_attribute_value + " ";
+    const std::string delimiter = " ";
+    std::stringstream single_connection;
+    int converted_connection;
+
+    size_t position = 0;
+
+    bool result = true;
+
+    // find the position of the first space in the connection list string
+    while ((position = modified_attribute_value.find(delimiter)) != std::string::npos) {
+        // the string upto the space represent a single connection, so grab the substring
+        single_connection << modified_attribute_value.substr(0, position);
+
+        // convert the connection to an integer
+        single_connection >> converted_connection;
+
+        /* we expect the connection list to be a string of integers seperated by spaces,
+         * where each integer represents a router id that the current router is connected to.
+         * So we make sure that the router id was an integer.
+         */
+        if (single_connection.fail()) {
+            // if we are here, then an integer was not supplied
+            result = false;
+            break;
+        }
+
+        // check the case where a duplicate connection was provided
+        if (std::find(connection_list.begin(), connection_list.end(), converted_connection) != connection_list.end()) {
+            archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
+                           "The router with id:'%d' was included multiple times in the connection list for another router.", converted_connection);
+        }
+
+        // make sure that the current router isn't connected to itself
+        if (router_id == converted_connection) {
+            archfpga_throw(loc_data.filename_c_str(), loc_data.line(router_tag),
+                           "The router with id:%d was added to its own connection list. A router cannot connect to itself.", router_id);
+        }
+
+        // if we are here then a legal router id was supplied, so store it
+        connection_list.push_back(converted_connection);
+        // update the connection information for the current router in the connection list
+        update_router_info_in_arch(converted_connection, true, routers_in_arch_info);
+
+        // before we process the next router connection, we need to delete the substring (current router connection)
+        modified_attribute_value.erase(0, position + delimiter.length());
+        // clear the buffer that stores the router connection in a string format for the next iteration
+        single_connection.clear();
+    }
+
+    return result;
+}
+
+static void update_router_info_in_arch(int router_id,
+                                       bool router_updated_as_a_connection,
+                                       std::map<int, std::pair<int, int>>& routers_in_arch_info) {
+    // try to add the router
+    // if it was already added, get the existing one
+    auto [curr_router_info, _] = routers_in_arch_info.insert({router_id, {0, 0}});
+
+    auto& [n_declarations, n_connections] = curr_router_info->second;
+
+    // case where the current router was provided while parsing the connections of another router
+    if (router_updated_as_a_connection) {
+        // since we are within the case where the current router is being processed as
+        // a connection to another router we just increment its number of connections
+        n_connections++;
+
+    } else {
+        // since we are within the case where the current router is processed from a <router> tag,
+        // we just increment its number of declarations
+        n_declarations++;
+    }
+}

--- a/libs/libarchfpga/src/read_xml_arch_file_noc_tag.h
+++ b/libs/libarchfpga/src/read_xml_arch_file_noc_tag.h
@@ -1,0 +1,20 @@
+
+#ifndef VTR_READ_XML_ARCH_FILE_NOC_TAG_H
+#define VTR_READ_XML_ARCH_FILE_NOC_TAG_H
+
+#include "pugixml.hpp"
+#include "pugixml_loc.hpp"
+#include "physical_types.h"
+
+/**
+ * @brief Parses NoC-related information under <noc> tag.
+ * @param noc_tag An XML node pointing to <noc> tag.
+ * @param arch High-level architecture information. This function fills
+ * arch->noc with NoC-related information.
+ * @param loc_data Points to the location in the xml file where the parser is reading.
+ */
+void process_noc_tag(pugi::xml_node noc_tag,
+                     t_arch* arch,
+                     const pugiutil::loc_data& loc_data);
+
+#endif //VTR_READ_XML_ARCH_FILE_NOC_TAG_H

--- a/libs/libarchfpga/src/read_xml_util.cpp
+++ b/libs/libarchfpga/src/read_xml_util.cpp
@@ -43,7 +43,7 @@ InstPort make_inst_port(pugi::xml_attribute attr, pugi::xml_node node, const pug
 void bad_tag(const pugi::xml_node node,
              const pugiutil::loc_data& loc_data,
              const pugi::xml_node parent_node,
-             const std::vector<std::string> expected_tags) {
+             const std::vector<std::string>& expected_tags) {
     std::string msg = "Unexpected tag ";
     msg += "<";
     msg += node.name();
@@ -76,7 +76,7 @@ void bad_tag(const pugi::xml_node node,
 void bad_attribute(const pugi::xml_attribute attr,
                    const pugi::xml_node node,
                    const pugiutil::loc_data& loc_data,
-                   const std::vector<std::string> expected_attributes) {
+                   const std::vector<std::string>& expected_attributes) {
     std::string msg = "Unexpected attribute ";
     msg += "'";
     msg += attr.name();
@@ -109,7 +109,7 @@ void bad_attribute(const pugi::xml_attribute attr,
 void bad_attribute_value(const pugi::xml_attribute attr,
                          const pugi::xml_node node,
                          const pugiutil::loc_data& loc_data,
-                         const std::vector<std::string> expected_values) {
+                         const std::vector<std::string>& expected_values) {
     std::string msg = "Invalid value '";
     msg += attr.value();
     msg += "'";

--- a/libs/libarchfpga/src/read_xml_util.h
+++ b/libs/libarchfpga/src/read_xml_util.h
@@ -11,16 +11,16 @@ pugiutil::ReqOpt BoolToReqOpt(bool b);
 void bad_tag(const pugi::xml_node node,
              const pugiutil::loc_data& loc_data,
              const pugi::xml_node parent_node = pugi::xml_node(),
-             const std::vector<std::string> expected_tags = std::vector<std::string>());
+             const std::vector<std::string>& expected_tags = std::vector<std::string>());
 
 void bad_attribute(const pugi::xml_attribute attr,
                    const pugi::xml_node node,
                    const pugiutil::loc_data& loc_data,
-                   const std::vector<std::string> expected_attributes = std::vector<std::string>());
+                   const std::vector<std::string>& expected_attributes = std::vector<std::string>());
 void bad_attribute_value(const pugi::xml_attribute attr,
                          const pugi::xml_node node,
                          const pugiutil::loc_data& loc_data,
-                         const std::vector<std::string> expected_attributes = std::vector<std::string>());
+                         const std::vector<std::string>& expected_attributes = std::vector<std::string>());
 
 InstPort make_inst_port(std::string str, pugi::xml_node node, const pugiutil::loc_data& loc_data);
 InstPort make_inst_port(pugi::xml_attribute attr, pugi::xml_node node, const pugiutil::loc_data& loc_data);

--- a/libs/libarchfpga/test/test_read_xml_arch_file.cpp
+++ b/libs/libarchfpga/test/test_read_xml_arch_file.cpp
@@ -2,8 +2,8 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_all.hpp"
 
-// testting statuc functions so include whole source file it is in
-#include "read_xml_arch_file.cpp"
+// testing static functions so include whole source file it is in
+#include "read_xml_arch_file_noc_tag.cpp"
 
 // for comparing floats
 #include "vtr_math.h"
@@ -25,7 +25,7 @@ TEST_CASE("Updating router info in arch", "[NoC Arch Tests]") {
 
         it = test_router_list.find(router_id);
 
-        // check first that the router was newly added to the router databse
+        // check first that the router was newly added to the router database
         REQUIRE(it != test_router_list.end());
 
         // no verify the components of the router parameter
@@ -39,7 +39,7 @@ TEST_CASE("Updating router info in arch", "[NoC Arch Tests]") {
 
         it = test_router_list.find(router_id);
 
-        // check first that the router was newly added to the router databse
+        // check first that the router was newly added to the router database
         REQUIRE(it != test_router_list.end());
 
         // no verify the components of the router parameter
@@ -56,7 +56,7 @@ TEST_CASE("Updating router info in arch", "[NoC Arch Tests]") {
 
         it = test_router_list.find(router_id);
 
-        // check first that the router was newly added to the router databse
+        // check first that the router was newly added to the router database
         REQUIRE(it != test_router_list.end());
 
         // no verify the components of the router parameter
@@ -75,7 +75,7 @@ TEST_CASE("Updating router info in arch", "[NoC Arch Tests]") {
 
         it = test_router_list.find(router_id);
 
-        // check first that the router was newly added to the router databse
+        // check first that the router was newly added to the router database
         REQUIRE(it != test_router_list.end());
 
         // no verify the components of the router parameter
@@ -172,7 +172,7 @@ TEST_CASE("Verifying mesh topology creation", "[NoC Arch Tests]") {
         mesh_end_x = 4;
         mesh_end_y = 4;
 
-        // create the golden golden results
+        // create the golden results
         double golden_results_x[9];
         double golden_results_y[9];
 

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -150,7 +150,7 @@ void expect_child_node_count(const pugi::xml_node node,
 //  child_names - expected attribute names
 //  loc_data - XML file location data
 void expect_only_children(const pugi::xml_node node,
-                          std::vector<std::string> child_names,
+                          const std::vector<std::string>& child_names,
                           const loc_data& loc_data) {
     for (auto child : node.children()) {
         std::string child_name = child.name();
@@ -161,7 +161,7 @@ void expect_only_children(const pugi::xml_node node,
             std::string msg = "Unexpected child '" + child_name + "'"
                               + " of node '" + node.name() + "'.";
 
-            if (child_names.size() > 0) {
+            if (!child_names.empty()) {
                 msg += " Expected (possibly) one of: ";
                 for (size_t i = 0; i < child_names.size(); i++) {
                     if (i != 0) {

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -188,7 +188,7 @@ void expect_only_children(const pugi::xml_node node,
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
-                            std::string explanation,
+                            const std::string& explanation,
                             const loc_data& loc_data) {
     for (auto attrib : node.attributes()) {
         std::string attrib_name = attrib.name();
@@ -205,7 +205,7 @@ void expect_only_attributes(const pugi::xml_node node,
 
             msg += ".";
 
-            if (attribute_names.size() > 0) {
+            if (!attribute_names.empty()) {
                 msg += " Expected (possibly) one of: ";
                 for (size_t i = 0; i < attribute_names.size(); i++) {
                     if (i != 0) {
@@ -225,13 +225,13 @@ void expect_only_attributes(const pugi::xml_node node,
 }
 
 //Throws a well formatted error if any attribute other than those named in 'attribute_names' are found on 'node'.
-//Note this does not check whether the attribues in 'attribute_names' actually exist; for that use get_attribute().
+//Note this does not check whether the attributes in 'attribute_names' actually exist; for that use get_attribute().
 //
 //  node - The parent xml node
 //  attribute_names - expected attribute names
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
-                            std::vector<std::string> attribute_names,
+                            const std::vector<std::string>& attribute_names,
                             const loc_data& loc_data) {
     expect_only_attributes(node, attribute_names, "", loc_data);
 }

--- a/libs/libpugiutil/src/pugixml_util.cpp
+++ b/libs/libpugiutil/src/pugixml_util.cpp
@@ -81,7 +81,7 @@ size_t count_children(const pugi::xml_node node,
         child = child.next_sibling(child_name.c_str());
     }
 
-    //Note that we don't do any error checking here since get_first_child does the existance check
+    //Note that we don't do any error checking here since get_first_child does the existence check
 
     return count;
 }
@@ -188,7 +188,7 @@ void expect_only_children(const pugi::xml_node node,
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
-                            const std::string& explanation,
+                            std::string_view explanation,
                             const loc_data& loc_data) {
     for (auto attrib : node.attributes()) {
         std::string attrib_name = attrib.name();
@@ -254,7 +254,7 @@ size_t count_attributes(const pugi::xml_node node,
     return count;
 }
 
-//Gets a named property on an node and returns it.
+//Gets a named property on a node and returns it.
 //
 //  node - The xml node
 //  attr_name - The attribute name

--- a/libs/libpugiutil/src/pugixml_util.hpp
+++ b/libs/libpugiutil/src/pugixml_util.hpp
@@ -148,7 +148,7 @@ void expect_only_children(const pugi::xml_node node,
 //  attribute_names - expected attribute names
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
-                            std::vector<std::string> attribute_names,
+                            const std::vector<std::string>& attribute_names,
                             const loc_data& loc_data);
 
 //Throws a well formatted error if any attribute other than those named in 'attribute_names' are found on 'node' with an additional explanation.
@@ -159,7 +159,7 @@ void expect_only_attributes(const pugi::xml_node node,
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
-                            std::string explanation,
+                            const std::string& explanation,
                             const loc_data& loc_data);
 
 //Counts the number of attributes on the specified node
@@ -171,7 +171,7 @@ size_t count_attributes(const pugi::xml_node node,
                         const loc_data& loc_data,
                         const ReqOpt req_opt = REQUIRED);
 
-//Gets a named property on an node and returns it.
+//Gets a named property on a node and returns it.
 //
 //  node - The xml node
 //  attr_name - The attribute name

--- a/libs/libpugiutil/src/pugixml_util.hpp
+++ b/libs/libpugiutil/src/pugixml_util.hpp
@@ -138,7 +138,7 @@ void expect_child_node_count(const pugi::xml_node node,
 //  child_names - expected attribute names
 //  loc_data - XML file location data
 void expect_only_children(const pugi::xml_node node,
-                          std::vector<std::string> child_names,
+                          const std::vector<std::string>& child_names,
                           const loc_data& loc_data);
 
 //Throws a well formatted error if any attribute other than those named in 'attribute_names' are found on 'node'.

--- a/libs/libpugiutil/src/pugixml_util.hpp
+++ b/libs/libpugiutil/src/pugixml_util.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <stdexcept>
 #include <cstdio>
+#include <string_view>
 
 #include "pugixml.hpp"
 
@@ -159,7 +160,7 @@ void expect_only_attributes(const pugi::xml_node node,
 //  loc_data - XML file location data
 void expect_only_attributes(const pugi::xml_node node,
                             std::vector<std::string> attribute_names,
-                            const std::string& explanation,
+                            std::string_view explanation,
                             const loc_data& loc_data);
 
 //Counts the number of attributes on the specified node

--- a/libs/libvtrutil/src/vtr_string_interning.h
+++ b/libs/libvtrutil/src/vtr_string_interning.h
@@ -11,7 +11,7 @@
  * 
  *  This string internment has an additional feature that is splitting the
  *  input string into "parts" based on '.', which happens to be the feature
- *  seperator for FASM.  This means the string "TILE.CLB.A" and "TILE.CLB.B"
+ *  separator for FASM.  This means the string "TILE.CLB.A" and "TILE.CLB.B"
  *  would be made up of the intern ids for {"TILE", "CLB", "A"} and
  *  {"TILE", "CLB", "B"} respectively, allowing some internal deduplication.
  * 
@@ -20,14 +20,14 @@
  * 
  *  Interned strings (interned_string) that come from the same internment
  *  object (string_internment) can safely be checked for equality and hashed
- *  without touching the underlying string.  Lexigraphical comprisions (e.g. <)
+ *  without touching the underlying string.  Lexigraphical comparisons (e.g. <)
  *  requires reconstructing the string.
  * 
  *  Basic usage:
  *  -# Create a string_internment
  *  -# Invoke string_internment::intern_string, which returns the
- *     interned_string object that is the interned string's unique idenfier.
- *     This idenfier can be checked for equality or hashed. If
+ *     interned_string object that is the interned string's unique identifier.
+ *     This identifier can be checked for equality or hashed. If
  *     string_internment::intern_string is called with the same string, a value
  *     equivalent interned_string object will be returned.
  *  -# If the original string is required, interned_string::get can be invoked

--- a/vpr/src/base/setup_noc.cpp
+++ b/vpr/src/base/setup_noc.cpp
@@ -1,18 +1,19 @@
-#include <climits>
 #include <cmath>
 
 #include "setup_noc.h"
 
-#include "vtr_assert.h"
+#include "globals.h"
 #include "vpr_error.h"
 #include "vtr_math.h"
 #include "echo_files.h"
 
-void setup_noc(const t_arch& arch) {
-    // variable to store all the noc router tiles within the FPGA device
-    // physical routers
-    std::vector<t_noc_router_tile_position> noc_router_tiles;
+// a default condition that helps keep track of whether a physical router has been assigned to a logical router or not
+static constexpr int PHYSICAL_ROUTER_NOT_ASSIGNED = -1;
 
+// a default index used for initialization purposes. No router will have a negative index
+static constexpr int INVALID_PHYSICAL_ROUTER_INDEX = -1;
+
+void setup_noc(const t_arch& arch) {
     // get references to global variables
     auto& device_ctx = g_vpr_ctx.device();
     auto& noc_ctx = g_vpr_ctx.mutable_noc();
@@ -25,17 +26,22 @@ void setup_noc(const t_arch& arch) {
 
     // go through the FPGA grid and find the noc router tiles
     // then store the position
-    identify_and_store_noc_router_tile_positions(device_ctx.grid, noc_router_tiles, arch.noc->noc_router_tile_name);
+    auto noc_router_tiles = identify_and_store_noc_router_tile_positions(device_ctx.grid, arch.noc->noc_router_tile_name);
 
     // check whether the noc topology information provided uses more than the number of available routers in the FPGA
     if (noc_router_tiles.size() < arch.noc->router_list.size()) {
-        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "The Provided NoC topology information in the architecture file has more number of routers than what is available in the FPGA device.");
-    } else if (noc_router_tiles.size() > arch.noc->router_list.size()) // check whether the noc topology information provided is using all the routers in the FPGA
-    {
-        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "The Provided NoC topology information in the architecture file uses less number of routers than what is available in the FPGA device.");
-    } else if (noc_router_tiles.size() == 0) // case where no physical router tiles were found
-    {
-        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "No physical NoC routers were found on the FPGA device. Either the provided name for the physical router tile was incorrect or the FPGA device has no routers.");
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                        "The Provided NoC topology information in the architecture file "
+                        "has more number of routers than what is available in the FPGA device.");
+    } else if (noc_router_tiles.size() > arch.noc->router_list.size()) {
+        // check whether the noc topology information provided is using all the routers in the FPGA
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                        "The Provided NoC topology information in the architecture file "
+                        "uses less number of routers than what is available in the FPGA device.");
+    } else if (noc_router_tiles.empty()) {  // case where no physical router tiles were found
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                        "No physical NoC routers were found on the FPGA device. "
+                        "Either the provided name for the physical router tile was incorrect or the FPGA device has no routers.");
     }
 
     // store the reference to device grid with
@@ -54,25 +60,18 @@ void setup_noc(const t_arch& arch) {
     if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_NOC_MODEL)) {
         noc_ctx.noc_model.echo_noc(getEchoFileName(E_ECHO_NOC_MODEL));
     }
-
-    return;
 }
 
-void identify_and_store_noc_router_tile_positions(const DeviceGrid& device_grid, std::vector<t_noc_router_tile_position>& noc_router_tiles, std::string noc_router_tile_name) {
+std::vector<t_noc_router_tile_position> identify_and_store_noc_router_tile_positions(const DeviceGrid& device_grid,
+                                                                                     std::string_view noc_router_tile_name) {
     const int num_layers = device_grid.get_num_layers();
-    int curr_tile_width;
-    int curr_tile_height;
-    int curr_tile_width_offset;
-    int curr_tile_height_offset;
-    std::string curr_tile_name;
+    const int grid_width = (int)device_grid.width();
+    const int grid_height = (int)device_grid.height();
 
-    double curr_tile_centroid_x;
-    double curr_tile_centroid_y;
+    std::vector<t_noc_router_tile_position> noc_router_tiles;
 
     // go through the device
     for (int layer_num = 0; layer_num < num_layers; layer_num++) {
-        int grid_width = (int)device_grid.width();
-        int grid_height = (int)device_grid.height();
         for (int i = 0; i < grid_width; i++) {
             for (int j = 0; j < grid_height; j++) {
                 // get some information from the current tile
@@ -80,34 +79,39 @@ void identify_and_store_noc_router_tile_positions(const DeviceGrid& device_grid,
                 int width_offset = device_grid.get_width_offset({i, j, layer_num});
                 int height_offset = device_grid.get_height_offset({i, j, layer_num});
 
-                curr_tile_name.assign(type->name);
-                curr_tile_width_offset = width_offset;
-                curr_tile_height_offset = height_offset;
+                std::string_view curr_tile_name = type->name;
+                int curr_tile_width_offset = width_offset;
+                int curr_tile_height_offset = height_offset;
 
-                curr_tile_height = type->height;
-                curr_tile_width = type->width;
+                int curr_tile_height = type->height;
+                int curr_tile_width = type->width;
 
                 /*
                  * Only store the tile position if it is a noc router.
-                 * Additionally, since a router tile can span multiple grid locations, we only add the tile if the height and width offset are zero (this prevents the router from being added multiple times for each grid location it spans).
+                 * Additionally, since a router tile can span multiple grid locations,
+                 * we only add the tile if the height and width offset are zero (this prevents the router from being added multiple times for each grid location it spans).
                  */
-                if (!(noc_router_tile_name.compare(curr_tile_name)) && !curr_tile_width_offset && !curr_tile_height_offset) {
+                if (noc_router_tile_name == curr_tile_name && !curr_tile_width_offset && !curr_tile_height_offset) {
                     // calculating the centroid position of the current tile
-                    curr_tile_centroid_x = (curr_tile_width - 1) / (double)2 + i;
-                    curr_tile_centroid_y = (curr_tile_height - 1) / (double)2 + j;
+                    double curr_tile_centroid_x = (curr_tile_width - 1) / (double)2 + i;
+                    double curr_tile_centroid_y = (curr_tile_height - 1) / (double)2 + j;
 
                     noc_router_tiles.emplace_back(i, j, layer_num, curr_tile_centroid_x, curr_tile_centroid_y);
                 }
             }
         }
     }
+
+    return noc_router_tiles;
 }
 
-void generate_noc(const t_arch& arch, NocContext& noc_ctx, std::vector<t_noc_router_tile_position>& noc_router_tiles) {
-    // refrernces to the noc
+void generate_noc(const t_arch& arch,
+                  NocContext& noc_ctx,
+                  const std::vector<t_noc_router_tile_position>& noc_router_tiles) {
+    // references to the noc
     NocStorage* noc_model = &noc_ctx.noc_model;
     // reference to the noc description
-    const t_noc_inf* noc_info = arch.noc;
+    const t_noc_inf& noc_info = *arch.noc;
 
     // initialize the noc
     noc_model->clear_noc();
@@ -120,26 +124,18 @@ void generate_noc(const t_arch& arch, NocContext& noc_ctx, std::vector<t_noc_rou
 
     // indicate that the NoC has been built, cannot be modified anymore
     noc_model->finished_building_noc();
-
-    return;
 }
 
-void create_noc_routers(const t_noc_inf& noc_info, NocStorage* noc_model, std::vector<t_noc_router_tile_position>& noc_router_tiles) {
+void create_noc_routers(const t_noc_inf& noc_info,
+                        NocStorage* noc_model,
+                        const std::vector<t_noc_router_tile_position>& noc_router_tiles) {
     // keep track of the shortest distance between a user described router (noc description in the arch file) and a physical router on the FPGA
     double shortest_distance;
-    double curr_calculated_distance;
+//    double curr_calculated_distance;
     // stores the index of a physical router within the noc_router_tiles that is closest to a given user described router
     int closest_physical_router;
 
-    // information regarding physical router position
-    double curr_physical_router_pos_x;
-    double curr_physical_router_pos_y;
-
-    // information regarding logical router position
-    double curr_logical_router_position_x;
-    double curr_logical_router_position_y;
-
-    // keep track of the index of each physical router (this helps uniqely identify them)
+    // keep track of the index of each physical router (this helps uniquely identify them)
     int curr_physical_router_index = 0;
 
     // keep track of the ids of the routers that create the case where multiple routers have the same distance to a physical router tile
@@ -147,39 +143,41 @@ void create_noc_routers(const t_noc_inf& noc_info, NocStorage* noc_model, std::v
     int error_case_physical_router_index_2;
 
     // keep track of the router assignments (store the user router id that was assigned to each physical router tile)
-    // this is used in error checking, after determining the closest physical router for a user described router in the arch file, the datastructure below can be used to check if that physical router was already assigned previously
+    // this is used in error checking, after determining the closest physical router for a user described router in the arch file,
+    // the datastructure below can be used to check if that physical router was already assigned previously
     std::vector<int> router_assignments;
     router_assignments.resize(noc_router_tiles.size(), PHYSICAL_ROUTER_NOT_ASSIGNED);
 
     // Below we create all the routers within the NoC //
 
-    // go through each user desctibed router in the arch file and assign it to a physical router on the FPGA
-    for (auto logical_router = noc_info.router_list.begin(); logical_router != noc_info.router_list.end(); logical_router++) {
-        // assign the shortest distance to a large value (this is done so that the first distance calculated and we can replace this)
-        shortest_distance = LLONG_MAX;
+    // go through each user described router in the arch file and assign it to a physical router on the FPGA
+    for (const auto& logical_router : noc_info.router_list) {
+        // assign the shortest distance to a large value (this is done so that the first distance calculated, and we can replace this)
+        shortest_distance = std::numeric_limits<double>::max();
 
         // get position of the current logical router
-        curr_logical_router_position_x = logical_router->device_x_position;
-        curr_logical_router_position_y = logical_router->device_y_position;
+        double curr_logical_router_position_x = logical_router.device_x_position;
+        double curr_logical_router_position_y = logical_router.device_y_position;
 
         closest_physical_router = 0;
 
         // the starting index of the physical router list
         curr_physical_router_index = 0;
 
-        // initialze the router ids that track the error case where two physical router tiles have the same distance to a user described router
-        // we initialize it to a in-valid index, so that it reflects the situation where we never hit this case
+        // initialize the router ids that track the error case where two physical router tiles have the same distance to a user described router
+        // we initialize it to an invalid index, so that it reflects the situation where we never hit this case
         error_case_physical_router_index_1 = INVALID_PHYSICAL_ROUTER_INDEX;
         error_case_physical_router_index_2 = INVALID_PHYSICAL_ROUTER_INDEX;
 
         // determine the physical router tile that is closest to the current user described router in the arch file
-        for (auto physical_router = noc_router_tiles.begin(); physical_router != noc_router_tiles.end(); physical_router++) {
+        for (const auto& physical_router : noc_router_tiles) {
             // get the position of the current physical router tile on the FPGA device
-            curr_physical_router_pos_x = physical_router->tile_centroid_x;
-            curr_physical_router_pos_y = physical_router->tile_centroid_y;
+            double curr_physical_router_pos_x = physical_router.tile_centroid_x;
+            double curr_physical_router_pos_y = physical_router.tile_centroid_y;
 
-            // use euclidean distance to calculate the length between the current user described router and the physical router
-            curr_calculated_distance = sqrt(pow(abs(curr_physical_router_pos_x - curr_logical_router_position_x), 2.0) + pow(abs(curr_physical_router_pos_y - curr_logical_router_position_y), 2.0));
+            // use Euclidean distance to calculate the length between the current user described router and the physical router
+            double curr_calculated_distance = std::hypot(curr_physical_router_pos_x - curr_logical_router_position_x,
+                                                         curr_physical_router_pos_y - curr_logical_router_position_y);
 
             // if the current distance is the same as the previous shortest distance
             if (vtr::isclose(curr_calculated_distance, shortest_distance)) {
@@ -187,8 +185,8 @@ void create_noc_routers(const t_noc_inf& noc_info, NocStorage* noc_model, std::v
                 error_case_physical_router_index_1 = closest_physical_router;
                 error_case_physical_router_index_2 = curr_physical_router_index;
 
-            } else if (curr_calculated_distance < shortest_distance) // case where the current logical router is closest to the physical router tile
-            {
+            // case where the current logical router is closest to the physical router tile
+            } else if (curr_calculated_distance < shortest_distance) {
                 // update the shortest distance and then the closest router
                 shortest_distance = curr_calculated_distance;
                 closest_physical_router = curr_physical_router_index;
@@ -202,32 +200,34 @@ void create_noc_routers(const t_noc_inf& noc_info, NocStorage* noc_model, std::v
         if (error_case_physical_router_index_1 == closest_physical_router) {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER,
                             "Router with ID:'%d' has the same distance to physical router tiles located at position (%d,%d) and (%d,%d). Therefore, no router assignment could be made.",
-                            logical_router->id, noc_router_tiles[error_case_physical_router_index_1].grid_width_position, noc_router_tiles[error_case_physical_router_index_1].grid_height_position,
+                            logical_router.id, noc_router_tiles[error_case_physical_router_index_1].grid_width_position, noc_router_tiles[error_case_physical_router_index_1].grid_height_position,
                             noc_router_tiles[error_case_physical_router_index_2].grid_width_position, noc_router_tiles[error_case_physical_router_index_2].grid_height_position);
         }
 
         // check if the current physical router was already assigned previously, if so then throw an error
         if (router_assignments[closest_physical_router] != PHYSICAL_ROUTER_NOT_ASSIGNED) {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Routers with IDs:'%d' and '%d' are both closest to physical router tile located at (%d,%d) and the physical router could not be assigned multiple times.",
-                            logical_router->id, router_assignments[closest_physical_router], noc_router_tiles[closest_physical_router].grid_width_position,
+                            logical_router.id, router_assignments[closest_physical_router], noc_router_tiles[closest_physical_router].grid_width_position,
                             noc_router_tiles[closest_physical_router].grid_height_position);
         }
 
+        auto it = noc_info.router_latency_overrides.find(logical_router.id);
+        double router_latency = (it == noc_info.router_latency_overrides.end()) ? noc_info.router_latency : it->second;
+
         // at this point, the closest user described router to the current physical router was found
         // so add the router to the NoC
-        noc_model->add_router(logical_router->id,
+        noc_model->add_router(logical_router.id,
                               noc_router_tiles[closest_physical_router].grid_width_position,
                               noc_router_tiles[closest_physical_router].grid_height_position,
-                              noc_router_tiles[closest_physical_router].layer_position);
+                              noc_router_tiles[closest_physical_router].layer_position,
+                              router_latency);
 
         // add the new assignment to the tracker
-        router_assignments[closest_physical_router] = logical_router->id;
+        router_assignments[closest_physical_router] = logical_router.id;
     }
-
-    return;
 }
 
-void create_noc_links(const t_noc_inf* noc_info, NocStorage* noc_model) {
+void create_noc_links(const t_noc_inf& noc_info, NocStorage* noc_model) {
     // the ids used to represent the routers in the NoC are not the same as the ones provided by the user in the arch desc file.
     // while going through the router connections, the user provided router ids are converted and then stored below before being used in the links.
     NocRouterId source_router;
@@ -237,19 +237,23 @@ void create_noc_links(const t_noc_inf* noc_info, NocStorage* noc_model) {
     noc_model->make_room_for_noc_router_link_list();
 
     // go through each router and add its outgoing links to the NoC
-    for (auto router = noc_info->router_list.begin(); router != noc_info->router_list.end(); router++) {
+    for (const auto& router : noc_info.router_list) {
         // get the converted id of the current source router
-        source_router = noc_model->convert_router_id(router->id);
+        source_router = noc_model->convert_router_id(router.id);
 
         // go through all the routers connected to the current one and add links to the noc
-        for (auto conn_router_id = router->connection_list.begin(); conn_router_id != router->connection_list.end(); conn_router_id++) {
+        for (const auto conn_router_id : router.connection_list) {
             // get the converted id of the currently connected sink router
-            sink_router = noc_model->convert_router_id(*conn_router_id);
+            sink_router = noc_model->convert_router_id(conn_router_id);
+
+            auto lat_it = noc_info.link_latency_overrides.find({router.id, conn_router_id});
+            double link_lat = (lat_it == noc_info.link_latency_overrides.end()) ? noc_info.link_latency : lat_it->second;
+
+            auto bw_it = noc_info.link_bandwidth_overrides.find({router.id, conn_router_id});
+            double link_bw = (bw_it == noc_info.link_bandwidth_overrides.end()) ? noc_info.link_bandwidth : bw_it->second;
 
             // add the link to the Noc
-            noc_model->add_link(source_router, sink_router);
+            noc_model->add_link(source_router, sink_router, link_bw, link_lat);
         }
     }
-
-    return;
 }

--- a/vpr/src/base/setup_noc.h
+++ b/vpr/src/base/setup_noc.h
@@ -16,14 +16,14 @@
  * 
  * Router Creation
  * ---------------
- * Each router described in the archietcture file is created and
+ * Each router described in the architecture file is created and
  * added to the NoC. Since the routers represents physical tiles on
  * the FPGA, when the router is created, it is also assigned to a
  * corresponding physical router tile. 
  * 
  * Link Creation
  * -------------
- * The user describes a "connection list", which rerpesents an intended
+ * The user describes a "connection list", which represents an intended
  * connection between two routers in the NoC. Each link connects two
  * routers together. For each router, a number
  * of Links are created to connect it to another router in its "connection
@@ -31,21 +31,11 @@
  * 
  */
 
-#include <iostream>
-#include <string>
+#include <string_view>
 #include <vector>
 
-#include "physical_types.h"
 #include "device_grid.h"
-#include "globals.h"
-#include "noc_storage.h"
-#include "vpr_error.h"
-
-// a default condition that helps keep track of whether a physical router has been assigned to a logical router or not
-#define PHYSICAL_ROUTER_NOT_ASSIGNED -1
-
-// a deafult index used for initiailization purposes. No router will have a negative index
-#define INVALID_PHYSICAL_ROUTER_INDEX -1
+#include "vpr_context.h"
 
 // a data structure to store the position information of a noc router in the FPGA device
 struct t_noc_router_tile_position {
@@ -83,13 +73,14 @@ void setup_noc(const t_arch& arch);
  *        stored in a list.
  * 
  * @param device_grid The FPGA device description.
- * @param list_of_noc_router_tiles Stores the grid position information
- *                                 for all NoC router tiles in the FPGA.
  * @param noc_router_tile_name The name used when describing the NoC router
  *                             tile in the FPGA architecture description
  *                             file.
+ *
+ * @return The grid position information for all NoC router tiles in the FPGA.
  */
-void identify_and_store_noc_router_tile_positions(const DeviceGrid& device_grid, std::vector<t_noc_router_tile_position>& list_of_noc_router_tiles, std::string noc_router_tile_name);
+std::vector<t_noc_router_tile_position> identify_and_store_noc_router_tile_positions(const DeviceGrid& device_grid,
+                                                                                     std::string_view noc_router_tile_name);
 
 /**
  * @brief Creates NoC routers and adds them to the NoC model based
@@ -104,7 +95,9 @@ void identify_and_store_noc_router_tile_positions(const DeviceGrid& device_grid,
  * @param list_of_noc_router_tiles Stores the grid position information
  *                                 for all NoC router tiles in the FPGA.
  */
-void generate_noc(const t_arch& arch, NocContext& noc_ctx, std::vector<t_noc_router_tile_position>& list_of_noc_router_tiles);
+void generate_noc(const t_arch& arch,
+                  NocContext& noc_ctx,
+                  const std::vector<t_noc_router_tile_position>& list_of_noc_router_tiles);
 
 /**
  * @brief Go through the outers described by the user
@@ -121,7 +114,9 @@ void generate_noc(const t_arch& arch, NocContext& noc_ctx, std::vector<t_noc_rou
  * @param list_of_noc_router_tiles Stores the grid position information
  *                                 for all NoC router tiles in the FPGA.
  */
-void create_noc_routers(const t_noc_inf& noc_info, NocStorage* noc_model, std::vector<t_noc_router_tile_position>& list_of_noc_router_tiles);
+void create_noc_routers(const t_noc_inf& noc_info,
+                        NocStorage* noc_model,
+                        const std::vector<t_noc_router_tile_position>& list_of_noc_router_tiles);
 
 /**
  * @brief Goes through the topology information as described in the FPGA
@@ -134,6 +129,6 @@ void create_noc_routers(const t_noc_inf& noc_info, NocStorage* noc_model, std::v
  * @param noc_model An internal model that describes the NoC. Contains a list of
  *                  routers and links that connect the routers together.
  */
-void create_noc_links(const t_noc_inf* noc_info, NocStorage* noc_model);
+void create_noc_links(const t_noc_inf& noc_info, NocStorage* noc_model);
 
 #endif

--- a/vpr/src/noc/noc_link.cpp
+++ b/vpr/src/noc/noc_link.cpp
@@ -1,12 +1,14 @@
 #include "noc_link.h"
 
 // constructor
-NocLink::NocLink(NocLinkId link_id, NocRouterId source, NocRouterId sink, double bw)
+NocLink::NocLink(NocLinkId link_id, NocRouterId source, NocRouterId sink,
+                 double bw, double lat)
     : id(link_id)
     , source_router(source)
     , sink_router(sink)
     , bandwidth_usage(0.0)
-    , bandwidth(bw) { }
+    , bandwidth(bw)
+    , latency(lat) { }
 
 // getters
 NocRouterId NocLink::get_source_router(void) const {

--- a/vpr/src/noc/noc_link.cpp
+++ b/vpr/src/noc/noc_link.cpp
@@ -63,6 +63,10 @@ double NocLink::get_congested_bandwidth_ratio() const {
     return congested_bw_ratio;
 }
 
+double NocLink::get_latency() const {
+    return latency;
+}
+
 NocLinkId NocLink::get_link_id() const {
     return id;
 }
@@ -70,3 +74,4 @@ NocLinkId NocLink::get_link_id() const {
 NocLink::operator NocLinkId() const {
     return get_link_id();
 }
+

--- a/vpr/src/noc/noc_link.h
+++ b/vpr/src/noc/noc_link.h
@@ -51,9 +51,11 @@ class NocLink {
 
     double bandwidth_usage; /*!< Represents the bandwidth of the data being transmitted on the link. Units in bits-per-second(bps)*/
     double bandwidth; /*!< Represents the maximum bits per second that can be transmitted over the link without causing congestion*/
+    double latency;
 
   public:
-    NocLink(NocLinkId link_id, NocRouterId source_router, NocRouterId sink_router, double bw);
+    NocLink(NocLinkId link_id, NocRouterId source_router, NocRouterId sink_router,
+            double bw, double lat);
 
     // getters
 

--- a/vpr/src/noc/noc_link.h
+++ b/vpr/src/noc/noc_link.h
@@ -99,6 +99,12 @@ class NocLink {
     double get_congested_bandwidth_ratio() const;
 
     /**
+     * @brief Returns the zero-load latency of the link.
+     * @return double Zero-load latency of the link.
+     */
+    double get_latency() const;
+
+    /**
      * @brief Returns the unique link ID. The ID can be used to index
      * vtr::vector<NoCLinkId, ...> instances.
      * @return The unique ID for the link

--- a/vpr/src/noc/noc_router.cpp
+++ b/vpr/src/noc/noc_router.cpp
@@ -39,6 +39,10 @@ t_physical_tile_loc NocRouter::get_router_physical_location(void) const {
     return phy_loc;
 }
 
+double NocRouter::get_latency() const {
+    return router_latency;
+}
+
 ClusterBlockId NocRouter::get_router_block_ref(void) const {
     return router_block_ref;
 }

--- a/vpr/src/noc/noc_router.cpp
+++ b/vpr/src/noc/noc_router.cpp
@@ -1,11 +1,14 @@
 #include "noc_router.h"
 
 // constructor
-NocRouter::NocRouter(int id, int grid_position_x, int grid_position_y, int layer_position)
+NocRouter::NocRouter(int id,
+                     int grid_position_x, int grid_position_y, int layer_position,
+                     double latency)
     : router_user_id(id)
     , router_grid_position_x(grid_position_x)
     , router_grid_position_y(grid_position_y)
-    , router_layer_position(layer_position) {
+    , router_layer_position(layer_position)
+    , router_latency(latency){
     // initialize variables
     router_block_ref = ClusterBlockId(0);
 }
@@ -43,5 +46,4 @@ ClusterBlockId NocRouter::get_router_block_ref(void) const {
 // setters
 void NocRouter::set_router_block_ref(ClusterBlockId router_block_ref_id) {
     router_block_ref = router_block_ref_id;
-    return;
 }

--- a/vpr/src/noc/noc_router.h
+++ b/vpr/src/noc/noc_router.h
@@ -53,12 +53,16 @@ class NocRouter {
      * that the physical router is located*/
     int router_layer_position;
 
+    double router_latency;
+
     /** A unique identifier that represents a router block in the 
      * clustered netlist that is placed on the physical router*/
     ClusterBlockId router_block_ref;
 
   public:
-    NocRouter(int id, int grid_position_x, int grid_position_y, int layer_position);
+    NocRouter(int id,
+              int grid_position_x, int grid_position_y, int layer_position,
+              double latency);
 
     // getters
 

--- a/vpr/src/noc/noc_router.h
+++ b/vpr/src/noc/noc_router.h
@@ -96,6 +96,8 @@ class NocRouter {
      */
     t_physical_tile_loc get_router_physical_location(void) const;
 
+    double get_latency() const;
+
     /**
      * @brief Gets the unique id of the router block that is current placed on the physical router
      * @return A ClusterBlockId that identifies a router block in the clustered netlist

--- a/vpr/src/noc/noc_storage.cpp
+++ b/vpr/src/noc/noc_storage.cpp
@@ -64,11 +64,11 @@ NocRouter& NocStorage::get_single_mutable_noc_router(NocRouterId id) {
 }
 
 // get link properties
-const NocLink& NocStorage::get_single_noc_link(NocLinkId id) const {
+    const NocLink& NocStorage::get_single_noc_link(NocLinkId id) const {
     return link_storage[id];
 }
 
-NocLinkId  NocStorage::get_single_noc_link_id(NocRouterId src_router, NocRouterId dst_router) const {
+NocLinkId NocStorage::get_single_noc_link_id(NocRouterId src_router, NocRouterId dst_router) const {
     NocLinkId link_id = NocLinkId::INVALID();
 
     for (const auto& link : link_storage) {
@@ -208,6 +208,8 @@ bool NocStorage::remove_link(NocRouterId src_router_id, NocRouterId sink_router_
 void NocStorage::finished_building_noc() {
     VTR_ASSERT_MSG(!built_noc, "NoC already built, cannot modify further.");
     built_noc = true;
+
+    returnable_noc_link_const_refs_.reserve(link_storage.size());
 
     /* We go through all NoC routers in the router_storage and check if there are any
      * two consecutive NoC routers whose latency is different. If such two routers are

--- a/vpr/src/noc/noc_storage.cpp
+++ b/vpr/src/noc/noc_storage.cpp
@@ -89,10 +89,12 @@ NocRouterId NocStorage::get_router_at_grid_location(const t_pl_loc& hard_router_
 
 // setters for the NoC
 
-void NocStorage::add_router(int id, int grid_position_x, int grid_posistion_y, int layer_position) {
+void NocStorage::add_router(int id,
+                            int grid_position_x, int grid_posistion_y, int layer_position,
+                            double latency) {
     VTR_ASSERT_MSG(!built_noc, "NoC already built, cannot modify further.");
 
-    router_storage.emplace_back(id, grid_position_x, grid_posistion_y, layer_position);
+    router_storage.emplace_back(id, grid_position_x, grid_posistion_y, layer_position, latency);
 
     /* Get the corresponding NocRouterId for the newly added router and
      * add it to the conversion table.
@@ -107,23 +109,18 @@ void NocStorage::add_router(int id, int grid_position_x, int grid_posistion_y, i
     // get the key to identify the current router
     int router_key = generate_router_key_from_grid_location(grid_position_x, grid_posistion_y, layer_position);
     grid_location_to_router_id.insert(std::pair<int, NocRouterId>(router_key, converted_id));
-
-    return;
 }
 
-void NocStorage::add_link(NocRouterId source, NocRouterId sink) {
+void NocStorage::add_link(NocRouterId source, NocRouterId sink, double bandwidth, double latency) {
     VTR_ASSERT_MSG(!built_noc, "NoC already built, cannot modify further.");
 
     // the new link will be added to the back of the list,
     // so we can use the total number of links added so far as id
     NocLinkId added_link_id((int)link_storage.size());
 
-    double link_bandwidth = get_noc_link_bandwidth();
-    link_storage.emplace_back(added_link_id, source, sink, link_bandwidth);
+    link_storage.emplace_back(added_link_id, source, sink, bandwidth, latency);
 
     router_link_list[source].push_back(added_link_id);
-
-    return;
 }
 
 void NocStorage::set_noc_link_bandwidth(double link_bandwidth) {

--- a/vpr/src/noc/noc_storage.h
+++ b/vpr/src/noc/noc_storage.h
@@ -133,6 +133,10 @@ class NocStorage {
      */
     double noc_router_latency;
 
+    bool detailed_router_latency_;
+    bool detailed_link_latency_;
+    bool detailed_link_bandwidth_;
+
     /**
      * @brief Internal reference to the device grid width. This is necessary
      * to compute a unique key for a given grid location which we can then use
@@ -234,6 +238,12 @@ class NocStorage {
      */
 
     double get_noc_router_latency(void) const;
+
+    bool get_detailed_router_latency() const;
+
+    bool get_detailed_link_latency() const;
+
+    bool get_detailed_link_bandwidth() const;
 
     // getters for  routers
 
@@ -342,34 +352,26 @@ class NocStorage {
 
     /**
      * @brief Set the maximum allowable bandwidth for a link
-     * within the NoC.
-     * 
+     * within the NoC
      */
-
     void set_noc_link_bandwidth(double link_bandwidth);
 
     /**
      * @brief Set the latency of traversing through a link in
      * the NoC.
-     * 
      */
-
     void set_noc_link_latency(double link_latency);
 
     /**
      * @brief Set the latency of traversing through a router in
      * the NoC.
-     * 
      */
-
     void set_noc_router_latency(double router_latency);
 
     /**
      * @brief Set the internal reference to the device
      * grid width.
-     * 
      */
-
     void set_device_grid_width(int grid_width);
 
     void set_device_grid_spec(int grid_width, int grid_height);
@@ -404,7 +406,7 @@ class NocStorage {
      * no future changes can be made.
      * 
      */
-    void finished_building_noc(void);
+    void finished_building_noc();
 
     /**
      * @brief Resets the NoC by clearing all internal datastructures.
@@ -413,7 +415,7 @@ class NocStorage {
      * recommended to run this function before building the NoC.
      * 
      */
-    void clear_noc(void);
+    void clear_noc();
 
     /**
      * @brief Given a user id of a router, this function converts

--- a/vpr/src/noc/noc_storage.h
+++ b/vpr/src/noc/noc_storage.h
@@ -317,12 +317,14 @@ class NocStorage {
      *
      * @tparam Container The type of standard library container used to carry
      * NoCLinkIds. This container type must be iterable in a range-based loop.
+     * @tparam Ts Used to help clang infer correct template types. GCC can compile
+     * without this extra template argument.
      * @param noc_link_ids A standard container that contains NoCLinkIds of the
      * requested NoC links
      * @return A const
      */
-    template <template<typename> class Container>
-    const std::vector<std::reference_wrapper<const NocLink>>& get_noc_links(const Container<NocLinkId>& noc_link_ids) const;
+    template <template<typename...> class Container, typename... Ts>
+    const std::vector<std::reference_wrapper<const NocLink>>& get_noc_links(const Container<NocLinkId, Ts...>& noc_link_ids) const;
 
 
     /**
@@ -550,8 +552,8 @@ class NocStorage {
 };
 
 
-template <template<typename> class Container>
-const std::vector<std::reference_wrapper<const NocLink>>& NocStorage::get_noc_links(const Container<NocLinkId>& noc_link_ids) const {
+template <template<typename...> class Container, typename... Ts>
+const std::vector<std::reference_wrapper<const NocLink>>& NocStorage::get_noc_links(const Container<NocLinkId, Ts...>& noc_link_ids) const {
     returnable_noc_link_const_refs_.clear();
 
     std::transform(noc_link_ids.begin(), noc_link_ids.end(), std::back_inserter(returnable_noc_link_const_refs_),

--- a/vpr/src/noc/noc_storage.h
+++ b/vpr/src/noc/noc_storage.h
@@ -322,7 +322,9 @@ class NocStorage {
      * @param grid_position_y The vertical position on the FPGA of the physical
      * tile that this router represents.
      */
-    void add_router(int id, int grid_position_x, int grid_position_y, int layer_poisition);
+    void add_router(int id,
+                    int grid_position_x, int grid_position_y, int layer_poisition,
+                    double latency);
 
     /**
      * @brief Creates a new link and adds it to the NoC. The newly created
@@ -336,7 +338,7 @@ class NocStorage {
      * @param sink A unique identifier for the router that the new link enters
      * into (incoming to the router) 
      */
-    void add_link(NocRouterId source, NocRouterId sink);
+    void add_link(NocRouterId source, NocRouterId sink, double bandwidth, double latency);
 
     /**
      * @brief Set the maximum allowable bandwidth for a link

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -146,10 +146,7 @@ void find_affected_noc_routers_and_update_noc_costs(const t_pl_blocks_to_be_move
     }
 
     // Iterate over all affected links and calculate their new congestion cost and store it
-    for (const auto& link_id : affected_noc_links) {
-        // get the affected link
-        const auto& link = noc_ctx.noc_model.get_single_noc_link(link_id);
-
+    for (const NocLink& link : noc_ctx.noc_model.get_noc_links(affected_noc_links)) {
         // calculate the new congestion cost for the link and store it
         proposed_link_congestion_costs[link] = calculate_link_congestion_cost(link);
 
@@ -174,10 +171,7 @@ void commit_noc_costs() {
     }
 
     // Iterate over all the NoC links whose bandwidth utilization was affected by the proposed move
-    for(auto link_id : affected_noc_links) {
-        // get the affected link
-        const auto& link = noc_ctx.noc_model.get_single_noc_link(link_id);
-
+    for (const NocLink& link : noc_ctx.noc_model.get_noc_links(affected_noc_links)) {
         // commit the new link congestion cost
         link_congestion_costs[link] = proposed_link_congestion_costs[link];
 
@@ -494,7 +488,7 @@ int check_noc_placement_costs(const t_placer_costs& costs, double error_toleranc
     }
 
     // Iterate over all NoC links and accumulate congestion cost
-    for(const auto& link : temp_noc_link_storage) {
+    for (const auto& link : temp_noc_link_storage) {
         cost_check.congestion += calculate_link_congestion_cost(link);
     }
 
@@ -555,10 +549,9 @@ std::pair<double, double> calculate_traffic_flow_latency_cost(const std::vector<
 
     double noc_link_latency_component = 0.0;
     if (noc_model.get_detailed_link_latency()) {
-        for (auto noc_link_id : traffic_flow_route) {
-            const NocLink& noc_link = noc_model.get_single_noc_link(noc_link_id);
-            double noc_link_latency = noc_link.get_latency();
-            noc_link_latency_component += noc_link_latency;
+        for (const NocLink& link : noc_model.get_noc_links(traffic_flow_route)) {
+            double link_latency = link.get_latency();
+            noc_link_latency_component += link_latency;
         }
     } else {
         auto num_of_links_in_traffic_flow = (double)traffic_flow_route.size();
@@ -575,9 +568,8 @@ std::pair<double, double> calculate_traffic_flow_latency_cost(const std::vector<
         const NocRouter& source_noc_router = noc_model.get_single_noc_router(source_noc_router_id);
         noc_router_latency_component = source_noc_router.get_latency();
 
-        for (auto noc_link_id : traffic_flow_route) {
-            const NocLink& noc_link = noc_model.get_single_noc_link(noc_link_id);
-            const NocRouterId sink_router_id = noc_link.get_sink_router();
+        for (const NocLink& link : noc_model.get_noc_links(traffic_flow_route)) {
+            const NocRouterId sink_router_id = link.get_sink_router();
             const NocRouter& sink_router = noc_model.get_single_noc_router(sink_router_id);
             double noc_router_latency = sink_router.get_latency();
             noc_router_latency_component += noc_router_latency;

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -552,19 +552,49 @@ double calculate_traffic_flow_aggregate_bandwidth_cost(const std::vector<NocLink
 std::pair<double, double> calculate_traffic_flow_latency_cost(const std::vector<NocLinkId>& traffic_flow_route,
                                                               const NocStorage& noc_model,
                                                               const t_noc_traffic_flow& traffic_flow_info) {
-    // there will always be one more router than links in a traffic flow
-    int num_of_links_in_traffic_flow = traffic_flow_route.size();
-    int num_of_routers_in_traffic_flow = num_of_links_in_traffic_flow + 1;
-    double max_latency = traffic_flow_info.max_traffic_flow_latency;
 
-    // latencies of the noc
-    double noc_link_latency = noc_model.get_noc_link_latency();
-    double noc_router_latency = noc_model.get_noc_router_latency();
+    double noc_link_latency_component = 0.0;
+    if (noc_model.get_detailed_link_latency()) {
+        for (auto noc_link_id : traffic_flow_route) {
+            const NocLink& noc_link = noc_model.get_single_noc_link(noc_link_id);
+            double noc_link_latency = noc_link.get_latency();
+            noc_link_latency_component += noc_link_latency;
+        }
+    } else {
+        auto num_of_links_in_traffic_flow = (double)traffic_flow_route.size();
+        double noc_link_latency = noc_model.get_noc_link_latency();
+        noc_link_latency_component = noc_link_latency * num_of_links_in_traffic_flow;
+    }
 
-    // calculate the traffic flow latency
-    double latency = (noc_link_latency * num_of_links_in_traffic_flow) + (noc_router_latency * num_of_routers_in_traffic_flow);
+    double noc_router_latency_component = 0.0;
+
+    if (noc_model.get_detailed_router_latency()) {
+        NocLinkId first_noc_link_id = traffic_flow_route[0];
+        const NocLink& first_noc_link = noc_model.get_single_noc_link(first_noc_link_id);
+        NocRouterId source_noc_router_id = first_noc_link.get_source_router();
+        const NocRouter& source_noc_router = noc_model.get_single_noc_router(source_noc_router_id);
+        noc_router_latency_component = source_noc_router.get_latency();
+
+        for (auto noc_link_id : traffic_flow_route) {
+            const NocLink& noc_link = noc_model.get_single_noc_link(noc_link_id);
+            const NocRouterId sink_router_id = noc_link.get_sink_router();
+            const NocRouter& sink_router = noc_model.get_single_noc_router(sink_router_id);
+            double noc_router_latency = sink_router.get_latency();
+            noc_router_latency_component += noc_router_latency;
+        }
+    } else {
+        // there will always be one more router than links in a traffic flow
+        auto num_of_routers_in_traffic_flow = (double)traffic_flow_route.size() + 1;
+        double noc_router_latency = noc_model.get_noc_router_latency();
+        noc_router_latency_component = noc_router_latency * num_of_routers_in_traffic_flow;
+    }
+
+
+    // calculate the total traffic flow latency
+    double latency = noc_router_latency_component + noc_link_latency_component;
 
     // calculate the traffic flow latency overrun
+    double max_latency = traffic_flow_info.max_traffic_flow_latency;
     double latency_overrun = std::max(latency - max_latency, 0.);
 
     // scale the latency cost by its priority to indicate its importance

--- a/vpr/test/test_bfs_routing.cpp
+++ b/vpr/test/test_bfs_routing.cpp
@@ -5,6 +5,9 @@
 
 namespace {
 
+constexpr double DUMMY_LATENCY = 1e-9;
+constexpr double DUMMY_BANDWIDTH = 1e12;
+
 TEST_CASE("test_route_flow", "[vpr_noc_bfs_routing]") {
     /*
      * Creating a test FPGA device below. The NoC itself will be
@@ -29,7 +32,7 @@ TEST_CASE("test_route_flow", "[vpr_noc_bfs_routing]") {
     // add all the routers
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
-            noc_model.add_router((i * 4) + j, j, i, 0);
+            noc_model.add_router((i * 4) + j, j, i, 0, DUMMY_LATENCY);
         }
     }
 
@@ -40,19 +43,19 @@ TEST_CASE("test_route_flow", "[vpr_noc_bfs_routing]") {
         for (int j = 0; j < 4; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 1));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 1), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= 3) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 4));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 4), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= 3) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 1));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 1), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 4));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 4), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
         }
     }
@@ -97,12 +100,12 @@ TEST_CASE("test_route_flow", "[vpr_noc_bfs_routing]") {
         int number_of_links = noc_model.get_noc_links().size();
 
         // add the diagonal links and also add them to the golden path
-        noc_model.add_link(NocRouterId(12), NocRouterId(9));
-        golden_path.push_back(NocLinkId(number_of_links++));
-        noc_model.add_link(NocRouterId(9), NocRouterId(6));
-        golden_path.push_back(NocLinkId(number_of_links++));
-        noc_model.add_link(NocRouterId(6), NocRouterId(3));
-        golden_path.push_back(NocLinkId(number_of_links++));
+        noc_model.add_link(NocRouterId(12), NocRouterId(9), DUMMY_BANDWIDTH, DUMMY_LATENCY);
+        golden_path.emplace_back(number_of_links++);
+        noc_model.add_link(NocRouterId(9), NocRouterId(6), DUMMY_BANDWIDTH, DUMMY_LATENCY);
+        golden_path.emplace_back(number_of_links++);
+        noc_model.add_link(NocRouterId(6), NocRouterId(3), DUMMY_BANDWIDTH, DUMMY_LATENCY);
+        golden_path.emplace_back(number_of_links++);
 
         // now run the routinjg algorithm
         // make sure that a legal route was found (no error should be thrown)

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -43,7 +43,11 @@ TEST_CASE("test_initial_noc_placement", "[noc_place_utils]") {
     // dist_2 is used to generate traffic flow bandwidths.
     // Setting the NoC link bandwidth to max() / 5 makes link congestion more likely to happen
     const double noc_link_bandwidth = dist_2.max() / 5;
+    constexpr double noc_link_latency = 1.0;
+    constexpr double noc_router_latency = 1.0;
     noc_ctx.noc_model.set_noc_link_bandwidth(noc_link_bandwidth);
+    noc_ctx.noc_model.set_noc_link_latency(noc_link_latency);
+    noc_ctx.noc_model.set_noc_router_latency(noc_router_latency);
 
     // individual router parameters
     int curr_router_id;
@@ -66,7 +70,8 @@ TEST_CASE("test_initial_noc_placement", "[noc_place_utils]") {
         noc_ctx.noc_model.add_router(curr_router_id,
                                      router_grid_position_x,
                                      router_grid_position_y,
-                                     0);
+                                     0,
+                                     noc_router_latency);
     }
 
     noc_ctx.noc_model.make_room_for_noc_router_link_list();
@@ -76,19 +81,19 @@ TEST_CASE("test_initial_noc_placement", "[noc_place_utils]") {
         for (int j = 0; j < MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1), noc_link_bandwidth, noc_router_latency);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), noc_link_bandwidth, noc_router_latency);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1), noc_link_bandwidth, noc_router_latency);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), noc_link_bandwidth, noc_router_latency);
             }
         }
     }
@@ -235,7 +240,11 @@ TEST_CASE("test_initial_comp_cost_functions", "[noc_place_utils]") {
     // dist_2 is used to generate traffic flow bandwidths.
     // Setting the NoC link bandwidth to max() / 5 makes link congestion more likely to happen
     const double noc_link_bandwidth = dist_2.max() / 5;
+    constexpr double noc_link_latency = 1.0;
+    constexpr double noc_router_latency = 1.0;
     noc_ctx.noc_model.set_noc_link_bandwidth(noc_link_bandwidth);
+    noc_ctx.noc_model.set_noc_link_latency(noc_link_latency);
+    noc_ctx.noc_model.set_noc_router_latency(noc_router_latency);
 
     // individual router parameters
     int curr_router_id;
@@ -258,7 +267,8 @@ TEST_CASE("test_initial_comp_cost_functions", "[noc_place_utils]") {
         noc_ctx.noc_model.add_router(curr_router_id,
                                      router_grid_position_x,
                                      router_grid_position_y,
-                                     0);
+                                     0,
+                                     noc_router_latency);
     }
 
     noc_ctx.noc_model.make_room_for_noc_router_link_list();
@@ -268,19 +278,19 @@ TEST_CASE("test_initial_comp_cost_functions", "[noc_place_utils]") {
         for (int j = 0; j < MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1), noc_link_bandwidth, noc_link_latency);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), noc_link_bandwidth, noc_link_latency);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1), noc_link_bandwidth, noc_link_latency);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), noc_link_bandwidth, noc_link_latency);
             }
         }
     }
@@ -518,9 +528,9 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
     noc_ctx.noc_model.set_noc_link_bandwidth(1);
 
     // needs to be the same as above
-    double router_latency = noc_ctx.noc_model.get_noc_router_latency();
-    double link_latency = noc_ctx.noc_model.get_noc_link_latency();
-    double link_bandwidth = noc_ctx.noc_model.get_noc_link_bandwidth();
+    const double router_latency = noc_ctx.noc_model.get_noc_router_latency();
+    const double link_latency = noc_ctx.noc_model.get_noc_link_latency();
+    const double link_bandwidth = noc_ctx.noc_model.get_noc_link_bandwidth();
 
     // keeps track of which hard router each cluster block is placed
     vtr::vector<ClusterBlockId, NocRouterId> router_where_cluster_is_placed;
@@ -537,7 +547,8 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
         noc_ctx.noc_model.add_router(curr_router_id,
                                      router_grid_position_x,
                                      router_grid_position_y,
-                                     0);
+                                     0,
+                                     router_latency);
     }
 
     noc_ctx.noc_model.make_room_for_noc_router_link_list();
@@ -547,19 +558,19 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
         for (int j = 0; j < MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1), link_bandwidth, link_latency);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), link_bandwidth, link_latency);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1), link_bandwidth, link_latency);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), link_bandwidth, link_latency);
             }
         }
     }
@@ -1387,10 +1398,14 @@ TEST_CASE("test_revert_noc_traffic_flow_routes", "[noc_place_utils]") {
     noc_opts.noc_latency_weighting = dist_3(double_engine);
     noc_opts.noc_congestion_weighting = dist_3(double_engine);
 
+    constexpr double LINK_LATENCY = 1;
+    constexpr double LINK_BANDWIDTH = 1;
+    constexpr double ROUTER_LATENCY = 1;
+
     // setting the NoC parameters
-    noc_ctx.noc_model.set_noc_link_latency(1);
-    noc_ctx.noc_model.set_noc_router_latency(1);
-    noc_ctx.noc_model.set_noc_link_bandwidth(1);
+    noc_ctx.noc_model.set_noc_link_latency(LINK_BANDWIDTH);
+    noc_ctx.noc_model.set_noc_router_latency(ROUTER_LATENCY);
+    noc_ctx.noc_model.set_noc_link_bandwidth(LINK_BANDWIDTH);
 
     // keeps track of which hard router each cluster block is placed
     vtr::vector<ClusterBlockId, NocRouterId> router_where_cluster_is_placed;
@@ -1407,7 +1422,8 @@ TEST_CASE("test_revert_noc_traffic_flow_routes", "[noc_place_utils]") {
         noc_ctx.noc_model.add_router(curr_router_id,
                                      router_grid_position_x,
                                      router_grid_position_y,
-                                     0);
+                                     0,
+                                     ROUTER_LATENCY);
     }
 
     noc_ctx.noc_model.make_room_for_noc_router_link_list();
@@ -1417,19 +1433,19 @@ TEST_CASE("test_revert_noc_traffic_flow_routes", "[noc_place_utils]") {
         for (int j = 0; j < MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1), LINK_BANDWIDTH, LINK_LATENCY);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), LINK_BANDWIDTH, LINK_LATENCY);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1), LINK_BANDWIDTH, LINK_LATENCY);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), LINK_BANDWIDTH, LINK_LATENCY);
             }
         }
     }
@@ -1758,7 +1774,8 @@ TEST_CASE("test_check_noc_placement_costs", "[noc_place_utils]") {
         noc_ctx.noc_model.add_router(curr_router_id,
                                      router_grid_position_x,
                                      router_grid_position_y,
-                                     0);
+                                     0,
+                                     router_latency);
     }
 
     noc_ctx.noc_model.make_room_for_noc_router_link_list();
@@ -1768,19 +1785,19 @@ TEST_CASE("test_check_noc_placement_costs", "[noc_place_utils]") {
         for (int j = 0; j < MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - 1), link_bandwidth, link_latency);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), link_bandwidth, link_latency);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST - 1) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) + 1), link_bandwidth, link_latency);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST));
+                noc_ctx.noc_model.add_link((NocRouterId)((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j), (NocRouterId)(((i * MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST) + j) - MESH_TOPOLOGY_SIZE_NOC_PLACE_UTILS_TEST), link_bandwidth, link_latency);
             }
         }
     }

--- a/vpr/test/test_noc_storage.cpp
+++ b/vpr/test/test_noc_storage.cpp
@@ -13,6 +13,9 @@
 
 namespace {
 
+constexpr double DUMMY_LATENCY = 1e-9;
+constexpr double DUMMY_BANDWIDTH = 1e12;
+
 TEST_CASE("test_adding_routers_to_noc_storage", "[vpr_noc]") {
     // setup random number generation
     std::random_device device;
@@ -44,10 +47,10 @@ TEST_CASE("test_adding_routers_to_noc_storage", "[vpr_noc]") {
         router_grid_position_y = router_number + dist(rand_num_gen);
 
         // add router to the golden vector
-        golden_set.emplace_back(router_number, router_grid_position_x, router_grid_position_y, 0);
+        golden_set.emplace_back(router_number, router_grid_position_x, router_grid_position_y, 0, DUMMY_LATENCY);
 
         // add tje router to the noc
-        test_noc.add_router(curr_router_id, router_grid_position_x, router_grid_position_y, 0);
+        test_noc.add_router(curr_router_id, router_grid_position_x, router_grid_position_y, 0, DUMMY_LATENCY);
     }
 
     // now verify that the routers were added properly by reading the routers back from the noc and comparing them to the golden set
@@ -96,10 +99,10 @@ TEST_CASE("test_router_id_conversion", "[vpr_noc]") {
         router_grid_position_y = router_number + dist(rand_num_gen);
 
         // add router to the golden vector
-        golden_set.emplace_back(router_number, router_grid_position_x, router_grid_position_y, 0);
+        golden_set.emplace_back(router_number, router_grid_position_x, router_grid_position_y, 0, DUMMY_LATENCY);
 
         // add tje router to the noc
-        test_noc.add_router(curr_router_id, router_grid_position_x, router_grid_position_y, 0);
+        test_noc.add_router(curr_router_id, router_grid_position_x, router_grid_position_y, 0, DUMMY_LATENCY);
     }
 
     // now verify that the routers were added properly by reading the routers back from the noc and comparing them to the golden set
@@ -150,7 +153,8 @@ TEST_CASE("test_add_link", "[vpr_noc]") {
         test_noc.add_router(router_id,
                             curr_router_x_pos,
                             curr_router_y_pos,
-                            0);
+                            0,
+                            DUMMY_LATENCY);
     }
 
     // allocate the size for outgoing link vector for each router
@@ -171,10 +175,10 @@ TEST_CASE("test_add_link", "[vpr_noc]") {
                 noc_link_id_counter++;
 
                 // add link to the golden reference
-                golden_set.emplace_back(link_id, source, sink, 0.0);
+                golden_set.emplace_back(link_id, source, sink, DUMMY_BANDWIDTH, DUMMY_LATENCY);
 
                 // add the link to the NoC
-                test_noc.add_link(source, sink);
+                test_noc.add_link(source, sink, DUMMY_BANDWIDTH, DUMMY_LATENCY);
 
                 total_num_of_links++;
             }
@@ -235,7 +239,7 @@ TEST_CASE("test_router_link_list", "[vpr_noc]") {
         router_id = router_number;
 
         // add tje router to the noc
-        test_noc.add_router(router_id, curr_router_x_pos, curr_router_y_pos, 0);
+        test_noc.add_router(router_id, curr_router_x_pos, curr_router_y_pos, 0, DUMMY_LATENCY);
     }
 
     // allocate the size for outgoing link vector for each router
@@ -250,7 +254,7 @@ TEST_CASE("test_router_link_list", "[vpr_noc]") {
             // makes sure we do not create a link for a router who acts as a sink and source
             if (source_router_id != sink_router_id) {
                 // add the link to the NoC
-                test_noc.add_link(source, sink);
+                test_noc.add_link(source, sink, DUMMY_BANDWIDTH, DUMMY_LATENCY);
 
                 // add the link id to the golden set
                 golden_set[source].push_back((NocLinkId)curr_link_number);
@@ -312,7 +316,8 @@ TEST_CASE("test_remove_link", "[vpr_noc]") {
         test_noc.add_router(router_id,
                             curr_router_x_pos,
                             curr_router_y_pos,
-                            0);
+                            0,
+                            DUMMY_LATENCY);
     }
 
     // now go through and add the links to the NoC
@@ -329,7 +334,7 @@ TEST_CASE("test_remove_link", "[vpr_noc]") {
             // makes sure we do not create a link for a router who acts as a sink and source
             if (source_router_id != sink_router_id) {
                 // add the link to the NoC
-                test_noc.add_link(source, sink);
+                test_noc.add_link(source, sink, DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
         }
     }
@@ -431,7 +436,8 @@ TEST_CASE("test_generate_router_key_from_grid_location", "[vpr_noc]") {
         test_noc.add_router(curr_router_id,
                             router_grid_position_x,
                             router_grid_position_y,
-                            0);
+                            0,
+                            DUMMY_LATENCY);
     }
 
     // now verify the test function by identifying all the routers using their grid locations

--- a/vpr/test/test_setup_noc.cpp
+++ b/vpr/test/test_setup_noc.cpp
@@ -45,7 +45,7 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
     std::vector<t_noc_router_tile_position> list_of_routers;
 
     // make sure the test result is not corrupted
-    REQUIRE(list_of_routers.size() == 0);
+    REQUIRE(list_of_routers.empty());
 
     SECTION("All routers are seperated by one or more grid spaces") {
         // in this test, the routers will be on the 4 corners of the FPGA
@@ -120,7 +120,7 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
 
         for (int i = 0; i < test_grid_width; i++) {
             for (int j = 0; j < test_grid_height; j++) {
-                // make sure the current tyle is not a router
+                // make sure the current tile is not a router
                 if (test_grid[0][i][j].type == nullptr) {
                     // assign the non-router tile as empty
                     test_grid[0][i][j].type = &empty_tile;
@@ -134,9 +134,9 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
         DeviceGrid test_device = DeviceGrid(device_grid_name, test_grid);
 
         // call the test function
-        identify_and_store_noc_router_tile_positions(test_device, list_of_routers, std::string(router_tile_name));
+        list_of_routers = identify_and_store_noc_router_tile_positions(test_device, router_tile_name);
 
-        // check that the physocal router tile positions were correctly determined
+        // check that the physical router tile positions were correctly determined
         // make sure that only 4 router tiles were found
         REQUIRE(list_of_routers.size() == 4);
 
@@ -251,9 +251,9 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
         DeviceGrid test_device = DeviceGrid(device_grid_name, test_grid);
 
         // call the test function
-        identify_and_store_noc_router_tile_positions(test_device, list_of_routers, std::string(router_tile_name));
+        list_of_routers = identify_and_store_noc_router_tile_positions(test_device, router_tile_name);
 
-        // check that the physocal router tile positions were correctly determined
+        // check that the physical router tile positions were correctly determined
         // make sure that only 4 router tiles were found
         REQUIRE(list_of_routers.size() == 4);
 
@@ -354,7 +354,7 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
 
         for (int i = 0; i < test_grid_width; i++) {
             for (int j = 0; j < test_grid_height; j++) {
-                // make sure the current tyle is not a router
+                // make sure the current tile is not a router
                 if (test_grid[0][i][j].type == nullptr) {
                     // assign the non-router tile as empty
                     test_grid[0][i][j].type = &empty_tile;
@@ -368,9 +368,9 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
         DeviceGrid test_device = DeviceGrid(device_grid_name, test_grid);
 
         // call the test function
-        identify_and_store_noc_router_tile_positions(test_device, list_of_routers, std::string(router_tile_name));
+        list_of_routers = identify_and_store_noc_router_tile_positions(test_device, router_tile_name);
 
-        // check that the physocal router tile positions were correctly determined
+        // check that the physical router tile positions were correctly determined
         // make sure that only 4 router tiles were found
         REQUIRE(list_of_routers.size() == 4);
 
@@ -418,17 +418,17 @@ TEST_CASE("test_create_noc_routers", "[vpr_setup_noc]") {
      * - router 8: (4,8)
      * - router 9: (8,8)
      */
-    list_of_routers.push_back({0, 0, 0, 0.5, 1});
-    list_of_routers.push_back({4, 0, 0, 4.5, 1});
-    list_of_routers.push_back({8, 0, 0, 8.5, 1});
+    list_of_routers.emplace_back(0, 0, 0, 0.5, 1);
+    list_of_routers.emplace_back(4, 0, 0, 4.5, 1);
+    list_of_routers.emplace_back(8, 0, 0, 8.5, 1);
 
-    list_of_routers.push_back({0, 4, 0, 0.5, 5});
-    list_of_routers.push_back({4, 4, 0, 4.5, 5});
-    list_of_routers.push_back({8, 4, 0, 8.5, 5});
+    list_of_routers.emplace_back(0, 4, 0, 0.5, 5);
+    list_of_routers.emplace_back(4, 4, 0, 4.5, 5);
+    list_of_routers.emplace_back(8, 4, 0, 8.5, 5);
 
-    list_of_routers.push_back({0, 8, 0, 0.5, 9});
-    list_of_routers.push_back({4, 8, 0, 4.5, 9});
-    list_of_routers.push_back({8, 8, 0, 8.5, 9});
+    list_of_routers.emplace_back(0, 8, 0, 0.5, 9);
+    list_of_routers.emplace_back(4, 8, 0, 4.5, 9);
+    list_of_routers.emplace_back(8, 8, 0, 8.5, 9);
 
     // create the noc model (to store the routers)
     NocStorage noc_model;
@@ -437,13 +437,13 @@ TEST_CASE("test_create_noc_routers", "[vpr_setup_noc]") {
     t_noc_inf noc_info;
 
     // pointer to each logical router
-    t_router* temp_router = NULL;
+    t_router* temp_router = nullptr;
 
-    const vtr::vector<NocRouterId, NocRouter>* noc_routers = NULL;
+    const vtr::vector<NocRouterId, NocRouter>* noc_routers = nullptr;
 
     SECTION("Test create routers when logical routers match to exactly one physical router. The number of routers is less than whats on the FPGA.") {
         // start by creating all the logical routers
-        // this is similiar to the user provided a config file
+        // this is similar to the user provided a config file
         temp_router = new t_router;
 
         NocRouterId noc_router_id;
@@ -481,9 +481,9 @@ TEST_CASE("test_create_noc_routers", "[vpr_setup_noc]") {
             REQUIRE(test_router.get_router_grid_position_y() == list_of_routers[router_id - 1].grid_height_position);
         }
     }
-    SECTION("Test create routers when logical routers match to exactly one physical router. The number of routers is exacrly the same as on the FPGA.") {
+    SECTION("Test create routers when logical routers match to exactly one physical router. The number of routers is exactly the same as on the FPGA.") {
         // start by creating all the logical routers
-        // this is similiar to the user provided a config file
+        // this is similar to the user provided a config file
         temp_router = new t_router;
 
         NocRouterId noc_router_id;
@@ -523,7 +523,7 @@ TEST_CASE("test_create_noc_routers", "[vpr_setup_noc]") {
     }
     SECTION("Test create routers when a logical router can be matched to two physical routers. The number of routers is exactly the same as on the FPGA.") {
         // start by creating all the logical routers
-        // this is similiar to the user provided a config file
+        // this is similar to the user provided a config file
         temp_router = new t_router;
 
         NocRouterId noc_router_id;
@@ -595,17 +595,17 @@ TEST_CASE("test_create_noc_links", "[vpr_setup_noc]") {
      * - router 8: (4,8)
      * - router 9: (8,8)
      */
-    list_of_routers.push_back({0, 0, 0, 0.5, 1});
-    list_of_routers.push_back({4, 0, 0, 4.5, 1});
-    list_of_routers.push_back({8, 0, 0, 8.5, 1});
+    list_of_routers.emplace_back(0, 0, 0, 0.5, 1);
+    list_of_routers.emplace_back(4, 0, 0, 4.5, 1);
+    list_of_routers.emplace_back(8, 0, 0, 8.5, 1);
 
-    list_of_routers.push_back({0, 4, 0, 0.5, 5});
-    list_of_routers.push_back({4, 4, 0, 4.5, 5});
-    list_of_routers.push_back({8, 4, 0, 8.5, 5});
+    list_of_routers.emplace_back(0, 4, 0, 0.5, 5);
+    list_of_routers.emplace_back(4, 4, 0, 4.5, 5);
+    list_of_routers.emplace_back(8, 4, 0, 8.5, 5);
 
-    list_of_routers.push_back({0, 8, 0, 0.5, 9});
-    list_of_routers.push_back({4, 8, 0, 4.5, 9});
-    list_of_routers.push_back({8, 8, 0, 8.5, 9});
+    list_of_routers.emplace_back(0, 8, 0, 0.5, 9);
+    list_of_routers.emplace_back(4, 8, 0, 4.5, 9);
+    list_of_routers.emplace_back(8, 8, 0, 8.5, 9);
 
     // create the noc model (to store the routers)
     NocStorage noc_model;
@@ -618,10 +618,10 @@ TEST_CASE("test_create_noc_links", "[vpr_setup_noc]") {
     t_noc_inf noc_info;
 
     // pointer to each logical router
-    t_router* temp_router = NULL;
+    t_router* temp_router = nullptr;
 
     // start by creating all the logical routers
-    // this is similiar to the user provided a config file
+    // this is similar to the user provided a config file
     temp_router = new t_router;
 
     for (int router_id = 1; router_id < 10; router_id++) {
@@ -635,7 +635,8 @@ TEST_CASE("test_create_noc_links", "[vpr_setup_noc]") {
         noc_model.add_router(router_id,
                              list_of_routers[router_id - 1].grid_width_position,
                              list_of_routers[router_id - 1].grid_height_position,
-                             list_of_routers[router_id - 1].layer_position);
+                             list_of_routers[router_id - 1].layer_position,
+                             1.0);
     }
 
     delete temp_router;
@@ -676,7 +677,7 @@ TEST_CASE("test_create_noc_links", "[vpr_setup_noc]") {
     noc_info.router_list[8].connection_list.push_back(8);
 
     // call the function to test
-    create_noc_links(&noc_info, &noc_model);
+    create_noc_links(noc_info, &noc_model);
 
     NocRouterId current_source_router_id;
     NocRouterId current_destination_router_id;
@@ -711,10 +712,10 @@ TEST_CASE("test_setup_noc", "[vpr_setup_noc]") {
     t_noc_inf noc_info;
 
     // pointer to each logical router
-    t_router* temp_router = NULL;
+    t_router* temp_router = nullptr;
 
     // start by creating all the logical routers
-    // this is similiar to the user provided a config file
+    // this is similar to the user provided a config file
     temp_router = new t_router;
 
     // datastructure to hold the list of physical tiles
@@ -741,17 +742,17 @@ TEST_CASE("test_setup_noc", "[vpr_setup_noc]") {
      * - router 8: (4,8)
      * - router 9: (8,8)
      */
-    list_of_routers.push_back({0, 0, 0, 0.5, 1});
-    list_of_routers.push_back({4, 0, 0, 4.5, 1});
-    list_of_routers.push_back({8, 0, 0, 8.5, 1});
+    list_of_routers.emplace_back(0, 0, 0, 0.5, 1);
+    list_of_routers.emplace_back(4, 0, 0, 4.5, 1);
+    list_of_routers.emplace_back(8, 0, 0, 8.5, 1);
 
-    list_of_routers.push_back({0, 4, 0, 0.5, 5});
-    list_of_routers.push_back({4, 4, 0, 4.5, 5});
-    list_of_routers.push_back({8, 4, 0, 8.5, 5});
+    list_of_routers.emplace_back(0, 4, 0, 0.5, 5);
+    list_of_routers.emplace_back(4, 4, 0, 4.5, 5);
+    list_of_routers.emplace_back(8, 4, 0, 8.5, 5);
 
-    list_of_routers.push_back({0, 8, 0, 0.5, 9});
-    list_of_routers.push_back({4, 8, 0, 4.5, 9});
-    list_of_routers.push_back({8, 8, 0, 8.5, 9});
+    list_of_routers.emplace_back(0, 8, 0, 0.5, 9);
+    list_of_routers.emplace_back(4, 8, 0, 4.5, 9);
+    list_of_routers.emplace_back(8, 8, 0, 8.5, 9);
 
     for (int router_id = 1; router_id < 10; router_id++) {
         // we will have 9 logical routers that will take up all physical routers
@@ -958,7 +959,7 @@ TEST_CASE("test_setup_noc", "[vpr_setup_noc]") {
 
         for (int i = 0; i < test_grid_width; i++) {
             for (int j = 0; j < test_grid_height; j++) {
-                // make sure the current tyle is not a router
+                // make sure the current tile is not a router
                 if (test_grid[0][i][j].type == nullptr) {
                     // assign the non-router tile as empty
                     test_grid[0][i][j].type = &empty_tile;

--- a/vpr/test/test_xy_routing.cpp
+++ b/vpr/test/test_xy_routing.cpp
@@ -5,6 +5,9 @@
 
 namespace {
 
+constexpr double DUMMY_LATENCY = 1e-9;
+constexpr double DUMMY_BANDWIDTH = 1e12;
+
 /**
  * @brief Compares two vectors of NocLinks. These vectors represent
  * two routes between a start and destination routers. This function
@@ -53,7 +56,7 @@ TEST_CASE("test_route_flow", "[vpr_noc_xy_routing]") {
     // add all the routers
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
-            noc_model.add_router((i * 4) + j, j, i, 0);
+            noc_model.add_router((i * 4) + j, j, i, 0, DUMMY_LATENCY);
         }
     }
 
@@ -64,19 +67,19 @@ TEST_CASE("test_route_flow", "[vpr_noc_xy_routing]") {
         for (int j = 0; j < 4; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 1));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 1), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= 3) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 4));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 4), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= 3) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 1));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 1), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 4));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 4), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
         }
     }
@@ -243,7 +246,7 @@ TEST_CASE("test_route_flow when it fails in a mesh topology.", "[vpr_noc_xy_rout
     // add all the routers
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
-            noc_model.add_router((i * 4) + j, j, i, 0);
+            noc_model.add_router((i * 4) + j, j, i, 0, DUMMY_LATENCY);
         }
     }
 
@@ -254,19 +257,19 @@ TEST_CASE("test_route_flow when it fails in a mesh topology.", "[vpr_noc_xy_rout
         for (int j = 0; j < 4; j++) {
             // add a link to the left of the router if there exists another router there
             if ((j - 1) >= 0) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 1));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 1), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the top of the router if there exists another router there
             if ((i + 1) <= 3) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 4));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 4), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the right of the router if there exists another router there
             if ((j + 1) <= 3) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 1));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) + 1), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
             // add a link to the bottom of the router if there exists another router there
             if ((i - 1) >= 0) {
-                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 4));
+                noc_model.add_link((NocRouterId)((i * 4) + j), (NocRouterId)(((i * 4) + j) - 4), DUMMY_BANDWIDTH, DUMMY_LATENCY);
             }
         }
     }
@@ -353,17 +356,17 @@ TEST_CASE("test_route_flow when it fails in a non mesh topology.", "[vpr_noc_xy_
     // this will be set to the device grid width
     noc_model.set_device_grid_spec((int)4, 0);
 
-    noc_model.add_router(0, 0, 0, 0);
-    noc_model.add_router(1, 2, 2, 0);
-    noc_model.add_router(2, 1, 2, 0);
-    noc_model.add_router(3, 3, 0, 0);
+    noc_model.add_router(0, 0, 0, 0, DUMMY_LATENCY);
+    noc_model.add_router(1, 2, 2, 0, DUMMY_LATENCY);
+    noc_model.add_router(2, 1, 2, 0, DUMMY_LATENCY);
+    noc_model.add_router(3, 3, 0, 0, DUMMY_LATENCY);
 
     noc_model.make_room_for_noc_router_link_list();
 
     // add the links
-    noc_model.add_link((NocRouterId)0, (NocRouterId)3);
-    noc_model.add_link((NocRouterId)3, (NocRouterId)0);
-    noc_model.add_link((NocRouterId)2, (NocRouterId)1);
+    noc_model.add_link((NocRouterId)0, (NocRouterId)3, DUMMY_BANDWIDTH, DUMMY_LATENCY);
+    noc_model.add_link((NocRouterId)3, (NocRouterId)0, DUMMY_BANDWIDTH, DUMMY_LATENCY);
+    noc_model.add_link((NocRouterId)2, (NocRouterId)1, DUMMY_BANDWIDTH, DUMMY_LATENCY);
 
     // now create the start and the destination routers of the route we want to test
     auto start_router_id = NocRouterId(3);


### PR DESCRIPTION
This PR adds support for heterogeneous NoCs description in the architecture file. It is now possible to specify the latency of each NoC link and NoC router seperately. The user can also specify the bandwidth of each individual NoC link.

The architecture file reference needs to be updated to explaing how <overrides> tag can be used. I think the code is done and the review process can begin. In meantime, I update the architecture file reference.

#### Description
The default latency and bandwidth for NoC links and routers are specified under <noc> tag with link_bandwidth, link_latency, and router_latency attributes. The user can override these default values for certain routers and links by adding an optional <overrides> tag under <noc> tag.

Before this PR, some NoC-related cost calcualtion functions assumed the latency and bandwidth is the same for all NoC components. Now, these functions check if the latnecy or bandwidth is the same for all NoC components. When this not the case, thse functions query the bandwidth or the latency of NoC components separately.

#### Motivation and Context
Make the architecture description file syntax support heterogeneous NoC topologies.

#### How Has This Been Tested?
Has been tested with a toy architecture file.


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
