### PR TITLE
[CI] Fixed Issue with Artifacts not Being Saved On Failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,9 @@ jobs:
         NUM_CORES: ${{ matrix.cores }}
 
     - name: Upload test results
+      # We always want the test results to be uploaded, even when cancelled.
+      # https://docs.github.com/en/actions/learn-github-actions/expressions#always
+      if: ${{ always() }}
       # TODO: This runnner is running on a self-hosted CPU. In order to upgrade
       #       to v4, need to upgrade the machine to support node20.
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Reverted a change I made in PR #2568 which caused the CI to not generate artifacts on failure for the nightly tests.

Added a comment to document what this feature does and prevent this issue for the future.
