### PR TITLE
[Route] Removed Unreachable Code

### DIFF
--- a/vpr/src/route/connection_router.cpp
+++ b/vpr/src/route/connection_router.cpp
@@ -116,11 +116,6 @@ std::tuple<bool, t_heap*> ConnectionRouter<Heap>::timing_driven_route_connection
         return std::make_tuple(true, nullptr);
     }
 
-    if (cheapest == nullptr) {
-        VTR_LOG("%s\n", describe_unrouteable_connection(source_node, sink_node, is_flat_).c_str());
-        return std::make_tuple(false, nullptr);
-    }
-
     return std::make_tuple(false, cheapest);
 }
 


### PR DESCRIPTION
In an old version of the router, a catch was made to exit the router with no solution and not to retry at max bounding box; however, the function was rewritten to explicitly do this. The old catch statement was left in the code and was unreachable.

Removed the unreachable code.

This resolves issue #2570 
