### PR TITLE
[CI] Cleaned Up Artifacts and Resolved Deprecation

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -36,7 +36,7 @@ jobs:
         id: generate
         run: |
           REPO='${{ github.repository }}'
-          echo "::set-output name=image::ghcr.io/${REPO,,}/ubuntu/focal/build"
+          echo "image=ghcr.io/${REPO,,}/ubuntu/focal/build" >> $GITHUB_OUTPUT
 
       - name: ⛴️ Build container image
         run: docker build -t ${{ steps.generate.outputs.image }} -f Dockerfile .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,10 @@ jobs:
         NUM_CORES: ${{ matrix.cores }}
 
     - name: Upload test results
-      # We always want the test results to be uploaded, even when cancelled.
+      # If the job was not cancelled, we want to save the result (this includes
+      # when the job fails). See warning here:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#always
-      if: ${{ always() }}
+      if: ${{ !cancelled() }}
       # TODO: This runnner is running on a self-hosted CPU. In order to upgrade
       #       to v4, need to upgrade the machine to support node20.
       uses: actions/upload-artifact@v3
@@ -275,17 +276,19 @@ jobs:
         ./run_reg_test.py ${{ matrix.suite }} -show_failures -j2
 
     - name: Upload regression run files
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.name}}_run_files
         path: |
           vtr_flow/**/*.out
-          vtr_flow/**/*.blif
+          # vtr_flow/**/*.blif  # Removed since it was taking too much space and was hardly used.
           vtr_flow/**/*.p
           vtr_flow/**/*.net
           vtr_flow/**/*.r
 
     - name: Upload regression results
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.name}}_results


### PR DESCRIPTION
When artifacts were being saved for the regression tests, it was saving
all of the benchmarks as blif files. This is incredibly wasteful (72 MB
per regression test or around 720 MB per CI run). These tests will no
longer save .blif files as artifacts anymore. If anyone needed these
files they could generate them themselves or can add a condition to add
the exact .blif files they may need.
    
The CI was also always generating artifacts (at least for the nightly
    tests) even when the run was cancelled. Made it so the artifacts are
    only saved if the run is not cancelled. This would mean an artifact is
    generated if the run succeeds or fails.

save-output was deprecated. Resolved. See:
    https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
<img width="1065" alt="image" src="https://github.com/verilog-to-routing/vtr-verilog-to-routing/assets/49374526/fdfb31ca-9c39-40d4-9899-1848bb222560">
