### PR TITLE
move lookup update to start_new_cluster... for consistency

### DIFF
--- a/vpr/src/pack/re_cluster.cpp
+++ b/vpr/src/pack/re_cluster.cpp
@@ -73,14 +73,6 @@ bool move_mol_to_new_cluster(t_pack_molecule* molecule,
     //Commit or revert the move
     if (is_created) {
         commit_mol_move(old_clb, new_clb, during_packing, true);
-        // Update the clb-->atoms lookup table
-        helper_ctx.atoms_lookup.resize(helper_ctx.total_clb_num);
-        for (int i_atom = 0; i_atom < molecule_size; ++i_atom) {
-            if (molecule->atom_block_ids[i_atom]) {
-                helper_ctx.atoms_lookup[new_clb].insert(molecule->atom_block_ids[i_atom]);
-            }
-        }
-
         VTR_LOGV(verbosity > 4, "Atom:%zu is moved to a new cluster\n", molecule->atom_block_ids[molecule->root]);
     } else {
         revert_mol_move(old_clb, molecule, old_router_data, during_packing, clustering_data);

--- a/vpr/src/pack/re_cluster_util.cpp
+++ b/vpr/src/pack/re_cluster_util.cpp
@@ -190,6 +190,14 @@ bool start_new_cluster_for_mol(t_pack_molecule* molecule,
         int molecule_size = get_array_size_of_molecule(molecule);
         update_cluster_pb_stats(molecule, molecule_size, clb_index, true);
 
+        // Update the clb-->atoms lookup table
+        helper_ctx.atoms_lookup.resize(helper_ctx.total_clb_num);
+        for (int i_atom = 0; i_atom < molecule_size; ++i_atom) {
+            if (molecule->atom_block_ids[i_atom]) {
+                helper_ctx.atoms_lookup[clb_index].insert(molecule->atom_block_ids[i_atom]);
+            }
+        }
+
         //If you are still in packing, update the clustering data. Otherwise, update the clustered netlist.
         if (during_packing) {
             clustering_data.intra_lb_routing.push_back((*router_data)->saved_lb_nets);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When removing a molecule from a cluster or adding a molecule to an existing cluster, the clb-atoms lookup is updated in the helper function responsible for the change.  For consistency, I've moved the lookup update to the helper function for creating a new cluster for a molecule.

#### Description
<!--- Describe your changes in detail -->
Moved code that resizes the lookup and adds all molecule atoms to the entry for the new cluster from the top level api function in re_cluster.cpp to the utility function in re_cluster_util.cpp.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the legalizer, it is confusing to sometimes have to update this data structure and sometimes not; always doing it in the helper function is more clear.  It does not change the functionality of the re-clustering API.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
