### PR TITLE
added bounds check for forced primitive site

### DIFF
--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -140,9 +140,15 @@ bool get_next_primitive_list(t_cluster_placement_stats* cluster_placement_stats,
                         continue;
                     }
 
-
                     /* check for force site match, if applicable */
                     if (force_site > -1) {
+                        /* check that the forced site index is within the available range */
+                        int max_site = it->second->pb_graph_node->total_primitive_count - 1;
+                        if (force_site > max_site) {
+                            VTR_LOG("The specified primitive site (%d) is out of range (max %d)\n",
+                                    force_site, max_site);
+                            break;
+                        }
                         if (force_site == it->second->pb_graph_node->flat_site_index) {
                             cost = try_place_molecule(molecule, it->second->pb_graph_node, primitives_list);
                             if (cost < HUGE_POSITIVE_FLOAT) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When seeking a primitive site matching a user-specified site index, verify that the index is within the available range for the primitive type within the current physical block type.

#### Description
<!--- Describe your changes in detail -->
Added a bounds check and error message.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A error message that alerts the user to out of bounds indices helps to identify indexing errors in externally generated flat placements.  For example, ISPD placement tools use different indexing for LUTs than is required by the legalizer.

#### How Has This Been Tested?
Tested by legalizing ISPD placements with and without out of bounds site indices.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
