### PR TITLE
[Warnings] Cleaned Up Most Warnings in GCC-13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,11 +130,6 @@ endif()
 # Build type flags
 #
 
-set(EXTRA_FLAGS "")
-if(VPR_ENABLE_INTERCHANGE)
-    set(EXTRA_FLAGS "-lz")
-endif()
-
 if(NOT MSVC)
     # for GCC and Clang
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -g3")
@@ -298,6 +293,7 @@ endif()
 #
 # Increased debugging vebosity
 #
+set(EXTRA_FLAGS "")
 if(VTR_ENABLE_VERBOSE)
     set(EXTRA_FLAGS "${EXTRA_FLAGS} -DVTR_ENABLE_DEBUG_LOGGING")
     message(STATUS "Enabling increased debugging verbosity")

--- a/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.hpp
+++ b/libs/EXTERNAL/libtatum/libtatum/tatum/tags/TimingTags.hpp
@@ -113,6 +113,7 @@ class TimingTags {
                 using value_type = T;
                 using pointer = T*;
                 using reference = T&;
+                using const_reference = const T&;
 
                 Iterator(): p_(nullptr) {}
                 Iterator(pointer p): p_(p) {}
@@ -123,7 +124,7 @@ class TimingTags {
                 friend bool operator!=(Iterator a, Iterator b) { return a.p_ != b.p_; }
 
                 reference operator*() { return *p_; }
-                const reference operator*() const { return *p_; } //Required for MSVC (gcc/clang are fine with only the non-cost version)
+                const_reference operator*() const { return *p_; } //Required for MSVC (gcc/clang are fine with only the non-cost version)
                 pointer operator->() { return p_; }
                 reference operator[](size_t n) { return *(p_ + n); }
 

--- a/libs/libvqm/vqm_common.c
+++ b/libs/libvqm/vqm_common.c
@@ -559,7 +559,7 @@ void add_node(char* type, char *name, t_array_ref **ports, t_parse_info* parse_i
 				new_assoc->associated_net = net;
 				new_assoc->port_index = counter;
 				new_assoc->port_name = (char *) malloc(strlen(association->port_name)+1);
-				strcpy(new_assoc->port_name, (char*)malloc(strlen(association->port_name)));
+				strcpy(new_assoc->port_name, association->port_name);
 				new_assoc->wire_index = wire_index;
 				wire_index += change;
 				m_ports->array_size = insert_element_at_index((intptr_t) new_assoc, m_ports, counter);

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -109,21 +109,22 @@ endif ()
 set_target_properties(libvpr PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
 #Specify link-time dependencies
+find_package(ZLIB)
 target_link_libraries(libvpr
-                        libvtrutil
-                        libarchfpga
-                        libsdcparse
-                        libblifparse
-                        libtatum
-                        libargparse
-                        libpugixml
-                        librrgraph
+                      libvtrutil
+                      libarchfpga
+                      libsdcparse
+                      libblifparse
+                      libtatum
+                      libargparse
+                      libpugixml
+                      librrgraph
+                      ZLIB::ZLIB
 )
 
 if(VPR_USE_SERVER)
     target_link_libraries(libvpr
                           sockpp-static
-                          -lz
     )
 endif()
 

--- a/vpr/src/base/ShowSetup.h
+++ b/vpr/src/base/ShowSetup.h
@@ -1,6 +1,13 @@
 #ifndef SHOWSETUP_H
 #define SHOWSETUP_H
 
+#include <ostream>
+#include <string>
+#include <vector>
+
+class t_logical_block_type;
+class t_vpr_setup;
+
 struct ClusteredNetlistStats {
   private:
     void writeHuman(std::ostream& output) const;

--- a/vpr/src/draw/draw_rr.cpp
+++ b/vpr/src/draw/draw_rr.cpp
@@ -926,8 +926,7 @@ void draw_get_rr_pin_coords(const t_rr_node& node, float* xcen, float* ycen, con
 
         default:
             vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
-                      "in draw_get_rr_pin_coords: Unexpected side %s.\n",
-                      SIDE_STRING[pin_side]);
+                      "in draw_get_rr_pin_coords: Unexpected side.\n");
             break;
     }
 

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -138,7 +138,7 @@ static void power_usage_primitive(t_power_usage* power_usage, t_pb* pb, t_pb_gra
     if (strcmp(pb_graph_node->pb_type->blif_model, MODEL_NAMES) == 0) {
         /* LUT */
 
-        char* SRAM_values;
+        std::string SRAM_values;
         float* input_probabilities;
         float* input_densities;
         int LUT_size;
@@ -174,7 +174,6 @@ static void power_usage_primitive(t_power_usage* power_usage, t_pb* pb, t_pb_gra
                         power_ctx.arch->LUT_transistor_size, SRAM_values,
                         input_probabilities, input_densities, power_ctx.solution_inf.T_crit);
         power_add_usage(power_usage, &sub_power_usage);
-        delete[] SRAM_values;
         delete[] input_probabilities;
         delete[] input_densities;
     } else if (strcmp(pb_graph_node->pb_type->blif_model, MODEL_LATCH) == 0) {

--- a/vpr/src/power/power_components.cpp
+++ b/vpr/src/power/power_components.cpp
@@ -23,6 +23,7 @@
 /************************* INCLUDES *********************************/
 #include <cstring>
 #include <cmath>
+#include <string>
 
 #include "vtr_math.h"
 #include "vtr_assert.h"
@@ -203,7 +204,7 @@ void power_usage_ff(t_power_usage* power_usage, float size, float D_prob, float 
  * 7 _Z_|
  *
  */
-void power_usage_lut(t_power_usage* power_usage, int lut_size, float transistor_size, char* SRAM_values, float* input_prob, float* input_dens, float period) {
+void power_usage_lut(t_power_usage* power_usage, int lut_size, float transistor_size, std::string SRAM_values, float* input_prob, float* input_dens, float period) {
     float** internal_prob;
     float** internal_dens;
     float** internal_v;

--- a/vpr/src/power/power_components.h
+++ b/vpr/src/power/power_components.h
@@ -24,6 +24,7 @@
 #define __POWER_COMPONENTS_H__
 
 /************************* INCLUDES *********************************/
+#include <string>
 #include "power.h"
 #include "clustered_netlist.h"
 
@@ -82,7 +83,7 @@ void power_component_add_usage(t_power_usage* power_usage,
 float power_component_get_usage_sum(e_power_component_type component_idx);
 
 void power_usage_ff(t_power_usage* power_usage, float size, float D_prob, float D_dens, float Q_prob, float Q_dens, float clk_prob, float clk_dens, float period);
-void power_usage_lut(t_power_usage* power_usage, int LUT_size, float transistor_size, char* SRAM_values, float* input_densities, float* input_probabilities, float period);
+void power_usage_lut(t_power_usage* power_usage, int LUT_size, float transistor_size, std::string SRAM_values, float* input_densities, float* input_probabilities, float period);
 void power_usage_local_interc_mux(t_power_usage* power_usage, t_pb* pb, t_interconnect_pins* interc_pins, ClusterBlockId iblk);
 void power_usage_mux_multilevel(t_power_usage* power_usage,
                                 t_mux_arch* mux_arch,

--- a/vpr/src/power/power_util.cpp
+++ b/vpr/src/power/power_util.cpp
@@ -213,17 +213,17 @@ float calc_buffer_stage_effort(int N, float final_stage_size) {
  */
 char* alloc_SRAM_values_from_truth_table(int LUT_size,
                                          const AtomNetlist::TruthTable& truth_table) {
-    int num_SRAM_bits = 1 << LUT_size;
+    size_t num_SRAM_bits = 1 << LUT_size;
 
     //SRAM value stored as a string of '0' and '1' characters
     // Initialize to all zeros
     char* SRAM_values = new char[num_SRAM_bits + 1];
-    for (int i = 0; i < num_SRAM_bits + 1; i++)
+    for (size_t i = 0; i < num_SRAM_bits + 1; i++)
         SRAM_values[i] = '0';
     SRAM_values[num_SRAM_bits] = '\0';
 
     if (truth_table.empty()) {
-        for (int i = 0; i < num_SRAM_bits; i++) {
+        for (size_t i = 0; i < num_SRAM_bits; i++) {
             SRAM_values[i] = '1';
         }
         return SRAM_values;
@@ -237,7 +237,7 @@ char* alloc_SRAM_values_from_truth_table(int LUT_size,
         if (truth_table[0].size() == 1) {
             if (truth_table[0][0] == vtr::LogicValue::TRUE) {
                 //Mark all the SRAM values as ON
-                for (int i = 0; i < num_SRAM_bits; i++) {
+                for (size_t i = 0; i < num_SRAM_bits; i++) {
                     SRAM_values[i] = '1';
                 }
                 return SRAM_values;
@@ -250,7 +250,7 @@ char* alloc_SRAM_values_from_truth_table(int LUT_size,
     auto expanded_truth_table = expand_truth_table(truth_table, LUT_size);
     std::vector<vtr::LogicValue> lut_mask = truth_table_to_lut_mask(expanded_truth_table, LUT_size);
 
-    VTR_ASSERT(lut_mask.size() == (size_t)num_SRAM_bits);
+    VTR_ASSERT(lut_mask.size() == num_SRAM_bits);
 
     //Convert to string
     for (size_t i = 0; i < lut_mask.size(); ++i) {

--- a/vpr/src/power/power_util.cpp
+++ b/vpr/src/power/power_util.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <cmath>
 #include <map>
+#include <string>
 
 #include "vtr_assert.h"
 #include "vtr_memory.h"
@@ -211,16 +212,13 @@ float calc_buffer_stage_effort(int N, float final_stage_size) {
  *  - LUT_size: The number of LUT inputs
  *  - truth_table: The logic terms saved from the BLIF file
  */
-char* alloc_SRAM_values_from_truth_table(int LUT_size,
-                                         const AtomNetlist::TruthTable& truth_table) {
+std::string alloc_SRAM_values_from_truth_table(int LUT_size,
+                                               const AtomNetlist::TruthTable& truth_table) {
     size_t num_SRAM_bits = 1 << LUT_size;
 
     //SRAM value stored as a string of '0' and '1' characters
     // Initialize to all zeros
-    char* SRAM_values = new char[num_SRAM_bits + 1];
-    for (size_t i = 0; i < num_SRAM_bits + 1; i++)
-        SRAM_values[i] = '0';
-    SRAM_values[num_SRAM_bits] = '\0';
+    std::string SRAM_values(num_SRAM_bits, '0');
 
     if (truth_table.empty()) {
         for (size_t i = 0; i < num_SRAM_bits; i++) {

--- a/vpr/src/power/power_util.h
+++ b/vpr/src/power/power_util.h
@@ -23,6 +23,7 @@
 #define __POWER_UTIL_H__
 
 /************************* INCLUDES *********************************/
+#include <string>
 #include "power.h"
 #include "power_components.h"
 #include "atom_netlist.h"
@@ -63,8 +64,8 @@ bool power_method_is_transistor_level(e_power_estimation_method estimation_metho
 bool power_method_is_recursive(e_power_estimation_method method);
 
 const char* transistor_type_name(e_tx_type type);
-char* alloc_SRAM_values_from_truth_table(int LUT_size,
-                                         const AtomNetlist::TruthTable& truth_table);
+std::string alloc_SRAM_values_from_truth_table(int LUT_size,
+                                               const AtomNetlist::TruthTable& truth_table);
 float clb_net_density(ClusterNetId net_idx);
 const char* interconnect_type_name(enum e_interconnect type);
 float clb_net_prob(ClusterNetId net_idx);

--- a/vpr/src/route/route_path_manager.h
+++ b/vpr/src/route/route_path_manager.h
@@ -28,7 +28,7 @@ struct t_heap_path {
 };
 
 // Forward declaration of RoutingContext needed for traceback insertion
-class RoutingContext;
+struct RoutingContext;
 
 /* A class to manage the extra data required for RCV
  * It manages a set containing all the nodes that currently exist in the route tree

--- a/vpr/test/test_post_verilog.cpp
+++ b/vpr/test/test_post_verilog.cpp
@@ -4,6 +4,7 @@
 #include "timing_place_lookup.h"
 
 #include <fstream>
+#include <memory>
 
 namespace {
 
@@ -87,7 +88,7 @@ void copy_file(const std::string& src_fname, const std::string& dst_fname) {
     size_t size = src_file.tellg();
     src_file.seekg(0, std::ios_base::beg);
 
-    auto buf = std::unique_ptr<uint8_t>(new uint8_t[size]);
+    auto buf = std::make_unique<uint8_t[]>(size);
     src_file.read((char*)buf.get(), size);
     dst_file.write((char*)buf.get(), size);
 }


### PR DESCRIPTION
This PR resolves several small issues which were causing warnings in the GCC13 build. Trying to get GCC13 warning clean before we upgrade the CI.

This resolves the following warnings:
- Fixed incorrect forward declaration
- Fixed ambiguous unique pointer allocation
- Converted an int into a size_t
- Fixed array access out of bounds
- Fixed potential memory leak
- Changed C String to STD String
- Fixed const reference
- Removed -lz flag from compilation
- Added missing headers to a file

See each of the associated commits for more details.

There are still warnings coming from the nDMatrix class (discussed previously) which should be resolved in its own PR. There are also a couple of other small warnings which are slightly more complex to resolve.