### PR TITLE
Fix compilation error with VTR_ASSERT_LEVEL=4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,11 @@ jobs:
             suite: 'vtr_reg_basic'
           },
           {
+            name: 'Basic with highest assertion level',
+            params: '-DCMAKE_COMPILE_WARNING_AS_ERROR=on -DVTR_ASSERT_LEVEL=4 -DWITH_BLIFEXPLORER=on',
+            suite: 'vtr_reg_basic'
+          },
+          {
             name: 'Basic_odin',
             params: '-DCMAKE_COMPILE_WARNING_AS_ERROR=on -DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DWITH_PARMYS=OFF -DWITH_ODIN=on',
             suite: 'vtr_reg_basic_odin'

--- a/vpr/src/place/place_timing_update.cpp
+++ b/vpr/src/place/place_timing_update.cpp
@@ -298,7 +298,7 @@ void update_td_costs(const PlaceDelayModel* delay_model,
 
 #ifdef VTR_ASSERT_DEBUG_ENABLED
     double check_timing_cost = 0.;
-    comp_td_costs(delay_model, place_crit, &check_timing_cost);
+    comp_td_costs(delay_model, place_crit, placer_state, &check_timing_cost);
     VTR_ASSERT_DEBUG_MSG(check_timing_cost == *timing_cost,
                          "Total timing cost calculated incrementally in update_td_costs() is "
                          "not consistent with value calculated from scratch in comp_td_costs()");


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2705).

The compilation error reported in the issues has been fixed. A new CI test compiler VTR with VTR_ASSERT_LEVEL=4 and tests vtr_reg_basic.
