### PR TITLE
[Prepacking] Re-Designed Prepacker API

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <mutex>
 
+#include "prepack.h"
 #include "vpr_types.h"
 #include "vtr_ndmatrix.h"
 #include "vtr_optional.h"
@@ -72,34 +73,17 @@ struct AtomContext : public Context {
     /********************************************************************
      * Atom Netlist
      ********************************************************************/
-    /**
-     * @brief constructor
-     *
-     * In the constructor initialize the list of pack molecules to nullptr and defines a custom deletor for it
-     */
-    AtomContext()
-        : list_of_pack_molecules(nullptr, free_pack_molecules) {}
-
-    ///@brief Atom netlist
+    /// @brief Atom netlist
     AtomNetlist nlist;
 
-    ///@brief Mappings to/from the Atom Netlist to physically described .blif models
+    /// @brief Mappings to/from the Atom Netlist to physically described .blif models
     AtomLookup lookup;
 
-    /**
-     * @brief The molecules associated with each atom block.
-     *
-     * This map is loaded in the pre-packing stage and freed at the very end of vpr flow run.
-     * The pointers in this multimap is shared with list_of_pack_molecules.
-     */
-    std::multimap<AtomBlockId, t_pack_molecule*> atom_molecules;
-
-    /**
-     * @brief A linked list of all the packing molecules that are loaded in pre-packing stage.
-     *
-     * Is is useful in freeing the pack molecules at the destructor of the Atom context using free_pack_molecules.
-     */
-    std::unique_ptr<t_pack_molecule, decltype(&free_pack_molecules)> list_of_pack_molecules;
+    /// @brief Prepacker object which performs prepacking and stores the pack
+    ///        molecules. Has a method to get the pack molecule of an AtomBlock.
+    /// TODO: This is mainly only used in the clusterer. It can probably be
+    ///       removed from the AtomContext entirely.
+    Prepacker prepacker;
 };
 
 /**

--- a/vpr/src/base/vpr_types.cpp
+++ b/vpr/src/base/vpr_types.cpp
@@ -452,15 +452,6 @@ void t_pb::set_atom_pin_bit_index(const t_pb_graph_pin* gpin, BitIndex atom_pin_
     pin_rotations_[gpin] = atom_pin_bit_idx;
 }
 
-void free_pack_molecules(t_pack_molecule* list_of_pack_molecules) {
-    t_pack_molecule* cur_pack_molecule = list_of_pack_molecules;
-    while (cur_pack_molecule != nullptr) {
-        cur_pack_molecule = list_of_pack_molecules->next;
-        delete list_of_pack_molecules;
-        list_of_pack_molecules = cur_pack_molecule;
-    }
-}
-
 /**
  * Free linked lists found in cluster_placement_stats_list
  */

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1848,11 +1848,6 @@ typedef vtr::vector<ClusterBlockId, std::vector<std::vector<RRNodeId>>> t_clb_op
 typedef std::vector<std::map<int, int>> t_arch_switch_fanin;
 
 /**
- * @brief Free the linked list that saves all the packing molecules.
- */
-void free_pack_molecules(t_pack_molecule* list_of_pack_molecules);
-
-/**
  * @brief Free the linked lists to placement locations based on status of primitive inside placement stats data structure.
  */
 void free_cluster_placement_stats(t_cluster_placement_stats* cluster_placement_stats);

--- a/vpr/src/pack/cluster.h
+++ b/vpr/src/pack/cluster.h
@@ -1,6 +1,6 @@
 #ifndef CLUSTER_H
 #define CLUSTER_H
-#include <unordered_map>
+
 #include <unordered_set>
 #include <map>
 #include <vector>
@@ -11,13 +11,14 @@
 #include "attraction_groups.h"
 #include "cluster_util.h"
 
+class Prepacker;
+
 std::map<t_logical_block_type_ptr, size_t> do_clustering(const t_packer_opts& packer_opts,
                                                          const t_analysis_opts& analysis_opts,
                                                          const t_arch* arch,
-                                                         t_pack_molecule* molecule_head,
+                                                         Prepacker& prepacker,
                                                          const std::unordered_set<AtomNetId>& is_clock,
                                                          const std::unordered_set<AtomNetId>& is_global,
-                                                         const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
                                                          bool allow_unrelated_clustering,
                                                          bool balance_block_type_utilization,
                                                          std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -1,9 +1,17 @@
 #include "cluster_util.h"
+#include <algorithm>
 
+#include "PreClusterTimingGraphResolver.h"
+#include "PreClusterDelayCalculator.h"
+#include "atom_netlist.h"
 #include "cluster_router.h"
 #include "cluster_placement.h"
+#include "concrete_timing_info.h"
 #include "output_clustering.h"
-
+#include "prepack.h"
+#include "tatum/TimingReporter.hpp"
+#include "tatum/echo_writer.hpp"
+#include "vpr_context.h"
 #include "vtr_math.h"
 #include "SetupGrid.h"
 
@@ -175,7 +183,7 @@ void check_clustering() {
 //calculate the initial timing at the start of packing stage
 void calc_init_packing_timing(const t_packer_opts& packer_opts,
                               const t_analysis_opts& analysis_opts,
-                              const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
+                              const Prepacker& prepacker,
                               std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc,
                               std::shared_ptr<SetupTimingInfo>& timing_info,
                               vtr::vector<AtomBlockId, float>& atom_criticality) {
@@ -184,7 +192,7 @@ void calc_init_packing_timing(const t_packer_opts& packer_opts,
     /*
      * Initialize the timing analyzer
      */
-    clustering_delay_calc = std::make_shared<PreClusterDelayCalculator>(atom_ctx.nlist, atom_ctx.lookup, packer_opts.inter_cluster_net_delay, expected_lowest_cost_pb_gnode);
+    clustering_delay_calc = std::make_shared<PreClusterDelayCalculator>(atom_ctx.nlist, atom_ctx.lookup, packer_opts.inter_cluster_net_delay, prepacker);
     timing_info = make_setup_timing_info(clustering_delay_calc, packer_opts.timing_update_type);
 
     //Calculate the initial timing
@@ -496,18 +504,14 @@ void add_molecule_to_pb_stats_candidates(t_pack_molecule* molecule,
 void alloc_and_init_clustering(const t_molecule_stats& max_molecule_stats,
                                t_cluster_placement_stats** cluster_placement_stats,
                                t_pb_graph_node*** primitives_list,
-                               t_pack_molecule* molecules_head,
+                               const Prepacker& prepacker,
                                t_clustering_data& clustering_data,
                                std::unordered_map<AtomNetId, int>& net_output_feeds_driving_block_input,
                                int& unclustered_list_head_size,
                                int num_molecules) {
     /* Allocates the main data structures used for clustering and properly *
      * initializes them.                                                   */
-
-    t_molecule_link* next_ptr;
-    t_pack_molecule* cur_molecule;
-    t_pack_molecule** molecule_array;
-    int max_molecule_size;
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
     /* alloc and load list of molecules to pack */
     clustering_data.unclustered_list_head = new t_molecule_link[max_molecule_stats.num_used_ext_inputs + 1];
@@ -518,36 +522,32 @@ void alloc_and_init_clustering(const t_molecule_stats& max_molecule_stats,
         clustering_data.unclustered_list_head[i].next = nullptr;
     }
 
-    molecule_array = new t_pack_molecule*[num_molecules];
-    cur_molecule = molecules_head;
-    for (int i = 0; i < num_molecules; i++) {
-        VTR_ASSERT(cur_molecule != nullptr);
-        molecule_array[i] = cur_molecule;
-        cur_molecule = cur_molecule->next;
-    }
-    VTR_ASSERT(cur_molecule == nullptr);
-    qsort((void*)molecule_array, num_molecules, sizeof(t_pack_molecule*),
-          compare_molecule_gain);
+    // Create a sorted list of molecules, sorted on increasing molecule base gain.
+    std::vector<t_pack_molecule*> molecules_vector = prepacker.get_molecules_vector();
+    VTR_ASSERT(molecules_vector.size() == (size_t)num_molecules);
+    std::stable_sort(molecules_vector.begin(),
+                     molecules_vector.end(),
+                     [](t_pack_molecule* a, t_pack_molecule* b) {
+                        return a->base_gain < b->base_gain;
+                     });
 
     clustering_data.memory_pool = new t_molecule_link[num_molecules];
-    next_ptr = clustering_data.memory_pool;
+    t_molecule_link* next_ptr = clustering_data.memory_pool;
 
-    for (int i = 0; i < num_molecules; i++) {
+    for (t_pack_molecule* mol : molecules_vector) {
         //Figure out how many external inputs are used by this molecule
-        t_molecule_stats molecule_stats = calc_molecule_stats(molecule_array[i]);
+        t_molecule_stats molecule_stats = calc_molecule_stats(mol, atom_ctx.nlist);
         int ext_inps = molecule_stats.num_used_ext_inputs;
 
         //Insert the molecule into the unclustered lists by number of external inputs
-        next_ptr->moleculeptr = molecule_array[i];
+        next_ptr->moleculeptr = mol;
         next_ptr->next = clustering_data.unclustered_list_head[ext_inps].next;
         clustering_data.unclustered_list_head[ext_inps].next = next_ptr;
 
         next_ptr++;
     }
-    delete[] molecule_array;
 
     /* load net info */
-    auto& atom_ctx = g_vpr_ctx.atom();
     for (AtomNetId net : atom_ctx.nlist.nets()) {
         AtomPinId driver_pin = atom_ctx.nlist.net_driver(net);
         AtomBlockId driver_block = atom_ctx.nlist.pin_block(driver_pin);
@@ -568,16 +568,9 @@ void alloc_and_init_clustering(const t_molecule_stats& max_molecule_stats,
      * primitive_list is referenced by index, for example a atom block in index 2 of a molecule matches to a primitive in index 2 in primitive_list
      * this array must be the size of the biggest molecule
      */
-    max_molecule_size = 1;
-    cur_molecule = molecules_head;
-    while (cur_molecule != nullptr) {
-        if (cur_molecule->num_blocks > max_molecule_size) {
-            max_molecule_size = cur_molecule->num_blocks;
-        }
-        cur_molecule = cur_molecule->next;
-    }
+    size_t max_molecule_size = prepacker.get_max_molecule_size();
     *primitives_list = new t_pb_graph_node*[max_molecule_size];
-    for (int i = 0; i < max_molecule_size; i++)
+    for (size_t i = 0; i < max_molecule_size; i++)
         (*primitives_list)[i] = nullptr;
 }
 
@@ -1120,8 +1113,8 @@ e_block_pack_status try_pack_molecule(t_cluster_placement_stats* cluster_placeme
                         if (molecule->atom_block_ids[i]) {
                             /* invalidate all molecules that share atom block with current molecule */
 
-                            auto rng = atom_ctx.atom_molecules.equal_range(molecule->atom_block_ids[i]);
-                            for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+                            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(molecule->atom_block_ids[i]);
+                            for (const auto& kv : mol_rng) {
                                 t_pack_molecule* cur_molecule = kv.second;
                                 cur_molecule->valid = false;
                             }
@@ -2324,8 +2317,8 @@ void add_cluster_molecule_candidates_by_connectivity_and_timing(t_pb* cur_pb,
 
     for (AtomBlockId blk_id : cur_pb->pb_stats->marked_blocks) {
         if (atom_ctx.lookup.atom_clb(blk_id) == ClusterBlockId::INVALID()) {
-            auto rng = atom_ctx.atom_molecules.equal_range(blk_id);
-            for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
+            for (const auto& kv : mol_rng) {
                 t_pack_molecule* molecule = kv.second;
                 if (molecule->valid) {
                     bool success = check_free_primitives_for_molecule_atoms(molecule, cluster_placement_stats_ptr);
@@ -2362,8 +2355,8 @@ void add_cluster_molecule_candidates_by_highfanout_connectivity(t_pb* cur_pb,
         AtomBlockId blk_id = atom_ctx.nlist.pin_block(pin_id);
 
         if (atom_ctx.lookup.atom_clb(blk_id) == ClusterBlockId::INVALID()) {
-            auto rng = atom_ctx.atom_molecules.equal_range(blk_id);
-            for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
+            for (const auto& kv : mol_rng) {
                 t_pack_molecule* molecule = kv.second;
                 if (molecule->valid) {
                     bool success = check_free_primitives_for_molecule_atoms(molecule, cluster_placement_stats_ptr);
@@ -2451,8 +2444,8 @@ void add_cluster_molecule_candidates_by_attraction_group(t_pb* cur_pb,
             //Only consider molecules that are unpacked and of the correct type
             if (atom_ctx.lookup.atom_clb(atom_id) == ClusterBlockId::INVALID()
                 && std::find(candidate_types.begin(), candidate_types.end(), cluster_type) != candidate_types.end()) {
-                auto rng = atom_ctx.atom_molecules.equal_range(atom_id);
-                for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+                auto mol_rng = atom_ctx.prepacker.get_atom_molecules(atom_id);
+                for (const auto& kv : mol_rng) {
                     t_pack_molecule* molecule = kv.second;
                     if (molecule->valid) {
                         bool success = check_free_primitives_for_molecule_atoms(molecule, cluster_placement_stats_ptr);
@@ -2486,8 +2479,8 @@ void add_cluster_molecule_candidates_by_attraction_group(t_pb* cur_pb,
         //Only consider molecules that are unpacked and of the correct type
         if (atom_ctx.lookup.atom_clb(blk_id) == ClusterBlockId::INVALID()
             && std::find(candidate_types.begin(), candidate_types.end(), cluster_type) != candidate_types.end()) {
-            auto rng = atom_ctx.atom_molecules.equal_range(blk_id);
-            for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
+            for (const auto& kv : mol_rng) {
                 t_pack_molecule* molecule = kv.second;
                 if (molecule->valid) {
                     bool success = check_free_primitives_for_molecule_atoms(molecule, cluster_placement_stats_ptr);
@@ -2604,25 +2597,9 @@ t_pack_molecule* get_molecule_for_cluster(t_pb* cur_pb,
     return best_molecule;
 }
 
-void mark_all_molecules_valid(t_pack_molecule* molecule_head) {
-    for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
-        cur_molecule->valid = true;
-    }
-}
-
-int count_molecules(t_pack_molecule* molecule_head) {
-    int num_molecules = 0;
-    for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
-        ++num_molecules;
-    }
-    return num_molecules;
-}
-
 //Calculates molecule statistics for a single molecule
-t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule) {
+t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule, const AtomNetlist& atom_nlist) {
     t_molecule_stats molecule_stats;
-
-    auto& atom_ctx = g_vpr_ctx.atom();
 
     //Calculate the number of available pins on primitives within the molecule
     for (auto blk : molecule->atom_block_ids) {
@@ -2630,7 +2607,7 @@ t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule) {
 
         ++molecule_stats.num_blocks; //Record number of valid blocks in molecule
 
-        const t_model* model = atom_ctx.nlist.block_model(blk);
+        const t_model* model = atom_nlist.block_model(blk);
 
         for (const t_model_ports* input_port = model->inputs; input_port != nullptr; input_port = input_port->next) {
             molecule_stats.num_input_pins += input_port->size;
@@ -2647,12 +2624,12 @@ t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule) {
     for (auto blk : molecule->atom_block_ids) {
         if (!blk) continue;
 
-        for (auto pin : atom_ctx.nlist.block_pins(blk)) {
-            auto net = atom_ctx.nlist.pin_net(pin);
+        for (auto pin : atom_nlist.block_pins(blk)) {
+            auto net = atom_nlist.pin_net(pin);
 
-            auto pin_type = atom_ctx.nlist.pin_type(pin);
+            auto pin_type = atom_nlist.pin_type(pin);
             if (pin_type == PinType::SINK) {
-                auto driver_blk = atom_ctx.nlist.net_driver_block(net);
+                auto driver_blk = atom_nlist.net_driver_block(net);
 
                 if (molecule_atoms.count(driver_blk)) {
                     //Pin driven by a block within the molecule
@@ -2666,8 +2643,8 @@ t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule) {
                 VTR_ASSERT(pin_type == PinType::DRIVER);
 
                 bool net_leaves_molecule = false;
-                for (auto sink_pin : atom_ctx.nlist.net_sinks(net)) {
-                    auto sink_blk = atom_ctx.nlist.pin_block(sink_pin);
+                for (auto sink_pin : atom_nlist.net_sinks(net)) {
+                    auto sink_blk = atom_nlist.pin_block(sink_pin);
 
                     if (!molecule_atoms.count(sink_blk)) {
                         //There is at least one sink outside of the current molecule
@@ -2689,33 +2666,10 @@ t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule) {
     return molecule_stats;
 }
 
-//Calculates maximum molecule statistics accross all molecules in linked list
-t_molecule_stats calc_max_molecules_stats(const t_pack_molecule* molecule_head) {
-    t_molecule_stats max_molecules_stats;
-
-    for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
-        //Calculate per-molecule statistics
-        t_molecule_stats cur_molecule_stats = calc_molecule_stats(cur_molecule);
-
-        //Record the maximums (member-wise) over all molecules
-        max_molecules_stats.num_blocks = std::max(max_molecules_stats.num_blocks, cur_molecule_stats.num_blocks);
-
-        max_molecules_stats.num_pins = std::max(max_molecules_stats.num_pins, cur_molecule_stats.num_pins);
-        max_molecules_stats.num_input_pins = std::max(max_molecules_stats.num_input_pins, cur_molecule_stats.num_input_pins);
-        max_molecules_stats.num_output_pins = std::max(max_molecules_stats.num_output_pins, cur_molecule_stats.num_output_pins);
-
-        max_molecules_stats.num_used_ext_pins = std::max(max_molecules_stats.num_used_ext_pins, cur_molecule_stats.num_used_ext_pins);
-        max_molecules_stats.num_used_ext_inputs = std::max(max_molecules_stats.num_used_ext_inputs, cur_molecule_stats.num_used_ext_inputs);
-        max_molecules_stats.num_used_ext_outputs = std::max(max_molecules_stats.num_used_ext_outputs, cur_molecule_stats.num_used_ext_outputs);
-    }
-
-    return max_molecules_stats;
-}
-
 std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_type,
                                                const t_molecule_stats& max_molecule_stats,
                                                const vtr::vector<AtomBlockId, float>& atom_criticality) {
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
     //Put all atoms in seed list
     std::vector<AtomBlockId> seed_atoms(atom_ctx.nlist.blocks().begin(), atom_ctx.nlist.blocks().end());
@@ -2733,11 +2687,11 @@ std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_type,
         //By number of used molecule input pins
         for (auto blk : atom_ctx.nlist.blocks()) {
             int max_molecule_inputs = 0;
-            auto molecule_rng = atom_ctx.atom_molecules.equal_range(blk);
-            for (const auto& kv : vtr::make_range(molecule_rng.first, molecule_rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk);
+            for (const auto& kv : mol_rng) {
                 const t_pack_molecule* blk_mol = kv.second;
 
-                const t_molecule_stats molecule_stats = calc_molecule_stats(blk_mol);
+                const t_molecule_stats molecule_stats = calc_molecule_stats(blk_mol, atom_ctx.nlist);
 
                 //Keep the max over all molecules associated with the atom
                 max_molecule_inputs = std::max(max_molecule_inputs, molecule_stats.num_used_ext_inputs);
@@ -2754,11 +2708,11 @@ std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_type,
             float seed_blend_fac = 0.5;
             float max_blend_gain = 0;
 
-            auto molecule_rng = atom_ctx.atom_molecules.equal_range(blk);
-            for (const auto& kv : vtr::make_range(molecule_rng.first, molecule_rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk);
+            for (const auto& kv : mol_rng) {
                 const t_pack_molecule* blk_mol = kv.second;
 
-                const t_molecule_stats molecule_stats = calc_molecule_stats(blk_mol);
+                const t_molecule_stats molecule_stats = calc_molecule_stats(blk_mol, atom_ctx.nlist);
 
                 VTR_ASSERT(max_molecule_stats.num_used_ext_inputs > 0);
 
@@ -2777,11 +2731,11 @@ std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_type,
 
         for (auto blk : atom_ctx.nlist.blocks()) {
             int max_molecule_pins = 0;
-            auto molecule_rng = atom_ctx.atom_molecules.equal_range(blk);
-            for (const auto& kv : vtr::make_range(molecule_rng.first, molecule_rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk);
+            for (const auto& kv : mol_rng) {
                 const t_pack_molecule* mol = kv.second;
 
-                const t_molecule_stats molecule_stats = calc_molecule_stats(mol);
+                const t_molecule_stats molecule_stats = calc_molecule_stats(mol, atom_ctx.nlist);
 
                 //Keep the max over all molecules associated with the atom
                 int molecule_pins = 0;
@@ -2803,11 +2757,11 @@ std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_type,
     } else if (seed_type == e_cluster_seed::BLEND2) {
         for (auto blk : atom_ctx.nlist.blocks()) {
             float max_gain = 0;
-            auto molecule_rng = atom_ctx.atom_molecules.equal_range(blk);
-            for (const auto& kv : vtr::make_range(molecule_rng.first, molecule_rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk);
+            for (const auto& kv : mol_rng) {
                 const t_pack_molecule* mol = kv.second;
 
-                const t_molecule_stats molecule_stats = calc_molecule_stats(mol);
+                const t_molecule_stats molecule_stats = calc_molecule_stats(mol, atom_ctx.nlist);
 
                 float pin_ratio = vtr::safe_ratio<float>(molecule_stats.num_pins, max_molecule_stats.num_pins);
                 float input_pin_ratio = vtr::safe_ratio<float>(molecule_stats.num_input_pins, max_molecule_stats.num_input_pins);
@@ -2880,8 +2834,8 @@ t_pack_molecule* get_highest_gain_seed_molecule(int& seed_index, const std::vect
 
             // Iterate over all the molecules associated with the selected atom
             // and select the one with the highest gain
-            auto rng = atom_ctx.atom_molecules.equal_range(blk_id);
-            for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
+            for (const auto& kv : mol_rng) {
                 t_pack_molecule* molecule = kv.second;
                 if (molecule->valid) {
                     if (best == nullptr || (best->base_gain) < (molecule->base_gain)) {
@@ -2959,24 +2913,6 @@ float get_molecule_gain(t_pack_molecule* molecule, std::map<AtomBlockId, float>&
     }
 
     return gain;
-}
-
-int compare_molecule_gain(const void* a, const void* b) {
-    float base_gain_a, base_gain_b, diff;
-    const t_pack_molecule *molecule_a, *molecule_b;
-    molecule_a = (*(const t_pack_molecule* const*)a);
-    molecule_b = (*(const t_pack_molecule* const*)b);
-
-    base_gain_a = molecule_a->base_gain;
-    base_gain_b = molecule_b->base_gain;
-    diff = base_gain_a - base_gain_b;
-    if (diff > 0) {
-        return 1;
-    }
-    if (diff < 0) {
-        return -1;
-    }
-    return 0;
 }
 
 /* Determine if speculatively packed cur_pb is pin feasible
@@ -3368,8 +3304,8 @@ void load_transitive_fanout_candidates(ClusterBlockId clb_index,
                                 } else {
                                     pb_stats->gain[blk_id] += 0.001;
                                 }
-                                auto rng = atom_ctx.atom_molecules.equal_range(blk_id);
-                                for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+                                auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
+                                for (const auto& kv : mol_rng) {
                                     t_pack_molecule* molecule = kv.second;
                                     if (molecule->valid) {
                                         transitive_fanout_candidates.insert({molecule->atom_block_ids[molecule->root], molecule});

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -1,18 +1,16 @@
 #ifndef CLUSTER_UTIL_H
 #define CLUSTER_UTIL_H
 
-#include "globals.h"
-#include "atom_netlist.h"
+#include <vector>
 #include "pack_types.h"
-#include "echo_files.h"
-#include "vpr_utils.h"
-#include "constraints_report.h"
+#include "vtr_vector.h"
 
-#include "concrete_timing_info.h"
-#include "PreClusterDelayCalculator.h"
-#include "PreClusterTimingGraphResolver.h"
-#include "tatum/echo_writer.hpp"
-#include "tatum/TimingReporter.hpp"
+class AtomNetId;
+class ClusterBlockId;
+class PreClusterDelayCalculator;
+class Prepacker;
+class SetupTimingInfo;
+class t_pack_molecule;
 
 /**
  * @file
@@ -113,7 +111,7 @@ void check_clustering();
 //calculate the initial timing at the start of packing stage
 void calc_init_packing_timing(const t_packer_opts& packer_opts,
                               const t_analysis_opts& analysis_opts,
-                              const std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
+                              const Prepacker& prepacker,
                               std::shared_ptr<PreClusterDelayCalculator>& clustering_delay_calc,
                               std::shared_ptr<SetupTimingInfo>& timing_info,
                               vtr::vector<AtomBlockId, float>& atom_criticality);
@@ -150,7 +148,7 @@ void remove_molecule_from_pb_stats_candidates(t_pack_molecule* molecule,
 void alloc_and_init_clustering(const t_molecule_stats& max_molecule_stats,
                                t_cluster_placement_stats** cluster_placement_stats,
                                t_pb_graph_node*** primitives_list,
-                               t_pack_molecule* molecules_head,
+                               const Prepacker& prepacker,
                                t_clustering_data& clustering_data,
                                std::unordered_map<AtomNetId, int>& net_output_feeds_driving_block_input,
                                int& unclustered_list_head_size,
@@ -437,13 +435,7 @@ t_pack_molecule* get_molecule_for_cluster(t_pb* cur_pb,
                                           const int& unclustered_list_head_size,
                                           std::map<const t_model*, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types);
 
-void mark_all_molecules_valid(t_pack_molecule* molecule_head);
-
-int count_molecules(t_pack_molecule* molecule_head);
-
-t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule);
-
-t_molecule_stats calc_max_molecules_stats(const t_pack_molecule* molecule_head);
+t_molecule_stats calc_molecule_stats(const t_pack_molecule* molecule, const AtomNetlist& atom_nlist);
 
 std::vector<AtomBlockId> initialize_seed_atoms(const e_cluster_seed seed_type,
                                                const t_molecule_stats& max_molecule_stats,
@@ -453,7 +445,6 @@ t_pack_molecule* get_highest_gain_seed_molecule(int& seed_index, const std::vect
 
 float get_molecule_gain(t_pack_molecule* molecule, std::map<AtomBlockId, float>& blk_gain, AttractGroupId cluster_attraction_group_id, AttractionInfo& attraction_groups, int num_molecule_failures);
 
-int compare_molecule_gain(const void* a, const void* b);
 int net_sinks_reachable_in_cluster(const t_pb_graph_pin* driver_pb_gpin, const int depth, const AtomNetId net_id);
 
 void print_seed_gains(const char* fname, const std::vector<AtomBlockId>& seed_atoms, const vtr::vector<AtomBlockId, float>& atom_gain, const vtr::vector<AtomBlockId, float>& atom_criticality);

--- a/vpr/src/pack/pack.h
+++ b/vpr/src/pack/pack.h
@@ -1,9 +1,11 @@
 #ifndef PACK_H
 #define PACK_H
+
 #include <vector>
 #include <unordered_set>
 #include "vpr_types.h"
-#include "atom_netlist_fwd.h"
+
+class AtomNetId;
 
 bool try_pack(t_packer_opts* packer_opts,
               const t_analysis_opts* analysis_opts,

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -6,16 +6,175 @@
 
 #ifndef PREPACK_H
 #define PREPACK_H
+
+#include <algorithm>
+#include <map>
 #include <unordered_map>
-#include "atom_netlist_fwd.h"
-#include "arch_types.h"
 #include "vpr_types.h"
+#include "vtr_range.h"
 
-std::vector<t_pack_patterns> alloc_and_load_pack_patterns();
-void free_list_of_pack_patterns(std::vector<t_pack_patterns>& list_of_pack_patterns);
-void free_pack_pattern(t_pack_patterns* pack_pattern);
+class AtomNetlist;
+class AtomBlockId;
+struct t_molecule_stats;
+struct t_logical_block_type;
 
-t_pack_molecule* alloc_and_load_pack_molecules(t_pack_patterns* list_of_pack_patterns,
-                                               std::unordered_map<AtomBlockId, t_pb_graph_node*>& expected_lowest_cost_pb_gnode,
-                                               const int num_packing_patterns);
+/**
+ * @brief Class that performs prepacking.
+ *
+ * This class maintains the prepacking state, allowing the use of molecules
+ * (prepacked atoms) while this object exists.
+ *
+ * To use the prepacker, call the init method with a complete atom netlist.
+ * Then maintain this object (do not reset or destroy it) so long as the molecules
+ * are needed:
+ *
+ * // Initialize device and atom netlist
+ * // ...
+ * Prepacker prepacker;
+ * prepacker.init(atom_ctx.nlist, device_ctx.logical_block_types);
+ * // ...
+ * // Use the prepacked molecules.
+ * // ...
+ * prepacker.reset(); // Or if the prepacker object is destroyed.
+ * // Prepacked molecules can no longer be used beyond this point.
+ *
+ */
+class Prepacker {
+    using atom_molecules_const_iterator = std::multimap<AtomBlockId, t_pack_molecule*>::const_iterator;
+public:
+    // The constructor is default, the init method performs prepacking.
+    Prepacker() = default;
+
+    // This class maintains pointers to internal data structures, and as such
+    // should not be copied or moved (prevents unsafe accesses).
+    Prepacker(const Prepacker&) = delete;
+    Prepacker& operator=(const Prepacker&) = delete;
+
+    /**
+     * @brief Performs prepacking.
+     *
+     * Initializes the prepacker by performing prepacking and allocating the
+     * necessary data strucutres.
+     *
+     *  @param atom_nlist           The atom netlist to prepack.
+     *  @param logical_block_types  A list of the logical block types on the device.
+     */
+    void init(const AtomNetlist& atom_nlist, const std::vector<t_logical_block_type> &logical_block_types);
+
+    /**
+     * @brief Get the cluster molecules containing the given atom block.
+     *
+     *  @param blk_id       The atom block to get the molecules of.
+     */
+    inline vtr::Range<atom_molecules_const_iterator> get_atom_molecules(AtomBlockId blk_id) const {
+        auto rng = atom_molecules.equal_range(blk_id);
+        return vtr::make_range(rng.first, rng.second);
+    }
+
+    /**
+     * @brief Get the expected lowest cost physical block graph node for the
+     *        given atom block.
+     *
+     *  @param blk_id       The atom block to get the pb graph node of.
+     */
+    inline t_pb_graph_node* get_expected_lowest_cost_pb_gnode(AtomBlockId blk_id) const {
+        auto iter = expected_lowest_cost_pb_gnode.find(blk_id);
+        VTR_ASSERT(iter != expected_lowest_cost_pb_gnode.end());
+        t_pb_graph_node* pb_gnode = iter->second;
+        VTR_ASSERT(pb_gnode != nullptr);
+        return pb_gnode;
+    }
+
+    /**
+     * @brief Returns the total number of molecules in the prepacker.
+     */
+    inline size_t get_num_molecules() const {
+        size_t num_molecules = 0;
+        t_pack_molecule* molecule_head = list_of_pack_molecules;
+        for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
+            ++num_molecules;
+        }
+        return num_molecules;
+    }
+
+    /**
+     * @brief Returns all of the molecules as a vector.
+     */
+    inline std::vector<t_pack_molecule*> get_molecules_vector() const {
+        std::vector<t_pack_molecule*> molecules;
+        t_pack_molecule* molecule_head = list_of_pack_molecules;
+        for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
+            molecules.push_back(cur_molecule);
+        }
+        return molecules;
+    }
+
+    /**
+     * @brief Marks all of the molecules as valid.
+     */
+    inline void mark_all_molecules_valid() {
+        t_pack_molecule* molecule_head = list_of_pack_molecules;
+        for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
+            cur_molecule->valid = true;
+        }
+    }
+
+    /**
+     * @brief Calculates maximum molecule statistics accross all molecules,
+     */
+    t_molecule_stats calc_max_molecule_stats(const AtomNetlist& netlist) const;
+
+    /**
+     * @brief Gets the largest number of blocks that any molecule has.
+     */
+    inline size_t get_max_molecule_size() const {
+        size_t max_molecule_size = 1;
+        t_pack_molecule* molecule_head = list_of_pack_molecules;
+        for (auto cur_molecule = molecule_head; cur_molecule != nullptr; cur_molecule = cur_molecule->next) {
+            max_molecule_size = std::max<size_t>(max_molecule_size, cur_molecule->num_blocks);
+        }
+        return max_molecule_size;
+    }
+
+    /**
+     * @brief Resets the prepacker object. Clearing all state.
+     *
+     * This resets the prepacker, allowing it to prepack again and also freeing
+     * any state.
+     */
+    void reset();
+
+    /// @brief Destructor of the prepacker class. Calls the reset method.
+    ~Prepacker() { reset(); }
+
+private:
+    /**
+     * @brief A linked list of all the packing molecules that are loaded in
+     *        prepacking stage.
+     *
+     * Is is useful in freeing the pack molecules at the destructor of the Atom
+     * context using free_pack_molecules.
+     *
+     * TODO: Instead of pointers, we should use some form of ID.
+     */
+    t_pack_molecule* list_of_pack_molecules = nullptr;
+
+    /**
+     * @brief The molecules associated with each atom block.
+     *
+     * This map is loaded in the prepacking stage and freed at the very end of
+     * vpr flow run. The pointers in this multimap is shared with
+     * list_of_pack_molecules.
+     */
+    std::multimap<AtomBlockId, t_pack_molecule*> atom_molecules;
+
+    /// @brief A map for the expected lowest cost physical block graph node.
+    std::unordered_map<AtomBlockId, t_pb_graph_node*> expected_lowest_cost_pb_gnode;
+
+    /// @brief A list of the pack patterns used for prepacking. I think the
+    ///        molecules keep pointers to this vector, so this needs to remain
+    ///        for the lifetime of the molecules.
+    std::vector<t_pack_patterns> list_of_pack_patterns;
+};
+
 #endif

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1556,8 +1556,8 @@ void revalid_molecules(const t_pb* pb) {
             atom_ctx.lookup.set_atom_clb(blk_id, ClusterBlockId::INVALID());
             atom_ctx.lookup.set_atom_pb(blk_id, nullptr);
 
-            auto rng = atom_ctx.atom_molecules.equal_range(blk_id);
-            for (const auto& kv : vtr::make_range(rng.first, rng.second)) {
+            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
+            for (const auto& kv : mol_rng) {
                 t_pack_molecule* cur_molecule = kv.second;
                 if (cur_molecule->valid == false) {
                     int i;

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1556,30 +1556,27 @@ void revalid_molecules(const t_pb* pb) {
             atom_ctx.lookup.set_atom_clb(blk_id, ClusterBlockId::INVALID());
             atom_ctx.lookup.set_atom_pb(blk_id, nullptr);
 
-            auto mol_rng = atom_ctx.prepacker.get_atom_molecules(blk_id);
-            for (const auto& kv : mol_rng) {
-                t_pack_molecule* cur_molecule = kv.second;
-                if (cur_molecule->valid == false) {
-                    int i;
-                    for (i = 0; i < get_array_size_of_molecule(cur_molecule); i++) {
-                        if (cur_molecule->atom_block_ids[i]) {
-                            if (atom_ctx.lookup.atom_clb(cur_molecule->atom_block_ids[i]) != ClusterBlockId::INVALID()) {
-                                break;
-                            }
+            t_pack_molecule* cur_molecule = atom_ctx.prepacker.get_atom_molecule(blk_id);
+            if (cur_molecule->valid == false) {
+                int i;
+                for (i = 0; i < get_array_size_of_molecule(cur_molecule); i++) {
+                    if (cur_molecule->atom_block_ids[i]) {
+                        if (atom_ctx.lookup.atom_clb(cur_molecule->atom_block_ids[i]) != ClusterBlockId::INVALID()) {
+                            break;
                         }
                     }
-                    /* All atom blocks are open for this molecule, place back in queue */
-                    if (i == get_array_size_of_molecule(cur_molecule)) {
-                        cur_molecule->valid = true;
-                        // when invalidating a molecule check if it's a chain molecule
-                        // that is part of a long chain. If so, check if this molecule
-                        // have modified the chain_id value based on the stale packing
-                        // then reset the chain id and the first packed molecule pointer
-                        // this is packing is being reset
-                        if (cur_molecule->is_chain() && cur_molecule->chain_info->is_long_chain && cur_molecule->chain_info->first_packed_molecule == cur_molecule) {
-                            cur_molecule->chain_info->first_packed_molecule = nullptr;
-                            cur_molecule->chain_info->chain_id = -1;
-                        }
+                }
+                /* All atom blocks are open for this molecule, place back in queue */
+                if (i == get_array_size_of_molecule(cur_molecule)) {
+                    cur_molecule->valid = true;
+                    // when invalidating a molecule check if it's a chain molecule
+                    // that is part of a long chain. If so, check if this molecule
+                    // have modified the chain_id value based on the stale packing
+                    // then reset the chain id and the first packed molecule pointer
+                    // this is packing is being reset
+                    if (cur_molecule->is_chain() && cur_molecule->chain_info->is_long_chain && cur_molecule->chain_info->first_packed_molecule == cur_molecule) {
+                        cur_molecule->chain_info->first_packed_molecule = nullptr;
+                        cur_molecule->chain_info->chain_id = -1;
                     }
                 }
             }

--- a/vpr/test/test_connection_router.cpp
+++ b/vpr/test/test_connection_router.cpp
@@ -193,8 +193,7 @@ TEST_CASE("connection_router", "[vpr]") {
                  vpr_setup);
 
     auto& atom_ctx = g_vpr_ctx.mutable_atom();
-    free_pack_molecules(atom_ctx.list_of_pack_molecules.release());
-    atom_ctx.atom_molecules.clear();
+    atom_ctx.prepacker.reset();
 }
 
 } // namespace

--- a/vpr/test/test_post_verilog.cpp
+++ b/vpr/test/test_post_verilog.cpp
@@ -37,8 +37,7 @@ void do_vpr_flow(const char* input_unc_opt, const char* output_unc_opt) {
 
     auto& atom_ctx = g_vpr_ctx.mutable_atom();
 
-    free_pack_molecules(atom_ctx.list_of_pack_molecules.release());
-    atom_ctx.atom_molecules.clear();
+    atom_ctx.prepacker.reset();
 
     REQUIRE(flow_succeeded == true);
 }

--- a/vpr/test/test_vpr.cpp
+++ b/vpr/test/test_vpr.cpp
@@ -171,8 +171,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
         vpr_free_all(arch, vpr_setup);
 
         auto& atom_ctx = g_vpr_ctx.mutable_atom();
-        free_pack_molecules(atom_ctx.list_of_pack_molecules.release());
-        atom_ctx.atom_molecules.clear();
+        atom_ctx.prepacker.reset();
     }
 
     REQUIRE(src_inode != -1);
@@ -236,8 +235,7 @@ TEST_CASE("read_rr_graph_metadata", "[vpr]") {
     vpr_free_all(arch, vpr_setup);
 
     auto& atom_ctx = g_vpr_ctx.mutable_atom();
-    free_pack_molecules(atom_ctx.list_of_pack_molecules.release());
-    atom_ctx.atom_molecules.clear();
+    atom_ctx.prepacker.reset();
 }
 
 } // namespace


### PR DESCRIPTION
The original Prepacker API created a lot of global variables which were confusing to work with and hard to maintain.

Created a Prepacker class which maintains the state of the Prepacker and provides methods to access prepacking information.

I also tried to remove the accesses to the global scope from within the prepacker to isolate it from the rest of VTR. This is in an attempt to make it easier to work with.