### PR TITLE
[vpr][place] ts_nets_to_update now uses size() instead of num_nets

### DIFF
--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -45,7 +45,7 @@ enum e_cost_methods {
  * @param timing_delta_c
  * @return The number of affected nets.
  */
-int find_affected_nets_and_update_costs(
+void find_affected_nets_and_update_costs(
     const t_place_algorithm& place_algorithm,
     const PlaceDelayModel* delay_model,
     const PlacerCriticalities* criticalities,
@@ -85,14 +85,13 @@ double comp_layer_bb_cost(e_cost_methods method);
  * @param num_nets_affected The number of nets affected by the move. It is used to determine the index up to which elements in ts_nets_to_update are valid.
  * @param cube_bb True if we should use the 3D bounding box (cube_bb), false otherwise.
  */
-void update_move_nets(int num_nets_affected,
-                      const bool cube_bb);
+void update_move_nets(const bool cube_bb);
 
 /**
  * @brief Reset the net cost function flags (proposed_net_cost and bb_updated_before)
  * @param num_nets_affected
  */
-void reset_move_nets(int num_nets_affected);
+void reset_move_nets();
 
 /**
  * @brief re-calculates different terms of the cost function (wire-length, timing, NoC) and update "costs" accordingly. It is important to note that

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1378,7 +1378,7 @@ static e_move_result try_swap(const t_annealing_state* state,
         //
         //Also find all the pins affected by the swap, and calculates new connection
         //delays and timing costs and store them in proposed_* data structures.
-        int num_nets_affected = find_affected_nets_and_update_costs(
+        find_affected_nets_and_update_costs(
             place_algorithm, delay_model, criticalities, blocks_affected,
             bb_delta_c, timing_delta_c);
 
@@ -1481,8 +1481,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             }
 
             /* Update net cost functions and reset flags. */
-            update_move_nets(num_nets_affected,
-                             g_vpr_ctx.placement().cube_bb);
+            update_move_nets(g_vpr_ctx.placement().cube_bb);
 
             /* Update clb data structures since we kept the move. */
             commit_move_blocks(blocks_affected);
@@ -1506,7 +1505,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             VTR_ASSERT_SAFE(move_outcome == REJECTED);
 
             /* Reset the net cost function flags first. */
-            reset_move_nets(num_nets_affected);
+            reset_move_nets();
 
             /* Restore the place_ctx.block_locs data structures to their state before the move. */
             revert_move_blocks(blocks_affected);


### PR DESCRIPTION
For runtime reasons, we initialize `ts_nets_to_update` to the number of nets in the netlist and use a variable `num_affected_nets` to indicate how many entries are valid. You can experiment to see how runtime is affected if we remove this variable and just reserve elements in this vector and use `.size()`.

The runtime comparison is here: https://docs.google.com/spreadsheets/d/16B169bYI39vUT3wa-vwdqTjXjzJsO9QO7mYUpHC_LdI/edit?usp=sharing

Functional statistic such as final wire length remains the same.
Run time also remains the same. 