### PR TITLE
RR graph edge creation uses a incorrect switch type for decremental tracks

### DIFF
--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -836,7 +836,7 @@ int get_unidir_opin_connections(RRGraphBuilder& rr_graph_builder,
         rr_edges_to_create.emplace_back(from_rr_node, inc_inode_index, to_switch, false);
         ++num_edges;
 
-        to_switch = (opin_layer == track_layer) ? seg_details[inc_track].arch_opin_switch() : seg_details[dec_track].arch_opin_between_dice_switch();
+        to_switch = (opin_layer == track_layer) ? seg_details[dec_track].arch_opin_switch() : seg_details[dec_track].arch_opin_between_dice_switch();
         rr_edges_to_create.emplace_back(from_rr_node, dec_inode_index, to_switch, false);
         ++num_edges;
     }


### PR DESCRIPTION
#### Description
While creating RR edge, incremental and decremental tracks use the same seg_details of inc_track. Although this is incorrect, it doesn't affect the quality of results because we don't have an architecture that uses different muxes for incremental and decremental tracks. So, I don't expect anything to change by this fix. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
