### PR TITLE
Update Netlist Creation Function Documentation to Prevent Duplicates

### DIFF
--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -165,7 +165,9 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
      */
 
     /**
-     * @brief Create or return an existing block in the netlist
+     * @brief Create a new block in the netlist or returns an existing block.
+              If a block with the specified name already exists, its associated data
+              (model and truth table) will be overwritten with the provided data.
      *
      *   @param name          The unique name of the block
      *   @param model         The primitive type of the block
@@ -176,7 +178,9 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomBlockId create_block(const std::string& name, const t_model* model, const TruthTable& truth_table = TruthTable());
 
     /**
-     * @brief Create or return an existing port in the netlist
+     * @brief Create a new port in the netlist or return an existing port.
+     *        If a port with the specified name already exists for the given block, 
+     *        its associated data (model) will be overwritten with the provided data.
      *
      *   @param blk_id      The block the port is associated with
      *   @param model_port  The model port the port is associated with
@@ -184,7 +188,8 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomPortId create_port(const AtomBlockId blk_id, const t_model_ports* model_port);
 
     /**
-     * @brief Create or return an existing pin in the netlist
+     * @brief Create a new pin in the netlist or return an existing pin.
+     *        If a pin with the specified ID already exists, it is returned.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port

--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -166,8 +166,8 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
 
     /**
      * @brief Create a new block in the netlist or returns an existing block.
-              If a block with the specified name already exists, its associated data
-              (model and truth table) will be overwritten with the provided data.
+              If a block with the specified name already exists, the existing block's ID is returned
+              and no new block is created.
      *
      *   @param name          The unique name of the block
      *   @param model         The primitive type of the block
@@ -180,7 +180,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     /**
      * @brief Create a new port in the netlist or return an existing port.
      *        If a port with the specified name already exists for the given block, 
-     *        its associated data (model) will be overwritten with the provided data.
+     *        the existing port's ID is returned, and no new port is created.
      *
      *   @param blk_id      The block the port is associated with
      *   @param model_port  The model port the port is associated with
@@ -189,7 +189,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
 
     /**
      * @brief Create a new pin in the netlist or return an existing pin.
-     *        If a pin with the specified ID already exists, it is returned.
+     *        If a pin with the specified ID already exists, it is returned, and no new pin is created.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port

--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -165,9 +165,9 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
      */
 
     /**
-     * @brief Create a new block in the netlist or returns an existing block.
-              If a block with the specified name already exists, the existing block's ID is returned
-              and no new block is created.
+     * @brief Create a new block in the netlist.
+     * 
+     * @note If a block with the specified name already exists, the function will crash.
      *
      *   @param name          The unique name of the block
      *   @param model         The primitive type of the block
@@ -178,9 +178,9 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomBlockId create_block(const std::string& name, const t_model* model, const TruthTable& truth_table = TruthTable());
 
     /**
-     * @brief Create a new port in the netlist or return an existing port.
-     *        If a port with the specified name already exists for the given block, 
-     *        the existing port's ID is returned, and no new port is created.
+     * @brief Create a new port in the netlist.
+     *        
+     * @note If a port with the specified name already exists for the given block, the function will crash.
      *
      *   @param blk_id      The block the port is associated with
      *   @param model_port  The model port the port is associated with
@@ -188,8 +188,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomPortId create_port(const AtomBlockId blk_id, const t_model_ports* model_port);
 
     /**
-     * @brief Create a new pin in the netlist or return an existing pin.
-     *        If a pin with the specified ID already exists, it is returned, and no new pin is created.
+     * @brief Create a new pin in the netlist.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port
@@ -200,7 +199,7 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     AtomPinId create_pin(const AtomPortId port_id, BitIndex port_bit, const AtomNetId net_id, const PinType pin_type, bool is_const = false);
 
     /**
-     * @brief Create an empty, or return an existing net in the netlist
+     * @brief Create a net in the netlist
      *
      *   @param name   The unique name of the net
      */

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -175,7 +175,9 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
 
   public: //Public Mutators
     /**
-     * @brief Create or return an existing block in the netlist
+     * @brief Create a new block in the netlist or return an existing block.
+     *        If a block with the specified name already exists, its associated data
+     *        will be overwritten.
      *
      *   @param name   The unique name of the block
      *   @param pb     The physical representation of the block
@@ -184,7 +186,9 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     ClusterBlockId create_block(const char* name, t_pb* pb, t_logical_block_type_ptr type);
 
     /**
-     * @brief Create or return an existing port in the netlist
+     * @brief Create a new port in the netlist or return an existing port.
+     *        If a port with the specified name already exists for the given block,
+     *        its associated data will be overwritten.
      *
      *   @param blk_id   The block the port is associated with
      *   @param name     The name of the port (must match the name of a port in the block's model)
@@ -193,7 +197,8 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
      */
     ClusterPortId create_port(const ClusterBlockId blk_id, const std::string& name, BitIndex width, PortType type);
     /**
-     * @brief Create or return an existing pin in the netlist
+     * @brief Create a new pin in the netlist or return an existing pin.
+     *        If a pin with the specified ID already exists, its associated data will be overwritten.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -176,8 +176,8 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
   public: //Public Mutators
     /**
      * @brief Create a new block in the netlist or return an existing block.
-     *        If a block with the specified name already exists, its associated data
-     *        will be overwritten.
+     *        If a block with the specified name already exists, the existing block's ID is returned,
+     *        and no new block is created.
      *
      *   @param name   The unique name of the block
      *   @param pb     The physical representation of the block
@@ -188,7 +188,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     /**
      * @brief Create a new port in the netlist or return an existing port.
      *        If a port with the specified name already exists for the given block,
-     *        its associated data will be overwritten.
+     *        the existing port's ID is returned, and no new port is created.
      *
      *   @param blk_id   The block the port is associated with
      *   @param name     The name of the port (must match the name of a port in the block's model)
@@ -198,7 +198,8 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     ClusterPortId create_port(const ClusterBlockId blk_id, const std::string& name, BitIndex width, PortType type);
     /**
      * @brief Create a new pin in the netlist or return an existing pin.
-     *        If a pin with the specified ID already exists, its associated data will be overwritten.
+     *        If a pin with the specified ID already exists, the existing pin's ID is returned,
+     *        and no new pin is created.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -175,9 +175,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
 
   public: //Public Mutators
     /**
-     * @brief Create a new block in the netlist or return an existing block.
-     *        If a block with the specified name already exists, the existing block's ID is returned,
-     *        and no new block is created.
+     * @brief Create a new block in the netlist.
      *
      *   @param name   The unique name of the block
      *   @param pb     The physical representation of the block
@@ -186,9 +184,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     ClusterBlockId create_block(const char* name, t_pb* pb, t_logical_block_type_ptr type);
 
     /**
-     * @brief Create a new port in the netlist or return an existing port.
-     *        If a port with the specified name already exists for the given block,
-     *        the existing port's ID is returned, and no new port is created.
+     * @brief Create a new port in the netlist.
      *
      *   @param blk_id   The block the port is associated with
      *   @param name     The name of the port (must match the name of a port in the block's model)
@@ -197,9 +193,8 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
      */
     ClusterPortId create_port(const ClusterBlockId blk_id, const std::string& name, BitIndex width, PortType type);
     /**
-     * @brief Create a new pin in the netlist or return an existing pin.
-     *        If a pin with the specified ID already exists, the existing pin's ID is returned,
-     *        and no new pin is created.
+     * @brief Create a new pin in the netlist.
+     * @note If a pin with the specified ID already exists, the function will crash.
      *
      *   @param port_id    The port this pin is associated with
      *   @param port_bit   The bit index of the pin in the port
@@ -211,7 +206,7 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     ClusterPinId create_pin(const ClusterPortId port_id, BitIndex port_bit, const ClusterNetId net_id, const PinType pin_type, int pin_index, bool is_const = false);
 
     /**
-     * @brief Create an empty, or return an existing net in the netlist
+     * @brief Create a net in the netlist
      *
      *   @param name  The unique name of the net
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Updated the documentation for the AtomNetlist and ClusteredNetlist classes to reflect the new behavior of the create_* functions. The documentation now specifies that these functions will return the existing ID if an element (block, port, pin, or net) with the specified name or ID already exists, instead of creating a duplicate
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #2690 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The update was necessary to avoid performance issues caused by unnecessary duplicate creations in the netlist
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
