### PR TITLE
add flat idx to pb_graph_node , populate in alloc_and_load_pb_graph

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1225,7 +1225,12 @@ struct t_pin_to_pin_annotation {
  *      parent_pb_graph_node  : parent pb graph node
  *      total_primitive_count : Total number of this primitive type in the cluster. If there are 10 ALMs per cluster
  *                              and 2 FFs per ALM (given the mode of the parent of this primitive) then the total is 20.
- *      flat_site_index       : index of this primitive within its primitive type in this cluster; in [0,...,total_primitive_count]
+ *                              This member is only used by nodes corresponding to primitive sites.
+ *      flat_site_index       : Index of this primitive site within its primitive type within this cluster type.
+ *                              Values are in [0...total_primitive_count-1], e.g. if there are 10 ALMs per cluster, 2 FFS
+ *                              and 2 LUTs per ALM, then flat site indices for FFs would run from 0 to 19, and flat site
+                                indices for LUTs would run from 0 to 19. This member is only used by nodes corresponding
+                                to primitive sites. It is used when reconstructing clusters from a flat placement file.
  *      illegal_modes         : vector containing illegal modes that result in conflicts during routing
  */
 class t_pb_graph_node {

--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1225,6 +1225,7 @@ struct t_pin_to_pin_annotation {
  *      parent_pb_graph_node  : parent pb graph node
  *      total_primitive_count : Total number of this primitive type in the cluster. If there are 10 ALMs per cluster
  *                              and 2 FFs per ALM (given the mode of the parent of this primitive) then the total is 20.
+ *      flat_site_index       : index of this primitive within its primitive type in this cluster; in [0,...,total_primitive_count]
  *      illegal_modes         : vector containing illegal modes that result in conflicts during routing
  */
 class t_pb_graph_node {
@@ -1281,6 +1282,8 @@ class t_pb_graph_node {
     int num_output_pin_class;   /* number of output pin classes that this pb_graph_node has */
 
     int total_primitive_count; /* total number of this primitive type in the cluster */
+     int flat_site_index;       /* index of this primitive within sites of its type in this cluster  */
+
 
     /* Interconnect instances for this pb
      * Only used for power

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -134,6 +134,9 @@ static bool check_input_pins_equivalence(const t_pb_graph_pin* cur_pin,
                                          const int i_pin,
                                          std::map<int, int>& edges_map,
                                          int* line_num);
+static int compute_flat_index_for_child_node(int num_children_of_type,
+                                             int parent_flat_index,
+                                             int child_index);
 
 /**
  * Allocate memory into types and load the pb graph with interconnect edges
@@ -240,7 +243,7 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
     pb_graph_node->num_clock_ports = 0;
 
     pb_graph_node->total_primitive_count = 0;
-    pb_graph_node->flat_site_index = flat_index;
+    pb_graph_node->flat_site_index = 0;
 
     /* Generate ports for pb graph node */
     for (i = 0; i < pb_type->num_ports; i++) {
@@ -353,14 +356,15 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
                                                                                 sizeof(t_pb_graph_node*));
         for (j = 0; j < pb_type->modes[i].num_pb_type_children; j++) {
             pb_graph_node->child_pb_graph_nodes[i][j] = (t_pb_graph_node*)vtr::calloc(pb_type->modes[i].pb_type_children[j].num_pb, sizeof(t_pb_graph_node));
-            int base = flat_index*(pb_type->modes[i].pb_type_children[j].num_pb);
+            int num_children_of_type = pb_type->modes[i].pb_type_children[j].num_pb;
 
-            for (k = 0; k < pb_type->modes[i].pb_type_children[j].num_pb; k++) {
+            for (k = 0; k < num_children_of_type; k++) {
+                int child_flat_index = compute_flat_index_for_child_node(num_children_of_type, flat_index, k);
                 alloc_and_load_pb_graph(&pb_graph_node->child_pb_graph_nodes[i][j][k],
                                         pb_graph_node,
                                         &pb_type->modes[i].pb_type_children[j],
                                         k,
-                                        base + k,
+                                        child_flat_index,
                                         load_power_structures,
                                         pin_count_in_cluster);
             }
@@ -387,6 +391,10 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
             pb_node = pb_node->parent_pb_graph_node;
         }
         pb_graph_node->total_primitive_count = total_count;
+
+        // if this is a primitive, then flat_index corresponds
+        // to its index within all primitives of this type
+        pb_graph_node->flat_site_index = flat_index;
     }
 }
 
@@ -1920,4 +1928,23 @@ const t_pb_graph_edge* get_edge_between_pins(const t_pb_graph_pin* driver_pin, c
     }
 
     return nullptr;
+}
+
+/* Date:June 8th, 2024
+ * Author: Kate Thurmer
+ * Purpose: This subroutine computes the index of a pb graph node at its
+            level of the pb hierarchy; it is computed by the parent and
+            passed to each child of each child pb type. When the child is
+            a primitive, the computed indes is its flat site index.
+            For example, if there are 10 ALMs, each with 2 FFs and 2 LUTs,
+            then the ALM at index N, when calling this function for
+            its FF child at index M, would compute the child's index as:
+                N*(FFs per ALM) + M
+            e.g. for FF[1] in ALM[5], this returns
+                5*(2 FFS per ALM) + 1 = 11
+ */
+static int compute_flat_index_for_child_node(int num_children_of_type,
+                                             int parent_flat_index,
+                                             int child_index) {
+    return parent_flat_index*num_children_of_type + child_index;
 }

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -48,6 +48,7 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
                                     t_pb_graph_node* parent_pb_graph_node,
                                     t_pb_type* pb_type,
                                     const int index,
+                                    const int flat_index,
                                     bool load_power_structures,
                                     int& pin_count_in_cluster);
 
@@ -151,6 +152,7 @@ void alloc_and_load_all_pb_graphs(bool load_power_structures, bool is_flat) {
                                     nullptr,
                                     type.pb_type,
                                     0,
+                                    0,
                                     load_power_structures,
                                     pin_count_in_cluster);
             type.pb_graph_head->total_pb_pins = pin_count_in_cluster;
@@ -224,6 +226,7 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
                                     t_pb_graph_node* parent_pb_graph_node,
                                     t_pb_type* pb_type,
                                     const int index,
+                                    const int flat_index,
                                     bool load_power_structures,
                                     int& pin_count_in_cluster) {
     int i, j, k, i_input, i_output, i_clockport;
@@ -237,6 +240,7 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
     pb_graph_node->num_clock_ports = 0;
 
     pb_graph_node->total_primitive_count = 0;
+    pb_graph_node->flat_site_index = flat_index;
 
     /* Generate ports for pb graph node */
     for (i = 0; i < pb_type->num_ports; i++) {
@@ -349,11 +353,14 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
                                                                                 sizeof(t_pb_graph_node*));
         for (j = 0; j < pb_type->modes[i].num_pb_type_children; j++) {
             pb_graph_node->child_pb_graph_nodes[i][j] = (t_pb_graph_node*)vtr::calloc(pb_type->modes[i].pb_type_children[j].num_pb, sizeof(t_pb_graph_node));
+            int base = flat_index*(pb_type->modes[i].pb_type_children[j].num_pb);
+
             for (k = 0; k < pb_type->modes[i].pb_type_children[j].num_pb; k++) {
                 alloc_and_load_pb_graph(&pb_graph_node->child_pb_graph_nodes[i][j][k],
                                         pb_graph_node,
                                         &pb_type->modes[i].pb_type_children[j],
                                         k,
+                                        base + k,
                                         load_power_structures,
                                         pin_count_in_cluster);
             }

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -134,6 +134,8 @@ static bool check_input_pins_equivalence(const t_pb_graph_pin* cur_pin,
                                          const int i_pin,
                                          std::map<int, int>& edges_map,
                                          int* line_num);
+
+/* computes the index of a pb graph node at its level of the pb hierarchy */
 static int compute_flat_index_for_child_node(int num_children_of_type,
                                              int parent_flat_index,
                                              int child_index);


### PR DESCRIPTION
Added a flat_site_idx to pb_graph_node struct, along with code to populate it in alloc_and_load_pb_graph.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
As alloc_and_load_pb_graph builds the graph from the top down, each parent computes its child's flat index and passes it to them as an argument to alloc_and_load_ph_graph.  
The child's flat site is computed by the parent as:
(parent's flat site)*(total children of this type) + child's sibling index.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
This is used to help the legalizer place a molecule on a user specified site. It is better to store this value in the node than to recompute it over and over.

#### How Has This Been Tested?
Compared this value to locally computed value in the legalizer, which is then printed to a flat placement file and compared via a script.  I tested on both StratixIV and ISPD Ultrascale architectures.  In all cases, computed sites and sites stored in the pb_graph_node match.


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
