### PR TITLE
[vpr][place] Placement move primitive refactoring

### DIFF
--- a/vpr/src/place/initial_noc_placement.cpp
+++ b/vpr/src/place/initial_noc_placement.cpp
@@ -220,7 +220,7 @@ static void noc_routers_anneal(const t_noc_opts& noc_opts) {
     // Generate and evaluate router moves
     for (int i_move = 0; i_move < N_MOVES; i_move++) {
         e_create_move create_move_outcome = e_create_move::ABORT;
-        clear_move_blocks(blocks_affected);
+        blocks_affected.clear_move_blocks();
         // Shrink the range limit over time
         float r_lim_decayed = 1.0f + (N_MOVES - i_move) * (max_r_lim / N_MOVES);
         create_move_outcome = propose_router_swap(blocks_affected, r_lim_decayed);

--- a/vpr/src/place/move_transactions.cpp
+++ b/vpr/src/place/move_transactions.cpp
@@ -1,8 +1,6 @@
 #include "move_utils.h"
 
 #include "globals.h"
-// Is this needed?
-#include "place_util.h"
 
 t_pl_blocks_to_be_moved::t_pl_blocks_to_be_moved(size_t max_blocks){
         moved_blocks.reserve(max_blocks);

--- a/vpr/src/place/move_transactions.cpp
+++ b/vpr/src/place/move_transactions.cpp
@@ -1,6 +1,7 @@
 #include "move_utils.h"
 
 #include "globals.h"
+#include "place_util.h"
 #include "vtr_assert.h"
 
 t_pl_blocks_to_be_moved::t_pl_blocks_to_be_moved(size_t max_blocks){

--- a/vpr/src/place/move_transactions.cpp
+++ b/vpr/src/place/move_transactions.cpp
@@ -1,3 +1,4 @@
+#include "move_transactions.h"
 #include "move_utils.h"
 
 #include "globals.h"
@@ -6,7 +7,6 @@
 
 t_pl_blocks_to_be_moved::t_pl_blocks_to_be_moved(size_t max_blocks){
         moved_blocks.reserve(max_blocks);
-        moved_blocks.resize(0);
 }
 
 size_t t_pl_blocks_to_be_moved::get_size_and_increment() {
@@ -16,9 +16,9 @@ size_t t_pl_blocks_to_be_moved::get_size_and_increment() {
 }
 
 //Records that block 'blk' should be moved to the specified 'to' location
-e_block_move_result record_block_move(t_pl_blocks_to_be_moved& blocks_affected, ClusterBlockId blk, t_pl_loc to) {
-    auto res = blocks_affected.moved_to.emplace(to);
-    if (!res.second) {
+e_block_move_result t_pl_blocks_to_be_moved::record_block_move(ClusterBlockId blk, t_pl_loc to) {
+    auto [to_it, to_success] = moved_to.emplace(to);
+    if (!to_success) {
         log_move_abort("duplicate block move to location");
         return e_block_move_result::ABORT;
     }
@@ -27,8 +27,9 @@ e_block_move_result record_block_move(t_pl_blocks_to_be_moved& blocks_affected, 
 
     t_pl_loc from = place_ctx.block_locs[blk].loc;
 
-    auto res2 = blocks_affected.moved_from.emplace(from);
-    if (!res2.second) {
+    auto [_, from_success] = moved_from.emplace(from);
+    if (!from_success) {
+        moved_to.erase(to_it);
         log_move_abort("duplicate block move from location");
         return e_block_move_result::ABORT;
     }
@@ -36,12 +37,33 @@ e_block_move_result record_block_move(t_pl_blocks_to_be_moved& blocks_affected, 
     VTR_ASSERT_SAFE(to.sub_tile < int(place_ctx.grid_blocks.num_blocks_at_location({to.x, to.y, to.layer})));
 
     // Sets up the blocks moved
-    size_t imoved_blk = blocks_affected.get_size_and_increment();
-    blocks_affected.moved_blocks[imoved_blk].block_num = blk;
-    blocks_affected.moved_blocks[imoved_blk].old_loc = from;
-    blocks_affected.moved_blocks[imoved_blk].new_loc = to;
+    size_t imoved_blk = get_size_and_increment();
+    moved_blocks[imoved_blk].block_num = blk;
+    moved_blocks[imoved_blk].old_loc = from;
+    moved_blocks[imoved_blk].new_loc = to;
 
     return e_block_move_result::VALID;
+}
+
+//Examines the currently proposed move and determine any empty locations
+std::set<t_pl_loc> t_pl_blocks_to_be_moved::t_pl_blocks_to_be_moved::determine_locations_emptied_by_move() {
+    std::set<t_pl_loc> moved_from_set;
+    std::set<t_pl_loc> moved_to_set;
+
+    for (const t_pl_moved_block& moved_block : moved_blocks) {
+        //When a block is moved its old location becomes free
+        moved_from_set.emplace(moved_block.old_loc);
+
+        //But any block later moved to a position fills it
+        moved_to_set.emplace(moved_block.new_loc);
+    }
+
+    std::set<t_pl_loc> empty_locs;
+    std::set_difference(moved_from_set.begin(), moved_from_set.end(),
+                        moved_to_set.begin(), moved_to_set.end(),
+                        std::inserter(empty_locs, empty_locs.begin()));
+
+    return empty_locs;
 }
 
 //Moves the blocks in blocks_affected to their new locations
@@ -51,11 +73,11 @@ void apply_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected) {
 
     //Swap the blocks, but don't swap the nets or update place_ctx.grid_blocks
     //yet since we don't know whether the swap will be accepted
-    for (const auto& block : blocks_affected.moved_blocks) {
-        ClusterBlockId blk = block.block_num;
+    for (const t_pl_moved_block& moved_block : blocks_affected.moved_blocks) {
+        ClusterBlockId blk = moved_block.block_num;
 
-        const t_pl_loc& old_loc = block.old_loc;
-        const t_pl_loc& new_loc = block.new_loc;
+        const t_pl_loc& old_loc = moved_block.old_loc;
+        const t_pl_loc& new_loc = moved_block.new_loc;
 
         // move the block to its new location
         place_ctx.block_locs[blk].loc = new_loc;
@@ -78,11 +100,11 @@ void commit_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected) {
     auto& place_ctx = g_vpr_ctx.mutable_placement();
 
     /* Swap physical location */
-    for (const auto& block : blocks_affected.moved_blocks) {
-        ClusterBlockId blk = block.block_num;
+    for (const t_pl_moved_block& moved_block : blocks_affected.moved_blocks) {
+        ClusterBlockId blk = moved_block.block_num;
 
-        const t_pl_loc& to = block.new_loc;
-        const t_pl_loc& from = block.old_loc;
+        const t_pl_loc& to = moved_block.new_loc;
+        const t_pl_loc& from = moved_block.old_loc;
 
         //Remove from old location only if it hasn't already been updated by a previous block update
         if (place_ctx.grid_blocks.block_at_location(from) == blk) {
@@ -108,11 +130,11 @@ void revert_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected) {
     auto& device_ctx = g_vpr_ctx.device();
 
     // Swap the blocks back, nets not yet swapped they don't need to be changed
-    for (const auto& block : blocks_affected.moved_blocks) {
-        ClusterBlockId blk = block.block_num;
+    for (const t_pl_moved_block& moved_block : blocks_affected.moved_blocks) {
+        ClusterBlockId blk = moved_block.block_num;
 
-        const t_pl_loc& old_loc = block.old_loc;
-        const t_pl_loc& new_loc = block.new_loc;
+        const t_pl_loc& old_loc = moved_block.old_loc;
+        const t_pl_loc& new_loc = moved_block.new_loc;
 
         // return the block to where it was before the swap
         place_ctx.block_locs[blk].loc = old_loc;
@@ -132,15 +154,15 @@ void revert_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected) {
 }
 
 //Clears the current move so a new move can be proposed
-void clear_move_blocks(t_pl_blocks_to_be_moved& blocks_affected) {
+void t_pl_blocks_to_be_moved::clear_move_blocks() {
     //Reset moved flags
-    blocks_affected.moved_to.clear();
-    blocks_affected.moved_from.clear();
+    moved_to.clear();
+    moved_from.clear();
 
     //For run-time, we just reset size of blocks_affected.moved_blocks to zero, but do not free the blocks_affected
     //array to avoid memory allocation
 
-    blocks_affected.moved_blocks.resize(0);
+    moved_blocks.resize(0);
 
-    blocks_affected.affected_pins.clear();
+    affected_pins.clear();
 }

--- a/vpr/src/place/move_transactions.h
+++ b/vpr/src/place/move_transactions.h
@@ -3,6 +3,13 @@
 #include "vpr_types.h"
 #include "clustered_netlist_utils.h"
 
+enum class e_block_move_result {
+    VALID,       //Move successful
+    ABORT,       //Unable to perform move
+    INVERT,      //Try move again but with from/to inverted
+    INVERT_VALID //Completed inverted move
+};
+
 /* Stores the information of the move for a block that is       *
  * moved during placement                                       *
  * block_num: the index of the moved block                      *
@@ -33,30 +40,37 @@ struct t_pl_moved_block {
  *                graph.                                        */
 struct t_pl_blocks_to_be_moved {
     explicit t_pl_blocks_to_be_moved(size_t max_blocks);
+    t_pl_blocks_to_be_moved() = delete;
+    t_pl_blocks_to_be_moved(const t_pl_blocks_to_be_moved&) = delete;
+    t_pl_blocks_to_be_moved(t_pl_blocks_to_be_moved&&) = delete;
+
+/**
+ * @brief This function increments the size of the moved_blocks vector and return the index
+ * of the newly added last elements. 
+ */
+    size_t get_size_and_increment();
+
+/**
+ * @brief This function clears all data structures of this struct.
+ */
+    void clear_move_blocks();
+
+    e_block_move_result record_block_move(ClusterBlockId blk, t_pl_loc to);
+    
+    std::set<t_pl_loc> determine_locations_emptied_by_move();
 
     std::vector<t_pl_moved_block> moved_blocks;
     std::unordered_set<t_pl_loc> moved_from;
     std::unordered_set<t_pl_loc> moved_to;
 
     std::vector<ClusterPinId> affected_pins;
-    size_t get_size_and_increment();
 };
 
-enum class e_block_move_result {
-    VALID,       //Move successful
-    ABORT,       //Unable to perform move
-    INVERT,      //Try move again but with from/to inverted
-    INVERT_VALID //Completed inverted move
-};
-
-e_block_move_result record_block_move(t_pl_blocks_to_be_moved& blocks_affected, ClusterBlockId blk, t_pl_loc to);
 
 void apply_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected);
 
 void commit_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected);
 
 void revert_move_blocks(const t_pl_blocks_to_be_moved& blocks_affected);
-
-void clear_move_blocks(t_pl_blocks_to_be_moved& blocks_affected);
 
 #endif

--- a/vpr/src/place/move_transactions.h
+++ b/vpr/src/place/move_transactions.h
@@ -25,8 +25,6 @@ struct t_pl_moved_block {
  * placement, in the form of array of structs instead of struct with    *
  * arrays for cache effifiency                                          *
  *
- * num_moved_blocks: total number of blocks moved when          *
- *                   swapping two blocks.                       *
  * moved blocks: a list of moved blocks data structure with     *
  *               information on the move.                       *
  *               [0...max_blocks-1]                       *
@@ -34,15 +32,14 @@ struct t_pl_moved_block {
  *                incrementally invalidate parts of the timing  *
  *                graph.                                        */
 struct t_pl_blocks_to_be_moved {
-    explicit t_pl_blocks_to_be_moved(size_t max_blocks)
-        : moved_blocks(max_blocks) {}
+    explicit t_pl_blocks_to_be_moved(size_t max_blocks);
 
-    int num_moved_blocks = 0;
     std::vector<t_pl_moved_block> moved_blocks;
     std::unordered_set<t_pl_loc> moved_from;
     std::unordered_set<t_pl_loc> moved_to;
 
     std::vector<ClusterPinId> affected_pins;
+    size_t get_size_and_increment();
 };
 
 enum class e_block_move_result {

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -488,7 +488,7 @@ std::set<t_pl_loc> determine_locations_emptied_by_move(t_pl_blocks_to_be_moved& 
     std::set<t_pl_loc> moved_from;
     std::set<t_pl_loc> moved_to;
 
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; ++iblk) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
         //When a block is moved its old location becomes free
         moved_from.emplace(blocks_affected.moved_blocks[iblk].old_loc);
 

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -1,6 +1,13 @@
 #include "move_utils.h"
+
+#include "place_util.h"
 #include "globals.h"
+
 #include "vtr_random.h"
+
+#include "draw_debug.h"
+#include "draw.h"
+
 #include "place_constraints.h"
 #include "placer_globals.h"
 

--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -1,13 +1,6 @@
 #include "move_utils.h"
-
-#include "place_util.h"
 #include "globals.h"
-
 #include "vtr_random.h"
-
-#include "draw_debug.h"
-#include "draw.h"
-
 #include "place_constraints.h"
 #include "placer_globals.h"
 
@@ -488,12 +481,12 @@ std::set<t_pl_loc> determine_locations_emptied_by_move(t_pl_blocks_to_be_moved& 
     std::set<t_pl_loc> moved_from;
     std::set<t_pl_loc> moved_to;
 
-    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
+    for (const auto& block : blocks_affected.moved_blocks) {
         //When a block is moved its old location becomes free
-        moved_from.emplace(blocks_affected.moved_blocks[iblk].old_loc);
+        moved_from.emplace(block.old_loc);
 
         //But any block later moved to a position fills it
-        moved_to.emplace(blocks_affected.moved_blocks[iblk].new_loc);
+        moved_to.emplace(block.new_loc);
     }
 
     std::set<t_pl_loc> empty_locs;

--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -125,8 +125,6 @@ e_block_move_result record_macro_self_swaps(t_pl_blocks_to_be_moved& blocks_affe
  */
 bool is_legal_swap_to_location(ClusterBlockId blk, t_pl_loc to);
 
-std::set<t_pl_loc> determine_locations_emptied_by_move(t_pl_blocks_to_be_moved& blocks_affected);
-
 /**
  * @brief Propose block for the RL agent based on required block type.
  *

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -156,7 +156,6 @@ static BBUpdater bb_updater;
  * @return True if the driver block of the net is among the moving blocks
  */
 static bool driven_by_moved_block(const ClusterNetId net,
-                                  const int num_blocks,
                                   const std::vector<t_pl_moved_block>& moved_blocks);
 /**
  * @brief Update the bounding box (3D) of the net connected to blk_pin. The old and new locations of the pin are
@@ -555,14 +554,13 @@ void BBUpdater::set_ts_edge(const ClusterNetId& net_id) {
 
 //Returns true if 'net' is driven by one of the blocks in 'blocks_affected'
 static bool driven_by_moved_block(const ClusterNetId net,
-                                  const int num_blocks,
                                   const std::vector<t_pl_moved_block>& moved_blocks) {
     auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     bool is_driven_by_move_blk = false;
     ClusterBlockId net_driver_block = clb_nlist.net_driver_block(
         net);
 
-    for (int block_num = 0; block_num < num_blocks; block_num++) {
+    for (size_t block_num = 0; block_num < moved_blocks.size(); block_num++) {
         if (net_driver_block == moved_blocks[block_num].block_num) {
             is_driven_by_move_blk = true;
             break;
@@ -1918,7 +1916,7 @@ void find_affected_nets_and_update_costs(
     ts_info.ts_nets_to_update.resize(0);
 
     /* Go through all the blocks moved. */
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; iblk++) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); iblk++) {
         const auto& moving_block_inf = blocks_affected.moved_blocks[iblk];
         auto& affected_pins = blocks_affected.affected_pins;
         ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
@@ -1929,7 +1927,6 @@ void find_affected_nets_and_update_costs(
             if (clb_nlist.pin_type(blk_pin) == PinType::SINK) {
                 ClusterNetId net_id = clb_nlist.pin_net(blk_pin);
                 is_src_moving = driven_by_moved_block(net_id,
-                                                      blocks_affected.num_moved_blocks,
                                                       blocks_affected.moved_blocks);
             }
             update_net_info_on_pin_move(place_algorithm,

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -24,7 +24,10 @@
  * @date July 12, 2024
  */
 #include "net_cost_handler.h"
+#include "clustered_netlist_fwd.h"
 #include "globals.h"
+#include "physical_types.h"
+#include "physical_types_util.h"
 #include "placer_globals.h"
 #include "move_utils.h"
 #include "place_timing_update.h"
@@ -116,14 +119,34 @@ static struct PLNetCost pl_net_cost;
  * layer_ts_bb_coord_new are used.
  */
 
-/* [0...cluster_ctx.clb_nlist.nets().size()-1] -> 3D bounding box*/
-static vtr::vector<ClusterNetId, t_bb> ts_bb_coord_new, ts_bb_edge_new;
-/* [0...cluster_ctx.clb_nlist.nets().size()-1][0...num_layers-1] -> 2D bonding box on a layer*/
-static vtr::vector<ClusterNetId, std::vector<t_2D_bb>> layer_ts_bb_edge_new, layer_ts_bb_coord_new;
-/* [0...cluster_ctx.clb_nlist.nets().size()-1][0...num_layers-1] -> number of sink pins on a layer*/
-static vtr::Matrix<int> ts_layer_sink_pin_count;
-/* [0...num_afftected_nets] -> net_id of the affected nets */
-static std::vector<ClusterNetId> ts_nets_to_update;
+struct TSInfo {
+    /* [0...cluster_ctx.clb_nlist.nets().size()-1] -> 3D bounding box*/
+    vtr::vector<ClusterNetId, t_bb> ts_bb_coord_new, ts_bb_edge_new;
+    /* [0...cluster_ctx.clb_nlist.nets().size()-1][0...num_layers-1] -> 2D bonding box on a layer*/
+    vtr::vector<ClusterNetId, std::vector<t_2D_bb>> layer_ts_bb_edge_new, layer_ts_bb_coord_new;
+    /* [0...cluster_ctx.clb_nlist.nets().size()-1][0...num_layers-1] -> number of sink pins on a layer*/
+    vtr::Matrix<int> ts_layer_sink_pin_count;
+    /* [0...num_afftected_nets] -> net_id of the affected nets */
+    std::vector<ClusterNetId> ts_nets_to_update;
+};
+static struct TSInfo ts_info;
+
+/**
+ * @brief This class is used to hide control flows needed to distinguish 2d and 3d placement
+ */
+class BB2D3DControlFlow {
+    bool cube_bb = false;
+
+  public:
+    void init(size_t num_nets, bool cube_bb);
+    void get_non_updatable_bb(const ClusterNetId& net);
+    bool is_driver(const t_physical_tile_type_ptr& blk_type, const ClusterPinId& blk_pin);
+    void update_bb(ClusterNetId net_id, t_physical_tile_loc pin_old_loc, t_physical_tile_loc pin_new_loc, bool is_driver);
+    double get_net_cost(const ClusterNetId& net_id);
+    void set_ts_bb_coord(const ClusterNetId& net_id);
+    void set_ts_edge(const ClusterNetId& net_id);
+};
+static BB2D3DControlFlow bb_2d_3d_control_flow;
 
 /**
  * @param net
@@ -233,25 +256,6 @@ static void update_bb(ClusterNetId net_id,
 static void get_non_updatable_bb(ClusterNetId net_id,
                                  t_bb& bb_coord_new,
                                  vtr::NdMatrixProxy<int, 1> num_sink_pin_layer);
-
-/**
- * @brief Update the bounding box (per-layer) of the net connected to blk_pin. The old and new locations of the pin are
- * stored in pl_moved_block. The updated bounding box will be stored in ts data structures.
- * @details Finds the bounding box of a net and stores its coordinates in the bb_coord_new
- * data structure.  This routine should only be called for small nets, since it does not
- * determine enough information for the bounding box to be updated incrementally later.
- * Currently assumes channels on both sides of the CLBs forming the edges of the bounding box
- * can be used.  Essentially, I am assuming the pins always lie on the outside of the
- * bounding box.
- * @param net ID of the net for which the bounding box is requested
- * @param blk ID of the moving block
- * @param blk_pin ID of the pin connected to the net
- * @param pl_moved_block Placement info about
- */
-static void update_net_layer_bb(const ClusterNetId& net,
-                                const ClusterBlockId& blk,
-                                const ClusterPinId& blk_pin,
-                                const t_pl_moved_block& pl_moved_block);
 
 /**
  * @brief Calculate the per-layer bounding box of "net_id" from scratch (based on the block locations stored in place_ctx) and
@@ -474,7 +478,88 @@ static double wirelength_crossing_count(size_t fanout);
 static void set_bb_delta_cost(const int num_affected_nets, double& bb_delta_c);
 
 /******************************* End of Function definitions ************************************/
+// Initialize the ts vectors
+void BB2D3DControlFlow::init(size_t num_nets, bool cube_bb_in) {
+    const int num_layers = g_vpr_ctx.device().grid.get_num_layers();
 
+    cube_bb = cube_bb_in;
+    if (cube_bb) {
+        ts_info.ts_bb_edge_new.resize(num_nets, t_bb());
+        ts_info.ts_bb_coord_new.resize(num_nets, t_bb());
+    } else {
+        VTR_ASSERT_SAFE(!cube_bb);
+        ts_info.layer_ts_bb_edge_new.resize(num_nets, std::vector<t_2D_bb>(num_layers, t_2D_bb()));
+        ts_info.layer_ts_bb_coord_new.resize(num_nets, std::vector<t_2D_bb>(num_layers, t_2D_bb()));
+    }
+
+    /*This initialize the whole matrix to OPEN which is an invalid value*/
+    ts_info.ts_layer_sink_pin_count.resize({num_nets, size_t(num_layers)}, OPEN);
+
+    ts_info.ts_nets_to_update.resize(num_nets, ClusterNetId::INVALID());
+}
+
+void BB2D3DControlFlow::get_non_updatable_bb(const ClusterNetId& net) {
+    if (cube_bb)
+        ::get_non_updatable_bb(net,
+                               ts_info.ts_bb_coord_new[net],
+                               ts_info.ts_layer_sink_pin_count[size_t(net)]);
+    else
+        ::get_non_updatable_layer_bb(net,
+                                     ts_info.layer_ts_bb_coord_new[net],
+                                     ts_info.ts_layer_sink_pin_count[size_t(net)]);
+}
+
+bool BB2D3DControlFlow::is_driver(const t_physical_tile_type_ptr& blk_type, const ClusterPinId& blk_pin) {
+    auto& cluster_ctx = g_vpr_ctx.clustering();
+    if (cube_bb)
+        return cluster_ctx.clb_nlist.pin_type(blk_pin) == PinType::DRIVER;
+    else
+        return get_pin_type_from_pin_physical_num(blk_type, tile_pin_index(blk_pin)) == e_pin_type::DRIVER;
+}
+
+void BB2D3DControlFlow::update_bb(ClusterNetId net_id, t_physical_tile_loc pin_old_loc, t_physical_tile_loc pin_new_loc, bool is_driver) {
+    if (cube_bb)
+        ::update_bb(net_id,
+                    ts_info.ts_bb_edge_new[net_id],
+                    ts_info.ts_bb_coord_new[net_id],
+                    ts_info.ts_layer_sink_pin_count[size_t(net_id)],
+                    pin_old_loc,
+                    pin_new_loc,
+                    is_driver);
+    else
+        ::update_layer_bb(net_id,
+                          ts_info.layer_ts_bb_edge_new[net_id],
+                          ts_info.layer_ts_bb_coord_new[net_id],
+                          ts_info.ts_layer_sink_pin_count[size_t(net_id)],
+                          pin_old_loc,
+                          pin_new_loc,
+                          is_driver);
+}
+
+double BB2D3DControlFlow::get_net_cost(const ClusterNetId& net_id) {
+    if (cube_bb)
+        return ::get_net_cost(net_id, ts_info.ts_bb_coord_new[net_id]);
+    else
+        return ::get_net_layer_bb_wire_cost(net_id, ts_info.layer_ts_bb_coord_new[net_id], ts_info.ts_layer_sink_pin_count[size_t(net_id)]);
+}
+
+void BB2D3DControlFlow::set_ts_bb_coord(const ClusterNetId& net_id) {
+    auto& place_move_ctx = g_placer_ctx.mutable_move();
+    if (cube_bb) {
+        place_move_ctx.bb_coords[net_id] = ts_info.ts_bb_coord_new[net_id];
+    } else {
+        place_move_ctx.layer_bb_coords[net_id] = ts_info.layer_ts_bb_coord_new[net_id];
+    }
+}
+
+void BB2D3DControlFlow::set_ts_edge(const ClusterNetId& net_id) {
+    auto& place_move_ctx = g_placer_ctx.mutable_move();
+    if (cube_bb) {
+        place_move_ctx.bb_num_on_edges[net_id] = ts_info.ts_bb_edge_new[net_id];
+    } else {
+        place_move_ctx.layer_bb_num_on_edges[net_id] = ts_info.layer_ts_bb_edge_new[net_id];
+    }
+}
 //Returns true if 'net' is driven by one of the blocks in 'blocks_affected'
 static bool driven_by_moved_block(const ClusterNetId net,
                                   const int num_blocks,
@@ -504,47 +589,7 @@ static void update_net_bb(const ClusterNetId& net,
         //For small nets brute-force bounding box update is faster
 
         if (pl_net_cost.bb_update_status[net] == NetUpdateState::NOT_UPDATED_YET) { //Only once per-net
-            get_non_updatable_bb(net,
-                                 ts_bb_coord_new[net],
-                                 ts_layer_sink_pin_count[size_t(net)]);
-        }
-    } else {
-        //For large nets, update bounding box incrementally
-        int iblk_pin = tile_pin_index(blk_pin);
-        bool src_pin = cluster_ctx.clb_nlist.pin_type(blk_pin) == PinType::DRIVER;
-
-        t_physical_tile_type_ptr blk_type = physical_tile_type(blk);
-        int pin_width_offset = blk_type->pin_width_offset[iblk_pin];
-        int pin_height_offset = blk_type->pin_height_offset[iblk_pin];
-
-        //Incremental bounding box update
-        update_bb(net,
-                  ts_bb_edge_new[net],
-                  ts_bb_coord_new[net],
-                  ts_layer_sink_pin_count[size_t(net)],
-                  {pl_moved_block.old_loc.x + pin_width_offset,
-                   pl_moved_block.old_loc.y + pin_height_offset,
-                   pl_moved_block.old_loc.layer},
-                  {pl_moved_block.new_loc.x + pin_width_offset,
-                   pl_moved_block.new_loc.y + pin_height_offset,
-                   pl_moved_block.new_loc.layer},
-                  src_pin);
-    }
-}
-
-static void update_net_layer_bb(const ClusterNetId& net,
-                                const ClusterBlockId& blk,
-                                const ClusterPinId& blk_pin,
-                                const t_pl_moved_block& pl_moved_block) {
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-
-    if (cluster_ctx.clb_nlist.net_sinks(net).size() < SMALL_NET) {
-        //For small nets brute-force bounding box update is faster
-
-        if (pl_net_cost.bb_update_status[net] == NetUpdateState::NOT_UPDATED_YET) { //Only once per-net
-            get_non_updatable_layer_bb(net,
-                                       layer_ts_bb_coord_new[net],
-                                       ts_layer_sink_pin_count[size_t(net)]);
+            bb_2d_3d_control_flow.get_non_updatable_bb(net);
         }
     } else {
         //For large nets, update bounding box incrementally
@@ -553,21 +598,17 @@ static void update_net_layer_bb(const ClusterNetId& net,
         t_physical_tile_type_ptr blk_type = physical_tile_type(blk);
         int pin_width_offset = blk_type->pin_width_offset[iblk_pin];
         int pin_height_offset = blk_type->pin_height_offset[iblk_pin];
-
-        auto pin_dir = get_pin_type_from_pin_physical_num(blk_type, iblk_pin);
+        bool is_driver = bb_2d_3d_control_flow.is_driver(blk_type, blk_pin);
 
         //Incremental bounding box update
-        update_layer_bb(net,
-                        layer_ts_bb_edge_new[net],
-                        layer_ts_bb_coord_new[net],
-                        ts_layer_sink_pin_count[size_t(net)],
-                        {pl_moved_block.old_loc.x + pin_width_offset,
-                         pl_moved_block.old_loc.y + pin_height_offset,
-                         pl_moved_block.old_loc.layer},
-                        {pl_moved_block.new_loc.x + pin_width_offset,
-                         pl_moved_block.new_loc.y + pin_height_offset,
-                         pl_moved_block.new_loc.layer},
-                        pin_dir == e_pin_type::DRIVER);
+        bb_2d_3d_control_flow.update_bb(net,
+                                        {pl_moved_block.old_loc.x + pin_width_offset,
+                                         pl_moved_block.old_loc.y + pin_height_offset,
+                                         pl_moved_block.old_loc.layer},
+                                        {pl_moved_block.new_loc.x + pin_width_offset,
+                                         pl_moved_block.new_loc.y + pin_height_offset,
+                                         pl_moved_block.new_loc.layer},
+                                        is_driver);
     }
 }
 
@@ -668,7 +709,7 @@ static void record_affected_net(const ClusterNetId net,
     /* Record effected nets. */
     if (pl_net_cost.proposed_net_cost[net] < 0.) {
         /* Net not marked yet. */
-        ts_nets_to_update[num_affected_nets] = net;
+        ts_info.ts_nets_to_update[num_affected_nets] = net;
         num_affected_nets++;
 
         /* Flag to say we've marked this net. */
@@ -700,14 +741,8 @@ static void update_pl_net_cost_on_pin_move(const t_place_algorithm& place_algori
     /* Record effected nets */
     record_affected_net(net_id, num_affected_nets);
 
-    const auto& cube_bb = g_vpr_ctx.placement().cube_bb;
-
     /* Update the net bounding boxes. */
-    if (cube_bb) {
-        update_net_bb(net_id, blk_id, pin_id, moving_blk_inf);
-    } else {
-        update_net_layer_bb(net_id, blk_id, pin_id, moving_blk_inf);
-    }
+    update_net_bb(net_id, blk_id, pin_id, moving_blk_inf);
 
     if (place_algorithm.is_timing_driven()) {
         /* Determine the change in connection delay and timing cost. */
@@ -1868,17 +1903,9 @@ static double wirelength_crossing_count(size_t fanout) {
 static void set_bb_delta_cost(const int num_affected_nets, double& bb_delta_c) {
     for (int inet_affected = 0; inet_affected < num_affected_nets;
          inet_affected++) {
-        ClusterNetId net_id = ts_nets_to_update[inet_affected];
-        const auto& cube_bb = g_vpr_ctx.placement().cube_bb;
+        ClusterNetId net_id = ts_info.ts_nets_to_update[inet_affected];
 
-        if (cube_bb) {
-            pl_net_cost.proposed_net_cost[net_id] = get_net_cost(net_id,
-                                                                 ts_bb_coord_new[net_id]);
-        } else {
-            pl_net_cost.proposed_net_cost[net_id] = get_net_layer_bb_wire_cost(net_id,
-                                                                               layer_ts_bb_coord_new[net_id],
-                                                                               ts_layer_sink_pin_count[size_t(net_id)]);
-        }
+        pl_net_cost.proposed_net_cost[net_id] = bb_2d_3d_control_flow.get_net_cost(net_id);
 
         bb_delta_c += pl_net_cost.proposed_net_cost[net_id] - pl_net_cost.net_cost[net_id];
     }
@@ -2010,32 +2037,23 @@ double comp_layer_bb_cost(e_cost_methods method) {
     return cost;
 }
 
-void update_move_nets(int num_nets_affected,
-                      const bool cube_bb) {
+void update_move_nets(int num_nets_affected) {
     /* update net cost functions and reset flags. */
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& place_move_ctx = g_placer_ctx.mutable_move();
 
     for (int inet_affected = 0; inet_affected < num_nets_affected;
          inet_affected++) {
-        ClusterNetId net_id = ts_nets_to_update[inet_affected];
+        ClusterNetId net_id = ts_info.ts_nets_to_update[inet_affected];
 
-        if (cube_bb) {
-            place_move_ctx.bb_coords[net_id] = ts_bb_coord_new[net_id];
-        } else {
-            place_move_ctx.layer_bb_coords[net_id] = layer_ts_bb_coord_new[net_id];
-        }
+        bb_2d_3d_control_flow.set_ts_bb_coord(net_id);
 
         for (int layer_num = 0; layer_num < g_vpr_ctx.device().grid.get_num_layers(); layer_num++) {
-            place_move_ctx.num_sink_pin_layer[size_t(net_id)][layer_num] = ts_layer_sink_pin_count[size_t(net_id)][layer_num];
+            place_move_ctx.num_sink_pin_layer[size_t(net_id)][layer_num] = ts_info.ts_layer_sink_pin_count[size_t(net_id)][layer_num];
         }
 
         if (cluster_ctx.clb_nlist.net_sinks(net_id).size() >= SMALL_NET) {
-            if (cube_bb) {
-                place_move_ctx.bb_num_on_edges[net_id] = ts_bb_edge_new[net_id];
-            } else {
-                place_move_ctx.layer_bb_num_on_edges[net_id] = layer_ts_bb_edge_new[net_id];
-            }
+            bb_2d_3d_control_flow.set_ts_edge(net_id);
         }
 
         pl_net_cost.net_cost[net_id] = pl_net_cost.proposed_net_cost[net_id];
@@ -2050,7 +2068,7 @@ void reset_move_nets(int num_nets_affected) {
     /* Reset the net cost function flags first. */
     for (int inet_affected = 0; inet_affected < num_nets_affected;
          inet_affected++) {
-        ClusterNetId net_id = ts_nets_to_update[inet_affected];
+        ClusterNetId net_id = ts_info.ts_nets_to_update[inet_affected];
         pl_net_cost.proposed_net_cost[net_id] = -1;
         pl_net_cost.bb_update_status[net_id] = NetUpdateState::NOT_UPDATED_YET;
     }
@@ -2241,28 +2259,14 @@ void free_place_move_structs() {
 }
 
 void init_try_swap_net_cost_structs(size_t num_nets, bool cube_bb) {
-    const int num_layers = g_vpr_ctx.device().grid.get_num_layers();
-
-    if (cube_bb) {
-        ts_bb_edge_new.resize(num_nets, t_bb());
-        ts_bb_coord_new.resize(num_nets, t_bb());
-    } else {
-        VTR_ASSERT_SAFE(!cube_bb);
-        layer_ts_bb_edge_new.resize(num_nets, std::vector<t_2D_bb>(num_layers, t_2D_bb()));
-        layer_ts_bb_coord_new.resize(num_nets, std::vector<t_2D_bb>(num_layers, t_2D_bb()));
-    }
-
-    /*This initialize the whole matrix to OPEN which is an invalid value*/
-    ts_layer_sink_pin_count.resize({num_nets, size_t(num_layers)}, OPEN);
-
-    ts_nets_to_update.resize(num_nets, ClusterNetId::INVALID());
+    bb_2d_3d_control_flow.init(num_nets, cube_bb);
 }
 
 void free_try_swap_net_cost_structs() {
-    vtr::release_memory(ts_bb_edge_new);
-    vtr::release_memory(ts_bb_coord_new);
-    vtr::release_memory(layer_ts_bb_edge_new);
-    vtr::release_memory(layer_ts_bb_coord_new);
-    ts_layer_sink_pin_count.clear();
-    vtr::release_memory(ts_nets_to_update);
+    vtr::release_memory(ts_info.ts_bb_edge_new);
+    vtr::release_memory(ts_info.ts_bb_coord_new);
+    vtr::release_memory(ts_info.layer_ts_bb_edge_new);
+    vtr::release_memory(ts_info.layer_ts_bb_coord_new);
+    ts_info.ts_layer_sink_pin_count.clear();
+    vtr::release_memory(ts_info.ts_nets_to_update);
 }

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -80,7 +80,7 @@ static vtr::NdMatrix<float, 2> chanx_place_cost_fac({0, 0}); // [0...device_ctx.
 static vtr::NdMatrix<float, 2> chany_place_cost_fac({0, 0}); // [0...device_ctx.grid.height()-2]
 
 /**
- * @brief For each of the vector in this struct, there is one entry per cluster level net:
+ * @brief For each of the vectors in this struct, there is one entry per cluster level net:
  * [0...cluster_ctx.clb_nlist.nets().size()-1].
  * net_cost and proposed_net_cost: Cost of a net, and a temporary cost of a net used during move assessment.
  * We also use negative cost values in proposed_net_cost as a flag to indicate that

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -192,7 +192,7 @@ static void update_td_delta_costs(const PlaceDelayModel* delay_model,
                                   bool is_src_moving);
 
 /**
- * @brief if "net" is not already stored as an affected net, mark it in ts_nets_to_update and increment the size ofts_nets_to_update.
+ * @brief if "net" is not already stored as an affected net, add it in ts_nets_to_update.
  * @param net ID of a net affected by a move
  */
 static void record_affected_net(const ClusterNetId net);
@@ -560,8 +560,8 @@ static bool driven_by_moved_block(const ClusterNetId net,
     ClusterBlockId net_driver_block = clb_nlist.net_driver_block(
         net);
 
-    for (size_t block_num = 0; block_num < moved_blocks.size(); block_num++) {
-        if (net_driver_block == moved_blocks[block_num].block_num) {
+    for (const auto& block : moved_blocks) {
+        if (net_driver_block == block.block_num) {
             is_driven_by_move_blk = true;
             break;
         }
@@ -1892,9 +1892,8 @@ static double wirelength_crossing_count(size_t fanout) {
 }
 
 static void set_bb_delta_cost(double& bb_delta_c) {
-    for (size_t inet_affected = 0; inet_affected < ts_info.ts_nets_to_update.size();
-         inet_affected++) {
-        ClusterNetId net_id = ts_info.ts_nets_to_update[inet_affected];
+    for (const auto& ts_net: ts_info.ts_nets_to_update) {
+        ClusterNetId net_id = ts_net;
 
         pl_net_cost.proposed_net_cost[net_id] = bb_updater.get_net_cost(net_id);
 
@@ -1916,10 +1915,10 @@ void find_affected_nets_and_update_costs(
     ts_info.ts_nets_to_update.resize(0);
 
     /* Go through all the blocks moved. */
-    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); iblk++) {
-        const auto& moving_block_inf = blocks_affected.moved_blocks[iblk];
+    for (const auto& block : blocks_affected.moved_blocks) {
+        const auto& moving_block_inf = block;
         auto& affected_pins = blocks_affected.affected_pins;
-        ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
+        ClusterBlockId blk = block.block_num;
 
         /* Go through all the pins in the moved block. */
         for (ClusterPinId blk_pin : clb_nlist.block_pins(blk)) {
@@ -2029,9 +2028,8 @@ void update_move_nets() {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& place_move_ctx = g_placer_ctx.mutable_move();
 
-    for (size_t inet_affected = 0; inet_affected < ts_info.ts_nets_to_update.size();
-         inet_affected++) {
-        ClusterNetId net_id = ts_info.ts_nets_to_update[inet_affected];
+    for (const auto& ts_net : ts_info.ts_nets_to_update) {
+        ClusterNetId net_id = ts_net;
 
         bb_updater.set_ts_bb_coord(net_id);
 
@@ -2053,9 +2051,8 @@ void update_move_nets() {
 
 void reset_move_nets() {
     /* Reset the net cost function flags first. */
-    for (size_t inet_affected = 0; inet_affected < ts_info.ts_nets_to_update.size();
-         inet_affected++) {
-        ClusterNetId net_id = ts_info.ts_nets_to_update[inet_affected];
+    for (const auto& ts_net : ts_info.ts_nets_to_update) {
+        ClusterNetId net_id = ts_net;
         pl_net_cost.proposed_net_cost[net_id] = -1;
         pl_net_cost.bb_update_status[net_id] = NetUpdateState::NOT_UPDATED_YET;
     }

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -36,6 +36,7 @@ enum e_cost_methods {
  *
  * The change in the bounding box cost is stored in `bb_delta_c`.
  * The change in the timing cost is stored in `timing_delta_c`.
+ * ts_nets_to_update is also extended with the latest net.
  *
  * @param place_algorithm
  * @param delay_model

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -83,10 +83,8 @@ double comp_layer_bb_cost(e_cost_methods method);
 /**
  * @brief update net cost data structures (in placer context and net_cost in .cpp file) and reset flags (proposed_net_cost and bb_updated_before).
  * @param num_nets_affected The number of nets affected by the move. It is used to determine the index up to which elements in ts_nets_to_update are valid.
- * @param cube_bb True if we should use the 3D bounding box (cube_bb), false otherwise.
  */
-void update_move_nets(int num_nets_affected,
-                      const bool cube_bb);
+void update_move_nets(int num_nets_affected);
 
 /**
  * @brief Reset the net cost function flags (proposed_net_cost and bb_updated_before)

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -6,8 +6,8 @@
 
 /**
  * @brief The method used to calculate palcement cost
- * @details For comp_cost.  NORMAL means use the method that generates updateable bounding boxes for speed.  
- * CHECK means compute all bounding boxes from scratch using a very simple routine to allow checks 
+ * @details For comp_cost.  NORMAL means use the method that generates updateable bounding boxes for speed.
+ * CHECK means compute all bounding boxes from scratch using a very simple routine to allow checks
  * of the other costs.
  * NORMAL: Compute cost efficiently using incremental techniques.
  * CHECK: Brute-force cost computation; useful to validate the more complex incremental cost update code.
@@ -36,7 +36,7 @@ enum e_cost_methods {
  *
  * The change in the bounding box cost is stored in `bb_delta_c`.
  * The change in the timing cost is stored in `timing_delta_c`.
- * 
+ *
  * @param place_algorithm
  * @param delay_model
  * @param criticalities
@@ -45,7 +45,7 @@ enum e_cost_methods {
  * @param timing_delta_c
  * @return The number of affected nets.
  */
-int find_affected_nets_and_update_costs(
+void find_affected_nets_and_update_costs(
     const t_place_algorithm& place_algorithm,
     const PlaceDelayModel* delay_model,
     const PlacerCriticalities* criticalities,
@@ -54,27 +54,27 @@ int find_affected_nets_and_update_costs(
     double& timing_delta_c);
 
 /**
- * @brief Finds the bb cost from scratch (based on 3D BB).  
- * Done only when the placement has been radically changed 
- * (i.e. after initial placement). Otherwise find the cost 
- * change incrementally. If method check is NORMAL, we find 
- * bounding boxes that are updatable for the larger nets.  
- * If method is CHECK, all bounding boxes are found via the 
- * non_updateable_bb routine, to provide a cost which can be 
- * used to check the correctness of the other routine.                                               
+ * @brief Finds the bb cost from scratch (based on 3D BB).
+ * Done only when the placement has been radically changed
+ * (i.e. after initial placement). Otherwise find the cost
+ * change incrementally. If method check is NORMAL, we find
+ * bounding boxes that are updatable for the larger nets.
+ * If method is CHECK, all bounding boxes are found via the
+ * non_updateable_bb routine, to provide a cost which can be
+ * used to check the correctness of the other routine.
  * @param method
  * @return The bounding box cost of the placement, computed by the 3D method.
  */
 double comp_bb_cost(e_cost_methods method);
 
 /**
- * @brief Finds the bb cost from scratch (based on per-layer BB).  
- * Done only when the placement has been radically changed 
- * (i.e. after initial placement). Otherwise find the cost change 
- * incrementally.  If method check is NORMAL, we find bounding boxes 
- * that are updateable for the larger nets.  If method is CHECK, all 
- * bounding boxes are found via the non_updateable_bb routine, to provide 
- * a cost which can be used to check the correctness of the other routine.                                              
+ * @brief Finds the bb cost from scratch (based on per-layer BB).
+ * Done only when the placement has been radically changed
+ * (i.e. after initial placement). Otherwise find the cost change
+ * incrementally.  If method check is NORMAL, we find bounding boxes
+ * that are updateable for the larger nets.  If method is CHECK, all
+ * bounding boxes are found via the non_updateable_bb routine, to provide
+ * a cost which can be used to check the correctness of the other routine.
  * @param method
  * @return The placement bounding box cost, computed by the per layer method.
  */
@@ -84,17 +84,17 @@ double comp_layer_bb_cost(e_cost_methods method);
  * @brief update net cost data structures (in placer context and net_cost in .cpp file) and reset flags (proposed_net_cost and bb_updated_before).
  * @param num_nets_affected The number of nets affected by the move. It is used to determine the index up to which elements in ts_nets_to_update are valid.
  */
-void update_move_nets(int num_nets_affected);
+void update_move_nets();
 
 /**
  * @brief Reset the net cost function flags (proposed_net_cost and bb_updated_before)
  * @param num_nets_affected
  */
-void reset_move_nets(int num_nets_affected);
+void reset_move_nets();
 
 /**
  * @brief re-calculates different terms of the cost function (wire-length, timing, NoC) and update "costs" accordingly. It is important to note that
- * in this function bounding box and connection delays are not calculated from scratch. However, it iterates over all nets and connections and updates 
+ * in this function bounding box and connection delays are not calculated from scratch. However, it iterates over all nets and connections and updates
  * their costs by a complete summation, rather than incrementally.
  * @param placer_opts
  * @param noc_opts
@@ -103,16 +103,16 @@ void reset_move_nets(int num_nets_affected);
  * @param costs passed by reference and computed by this routine (i.e. returned by reference)
  */
 void recompute_costs_from_scratch(const t_placer_opts& placer_opts,
-                                const t_noc_opts& noc_opts,
-                                const PlaceDelayModel* delay_model,
-                                const PlacerCriticalities* criticalities,
-                                t_placer_costs* costs);
+                                  const t_noc_opts& noc_opts,
+                                  const PlaceDelayModel* delay_model,
+                                  const PlacerCriticalities* criticalities,
+                                  t_placer_costs* costs);
 
 /**
  * @brief Allocates and loads the chanx_place_cost_fac and chany_place_cost_fac
  * arrays with the inverse of the average number of tracks per channel
  * between [subhigh] and [sublow].
- * @param place_cost_exp It is an exponent to which you take the average inverse channel 
+ * @param place_cost_exp It is an exponent to which you take the average inverse channel
  * capacity; a higher value would favour wider channels more over narrower channels during placement (usually we use 1).
  */
 void alloc_and_load_chan_w_factors_for_place_cost(float place_cost_exp);
@@ -120,7 +120,7 @@ void alloc_and_load_chan_w_factors_for_place_cost(float place_cost_exp);
 /**
  * @brief Frees the chanx_place_cost_fac and chany_place_cost_fac arrays.
  */
-void free_chan_w_factors_for_place_cost ();
+void free_chan_w_factors_for_place_cost();
 
 /**
  * @brief Resize net_cost, proposed_net_cost, and  bb_updated_before data structures to accommodate all nets.
@@ -134,8 +134,8 @@ void init_place_move_structs(size_t num_nets);
 void free_place_move_structs();
 
 /**
- * @brief Resize temporary storage data structures needed to determine which nets are affected by a move and data needed per net 
- * about where their terminals are in order to quickly (incrementally) update their wirelength costs. These data structures are  
+ * @brief Resize temporary storage data structures needed to determine which nets are affected by a move and data needed per net
+ * about where their terminals are in order to quickly (incrementally) update their wirelength costs. These data structures are
  * (layer_)ts_bb_edge_new, (layer_)ts_bb_coord_new, ts_layer_sink_pin_count, and ts_nets_to_update.
  * @param num_nets Number of nets in the netlist used by the placement engine (currently clustered netlist)
  * @param cube_bb True if the 3D bounding box should be used, false otherwise.

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -136,7 +136,7 @@ void find_affected_noc_routers_and_update_noc_costs(const t_pl_blocks_to_be_move
     affected_noc_links.clear();
 
     // go through the moved blocks and process them only if they are NoC routers
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; ++iblk) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
         ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
 
         // check if the current moved block is a noc router
@@ -291,7 +291,7 @@ void revert_noc_traffic_flow_routes(const t_pl_blocks_to_be_moved& blocks_affect
     std::unordered_set<NocTrafficFlowId> reverted_traffic_flows;
 
     // go through the moved blocks and process them only if they are NoC routers
-    for (int iblk = 0; iblk < blocks_affected.num_moved_blocks; ++iblk) {
+    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
         ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
 
         // check if the current moved block is a noc router

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -136,8 +136,8 @@ void find_affected_noc_routers_and_update_noc_costs(const t_pl_blocks_to_be_move
     affected_noc_links.clear();
 
     // go through the moved blocks and process them only if they are NoC routers
-    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
-        ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
+    for (const auto& block : blocks_affected.moved_blocks) {
+        ClusterBlockId blk = block.block_num;
 
         // check if the current moved block is a noc router
         if (noc_traffic_flows_storage.check_if_cluster_block_has_traffic_flows(blk)) {
@@ -291,8 +291,8 @@ void revert_noc_traffic_flow_routes(const t_pl_blocks_to_be_moved& blocks_affect
     std::unordered_set<NocTrafficFlowId> reverted_traffic_flows;
 
     // go through the moved blocks and process them only if they are NoC routers
-    for (size_t iblk = 0; iblk < blocks_affected.moved_blocks.size(); ++iblk) {
-        ClusterBlockId blk = blocks_affected.moved_blocks[iblk].block_num;
+    for (const auto& block : blocks_affected.moved_blocks) {
+        ClusterBlockId blk = block.block_num;
 
         // check if the current moved block is a noc router
         if (noc_traffic_flows_storage.check_if_cluster_block_has_traffic_flows(blk)) {
@@ -323,7 +323,7 @@ void re_route_traffic_flow(NocTrafficFlowId traffic_flow_id,
     // get the current traffic flow info
     const t_noc_traffic_flow& curr_traffic_flow = noc_traffic_flows_storage.get_single_noc_traffic_flow(traffic_flow_id);
 
-    /*  since the current traffic flow route will be 
+    /*  since the current traffic flow route will be
      * changed, first we need to decrement the bandwidth
      * usage of all links that are part of
      * the existing traffic flow route

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1,11 +1,20 @@
 #include <cstdio>
 #include <cmath>
 #include <memory>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <chrono>
+#include <optional>
+
+#include "NetPinTimingInvalidator.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
 #include "vtr_util.h"
 #include "vtr_random.h"
+#include "vtr_geometry.h"
 #include "vtr_time.h"
+#include "vtr_math.h"
 #include "vtr_ndmatrix.h"
 
 #include "vpr_types.h"
@@ -18,6 +27,11 @@
 #include "placer_globals.h"
 #include "read_place.h"
 #include "draw.h"
+#include "place_and_route.h"
+#include "net_delay.h"
+#include "timing_place_lookup.h"
+#include "timing_place.h"
+#include "read_xml_arch_file.h"
 #include "echo_files.h"
 #include "place_macro.h"
 #include "histogram.h"
@@ -31,7 +45,10 @@
 #include "read_place.h"
 #include "place_constraints.h"
 #include "manual_moves.h"
+#include "buttons.h"
 
+#include "static_move_generator.h"
+#include "simpleRL_move_generator.h"
 #include "manual_move_generator.h"
 
 #include "PlacementDelayCalculator.h"
@@ -42,11 +59,13 @@
 #include "tatum/echo_writer.hpp"
 #include "tatum/TimingReporter.hpp"
 
+#include "placer_breakpoint.h"
 #include "RL_agent_util.h"
 #include "place_checkpoint.h"
 
 #include "clustered_netlist_utils.h"
 
+#include "cluster_placement.h"
 
 #include "noc_place_utils.h"
 

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1,20 +1,11 @@
 #include <cstdio>
 #include <cmath>
 #include <memory>
-#include <fstream>
-#include <iostream>
-#include <numeric>
-#include <chrono>
-#include <optional>
-
-#include "NetPinTimingInvalidator.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
 #include "vtr_util.h"
 #include "vtr_random.h"
-#include "vtr_geometry.h"
 #include "vtr_time.h"
-#include "vtr_math.h"
 #include "vtr_ndmatrix.h"
 
 #include "vpr_types.h"
@@ -27,11 +18,6 @@
 #include "placer_globals.h"
 #include "read_place.h"
 #include "draw.h"
-#include "place_and_route.h"
-#include "net_delay.h"
-#include "timing_place_lookup.h"
-#include "timing_place.h"
-#include "read_xml_arch_file.h"
 #include "echo_files.h"
 #include "place_macro.h"
 #include "histogram.h"
@@ -45,10 +31,7 @@
 #include "read_place.h"
 #include "place_constraints.h"
 #include "manual_moves.h"
-#include "buttons.h"
 
-#include "static_move_generator.h"
-#include "simpleRL_move_generator.h"
 #include "manual_move_generator.h"
 
 #include "PlacementDelayCalculator.h"
@@ -59,13 +42,11 @@
 #include "tatum/echo_writer.hpp"
 #include "tatum/TimingReporter.hpp"
 
-#include "placer_breakpoint.h"
 #include "RL_agent_util.h"
 #include "place_checkpoint.h"
 
 #include "clustered_netlist_utils.h"
 
-#include "cluster_placement.h"
 
 #include "noc_place_utils.h"
 
@@ -150,7 +131,7 @@ std::unique_ptr<FILE, decltype(&vtr::fclose)> f_move_stats_file(nullptr,
                         t,                                                                     \
                         int(b_from), int(b_to),                                                \
                         from_type->name, (to_type ? to_type->name : "EMPTY"),                  \
-                        affected_blocks.moved_blocks.size());                                     \
+                        affected_blocks.moved_blocks.size());                                  \
             }                                                                                  \
         } while (false)
 
@@ -1325,7 +1306,7 @@ static e_move_result try_swap(const t_annealing_state* state,
     if (manual_move_enabled) {
 #ifndef NO_GRAPHICS
         create_move_outcome = manual_move_display_and_propose(manual_move_generator, blocks_affected, proposed_action.move_type, rlim, placer_opts, criticalities);
-#else  //NO_GRAPHICS \
+#else  //NO_GRAPHICS
        //Cast to void to explicitly avoid warning.
         (void)manual_move_generator;
 #endif //NO_GRAPHICS

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1378,9 +1378,8 @@ static e_move_result try_swap(const t_annealing_state* state,
         //
         //Also find all the pins affected by the swap, and calculates new connection
         //delays and timing costs and store them in proposed_* data structures.
-        find_affected_nets_and_update_costs(
-            place_algorithm, delay_model, criticalities, blocks_affected,
-            bb_delta_c, timing_delta_c);
+        find_affected_nets_and_update_costs(place_algorithm, delay_model, criticalities, 
+                                            blocks_affected, bb_delta_c, timing_delta_c);
 
         //For setup slack analysis, we first do a timing analysis to get the newest
         //slack values resulted from the proposed block moves. If the move turns out
@@ -1567,8 +1566,6 @@ static e_move_result try_swap(const t_annealing_state* state,
     if (!router_block_move) {
         calculate_reward_and_process_outcome(placer_opts, move_outcome_stats,
                                              delta_c, timing_bb_factor, move_generator);
-    } else {
-        //        std::cout << "Group move delta cost: " << delta_c << std::endl;
     }
 
 #ifdef VTR_ENABLE_DEBUG_LOGGING
@@ -1578,7 +1575,7 @@ static e_move_result try_swap(const t_annealing_state* state,
 #endif
 
     /* Clear the data structure containing block move info */
-    clear_move_blocks(blocks_affected);
+    blocks_affected.clear_move_blocks();
 
     //VTR_ASSERT(check_macro_placement_consistency() == 0);
 #if 0

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1481,8 +1481,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             }
 
             /* Update net cost functions and reset flags. */
-            update_move_nets(num_nets_affected,
-                             g_vpr_ctx.placement().cube_bb);
+            update_move_nets(num_nets_affected);
 
             /* Update clb data structures since we kept the move. */
             commit_move_blocks(blocks_affected);

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1325,8 +1325,8 @@ static e_move_result try_swap(const t_annealing_state* state,
     if (manual_move_enabled) {
 #ifndef NO_GRAPHICS
         create_move_outcome = manual_move_display_and_propose(manual_move_generator, blocks_affected, proposed_action.move_type, rlim, placer_opts, criticalities);
-#else  //NO_GRAPHICS 
-        //Cast to void to explicitly avoid warning.
+#else  //NO_GRAPHICS \
+       //Cast to void to explicitly avoid warning.
         (void)manual_move_generator;
 #endif //NO_GRAPHICS
     } else if (router_block_move) {
@@ -1378,7 +1378,7 @@ static e_move_result try_swap(const t_annealing_state* state,
         //
         //Also find all the pins affected by the swap, and calculates new connection
         //delays and timing costs and store them in proposed_* data structures.
-        int num_nets_affected = find_affected_nets_and_update_costs(
+        find_affected_nets_and_update_costs(
             place_algorithm, delay_model, criticalities, blocks_affected,
             bb_delta_c, timing_delta_c);
 
@@ -1481,7 +1481,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             }
 
             /* Update net cost functions and reset flags. */
-            update_move_nets(num_nets_affected);
+            update_move_nets();
 
             /* Update clb data structures since we kept the move. */
             commit_move_blocks(blocks_affected);
@@ -1505,7 +1505,7 @@ static e_move_result try_swap(const t_annealing_state* state,
             VTR_ASSERT_SAFE(move_outcome == REJECTED);
 
             /* Reset the net cost function flags first. */
-            reset_move_nets(num_nets_affected);
+            reset_move_nets();
 
             /* Restore the place_ctx.block_locs data structures to their state before the move. */
             revert_move_blocks(blocks_affected);
@@ -1568,7 +1568,7 @@ static e_move_result try_swap(const t_annealing_state* state,
         calculate_reward_and_process_outcome(placer_opts, move_outcome_stats,
                                              delta_c, timing_bb_factor, move_generator);
     } else {
-//        std::cout << "Group move delta cost: " << delta_c << std::endl;
+        //        std::cout << "Group move delta cost: " << delta_c << std::endl;
     }
 
 #ifdef VTR_ENABLE_DEBUG_LOGGING
@@ -1626,9 +1626,9 @@ static bool is_cube_bb(const e_place_bounding_box_mode place_bb_mode,
  * loop iteration of the placement. At each temperature change, these
  * values are updated so that we can balance the tradeoff between the
  * different placement cost components (timing, wirelength and NoC).
- * Depending on the placement mode the corresponding normalization factors are 
+ * Depending on the placement mode the corresponding normalization factors are
  * updated.
- * 
+ *
  * @param costs Contains the normalization factors which need to be updated
  * @param placer_opts Determines the placement mode
  * @param noc_opts Determines if placement includes the NoC
@@ -1651,7 +1651,7 @@ static void update_placement_cost_normalization_factors(t_placer_costs* costs, c
 /**
  * @brief Compute the total normalized cost for a given placement. This
  * computation will vary depending on the placement modes.
- * 
+ *
  * @param costs The current placement cost components and their normalization
  * factors
  * @param placer_opts Determines the placement mode
@@ -1915,7 +1915,7 @@ static void alloc_and_load_placement_structs(float place_cost_exp,
         elem = OPEN;
     }
 
-    alloc_and_load_chan_w_factors_for_place_cost (place_cost_exp);
+    alloc_and_load_chan_w_factors_for_place_cost(place_cost_exp);
 
     alloc_and_load_try_swap_structs(cube_bb);
 
@@ -1955,7 +1955,7 @@ static void free_placement_structs(const t_placer_opts& placer_opts, const t_noc
 
     place_move_ctx.num_sink_pin_layer.clear();
 
-    free_chan_w_factors_for_place_cost ();
+    free_chan_w_factors_for_place_cost();
 
     free_try_swap_structs();
 
@@ -2184,7 +2184,7 @@ int check_macro_placement_consistency() {
                 error++;
             }
         } // Finish going through all the members
-    }     // Finish going through all the macros
+    } // Finish going through all the macros
     return error;
 }
 
@@ -2372,9 +2372,8 @@ static void print_placement_move_types_stats(const MoveTypeStat& move_type_stat)
 
     int total_moves = 0;
     for (size_t i = 0; i < move_type_stat.blk_type_moves.size(); ++i) {
-        total_moves +=  move_type_stat.blk_type_moves.get(i);
+        total_moves += move_type_stat.blk_type_moves.get(i);
     }
-
 
     auto& device_ctx = g_vpr_ctx.device();
     int count = 0;

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -150,7 +150,7 @@ std::unique_ptr<FILE, decltype(&vtr::fclose)> f_move_stats_file(nullptr,
                         t,                                                                     \
                         int(b_from), int(b_to),                                                \
                         from_type->name, (to_type ? to_type->name : "EMPTY"),                  \
-                        affected_blocks.num_moved_blocks);                                     \
+                        affected_blocks.moved_blocks.size());                                     \
             }                                                                                  \
         } while (false)
 

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -100,16 +100,16 @@ void print_macro_constraint_error(const t_pl_macro& pl_macro);
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;
 
-    for (const auto& block : blocks_affected.moved_blocks) {
-        floorplan_legal = cluster_floorplanning_legal(block.block_num,
-                                                      block.new_loc);
+    for (const t_pl_moved_block& moved_block : blocks_affected.moved_blocks) {
+        floorplan_legal = cluster_floorplanning_legal(moved_block.block_num,
+                                                      moved_block.new_loc);
         if (!floorplan_legal) {
             VTR_LOGV_DEBUG(g_vpr_ctx.placement().f_placer_debug,
                            "\tMove aborted for block %zu, location tried was x: %d, y: %d, subtile: %d \n",
-                           size_t(block.block_num),
-                           block.new_loc.x,
-                           block.new_loc.y,
-                           block.new_loc.sub_tile);
+                           size_t(moved_block.block_num),
+                           moved_block.new_loc.x,
+                           moved_block.new_loc.y,
+                           moved_block.new_loc.sub_tile);
             return false;
         }
     }

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -100,7 +100,7 @@ void print_macro_constraint_error(const t_pl_macro& pl_macro);
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;
 
-    for (int i = 0; i < blocks_affected.num_moved_blocks; i++) {
+    for (size_t i = 0; i < blocks_affected.moved_blocks.size(); i++) {
         floorplan_legal = cluster_floorplanning_legal(blocks_affected.moved_blocks[i].block_num,
                                                       blocks_affected.moved_blocks[i].new_loc);
         if (!floorplan_legal) {

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -10,7 +10,6 @@
  */
 #include "move_transactions.h"
 #include "region.h"
-#include "clustered_netlist_utils.h"
 #include "partition_region.h"
 #include "place_macro.h"
 #include "grid_tile_lookup.h"
@@ -100,16 +99,16 @@ void print_macro_constraint_error(const t_pl_macro& pl_macro);
 inline bool floorplan_legal(const t_pl_blocks_to_be_moved& blocks_affected) {
     bool floorplan_legal;
 
-    for (size_t i = 0; i < blocks_affected.moved_blocks.size(); i++) {
-        floorplan_legal = cluster_floorplanning_legal(blocks_affected.moved_blocks[i].block_num,
-                                                      blocks_affected.moved_blocks[i].new_loc);
+    for (const auto& block : blocks_affected.moved_blocks) {
+        floorplan_legal = cluster_floorplanning_legal(block.block_num,
+                                                      block.new_loc);
         if (!floorplan_legal) {
             VTR_LOGV_DEBUG(g_vpr_ctx.placement().f_placer_debug,
                            "\tMove aborted for block %zu, location tried was x: %d, y: %d, subtile: %d \n",
-                           size_t(blocks_affected.moved_blocks[i].block_num),
-                           blocks_affected.moved_blocks[i].new_loc.x,
-                           blocks_affected.moved_blocks[i].new_loc.y,
-                           blocks_affected.moved_blocks[i].new_loc.sub_tile);
+                           size_t(block.block_num),
+                           block.new_loc.x,
+                           block.new_loc.y,
+                           block.new_loc.sub_tile);
             return false;
         }
     }

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -10,6 +10,7 @@
  */
 #include "move_transactions.h"
 #include "region.h"
+#include "clustered_netlist_utils.h"
 #include "partition_region.h"
 #include "place_macro.h"
 #include "grid_tile_lookup.h"

--- a/vpr/src/place/placer_breakpoint.cpp
+++ b/vpr/src/place/placer_breakpoint.cpp
@@ -8,7 +8,7 @@ std::map<int, std::string> available_move_types = {
 
 #    ifndef NO_GRAPHICS
 //transforms the vector moved_blocks to a vector of ints and adds it in glob_breakpoint_state
-void transform_blocks_affected(t_pl_blocks_to_be_moved blocksAffected) {
+void transform_blocks_affected(const t_pl_blocks_to_be_moved& blocksAffected) {
     get_bp_state_globals()->get_glob_breakpoint_state()->blocks_affected_by_move.clear();
     for (size_t i = 0; i < blocksAffected.moved_blocks.size(); i++) {
         //size_t conversion is required since block_num is of type ClusterBlockId and can't be cast to an int. And this vector has to be of type int to be recognized in expr_eval class

--- a/vpr/src/place/placer_breakpoint.h
+++ b/vpr/src/place/placer_breakpoint.h
@@ -10,7 +10,7 @@
 #ifdef VTR_ENABLE_DEBUG_LOGGING
 
 //transforms the vector moved_blocks to a vector of ints and adds it in glob_breakpoint_state
-void transform_blocks_affected(t_pl_blocks_to_be_moved blocksAffected);
+void transform_blocks_affected(const t_pl_blocks_to_be_moved& blocksAffected);
 
 //checks the breakpoint and see whether one of them was reached and pause place,emt accordingly
 void stop_placement_and_check_breakpoints(t_pl_blocks_to_be_moved& blocks_affected, e_move_result move_outcome, double delta_c, double bb_delta_c, double timing_delta_c);

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -878,7 +878,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
         commit_noc_costs();
 
         // clear the affected blocks
-        clear_move_blocks(blocks_affected);
+        blocks_affected.clear_move_blocks();
 
         // clear the routed traffic flows
         routed_traffic_flows.clear();
@@ -1026,7 +1026,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
     commit_noc_costs();
 
     // clear the affected blocks
-    clear_move_blocks(blocks_affected);
+    blocks_affected.clear_move_blocks();
 
     /*
      * Now we will run a test where one of the router clusters we will swap has no traffic flows associated with it. This will make sure whether the test
@@ -1127,7 +1127,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
     commit_noc_costs();
 
     // clear the affected blocks
-    clear_move_blocks(blocks_affected);
+    blocks_affected.clear_move_blocks();
 
     /*
      * Now we will run a test where both of the router clusters being swapped
@@ -1192,7 +1192,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
     commit_noc_costs();
 
     // clear the affected blocks
-    clear_move_blocks(blocks_affected);
+    blocks_affected.clear_move_blocks();
 
     // now verify the test function by comparing the link bandwidths in the noc model (should have been updated by the test function) to the golden set
     int number_of_links = golden_link_bandwidths.size();

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -748,7 +748,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
         } while (swap_router_block_one == swap_router_block_two);
 
         //set up the moved blocks datastructure for the test function
-        blocks_affected.num_moved_blocks = 2;
+        blocks_affected.moved_blocks.resize(2);
 
         blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
         blocks_affected.moved_blocks[0].old_loc = t_pl_loc(noc_ctx.noc_model.get_single_noc_router(router_where_cluster_is_placed[swap_router_block_one]).get_router_grid_position_x(),
@@ -903,7 +903,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
 
     // now perform the swap
     //set up the moved blocks datastructure for the test function
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
 
@@ -1039,7 +1039,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
 
     // now perform the swap
     //set up the moved blocks datastructure for the test function
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
 
@@ -1142,7 +1142,7 @@ TEST_CASE("test_find_affected_noc_routers_and_update_noc_costs, test_commit_noc_
 
     // now perform the swap
     //set up the moved blocks datastructure for the test function
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
 
@@ -1584,7 +1584,7 @@ TEST_CASE("test_revert_noc_traffic_flow_routes", "[noc_place_utils]") {
 
     //set up the moved blocks datastructure for the test function
     // this is needed for the test function (it needs to know what blocks were swapped, so it can undo it)
-    blocks_affected.num_moved_blocks = 2;
+    blocks_affected.moved_blocks.resize(2);
 
     blocks_affected.moved_blocks[0].block_num = swap_router_block_one;
     blocks_affected.moved_blocks[0].old_loc = t_pl_loc(noc_ctx.noc_model.get_single_noc_router(router_where_cluster_is_placed[swap_router_block_one]).get_router_grid_position_x(),


### PR DESCRIPTION
1. In "[net_cost_handler.cpp](https://can01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fverilog-to-routing%2Fvtr-verilog-to-routing%2Fblob%2Fplacement_move_primitive%2Fvpr%2Fsrc%2Fplace%2Fnet_cost_handler.cpp&data=05%7C02%7Cyulang.luo%40mail.utoronto.ca%7C5e26bbdc343c4119a05f08dc9fb5ddf1%7C78aac2262f034b4d9037b46d56c55210%7C0%7C0%7C638560850665905503%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=58ozr4ygx6cDyqFr5NL0%2BYAXmebPJsq5xthyQtC28iA%3D&reserved=0)", there are [three](https://can01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fverilog-to-routing%2Fvtr-verilog-to-routing%2Fblob%2Fplacement_move_primitive%2Fvpr%2Fsrc%2Fplace%2Fnet_cost_handler.cpp%23L62-L77&data=05%7C02%7Cyulang.luo%40mail.utoronto.ca%7C5e26bbdc343c4119a05f08dc9fb5ddf1%7C78aac2262f034b4d9037b46d56c55210%7C0%7C0%7C638560850665913899%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=n1SBtPnW2y4RgGmenIt6RbSk71qlkJRqcGUOXwUBdMA%3D&reserved=0) related global variables: `net_cost`, `proposed_net_cost`, and `bb_updated_before`. We can organize these by putting them into a struct called `t_net_cost_data`. You may also rename `bb_updated_before` to `bb_update_status`.

2. In placement, we use two methods to update the bounding box: the 3D bounding box (also used for 2D architecture) and the per-layer bounding box. When a swap happens, [multiple variables](https://can01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fverilog-to-routing%2Fvtr-verilog-to-routing%2Fblob%2Fplacement_move_primitive%2Fvpr%2Fsrc%2Fplace%2Fnet_cost_handler.cpp%23L91-L98&data=05%7C02%7Cyulang.luo%40mail.utoronto.ca%7C5e26bbdc343c4119a05f08dc9fb5ddf1%7C78aac2262f034b4d9037b46d56c55210%7C0%7C0%7C638560850665920141%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=GjyyvhqPAvipLmtoMdc4Gr%2BPstuZ0wNKpgQZ8VOYN%2FY%3D&reserved=0) are updated, indicated by the `ts` (temporary swap) prefix. We can put all these variables into a class. Since only a subset is used depending on the bounding box type, you can examine how these variables are updated throughout the file and write methods for this class to update the appropriate ones.

3. For runtime reasons, we initialize `ts_nets_to_update` to the number of nets in the netlist and use a variable `num_affected_nets` to indicate how many entries are valid. You can experiment to see how runtime is affected if we remove this variable and just reserve elements in this vector and use `.size()`.

4. The same approach is used for `std::vector<t_pl_moved_block>& moved_blocks`, which has as many entries as the total number of blocks, and we pass an integer to show how many entries are valid. You can also run an experiment to see how much runtime is affected if you remove this.


QoR  bitcoin_miner_stratixiv_arch_timing (final wire length remains the same):
baseline: packing: 354.64, placement: 3706.12, routing 409.20, vpr flow: 4930.11
modified: packing: 356.83, placement: 3777.65, routing 412.23, vpr flow: 4994.61

