### PR TITLE
[vpr][place] moved_block uses size() to indicate valid elements

### DIFF
--- a/vpr/src/place/move_transactions.cpp
+++ b/vpr/src/place/move_transactions.cpp
@@ -1,8 +1,6 @@
 #include "move_utils.h"
 
 #include "globals.h"
-// Is this needed?
-#include "place_util.h"
 
 t_pl_blocks_to_be_moved::t_pl_blocks_to_be_moved(size_t max_blocks){
         moved_blocks.reserve(max_blocks);

--- a/vpr/src/place/move_transactions.h
+++ b/vpr/src/place/move_transactions.h
@@ -25,8 +25,6 @@ struct t_pl_moved_block {
  * placement, in the form of array of structs instead of struct with    *
  * arrays for cache effifiency                                          *
  *
- * num_moved_blocks: total number of blocks moved when          *
- *                   swapping two blocks.                       *
  * moved blocks: a list of moved blocks data structure with     *
  *               information on the move.                       *
  *               [0...max_blocks-1]                       *
@@ -34,15 +32,14 @@ struct t_pl_moved_block {
  *                incrementally invalidate parts of the timing  *
  *                graph.                                        */
 struct t_pl_blocks_to_be_moved {
-    explicit t_pl_blocks_to_be_moved(size_t max_blocks)
-        : moved_blocks(max_blocks) {}
+    explicit t_pl_blocks_to_be_moved(size_t max_blocks);
 
-    int num_moved_blocks = 0;
     std::vector<t_pl_moved_block> moved_blocks;
     std::unordered_set<t_pl_loc> moved_from;
     std::unordered_set<t_pl_loc> moved_to;
 
     std::vector<ClusterPinId> affected_pins;
+    size_t get_size_and_increment();
 };
 
 enum class e_block_move_result {

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -488,7 +488,7 @@ std::set<t_pl_loc> determine_locations_emptied_by_move(t_pl_blocks_to_be_moved& 
     std::set<t_pl_loc> moved_from;
     std::set<t_pl_loc> moved_to;
 
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; ++iblk) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
         //When a block is moved its old location becomes free
         moved_from.emplace(blocks_affected.moved_blocks[iblk].old_loc);
 

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -103,7 +103,6 @@ static std::vector<ClusterNetId> ts_nets_to_update;
  * @return True if the driver block of the net is among the moving blocks
  */
 static bool driven_by_moved_block(const ClusterNetId net,
-                                  const int num_blocks,
                                   const std::vector<t_pl_moved_block>& moved_blocks);
 /**
  * @brief Update the bounding box (3D) of the net connected to blk_pin. The old and new locations of the pin are
@@ -451,14 +450,13 @@ static void set_bb_delta_cost(double& bb_delta_c);
 
 //Returns true if 'net' is driven by one of the blocks in 'blocks_affected'
 static bool driven_by_moved_block(const ClusterNetId net,
-                                  const int num_blocks,
                                   const std::vector<t_pl_moved_block>& moved_blocks) {
     auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     bool is_driven_by_move_blk = false;
     ClusterBlockId net_driver_block = clb_nlist.net_driver_block(
         net);
 
-    for (int block_num = 0; block_num < num_blocks; block_num++) {
+    for (size_t block_num = 0; block_num < moved_blocks.size(); block_num++) {
         if (net_driver_block == moved_blocks[block_num].block_num) {
             is_driven_by_move_blk = true;
             break;
@@ -1881,7 +1879,7 @@ void find_affected_nets_and_update_costs(
     ts_nets_to_update.resize(0);
 
     /* Go through all the blocks moved. */
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; iblk++) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); iblk++) {
         const auto& moving_block_inf = blocks_affected.moved_blocks[iblk];
         auto& affected_pins = blocks_affected.affected_pins;
         ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
@@ -1892,7 +1890,6 @@ void find_affected_nets_and_update_costs(
             if (clb_nlist.pin_type(blk_pin) == PinType::SINK) {
                 ClusterNetId net_id = clb_nlist.pin_net(blk_pin);
                 is_src_moving = driven_by_moved_block(net_id,
-                                                      blocks_affected.num_moved_blocks,
                                                       blocks_affected.moved_blocks);
             }
             update_net_info_on_pin_move(place_algorithm,

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -45,7 +45,7 @@ enum e_cost_methods {
  * @param timing_delta_c
  * @return The number of affected nets.
  */
-int find_affected_nets_and_update_costs(
+void find_affected_nets_and_update_costs(
     const t_place_algorithm& place_algorithm,
     const PlaceDelayModel* delay_model,
     const PlacerCriticalities* criticalities,
@@ -85,14 +85,13 @@ double comp_layer_bb_cost(e_cost_methods method);
  * @param num_nets_affected The number of nets affected by the move. It is used to determine the index up to which elements in ts_nets_to_update are valid.
  * @param cube_bb True if we should use the 3D bounding box (cube_bb), false otherwise.
  */
-void update_move_nets(int num_nets_affected,
-                      const bool cube_bb);
+void update_move_nets(const bool cube_bb);
 
 /**
  * @brief Reset the net cost function flags (proposed_net_cost and bb_updated_before)
  * @param num_nets_affected
  */
-void reset_move_nets(int num_nets_affected);
+void reset_move_nets();
 
 /**
  * @brief re-calculates different terms of the cost function (wire-length, timing, NoC) and update "costs" accordingly. It is important to note that

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -136,7 +136,7 @@ void find_affected_noc_routers_and_update_noc_costs(const t_pl_blocks_to_be_move
     affected_noc_links.clear();
 
     // go through the moved blocks and process them only if they are NoC routers
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; ++iblk) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
         ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
 
         // check if the current moved block is a noc router
@@ -291,7 +291,7 @@ void revert_noc_traffic_flow_routes(const t_pl_blocks_to_be_moved& blocks_affect
     std::unordered_set<NocTrafficFlowId> reverted_traffic_flows;
 
     // go through the moved blocks and process them only if they are NoC routers
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; ++iblk) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
         ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
 
         // check if the current moved block is a noc router

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -150,7 +150,7 @@ std::unique_ptr<FILE, decltype(&vtr::fclose)> f_move_stats_file(nullptr,
                         t,                                                                     \
                         int(size_t(b_from)), int(size_t(b_to)),                                \
                         from_type->name, (to_type ? to_type->name : "EMPTY"),                  \
-                        affected_blocks.num_moved_blocks);                                     \
+                        affected_blocks.moved_blocks.size());                                     \
             }                                                                                  \
         } while (false)
 

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1378,7 +1378,7 @@ static e_move_result try_swap(const t_annealing_state* state,
         //
         //Also find all the pins affected by the swap, and calculates new connection
         //delays and timing costs and store them in proposed_* data structures.
-        int num_nets_affected = find_affected_nets_and_update_costs(
+        find_affected_nets_and_update_costs(
             place_algorithm, delay_model, criticalities, blocks_affected,
             bb_delta_c, timing_delta_c);
 
@@ -1481,8 +1481,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             }
 
             /* Update net cost functions and reset flags. */
-            update_move_nets(num_nets_affected,
-                             g_vpr_ctx.placement().cube_bb);
+            update_move_nets(g_vpr_ctx.placement().cube_bb);
 
             /* Update clb data structures since we kept the move. */
             commit_move_blocks(blocks_affected);
@@ -1506,7 +1505,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             VTR_ASSERT_SAFE(move_outcome == REJECTED);
 
             /* Reset the net cost function flags first. */
-            reset_move_nets(num_nets_affected);
+            reset_move_nets();
 
             /* Restore the place_ctx.block_locs data structures to their state before the move. */
             revert_move_blocks(blocks_affected);

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -100,7 +100,7 @@ void print_macro_constraint_error(const t_pl_macro& pl_macro);
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;
 
-    for (int i = 0; i < blocks_affected.num_moved_blocks; i++) {
+    for (size_t i = 0; i < blocks_affected.moved_blocks.size(); i++) {
         floorplan_legal = cluster_floorplanning_legal(blocks_affected.moved_blocks[i].block_num,
                                                       blocks_affected.moved_blocks[i].new_loc);
         if (!floorplan_legal) {

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -748,7 +748,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
         } while (swap_router_block_one == swap_router_block_two);
 
         //set up the moved blocks datastructure for the test function
-        blocks_affected.num_moved_blocks = 2;
+        blocks_affected.moved_blocks.resize(2);
 
         blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
         blocks_affected.moved_blocks[0].old_loc = t_pl_loc(noc_ctx.noc_model.get_single_noc_router(router_where_cluster_is_placed[swap_router_block_one]).get_router_grid_position_x(),
@@ -903,7 +903,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
 
     // now perform the swap
     //set up the moved blocks datastructure for the test function
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
 
@@ -1039,7 +1039,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
 
     // now perform the swap
     //set up the moved blocks datastructure for the test function
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
 
@@ -1142,7 +1142,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
 
     // now perform the swap
     //set up the moved blocks datastructure for the test function
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
 
@@ -1584,7 +1584,7 @@ TEST_CASE("test_revert_noc_traffic_flow_routes", "[noc_place_utils]") {
 
     //set up the moved blocks datastructure for the test function
     // this is needed for the test function (it needs to know what blocks were swapped, so it can undo it)
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
     blocks_affected.moved_blocks[0].old_loc = t_pl_loc(noc_ctx.noc_model.get_single_noc_router(router_where_cluster_is_placed[swap_router_block_one]).get_router_grid_position_x(),


### PR DESCRIPTION
`std::vector<t_pl_moved_block>& moved_blocks` has as many entries as the total number of blocks, and we pass an integer to show how many entries are valid. size() can be used instead. 

https://docs.google.com/spreadsheets/d/1CvJ-HcgW1FnkkrhhhtByHFcUm5zOhWdfVIwBDf5DpAI/edit?usp=sharing

The run time was not affected.