### PR TITLE
[vpr][place] refactoring variables in net_cost_handler

### DIFF
--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -55,7 +55,7 @@ static vtr::NdMatrix<float, 2> chanx_place_cost_fac({0, 0}); // [0...device_ctx.
 static vtr::NdMatrix<float, 2> chany_place_cost_fac({0, 0}); // [0...device_ctx.grid.height()-2]
 
 /**
- * @brief For each of the vector in this struct, there is one entry per cluster level net: 
+ * @brief For each of the vectors in this struct, there is one entry per cluster level net: 
  * [0...cluster_ctx.clb_nlist.nets().size()-1].
  * net_cost and proposed_net_cost: Cost of a net, and a temporary cost of a net used during move assessment. 
  * We also use negative cost values in proposed_net_cost as a flag to indicate that 


### PR DESCRIPTION
net_cost, proposed_net_cost, and bb_updated_before grouped in a struct. bb_updated_before renamed to bb_update_status.

performance data is compared in:
[https://docs.google.com/spreadsheets/d/1VVvTxhVbGLO6Hq9d2ZmZqi7IWLRDFhMkFIhwDXQtYcw/edit?usp=sharing]

Geomean of vtr flow runtime on titan quick qor increased by 3%. Routed wire length remains unchanged. 