### PR TITLE
Redundant Physical Type

### DIFF
--- a/vpr/src/draw/draw_types.cpp
+++ b/vpr/src/draw/draw_types.cpp
@@ -13,7 +13,15 @@
  *******************************************/
 ezgl::color t_draw_state::block_color(ClusterBlockId blk) const {
     if (use_default_block_color_[blk]) {
-        t_physical_tile_type_ptr tile_type = get_physical_tile_type(blk);
+        t_physical_tile_type_ptr tile_type = nullptr;
+        auto& cluster_ctx = g_vpr_ctx.clustering();
+        auto& place_ctx = g_vpr_ctx.placement();
+        if (place_ctx.block_locs.empty()) { //No placement, pick best match
+            tile_type = pick_physical_type(cluster_ctx.clb_nlist.block_type(blk));
+        } else { // Have placement, select physical tile implementing blk
+            tile_type = physical_tile_type(blk);
+        }
+        VTR_ASSERT(tile_type != nullptr);
         return get_block_type_color(tile_type);
     } else {
         return block_color_[blk];

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -527,10 +527,9 @@ t_physical_tile_type_ptr physical_tile_type(ClusterBlockId blk) {
     auto& place_ctx = g_vpr_ctx.placement();
     auto& device_ctx = g_vpr_ctx.device();
 
-    auto block_loc = place_ctx.block_locs[blk];
-    auto loc = block_loc.loc;
+    auto block_loc = place_ctx.block_locs[blk].loc;
 
-    return device_ctx.grid.get_physical_type({loc.x, loc.y, loc.layer});
+    return device_ctx.grid.get_physical_type({block_loc.x, block_loc.y, block_loc.layer});
 }
 
 t_physical_tile_type_ptr physical_tile_type(AtomBlockId atom_blk) {
@@ -2148,20 +2147,6 @@ int max_pins_per_grid_tile() {
         max_pins = std::max(max_pins, pins_per_grid_tile);
     }
     return max_pins;
-}
-
-t_physical_tile_type_ptr get_physical_tile_type(const ClusterBlockId blk) {
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& place_ctx = g_vpr_ctx.placement();
-    if (place_ctx.block_locs.empty()) { //No placement, pick best match
-        return pick_physical_type(cluster_ctx.clb_nlist.block_type(blk));
-    } else { //Have placement, select physical tile implementing blk
-        auto& device_ctx = g_vpr_ctx.device();
-
-        t_pl_loc loc = place_ctx.block_locs[blk].loc;
-
-        return device_ctx.grid.get_physical_type({loc.x, loc.y, loc.layer});
-    }
 }
 
 int net_pin_to_tile_pin_index(const ClusterNetId net_id, int net_pin_index) {

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -234,10 +234,6 @@ AtomBlockId find_memory_sibling(const t_pb* pb);
  */
 void place_sync_external_block_connections(ClusterBlockId iblk);
 
-//Returns the current tile implemnting blk (if placement is valid), or
-//the best expected physical tile the block should use (if no valid placement).
-t_physical_tile_type_ptr get_physical_tile_type(const ClusterBlockId blk);
-
 //Returns the physical pin of the tile, related to the given ClusterNedId, and the net pin index
 int net_pin_to_tile_pin_index(const ClusterNetId net_id, int net_pin_index);
 


### PR DESCRIPTION
`get_physical_tile_type` is a function that returns a pointer to the physical tile corresponding to a `ClusterId`. There is a similar function in `vpr_utils` with similar functionality (`physical_tile_type`). The only difference is that `get_physical_tile_type` will return a tile type even if the cluster is not placed (for drawing purposes). Instead of having a separate function, I call that function directly if the block is not placed.

