### PR TITLE
[CI] Upgrade Self-Hosted Runners Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,6 @@ jobs:
 
     timeout-minutes: 420
     
-    container: ubuntu:jammy
-
     runs-on: [self-hosted, Linux, X64]
 
     strategy:
@@ -78,13 +76,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
-
-      # Node 20 is required for recent versions of the upload artifacts action.
-      # This may not be required once we upgrade to Ubuntu 24.04
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-        cache: 'npm'
 
     - name: Setup
       run: stdbuf -i0 -i0 -e0 ./.github/scripts/hostsetup.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
 
     timeout-minutes: 420
     
+    container: ubuntu:jammy
+
     runs-on: [self-hosted, Linux, X64]
 
     strategy:
@@ -76,6 +78,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
+
+      # Node 20 is required for recent versions of the upload artifacts action.
+      # This may not be required once we upgrade to Ubuntu 24.04
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
 
     - name: Setup
       run: stdbuf -i0 -i0 -e0 ./.github/scripts/hostsetup.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,18 +73,16 @@ jobs:
 
     steps:
 
-      # TODO: This runnner is running on a self-hosted CPU. In order to upgrade
-      #       to v4, need to upgrade the machine to support node20.
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
       # Node 20 is required for recent versions of the upload artifacts action.
       # This may not be required once we upgrade to Ubuntu 24.04
     - uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: 'npm'
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
 
     - name: Setup
       run: stdbuf -i0 -i0 -e0 ./.github/scripts/hostsetup.sh
@@ -107,8 +105,6 @@ jobs:
       # when the job fails). See warning here:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#always
       if: ${{ !cancelled() }}
-      # TODO: This runnner is running on a self-hosted CPU. In order to upgrade
-      #       to v4, need to upgrade the machine to support node20.
       uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.test}}_test_results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
     timeout-minutes: 420
     
-    container: ubuntu:jammy
+    container: ubuntu-22.04
 
     runs-on: [self-hosted, Linux, X64]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,16 @@ jobs:
 
       # TODO: This runnner is running on a self-hosted CPU. In order to upgrade
       #       to v4, need to upgrade the machine to support node20.
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
+
+      # Node 20 is required for recent versions of the upload artifacts action.
+      # This may not be required once we upgrade to Ubuntu 24.04
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
 
     - name: Setup
       run: stdbuf -i0 -i0 -e0 ./.github/scripts/hostsetup.sh
@@ -102,7 +109,7 @@ jobs:
       if: ${{ !cancelled() }}
       # TODO: This runnner is running on a self-hosted CPU. In order to upgrade
       #       to v4, need to upgrade the machine to support node20.
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.test}}_test_results
         path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
     timeout-minutes: 420
     
-    container: ubuntu-22.04
+    container: ubuntu:24.04
 
     runs-on: [self-hosted, Linux, X64]
 
@@ -72,13 +72,6 @@ jobs:
       DEBIAN_FRONTEND: "noninteractive"
 
     steps:
-
-      # Node 20 is required for recent versions of the upload artifacts action.
-      # This may not be required once we upgrade to Ubuntu 24.04
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-        cache: 'npm'
 
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Upgraded the self-hosted runners actions to their most recent versions. Specifically, the upload-artifact action will fully deprecate soon and needs to be upgraded.

These upgrades require Node 20 to work. The self-hosted runners do not have Node 20 installed by default for their image of Ubuntu (unlike the GitHub-hosted runners), therefore Node20 needs to be installed using another action for the self-hosted jobs.
