### PR TITLE
Doc update: mux and wire_switch for segments in arch file

### DIFF
--- a/doc/src/arch/reference.rst
+++ b/doc/src/arch/reference.rst
@@ -2026,7 +2026,7 @@ The ``<segment>`` tag and its contents are described below.
 
 .. arch:tag:: <mux name="string"/>
 
-    :req_param name: Name of the mux switch type used to drive this type of segment.
+    :req_param name: Name of the mux switch type used to drive this type of segment by default, from both block outputs and other wires. This information is used during rr-graph construction, and a custom switch block can override this switch type for specific connections if desired.
 
     .. note:: For UNIDIRECTIONAL only.
 
@@ -2034,7 +2034,7 @@ The ``<segment>`` tag and its contents are described below.
 
 .. arch:tag:: <wire_switch name="string"/>
 
-    :req_param name: Name of the switch type used by other wires to drive this type of segment.
+    :req_param name: Name of the switch type used by other wires to drive this type of segment by default. This information is used during rr-graph construction, and a custom switch block can override this switch type for specific connections if desired.
 
     .. note:: For BIDIRECTIONAL only.
 


### PR DESCRIPTION
Clarified these are defaults only for rr-graph construction and can be overridden in custom switch blocks.

#### Motivation and Context
Current text implied to some that this data was crucial in the routing arch, when it is actually just a default for rr-graph construction.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly

