### PR TITLE
Fixed enum value in cluster_utils.cpp to fix build.

### DIFF
--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -1245,7 +1245,7 @@ enum e_block_pack_status try_place_atom_block_rec(const t_pb_graph_node* pb_grap
     } else {
        /* if this is not the first child of this parent, must match existing parent mode */
        if (parent_pb->mode != pb_graph_node->pb_type->parent_mode->index) {
-            return BLK_FAILED_FEASIBLE;
+            return e_block_pack_status::BLK_FAILED_FEASIBLE;
         }
     }
 


### PR DESCRIPTION
A PR I merged today (https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2433) had an out of date enum (other changes on the master changed it to an enum class).  This PR fixes it so the build compiles.

#### Description
cluster_util.cpp: --> changing return at line 1248 to  e_block_pack_status::BLK_STATUS_FAILED.

