### PR TITLE
Enable VTR to flush stdout and stderr before assertion

### DIFF
--- a/libs/libvtrutil/src/vtr_assert.cpp
+++ b/libs/libvtrutil/src/vtr_assert.cpp
@@ -16,6 +16,8 @@ void handle_assert(const char* expr, const char* file, unsigned int line, const 
         fprintf(stderr, " (%s)", msg);
     }
     fprintf(stderr, ".\n");
+    fflush(stdout);
+    fflush(stderr);
     std::abort();
 }
 


### PR DESCRIPTION
When debugging, I find that sometimes when the program hits an assertion, some log would not be printed as expected. Manually flushing before abort() brings more consistent printing.