### PR TITLE
Router Heap documentation update

### DIFF
--- a/doc/src/api/vprinternals/router_heap.rst
+++ b/doc/src/api/vprinternals/router_heap.rst
@@ -24,10 +24,8 @@ KAryHeap
 ----------
 .. doxygenclass:: KAryHeap
    :project: vpr
-   :members:
 
 FourAryHeap
 ----------
 .. doxygenclass:: FourAryHeap
    :project: vpr
-   :members:

--- a/vpr/src/route/heap_type.h
+++ b/vpr/src/route/heap_type.h
@@ -27,21 +27,21 @@ struct t_heap {
     t_heap_path* path_data;
 
     /**
-     * @brief Get <i>u.next</i>.
+     * @brief Get the next t_heap item in the linked list.
      */
     t_heap* next_heap_item() const {
         return u.next;
     }
 
     /**
-     * @brief Set <i>u.next</i>.
+     * @brief Set the next t_heap item in the linked list.
      */
     void set_next_heap_item(t_heap* next) {
         u.next = next;
     }
 
     /**
-     * @brief Get <i>u.prev_edge</i>.
+     * @brief Get the edge from the previous node used to reach the current node.
      *
      * @note
      * Be careful: will return 0 (a valid id!) if uninitialized.
@@ -52,7 +52,7 @@ struct t_heap {
     }
 
     /**
-     * @brief Set <i>u.prev_edge</i>.
+     * @brief Set the edge from the previous node used to reach the current node..
      */
     inline void set_prev_edge(RREdgeId edge) {
         static_assert(sizeof(uint32_t) == sizeof(RREdgeId));
@@ -61,7 +61,7 @@ struct t_heap {
 
   private:
     union {
-        ///@brief Pointer to the next s_heap structure in the free linked list.
+        ///@brief Pointer to the next t_heap structure in the free linked list.
         t_heap* next = nullptr;
 
         /**
@@ -121,7 +121,7 @@ class HeapStorage {
  * As a general rule, any t_heap objects returned from this interface,
  * **must** be HeapInterface::free'd before destroying the HeapInterface
  * instance. This ensure that no leaks are present in the users of the heap.
- * Violating this assumption may result in a assertion violation.
+ * Violating this assumption may result in an assertion violation.
  */
 class HeapInterface {
   public:
@@ -160,7 +160,7 @@ class HeapInterface {
      *  - empty_heap<BR>
      *  - build_heap<BR>
      *
-     *  @param grid
+     *  @param grid The FPGA device grid
      */
     virtual void init_heap(const DeviceGrid& grid) = 0;
 


### PR DESCRIPTION
Two changes to [Router Heap documentation](https://docs.verilogtorouting.org/en/latest/api/vprinternals/router_heap/#classHeapInterface_1af6cf3e31510d0ab16da15dfcb4f0ce35):

1. _Currently_: ``u`` is protected and so doesn't appear in the documentation, but [the descriptions of its accessors/mutators refer to it](https://docs.verilogtorouting.org/en/latest/api/vprinternals/router_heap/#classHeapInterface_1af6cf3e31510d0ab16da15dfcb4f0ce35:~:text=inline%20t_heap%20*next_heap_item,Set%20u.prev_edge.). _Now_: these functions' descriptions don't reference ``u`` and state explicitly what they do.
2.  _Currently_: there are duplicate descriptions for public pure virtual functions inherited from ``HeapInterface`` and/or ``KAryHeap``. _Now_: only ``HeapInterface`` has descriptions for its public members (its inherited classes do not have any additional public functions).