### PR TITLE
Fix submodule init issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = https://github.com/catchorg/Catch2.git
 [submodule "libs/EXTERNAL/sockpp"]
 	path = libs/EXTERNAL/sockpp
-	#url = git@github.com:fpagliughi/sockpp.git
-	url = git@github.com:w0lek/sockpp.git # fork where in branch v1.0.0_no_complication_warnings there are compilation warnings fixes for upstream tag v1.0.0 of sockpp
+	url = https://github.com/w0lek/sockpp.git # fork where in branch v1.0.0_no_complication_warnings there are compilation warnings fixes for upstream tag v1.0.0 of sockpp


### PR DESCRIPTION
Solves [this issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2586)

Since sockpp uses ssh to clone the repo, ssh keys need to be set up. Alternatively, we can use https for cloning the repo.