### PR TITLE
update fracturable LUT connectivity based on known legal external placements

### DIFF
--- a/vtr_flow/arch/ispd/ultrascale_ispd.xml
+++ b/vtr_flow/arch/ispd/ultrascale_ispd.xml
@@ -504,11 +504,12 @@
           </pb_type>
           <interconnect>
             <!-- Fracturable LUT connectivity: Based on Fig 3-1 of 'UltraScale Architecture CLB User Guide' UG574 (v1.5) -->
-            <direct name="I0" input="LUT6_2.I0" output="LUTX[0].I0 LUTX[1].I0"/>
-            <direct name="I1" input="LUT6_2.I1" output="LUTX[0].I1 LUTX[1].I1"/>
-            <direct name="I2" input="LUT6_2.I2" output="LUTX[0].I2 LUTX[1].I2"/>
-            <direct name="I3" input="LUT6_2.I3" output="LUTX[0].I3 LUTX[1].I3"/>
-            <direct name="I4" input="LUT6_2.I4" output="LUTX[0].I4 LUTX[1].I4"/>
+            <!-- UPDATED based on known legal external ISPD placements -->
+            <complete name="I0" input="LUT6_2.I0" output="LUTX[0].I0 LUTX[1].I0 LUTX[0].I1 LUTX[1].I1 LUTX[0].I2 LUTX[1].I2 LUTX[0].I3 LUTX[1].I3 LUTX[0].I4 LUTX[1].I4"/>
+            <complete name="I1" input="LUT6_2.I1" output="LUTX[0].I0 LUTX[1].I0 LUTX[0].I1 LUTX[1].I1 LUTX[0].I2 LUTX[1].I2 LUTX[0].I3 LUTX[1].I3 LUTX[0].I4 LUTX[1].I4"/>
+            <complete name="I2" input="LUT6_2.I2" output="LUTX[0].I0 LUTX[1].I0 LUTX[0].I1 LUTX[1].I1 LUTX[0].I2 LUTX[1].I2 LUTX[0].I3 LUTX[1].I3 LUTX[0].I4 LUTX[1].I4"/>
+            <complete name="I3" input="LUT6_2.I3" output="LUTX[0].I0 LUTX[1].I0 LUTX[0].I1 LUTX[1].I1 LUTX[0].I2 LUTX[1].I2 LUTX[0].I3 LUTX[1].I3 LUTX[0].I4 LUTX[1].I4"/>
+            <complete name="I4" input="LUT6_2.I4" output="LUTX[0].I0 LUTX[1].I0 LUTX[0].I1 LUTX[1].I1 LUTX[0].I2 LUTX[1].I2 LUTX[0].I3 LUTX[1].I3 LUTX[0].I4 LUTX[1].I4"/>
             <direct name="O6" input="LUTX[0].O" output="LUT6_2.O6"/>
             <direct name="O5" input="LUTX[1].O" output="LUT6_2.O5"/>
           </interconnect>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated fracturable LUT connectivity in order to successfully reconstruct known legal clusters.

#### Description
<!--- Describe your changes in detail -->
Added complete interconnect from fracturable LUT data inputs to data inputs for each half LUT.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Unable to reconstruct known legal RippleFPGA-generated clusters without this change.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Successfully reconstructed RippleFPGA solutions for all 12 ISPD benchmarks.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
