### PR TITLE
[CI] Added GCC-13 as a Compatability Test

### DIFF
--- a/.github/scripts/install_dependencies.sh
+++ b/.github/scripts/install_dependencies.sh
@@ -52,6 +52,8 @@ sudo apt install -y \
   gcc-11 \
   g++-12 \
   gcc-12 \
+  g++-13 \
+  gcc-13 \
   clang-11 \
   clang-12 \
   clang-13 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -401,9 +401,10 @@ jobs:
       matrix:
         include:
         - { name: 'GCC 9 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           }
-        - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         }
-        - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-11 && CXX=g++-11',         }
-        - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-12 && CXX=g++-12',         }
+        - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-10 && CXX=g++-10',         }
+        - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-11 && CXX=g++-11',         }
+        - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-12 && CXX=g++-12',         }
+        - { name: 'GCC 13 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-13 && CXX=g++-13',         }
         - { name: 'Clang 11 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-11 && CXX=clang++-11',   }
         - { name: 'Clang 12 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-12 && CXX=clang++-12',   }
         - { name: 'Clang 13 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-13 && CXX=clang++-13',   }


### PR DESCRIPTION
Ubuntu 24.04 uses GCC-13 as its default GCC version. The CI should ensure that VTR builds for this version of GCC.