### PR TITLE
resize atoms_lookup after adding a new cluster

### DIFF
--- a/vpr/src/pack/re_cluster_util.cpp
+++ b/vpr/src/pack/re_cluster_util.cpp
@@ -184,6 +184,11 @@ bool start_new_cluster_for_mol(t_pack_molecule* molecule,
         pb->name = vtr::strdup(new_name.c_str());
         clb_index = cluster_ctx.clb_nlist.create_block(new_name.c_str(), pb, type);
         helper_ctx.total_clb_num++;
+
+        if (helper_ctx.atoms_lookup.size() < helper_ctx.total_clb_num) {
+            helper_ctx.atoms_lookup.resize(helper_ctx.total_clb_num);
+        }
+
         int molecule_size = get_array_size_of_molecule(molecule);
         update_cluster_pb_stats(molecule, molecule_size, clb_index, true);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
resize the atoms_lookup data structure after adding a new cluster

#### Description
<!--- Describe your changes in detail -->
resize the atoms_lookup data structure after adding a new cluster using the re-clustering API

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
The legalizer creates clusters and later uses this lookup during legality checking and repair; the data structure needs to be resized to accommodate the new cluster.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
