### PR TITLE
enable option to force molecule placement on a specified primitive site

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1287,7 +1287,7 @@ class t_pb_graph_node {
     int num_output_pin_class;   /* number of output pin classes that this pb_graph_node has */
 
     int total_primitive_count; /* total number of this primitive type in the cluster */
-     int flat_site_index;       /* index of this primitive within sites of its type in this cluster  */
+    int flat_site_index;       /* index of this primitive within sites of its type in this cluster  */
 
 
     /* Interconnect instances for this pb

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -11,7 +11,8 @@ t_cluster_placement_stats* alloc_and_load_cluster_placement_stats();
 bool get_next_primitive_list(
     t_cluster_placement_stats* cluster_placement_stats,
     const t_pack_molecule* molecule,
-    t_pb_graph_node** primitives_list);
+    t_pb_graph_node** primitives_list,
+    int force_site = -1);
 void commit_primitive(t_cluster_placement_stats* cluster_placement_stats,
                       const t_pb_graph_node* primitive);
 void set_mode_cluster_placement_stats(const t_pb_graph_node* complex_block,

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -932,7 +932,8 @@ e_block_pack_status try_pack_molecule(t_cluster_placement_stats* cluster_placeme
                                       int feasible_block_array_size,
                                       t_ext_pin_util max_external_pin_util,
                                       PartitionRegion& temp_cluster_pr,
-                                      NocGroupId& temp_noc_grp_id) {
+                                      NocGroupId& temp_noc_grp_id,
+                                      int force_site) {
     t_pb* parent;
     t_pb* cur_pb;
 
@@ -1009,7 +1010,7 @@ e_block_pack_status try_pack_molecule(t_cluster_placement_stats* cluster_placeme
 
     while (block_pack_status != e_block_pack_status::BLK_PASSED) {
         if (get_next_primitive_list(cluster_placement_stats_ptr, molecule,
-                                    primitives_list)) {
+                                    primitives_list, force_site)) {
             block_pack_status = e_block_pack_status::BLK_PASSED;
 
             int failed_location = 0;

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -214,7 +214,8 @@ e_block_pack_status try_pack_molecule(t_cluster_placement_stats* cluster_placeme
                                       int feasible_block_array_size,
                                       t_ext_pin_util max_external_pin_util,
                                       PartitionRegion& temp_cluster_pr,
-                                      NocGroupId& temp_noc_grp_id);
+                                      NocGroupId& temp_noc_grp_id,
+                                      int force_site = -1);
 
 void try_fill_cluster(const t_packer_opts& packer_opts,
                       t_cluster_placement_stats* cur_cluster_placement_stats_ptr,

--- a/vpr/src/pack/re_cluster_util.cpp
+++ b/vpr/src/pack/re_cluster_util.cpp
@@ -130,7 +130,8 @@ bool start_new_cluster_for_mol(t_pack_molecule* molecule,
                                t_lb_router_data** router_data,
                                PartitionRegion& temp_cluster_pr,
                                NocGroupId& temp_cluster_noc_grp_id,
-                               enum e_detailed_routing_stages detailed_routing_stage) {
+                               enum e_detailed_routing_stages detailed_routing_stage,
+                               int force_site) {
     auto& atom_ctx = g_vpr_ctx.atom();
     auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
     auto& helper_ctx = g_vpr_ctx.mutable_cl_helper();
@@ -172,7 +173,8 @@ bool start_new_cluster_for_mol(t_pack_molecule* molecule,
                                     0,
                                     FULL_EXTERNAL_PIN_UTIL,
                                     temp_cluster_pr,
-                                    temp_cluster_noc_grp_id);
+                                    temp_cluster_noc_grp_id,
+                                    force_site);
 
     // If clustering succeeds, add it to the clb netlist
     if (pack_result == e_block_pack_status::BLK_PASSED) {
@@ -215,7 +217,8 @@ bool pack_mol_in_existing_cluster(t_pack_molecule* molecule,
                                   t_clustering_data& clustering_data,
                                   t_lb_router_data*& router_data,
                                   enum e_detailed_routing_stages detailed_routing_stage,
-                                  bool enable_pin_feasibility_filter) {
+                                  bool enable_pin_feasibility_filter,
+                                  int force_site) {
 
     auto& helper_ctx = g_vpr_ctx.mutable_cl_helper();
     auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
@@ -250,7 +253,8 @@ bool pack_mol_in_existing_cluster(t_pack_molecule* molecule,
                                     helper_ctx.feasible_block_array_size,
                                     target_ext_pin_util,
                                     temp_cluster_pr,
-                                    temp_cluster_noc_grp_id);
+                                    temp_cluster_noc_grp_id,
+                                    force_site);
 
     // If clustering succeeds, add it to the clb netlist
     if (pack_result == e_block_pack_status::BLK_PASSED) {

--- a/vpr/src/pack/re_cluster_util.h
+++ b/vpr/src/pack/re_cluster_util.h
@@ -84,6 +84,10 @@ void remove_mol_from_cluster(const t_pack_molecule* molecule,
  *                                the function does not run a detailed intra-cluster routing-based legality check.
  *                                If many molecules will be added to a cluster, this option enables use of a single
  *                                routing check on the completed cluster (vs many incremental checks).
+ * @param force_site: optional user-specified primitive site on which to place the molecule; this is passed to
+ *                    try_pack_molecule and then to get_next_primitive_site. If a force_site argument is provided,
+ *                    the molecule is either placed on the specified site or fails to add to the cluster.
+ *                    If the force_site argument is set to its default value (-1), vpr selects an available site.
  */
 bool start_new_cluster_for_mol(t_pack_molecule* molecule,
                                const t_logical_block_type_ptr& type,
@@ -97,7 +101,8 @@ bool start_new_cluster_for_mol(t_pack_molecule* molecule,
                                t_lb_router_data** router_data,
                                PartitionRegion& temp_cluster_pr,
                                NocGroupId& temp_cluster_noc_grp_id,
-                               enum e_detailed_routing_stages detailed_routing_stage = E_DETAILED_ROUTE_FOR_EACH_ATOM);
+                               enum e_detailed_routing_stages detailed_routing_stage = E_DETAILED_ROUTE_FOR_EACH_ATOM,
+                               int force_site = -1);
 
 /**
  * @brief A function that packs a molecule into an existing cluster
@@ -118,6 +123,10 @@ bool start_new_cluster_for_mol(t_pack_molecule* molecule,
  *                                If many molecules will be added to a cluster, this option enables use of a single
  *                                routing check on the completed cluster (vs many incremental checks).
  * @param enable_pin_feasibility_filter: do a pin couting based legality check (before or in place of intra-cluster routing check).
+ * @param force_site: optional user-specified primitive site on which to place the molecule; this is passed to
+ *                    try_pack_molecule and then to get_next_primitive_site. If a force_site argument is provided,
+ *                    the molecule is either placed on the specified site or fails to add to the cluster.
+ *                    If the force_site argument is set to its default value (-1), vpr selects an available site.
  */
 bool pack_mol_in_existing_cluster(t_pack_molecule* molecule,
                                   int molecule_size,
@@ -127,7 +136,8 @@ bool pack_mol_in_existing_cluster(t_pack_molecule* molecule,
                                   t_clustering_data& clustering_data,
                                   t_lb_router_data*& router_data,
                                   enum e_detailed_routing_stages detailed_routing_stage = E_DETAILED_ROUTE_FOR_EACH_ATOM,
-                                  bool enable_pin_feasibility_filter = true);
+                                  bool enable_pin_feasibility_filter = true,
+                                  int force_site = -1);
 
 /**
  * @brief A function that fix the clustered netlist if the move is performed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added an optional primitive site parameter; if specified, vpr will either place the molecule on the specified site or fail; if not specified, vpr will select an available, legal site (if possible).

#### Description
<!--- Describe your changes in detail -->
Added optional force_site parameter to pack_mol_in_existing_cluster and start_new_cluster_for_mol; these functions pass the parameter to try_pack_mol, which passes it to get_next_primitive_list.  If a force site is passed to get_next_primitive_list, it either places the molecule on this site or else returns failure. 

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required for reconstructing clusters from an externally generated flat placement.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by ingesting and reconstructing VPR-generated flat placement files.
This has no impact on QoR (in a previous PR I reported results for this and several other legalizer-related code changes compared to the master branch).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
