### PR TITLE
Fix for Handling Missing Switch Types in RR Graph Builder

### DIFF
--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -1187,12 +1187,12 @@ void initial_placement(const t_placer_opts& placer_opts,
     clear_all_grid_locs();
 
     /* Go through cluster blocks to calculate the tightest placement
-     * floorplan constraint for each constrained block
-     */
+    * floorplan constraint for each constrained block
+    */
     propagate_place_constraints();
 
     /*Mark the blocks that have already been locked to one spot via floorplan constraints
-     * as fixed, so they do not get moved during initial placement or later during the simulated annealing stage of placement*/
+    * as fixed, so they do not get moved during initial placement or later during the simulated annealing stage of placement*/
     mark_fixed_blocks();
 
     // Compute and store compressed floorplanning constraints
@@ -1204,17 +1204,22 @@ void initial_placement(const t_placer_opts& placer_opts,
         read_constraints(constraints_file);
     }
 
-    if (noc_opts.noc) {
-        // NoC routers are placed before other blocks
-        initial_noc_placement(noc_opts, placer_opts);
-        propagate_place_constraints();
+    if(!placer_opts.read_initial_place_file.empty()) {
+        const auto& grid = g_vpr_ctx.device().grid;
+        read_place(nullptr, placer_opts.read_initial_place_file.c_str(), false, grid);
+    } else {
+        if (noc_opts.noc) {
+            // NoC routers are placed before other blocks
+            initial_noc_placement(noc_opts, placer_opts);
+            propagate_place_constraints();
+        }
+
+        //Assign scores to blocks and placement macros according to how difficult they are to place
+        vtr::vector<ClusterBlockId, t_block_score> block_scores = assign_block_scores();
+
+        //Place all blocks
+        place_all_blocks(placer_opts, block_scores, placer_opts.pad_loc_type, constraints_file);
     }
-
-    //Assign scores to blocks and placement macros according to how difficult they are to place
-    vtr::vector<ClusterBlockId, t_block_score> block_scores = assign_block_scores();
-
-    //Place all blocks
-    place_all_blocks(placer_opts, block_scores, placer_opts.pad_loc_type, constraints_file);
 
     alloc_and_load_movable_blocks();
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -272,7 +272,7 @@ static void connect_src_sink_to_pins(RRGraphBuilder& rr_graph_builder,
                                      t_rr_edge_info_set& rr_edges_to_create,
                                      const int delayless_switch,
                                      t_physical_tile_type_ptr physical_type_ptr,
-                                     bool is_remapped);
+                                     bool switches_remapped);
 
 static void alloc_and_load_tile_rr_graph(RRGraphBuilder& rr_graph_builder,
                                          std::map<int, t_arch_switch_inf>& arch_sw_inf_map,
@@ -381,7 +381,7 @@ static void add_pb_edges(RRGraphBuilder& rr_graph_builder,
                          int layer,
                          int i,
                          int j,
-                         bool is_remapped);
+                         bool switches_remapped);
 
 /**
  * Edges going in/out of collapse nodes are not added by the normal routine. This function add those edges
@@ -2039,7 +2039,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
     *Fc_clipped = false;
 
     /* This function is called to build the general routing graph resoruces. Thus, the edges are not remapped yet.*/
-    bool is_remapped = false;
+    bool switches_remapped = false;
 
     int num_edges = 0;
     /* Connection SINKS and SOURCES to their pins - Initializing IPINs/OPINs. */
@@ -2074,7 +2074,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
                                              rr_edges_to_create,
                                              delayless_switch,
                                              physical_tile,
-                                             is_remapped);
+                                             switches_remapped);
 
                     //Create the actual SOURCE->OPIN, IPIN->SINK edges
                     uniquify_edges(rr_edges_to_create);
@@ -2477,7 +2477,7 @@ static void connect_src_sink_to_pins(RRGraphBuilder& rr_graph_builder,
                                      t_rr_edge_info_set& rr_edges_to_create,
                                      const int delayless_switch,
                                      t_physical_tile_type_ptr physical_type_ptr,
-                                     bool is_remapped) {
+                                     bool switches_remapped) {
     for (auto class_num : class_num_vec) {
         const auto& pin_list = get_pin_list_from_class_physical_num(physical_type_ptr, class_num);
         auto class_type = get_class_type_from_class_physical_num(physical_type_ptr, class_num);
@@ -2497,11 +2497,11 @@ static void connect_src_sink_to_pins(RRGraphBuilder& rr_graph_builder,
             auto pin_type = get_pin_type_from_pin_physical_num(physical_type_ptr, pin_num);
             if (class_type == DRIVER) {
                 VTR_ASSERT(pin_type == DRIVER);
-                rr_edges_to_create.emplace_back(class_rr_node_id, pin_rr_node_id, delayless_switch, is_remapped);
+                rr_edges_to_create.emplace_back(class_rr_node_id, pin_rr_node_id, delayless_switch, switches_remapped);
             } else {
                 VTR_ASSERT(class_type == RECEIVER);
                 VTR_ASSERT(pin_type == RECEIVER);
-                rr_edges_to_create.emplace_back(pin_rr_node_id, class_rr_node_id, delayless_switch, is_remapped);
+                rr_edges_to_create.emplace_back(pin_rr_node_id, class_rr_node_id, delayless_switch, switches_remapped);
             }
         }
     }
@@ -2745,7 +2745,7 @@ static void add_pb_edges(RRGraphBuilder& rr_graph_builder,
                          int layer,
                          int i,
                          int j,
-                         bool is_remapped) {
+                         bool switches_remapped) {
     auto pin_num_range = get_pb_pins(physical_type,
                                      sub_tile,
                                      logical_block,
@@ -2799,7 +2799,7 @@ static void add_pb_edges(RRGraphBuilder& rr_graph_builder,
                                               pin_physical_num,
                                               conn_pin_physical_num);
 
-            if (is_remapped) {
+            if (switches_remapped) {
                 auto& all_sw_inf = g_vpr_ctx.mutable_device().all_sw_inf;
                 float delay = g_vpr_ctx.device().all_sw_inf.at(sw_idx).Tdel();
                 bool is_new_sw;
@@ -2807,10 +2807,10 @@ static void add_pb_edges(RRGraphBuilder& rr_graph_builder,
                                                                         all_sw_inf,
                                                                         R_minW_nmos,
                                                                         R_minW_pmos,
-                                                                        is_remapped,
+                                                                        switches_remapped,
                                                                         delay);
             }
-            rr_edges_to_create.emplace_back(parent_pin_node_id, conn_pin_node_id, sw_idx, is_remapped);
+            rr_edges_to_create.emplace_back(parent_pin_node_id, conn_pin_node_id, sw_idx, switches_remapped);
         }
     }
 }

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -677,8 +677,8 @@ static void build_intra_cluster_rr_graph(const t_graph_type graph_type,
  * @param det_routing_arch Contain the information from architecture file
  * @param load_rr_graph Indicate whether the RR graph is loaded from a file
  */
-static short get_delayless_switch_id (t_det_routing_arch* det_routing_arch, 
-                                        bool load_rr_graph);
+static int get_delayless_switch_id(t_det_routing_arch* det_routing_arch, 
+                                    bool load_rr_graph);
 
 /******************* Subroutine definitions *******************************/
 
@@ -765,7 +765,7 @@ void create_rr_graph(const t_graph_type graph_type,
     }
 
     if (is_flat) {
-        short delayless_switch = get_delayless_switch_id(det_routing_arch, load_rr_graph);
+        int delayless_switch = get_delayless_switch_id(det_routing_arch, load_rr_graph);
         VTR_ASSERT(delayless_switch != OPEN);
         build_intra_cluster_rr_graph(graph_type,
                                      grid,
@@ -1538,21 +1538,21 @@ static void build_intra_cluster_rr_graph(const t_graph_type graph_type,
                    is_flat);
 }
 
-static short get_delayless_switch_id (t_det_routing_arch* det_routing_arch,
-                                        bool load_rr_graph) {
+static int get_delayless_switch_id(t_det_routing_arch* det_routing_arch,
+                                    bool load_rr_graph) {
     const auto& device_ctx = g_vpr_ctx.device();
-    short delayless_switch;
+    int delayless_switch = OPEN;
     if (load_rr_graph) {
         const auto& rr_switches = device_ctx.rr_graph.rr_switch();
         for (size_t switch_id = 0; switch_id < rr_switches.size(); switch_id++){
             const auto& rr_switch = rr_switches[RRSwitchId(switch_id)];
             if (rr_switch.name.find("delayless") != std::string::npos) {
-                delayless_switch = static_cast<short>(switch_id);
+                delayless_switch = static_cast<int>(switch_id);
                 break;
             }
         }
     } else {
-        delayless_switch = det_routing_arch->delayless_switch;
+        delayless_switch = static_cast<int>(det_routing_arch->delayless_switch);
     }
 
     return delayless_switch;

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -671,6 +671,12 @@ static void build_intra_cluster_rr_graph(const t_graph_type graph_type,
                                          bool is_flat,
                                          bool load_rr_graph);
 
+/**
+ * Return the ID for delayess switch. If the RR graph is loaded from a file, then the assumption
+ * is that the returned ID should be a RR switch ID not architecture ID.
+ * @param det_routing_arch Contain the information from architecture file
+ * @param load_rr_graph Indicate whether the RR graph is loaded from a file
+ */
 static short get_delayless_switch_id (t_det_routing_arch* det_routing_arch, 
                                         bool load_rr_graph);
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -747,7 +747,7 @@ void create_rr_graph(const t_graph_type graph_type,
         short delayless_switch = OPEN;
         if (load_rr_graph) {
             const auto& rr_switches = device_ctx.rr_graph.rr_switch();
-            for (int switch_id = 0; switch_id < rr_switches.size(); switch_id++){
+            for (int switch_id = 0; switch_id < static_cast<int>(rr_switches.size()); switch_id++){
                 const auto& rr_switch = rr_switches[RRSwitchId(switch_id)];
                 if (rr_switch.name.find("delayless") != std::string::npos) {
                     delayless_switch = static_cast<short>(switch_id);
@@ -762,7 +762,7 @@ void create_rr_graph(const t_graph_type graph_type,
                                      grid,
                                      block_types,
                                      device_ctx.rr_graph,
-                                     det_routing_arch->delayless_switch,
+                                     delayless_switch,
                                      det_routing_arch->R_minW_nmos,
                                      det_routing_arch->R_minW_pmos,
                                      mutable_device_ctx.rr_graph_builder,
@@ -794,7 +794,7 @@ void create_rr_graph(const t_graph_type graph_type,
     // When this function is called in any stage other than routing, the is_flat flag passed to this function is false, regardless of the flag passed
     // through command line. So, the graph corresponding to global resources will be created and written down to file if needed. During routing, if flat-routing
     // is enabled, intra-cluster resources will be added to the graph, but this new bigger graph will not be written down.
-    if (!det_routing_arch->write_rr_graph_filename.empty() && !is_flat) {
+    if (!det_routing_arch->write_rr_graph_filename.empty()) {
         write_rr_graph(&mutable_device_ctx.rr_graph_builder,
                        &mutable_device_ctx.rr_graph,
                        device_ctx.physical_tile_types,

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -794,7 +794,7 @@ void create_rr_graph(const t_graph_type graph_type,
     // When this function is called in any stage other than routing, the is_flat flag passed to this function is false, regardless of the flag passed
     // through command line. So, the graph corresponding to global resources will be created and written down to file if needed. During routing, if flat-routing
     // is enabled, intra-cluster resources will be added to the graph, but this new bigger graph will not be written down.
-    if (!det_routing_arch->write_rr_graph_filename.empty()) {
+    if (!det_routing_arch->write_rr_graph_filename.empty() && !is_flat) {
         write_rr_graph(&mutable_device_ctx.rr_graph_builder,
                        &mutable_device_ctx.rr_graph,
                        device_ctx.physical_tile_types,


### PR DESCRIPTION
Previously, when the run-flat option was used and the RR graph was read from a file, the assumption was that all switch types (both inter-cluster and intra-cluster) were listed under the switch tag in the RR graph file. Consequently, when adding intra-cluster edges, if the RR graph builder encountered an edge that didn't have a corresponding switch type, it would throw an error.

In this PR, we removed this assumption. Now, if the RR graph builder cannot find a switch type, it will add a new RR switch type.

To test this PR, I used the Titan Murax circuit. The first run was with run-flat enabled, and the graph was built from scratch. For the second run, I first wrote the RR graph with run-flat disabled, so the RR graph file did not contain any of the intra-cluster switches. Then, I ran VPR with run-flat enabled again and read in the aforementioned RR graph. The routing results between these two runs were the same.
