### PR TITLE
cluster_placement.h is missing #include vpr_types.h

### DIFF
--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -6,6 +6,7 @@
 #ifndef CLUSTER_PLACEMENT_H
 #define CLUSTER_PLACEMENT_H
 #include "arch_types.h"
+#include "vpr_types.h"
 
 t_cluster_placement_stats* alloc_and_load_cluster_placement_stats();
 bool get_next_primitive_list(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#### Description
cluster_placement.h needs vpr_types.h for definitions of t_pack_molecule and t_cluster_placement_stats.

<!--- Describe your changes in detail -->
added #include "vpr_types.h" to cluster_placement.h

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
VPR fails to compile when cluster_placement.h is included in a .cpp file that does not include vpr_types.h earlier in the file.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
VPR still compiles and there is no change in QoR (based on quick neuron test referenced in another PR).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
