### PR TITLE
[RR Graph] Add length attribute to segment tag

### DIFF
--- a/libs/librrgraph/src/io/gen/README.gen.md
+++ b/libs/librrgraph/src/io/gen/README.gen.md
@@ -2,4 +2,4 @@
 `rr_graph_uxsdcxx_interface.h` are generated via uxsdcxx and are checked in to
 avoid requiring python3 and the uxsdcxx depedencies to build VPR.
 
-See `vpr/src/route/gen/SCHEMA_GENERATOR.md` for details.
+See `$VTR_DIR/libs/librrgraph/src/base/SCHEMA_GENERATOR.md` for details.

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: /home/talaeikh/uxsdcxx/uxsdcxx.py /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 9c14a0ddd3c6bc1e690ca6abf467bae6
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
  */
 
 #include <functional>
@@ -247,8 +247,8 @@ constexpr const char *atok_lookup_t_segment_timing[] = {"C_per_meter", "R_per_me
 
 enum class gtok_t_segment {TIMING};
 constexpr const char *gtok_lookup_t_segment[] = {"timing"};
-enum class atok_t_segment {ID, NAME, RES_TYPE};
-constexpr const char *atok_lookup_t_segment[] = {"id", "name", "res_type"};
+enum class atok_t_segment {ID, LENGTH, NAME, RES_TYPE};
+constexpr const char *atok_lookup_t_segment[] = {"id", "length", "name", "res_type"};
 
 enum class gtok_t_segments {SEGMENT};
 constexpr const char *gtok_lookup_t_segments[] = {"segment"};
@@ -788,6 +788,24 @@ inline atok_t_segment lex_attr_t_segment(const char *in, const std::function<voi
 		switch(*((triehash_uu32*)&in[0])){
 		case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
 			return atok_t_segment::NAME;
+		break;
+		default: break;
+		}
+		break;
+	case 6:
+		switch(*((triehash_uu32*)&in[0])){
+		case onechar('l', 0, 32) | onechar('e', 8, 32) | onechar('n', 16, 32) | onechar('g', 24, 32):
+			switch(in[4]){
+			case onechar('t', 0, 8):
+				switch(in[5]){
+				case onechar('h', 0, 8):
+					return atok_t_segment::LENGTH;
+				break;
+				default: break;
+				}
+			break;
+			default: break;
+			}
 		break;
 		default: break;
 		}
@@ -2325,7 +2343,7 @@ inline void load_switch_required_attributes(const pugi::xml_node &root, int * id
 }
 
 inline void load_segment_required_attributes(const pugi::xml_node &root, int * id, const std::function<void(const char *)> * report_error){
-	std::bitset<3> astate = 0;
+	std::bitset<4> astate = 0;
 	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
 		atok_t_segment in = lex_attr_t_segment(attr.name(), report_error);
 		if(astate[(int)in] == 0) astate[(int)in] = 1;
@@ -2333,6 +2351,9 @@ inline void load_segment_required_attributes(const pugi::xml_node &root, int * i
 		switch(in){
 		case atok_t_segment::ID:
 			*id = load_int(attr.value(), report_error);
+			break;
+		case atok_t_segment::LENGTH:
+			/* Attribute length set after element init */
 			break;
 		case atok_t_segment::NAME:
 			/* Attribute name set after element init */
@@ -2343,7 +2364,7 @@ inline void load_segment_required_attributes(const pugi::xml_node &root, int * i
 		default: break; /* Not possible. */
 		}
 	}
-	std::bitset<3> test_astate = astate | std::bitset<3>(0b100);
+	std::bitset<4> test_astate = astate | std::bitset<4>(0b1010);
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_segment, report_error);
 }
 
@@ -2935,6 +2956,9 @@ inline void load_segment(const pugi::xml_node &root, T &out, Context &context, c
 		switch(in){
 		case atok_t_segment::ID:
 			/* Attribute id is already set */
+			break;
+		case atok_t_segment::LENGTH:
+			out.set_segment_length(load_int(attr.value(), report_error), context);
 			break;
 		case atok_t_segment::NAME:
 			out.set_segment_name(attr.value(), context);
@@ -4006,6 +4030,8 @@ inline void write_segments(T &in, std::ostream &os, Context &context){
 			auto child_context = in.get_segments_segment(i, context);
 			os << "<segment";
 			os << " id=\"" << in.get_segment_id(child_context) << "\"";
+			if((bool)in.get_segment_length(child_context))
+				os << " length=\"" << in.get_segment_length(child_context) << "\"";
 			os << " name=\"" << in.get_segment_name(child_context) << "\"";
 			if((bool)in.get_segment_res_type(child_context))
 				os << " res_type=\"" << lookup_segment_res_type[(int)in.get_segment_res_type(child_context)] << "\"";

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: /home/talaeikh/uxsdcxx/uxsdcap.py /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 9c14a0ddd3c6bc1e690ca6abf467bae6
+ * Cmdline: uxsdcxx/uxsdcap.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
  */
 
 #include <functional>
@@ -601,6 +601,7 @@ inline void load_segment_capnp_type(const ucap::Segment::Reader &root, T &out, C
 	(void)report_error;
 	(void)stack;
 
+	out.set_segment_length(root.getLength(), context);
 	out.set_segment_name(root.getName().cStr(), context);
 	out.set_segment_res_type(conv_enum_segment_res_type(root.getResType(), report_error), context);
 	stack->push_back(std::make_pair("getTiming", 0));
@@ -1101,6 +1102,8 @@ inline void write_segments_capnp_type(T &in, ucap::Segments::Builder &root, Cont
 		auto segments_segment = segments_segments[i];
 		auto child_context = in.get_segments_segment(i, context);
 		segments_segment.setId(in.get_segment_id(child_context));
+		if((bool)in.get_segment_length(child_context))
+			segments_segment.setLength(in.get_segment_length(child_context));
 		segments_segment.setName(in.get_segment_name(child_context));
 		if((bool)in.get_segment_res_type(child_context))
 			segments_segment.setResType(conv_to_enum_segment_res_type(in.get_segment_res_type(child_context)));

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: /home/talaeikh/uxsdcxx/uxsdcxx.py /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * md5sum of input file: 9c14a0ddd3c6bc1e690ca6abf467bae6
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
  */
 
 #include <functional>
@@ -245,11 +245,14 @@ public:
 	 *     <xs:element minOccurs="0" name="timing" type="segment_timing" />
 	 *   </xs:all>
 	 *   <xs:attribute name="id" type="xs:int" use="required" />
+	 *   <xs:attribute name="length" type="xs:int" />
 	 *   <xs:attribute name="name" type="xs:string" use="required" />
 	 *   <xs:attribute name="res_type" type="segment_res_type" />
 	 * </xs:complexType>
 	*/
 	virtual inline int get_segment_id(typename ContextTypes::SegmentReadContext &ctx) = 0;
+	virtual inline int get_segment_length(typename ContextTypes::SegmentReadContext &ctx) = 0;
+	virtual inline void set_segment_length(int length, typename ContextTypes::SegmentWriteContext &ctx) = 0;
 	virtual inline const char * get_segment_name(typename ContextTypes::SegmentReadContext &ctx) = 0;
 	virtual inline void set_segment_name(const char * name, typename ContextTypes::SegmentWriteContext &ctx) = 0;
 	virtual inline enum_segment_res_type get_segment_res_type(typename ContextTypes::SegmentReadContext &ctx) = 0;

--- a/libs/librrgraph/src/io/rr_graph.xsd
+++ b/libs/librrgraph/src/io/rr_graph.xsd
@@ -155,6 +155,7 @@
       <xs:element name="timing" type="segment_timing" minOccurs="0"/>
     </xs:all>
     <xs:attribute name="id" type="xs:int" use="required"/>
+    <xs:attribute name="length" type="xs:int"/>
     <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="res_type" type="segment_res_type"/>
   </xs:complexType>

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1357,7 +1357,13 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 segment->name.c_str(), name);
         }
     }
-    inline void set_segment_length(int /*length*/, const t_segment_inf*& /*segment*/) final {}
+    inline void set_segment_length(int length, const t_segment_inf*& segment) final {
+        if (segment->length != length) {
+            report_error(
+                "Architecture file does not match RR graph's length: arch uses %d, RR graph uses %d",
+                segment->length, length);
+        }
+    }
     inline uxsd::enum_segment_res_type get_segment_res_type(const t_segment_inf*& segment) final {
         return to_uxsd_segment_res_type(segment->res_type);
     }

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1347,6 +1347,9 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     inline const char* get_segment_name(const t_segment_inf*& segment) final {
         return segment->name.c_str();
     }
+    inline int get_segment_length(const t_segment_inf*& segment) final {
+        return segment->length;
+    }
     inline void set_segment_name(const char* name, const t_segment_inf*& segment) final {
         if (segment->name != name) {
             report_error(
@@ -1354,6 +1357,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 segment->name.c_str(), name);
         }
     }
+    inline void set_segment_length(int /*length*/, const t_segment_inf*& /*segment*/) final {}
     inline uxsd::enum_segment_res_type get_segment_res_type(const t_segment_inf*& segment) final {
         return to_uxsd_segment_res_type(segment->res_type);
     }

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -2,11 +2,11 @@
 # https://github.com/duck2/uxsdcxx
 # Modify only if your build process doesn't involve regenerating this file.
 #
-# Cmdline: /home/talaeikh/uxsdcxx/uxsdcap.py /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# Input file: /home/talaeikh/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# md5sum of input file: 9c14a0ddd3c6bc1e690ca6abf467bae6
+# Cmdline: uxsdcxx/uxsdcap.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
 
-@0xa136dd28cdc8783b;
+@0xe787bf7696810419;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -129,9 +129,10 @@ struct SegmentTiming {
 
 struct Segment {
 	id @0 :Int32;
-	name @1 :Text;
-	resType @2 :SegmentResType;
-	timing @3 :SegmentTiming;
+	length @1 :Int32;
+	name @2 :Text;
+	resType @3 :SegmentResType;
+	timing @4 :SegmentTiming;
 }
 
 struct Segments {


### PR DESCRIPTION
In this PR, the feature requested in issue #2503 has been implemented. To maintain backward compatibility, adding the `length` attribute is optional. However, if the attribute is included and the specified length is incompatible with the one in the architecture file, an error will be raised.