### PR TITLE
[CI] Added GCC-13 as a Compatability Test

### DIFF
--- a/.github/scripts/install_noble_dependencies.sh
+++ b/.github/scripts/install_noble_dependencies.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+sudo apt update
+
+sudo apt install -y \
+  autoconf \
+  automake \
+  bash \
+  bison \
+  binutils \
+  binutils-gold \
+  build-essential \
+  capnproto \
+  exuberant-ctags \
+  curl \
+  doxygen \
+  flex \
+  fontconfig \
+  gdb \
+  git \
+  gperf \
+  libcairo2-dev \
+  libcapnp-dev \
+  libgtk-3-dev \
+  libevent-dev \
+  libfontconfig1-dev \
+  liblist-moreutils-perl \
+  libncurses5-dev \
+  libx11-dev \
+  libxft-dev \
+  libxml2-utils \
+  libxml++2.6-dev \
+  libreadline-dev \
+  tcllib \
+  tcl8.6-dev \
+  libffi-dev \
+  perl \
+  pkg-config \
+  texinfo \
+  time \
+  valgrind \
+  zip \
+  qtbase5-dev \
+  uuid-dev \
+  default-jdk \
+  g++-9 \
+  gcc-9 \
+  g++-10 \
+  gcc-10 \
+  g++-11 \
+  gcc-11 \
+  g++-12 \
+  gcc-12 \
+  g++-13 \
+  gcc-13 \
+  clang-14 \
+  clang-18 \
+  clang-format-14 \
+  libtbb-dev
+
+pip install -r requirements.txt
+
+git clone https://github.com/capnproto/capnproto-java.git $GITHUB_WORKSPACE/env/capnproto-java
+pushd $GITHUB_WORKSPACE/env/capnproto-java
+make
+sudo make install
+popd

--- a/.github/workflows/noble.yml
+++ b/.github/workflows/noble.yml
@@ -1,0 +1,51 @@
+# This workflow is designed to test that VTR can run on Ubuntu 24.04. Since
+# the Ubuntu 24.04 GitHub runners are still in Beta, this is left as a workflow
+# that must be dispatched manually. In the future this workflow should be
+# removed and made the default (integrated into test.yml).
+name: Noble
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 0 * * *' # daily
+
+# We want to cancel previous runs for a given PR or branch / ref if another CI
+# run is requested.
+# See: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  MATRIX_EVAL: "CC=gcc-13 && CXX=g++-13"
+
+jobs:
+  FutureCompatibility:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { name: 'GCC 13 (Ubuntu Noble - 24.04)',    eval: 'CC=gcc-13 && CXX=g++-13',         }
+        - { name: 'Clang 18 (Ubuntu Noble - 24.04)',  eval: 'CC=clang-18 && CXX=clang++-18',   }
+    name: 'B: ${{ matrix.name }}'
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12.3
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+    - run: ./.github/scripts/install_noble_dependencies.sh
+
+    - uses: hendrikmuhs/ccache-action@v1.2
+
+    - name: Test
+      env:
+        CMAKE_PARAMS: "-DVTR_ASSERT_LEVEL=3 -DVTR_IPO_BUILD=off"
+        MATRIX_EVAL: ${{ matrix.eval }}
+        BUILD_TYPE: release
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        ./.github/scripts/build.sh
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -421,9 +421,9 @@ jobs:
       matrix:
         include:
         - { name: 'GCC 9 (Ubuntu Jammy - 22.04)',     eval: 'CC=gcc-9 && CXX=g++-9',           }
-        - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',  eval: 'CC=gcc-10 && CXX=g++-10',         }
-        - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-11 && CXX=g++-11',         }
-        - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',                  eval: 'CC=gcc-12 && CXX=g++-12',         }
+        - { name: 'GCC 10 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-10 && CXX=g++-10',         }
+        - { name: 'GCC 11 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-11 && CXX=g++-11',         }
+        - { name: 'GCC 12 (Ubuntu Jammy - 22.04)',    eval: 'CC=gcc-12 && CXX=g++-12',         }
         - { name: 'Clang 11 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-11 && CXX=clang++-11',   }
         - { name: 'Clang 12 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-12 && CXX=clang++-12',   }
         - { name: 'Clang 13 (Ubuntu Jammy - 22.04)',  eval: 'CC=clang-13 && CXX=clang++-13',   }
@@ -449,7 +449,6 @@ jobs:
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         ./.github/scripts/build.sh
-
 
   Coverity:
     name: 'Coverity Scan'

--- a/vpr/src/server/bytearray.h
+++ b/vpr/src/server/bytearray.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <cstdint>
 
 namespace comm {
 

--- a/vpr/src/server/telegramheader.h
+++ b/vpr/src/server/telegramheader.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstring>
+#include <cstdint>
 
 namespace comm {
 


### PR DESCRIPTION
Ubuntu 24.04 uses GCC-13 as its default GCC version. The CI should ensure that VTR builds for this version of GCC.

Also added the version of Clang that would come with Ubuntu 24.04

Versions of tools were found from here:
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
