### PR TITLE
fixed Issue When Re-Creating Elements in Atom and Clustered Netlists

### DIFF
--- a/vpr/src/base/atom_netlist.cpp
+++ b/vpr/src/base/atom_netlist.cpp
@@ -141,8 +141,9 @@ AtomBlockId AtomNetlist::create_block(const std::string& name, const t_model* mo
     AtomBlockId blk_id = Netlist::create_block(name);
 
     //Initialize the data
-    block_models_.push_back(model);
-    block_truth_tables_.push_back(truth_table);
+    // Use insert instead of push_back
+    block_models_.insert(blk_id, model);
+    block_truth_tables_.insert(blk_id, truth_table);
 
     //Check post-conditions: size
     VTR_ASSERT(validate_block_sizes());
@@ -174,7 +175,8 @@ AtomPortId AtomNetlist::create_port(const AtomBlockId blk_id, const t_model_port
     if (!port_id) {
         port_id = Netlist::create_port(blk_id, model_port->name, model_port->size, type);
 
-        port_models_.push_back(model_port);
+        // Use insert instead of push_back
+        port_models_.insert(port_id, model_port);
         associate_port_with_block(port_id, port_type(port_id), blk_id);
     }
 

--- a/vpr/src/base/atom_netlist.cpp
+++ b/vpr/src/base/atom_netlist.cpp
@@ -141,7 +141,7 @@ AtomBlockId AtomNetlist::create_block(const std::string& name, const t_model* mo
     AtomBlockId blk_id = Netlist::create_block(name);
 
     //Initialize the data
-    // Use insert instead of push_back
+    // Push back new data or overwrite existing data 
     block_models_.insert(blk_id, model);
     block_truth_tables_.insert(blk_id, truth_table);
 
@@ -175,7 +175,7 @@ AtomPortId AtomNetlist::create_port(const AtomBlockId blk_id, const t_model_port
     if (!port_id) {
         port_id = Netlist::create_port(blk_id, model_port->name, model_port->size, type);
 
-        // Use insert instead of push_back
+        // Push back new data or overwrite existing data 
         port_models_.insert(port_id, model_port);
         associate_port_with_block(port_id, port_type(port_id), blk_id);
     }

--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -165,7 +165,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
      */
 
     /**
-     * @brief Create or return an existing block in the netlist
+     * @brief Create or return an existing block in the netlist. If the block already exists, its associated data (model and truth table) will be overwritten.
      *
      *   @param name          The unique name of the block
      *   @param model         The primitive type of the block
@@ -176,7 +176,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomBlockId create_block(const std::string& name, const t_model* model, const TruthTable& truth_table = TruthTable());
 
     /**
-     * @brief Create or return an existing port in the netlist
+     * @brief Create or return an existing port in the netlist. If the port already exists, its associated data (model) will be overwritten.
      *
      *   @param blk_id      The block the port is associated with
      *   @param model_port  The model port the port is associated with
@@ -184,7 +184,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomPortId create_port(const AtomBlockId blk_id, const t_model_ports* model_port);
 
     /**
-     * @brief Create or return an existing pin in the netlist
+     * @brief Create or return an existing pin in the netlist.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port

--- a/vpr/src/base/clustered_netlist.cpp
+++ b/vpr/src/base/clustered_netlist.cpp
@@ -107,6 +107,7 @@ ClusterBlockId ClusteredNetlist::create_block(const char* name, t_pb* pb, t_logi
     if (blk_id == ClusterBlockId::INVALID()) {
         blk_id = Netlist::create_block(name);
 
+        // Push back new data or overwrite existing data
         block_pbs_.insert(blk_id, pb);
         block_types_.insert(blk_id, type);
 
@@ -144,7 +145,7 @@ ClusterPortId ClusteredNetlist::create_port(const ClusterBlockId blk_id, const s
 ClusterPinId ClusteredNetlist::create_pin(const ClusterPortId port_id, BitIndex port_bit, const ClusterNetId net_id, const PinType pin_type_, int pin_index, bool is_const) {
     ClusterPinId pin_id = Netlist::create_pin(port_id, port_bit, net_id, pin_type_, is_const);
 
-    // insert
+    // Push back new data or overwrite existing data
     pin_logical_index_.insert(pin_id, pin_index); 
 
     ClusterBlockId block_id = port_block(port_id);

--- a/vpr/src/base/clustered_netlist.cpp
+++ b/vpr/src/base/clustered_netlist.cpp
@@ -144,7 +144,8 @@ ClusterPortId ClusteredNetlist::create_port(const ClusterBlockId blk_id, const s
 ClusterPinId ClusteredNetlist::create_pin(const ClusterPortId port_id, BitIndex port_bit, const ClusterNetId net_id, const PinType pin_type_, int pin_index, bool is_const) {
     ClusterPinId pin_id = Netlist::create_pin(port_id, port_bit, net_id, pin_type_, is_const);
 
-    pin_logical_index_.push_back(pin_index);
+    // insert
+    pin_logical_index_.insert(pin_id, pin_index); 
 
     ClusterBlockId block_id = port_block(port_id);
     block_logical_pins_[block_id][pin_index] = pin_id;

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -175,7 +175,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
 
   public: //Public Mutators
     /**
-     * @brief Create or return an existing block in the netlist
+     * @brief Create or return an existing block in the netlist. If the block already exists, its associated data (physical block, type, and logical pins) will be overwritten.
      *
      *   @param name   The unique name of the block
      *   @param pb     The physical representation of the block
@@ -184,7 +184,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     ClusterBlockId create_block(const char* name, t_pb* pb, t_logical_block_type_ptr type);
 
     /**
-     * @brief Create or return an existing port in the netlist
+     * @brief Create or return an existing port in the netlist.
      *
      *   @param blk_id   The block the port is associated with
      *   @param name     The name of the port (must match the name of a port in the block's model)
@@ -193,7 +193,8 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
      */
     ClusterPortId create_port(const ClusterBlockId blk_id, const std::string& name, BitIndex width, PortType type);
     /**
-     * @brief Create or return an existing pin in the netlist
+     * @brief Create or return an existing pin in the netlist. If the pin already exists, its associated data (logical index) will be overwritten.
+ *
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
I fixed an issue in the AtomNetlist and ClusteredNetlist classes where the create methods (such as create_block, create_port, create_pin) used push_back to add elements to internal data structures. This caused a mismatch when a block, port, or pin with the same name was re-created, leading to potential crashes. The fix involved replacing push_back with insert to ensure that the internal data structures remain consistent even when elements are re-created.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #2690 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to prevent potential crashes and data inconsistencies in the AtomNetlist and ClusteredNetlist classes when blocks, ports, or pins are re-created
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested by running the VTR project's regression test suites
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
