### PR TITLE
Placement move primitive refactoring assignment 2

### DIFF
--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -55,7 +55,7 @@ static vtr::NdMatrix<float, 2> chanx_place_cost_fac({0, 0}); // [0...device_ctx.
 static vtr::NdMatrix<float, 2> chany_place_cost_fac({0, 0}); // [0...device_ctx.grid.height()-2]
 
 /**
- * @brief For each of the vector in this struct, there is one entry per cluster level net: 
+ * @brief For each of the vectors in this struct, there is one entry per cluster level net: 
  * [0...cluster_ctx.clb_nlist.nets().size()-1].
  * net_cost and proposed_net_cost: Cost of a net, and a temporary cost of a net used during move assessment. 
  * We also use negative cost values in proposed_net_cost as a flag to indicate that 

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -83,10 +83,8 @@ double comp_layer_bb_cost(e_cost_methods method);
 /**
  * @brief update net cost data structures (in placer context and net_cost in .cpp file) and reset flags (proposed_net_cost and bb_updated_before).
  * @param num_nets_affected The number of nets affected by the move. It is used to determine the index up to which elements in ts_nets_to_update are valid.
- * @param cube_bb True if we should use the 3D bounding box (cube_bb), false otherwise.
  */
-void update_move_nets(int num_nets_affected,
-                      const bool cube_bb);
+void update_move_nets(int num_nets_affected);
 
 /**
  * @brief Reset the net cost function flags (proposed_net_cost and bb_updated_before)

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1481,8 +1481,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             }
 
             /* Update net cost functions and reset flags. */
-            update_move_nets(num_nets_affected,
-                             g_vpr_ctx.placement().cube_bb);
+            update_move_nets(num_nets_affected);
 
             /* Update clb data structures since we kept the move. */
             commit_move_blocks(blocks_affected);


### PR DESCRIPTION
In placement, we use two methods to update the bounding box: the 3D bounding box (also used for 2D architecture) and the per-layer bounding box. When a swap happens, [multiple variables](https://can01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fverilog-to-routing%2Fvtr-verilog-to-routing%2Fblob%2Fplacement_move_primitive%2Fvpr%2Fsrc%2Fplace%2Fnet_cost_handler.cpp%23L91-L98&data=05%7C02%7Cyulang.luo%40mail.utoronto.ca%7C5e26bbdc343c4119a05f08dc9fb5ddf1%7C78aac2262f034b4d9037b46d56c55210%7C0%7C0%7C638560850665920141%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=GjyyvhqPAvipLmtoMdc4Gr%2BPstuZ0wNKpgQZ8VOYN%2FY%3D&reserved=0) are updated, indicated by the `ts` (temporary swap) prefix. We can put all these variables into a class. Since only a subset is used depending on the bounding box type, you can examine how these variables are updated throughout the file and write methods for this class to update the appropriate ones.

After some discussion, it was decided to not use inheritance or the type eraser due to potential performance degradation and the lack of readability. In this PR, the control flow that decides 3d or 2d placement are wrapped into a class. 

