### PR TITLE
[CI] Prevented Running the CI If Only the Documentation Is Updated

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -7,7 +7,17 @@ on:
   push:
     branches:
       - master
+    paths-ignore: # Prevents from running if only docs are updated
+      - 'doc/**'
+      - '**/*README*'
+      - '**.md'
+      - '**.rst'
   pull_request:
+    paths-ignore: # Prevents from running if only docs are updated
+      - 'doc/**'
+      - '**/*README*'
+      - '**.md'
+      - '**.rst'
   workflow_dispatch:
   schedule:
   - cron: '0 0 * * 0' # weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,17 @@ on:
   push:
     branches:
       - master
+    paths-ignore: # Prevents from running if only docs are updated
+      - 'doc/**'
+      - '**/*README*'
+      - '**.md'
+      - '**.rst'
   pull_request:
+    paths-ignore: # Prevents from running if only docs are updated
+      - 'doc/**'
+      - '**/*README*'
+      - '**.md'
+      - '**.rst'
   workflow_dispatch:
   schedule:
   - cron: '0 0 * * *' # daily


### PR DESCRIPTION
Solved https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2598.

Added a `path-ignore` filter to the GitHub Actions triggers (including `push` and `pull_request`) to filter out any push or pull request that only includes docs updates.

The "Test" and "Containers" workflows will be skipped if a push or a PR only contains changes to the documentation, such as the developer guide and README, so that we can save CI resources for other uses.

For more details, please refer to the issue page :)

