### PR TITLE
[TestScript] Enhanced the Robustness of the VTR Flow Log Parser Script

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/log_parse.py
+++ b/vtr_flow/scripts/python_libs/vtr/log_parse.py
@@ -23,6 +23,8 @@ class ParsePattern:
     def __init__(self, name, filename, regex_str, default_value=None):
         self._name = name
         self._filename = filename
+        # Look for the specified pattern somewhere in the line, but any characters
+        # can occur before and after it. Detailed in GitHub Issue #2743.
         self._regex = re.compile(f'^.*{regex_str}.*$')
         self._default_value = default_value
 

--- a/vtr_flow/scripts/python_libs/vtr/log_parse.py
+++ b/vtr_flow/scripts/python_libs/vtr/log_parse.py
@@ -23,7 +23,7 @@ class ParsePattern:
     def __init__(self, name, filename, regex_str, default_value=None):
         self._name = name
         self._filename = filename
-        self._regex = re.compile(regex_str)
+        self._regex = re.compile(f'^.*{regex_str}.*$')
         self._default_value = default_value
 
     def name(self):

--- a/vtr_flow/scripts/python_libs/vtr/parse_vtr_flow.py
+++ b/vtr_flow/scripts/python_libs/vtr/parse_vtr_flow.py
@@ -36,9 +36,6 @@ def parse_file_and_update_results(filename, patterns, results):
 
         with open(filepaths[0], "r") as file:
             for line in file:
-                while line[0] == "#":
-                    line = line[1:]
-
                 for parse_pattern in patterns:
                     match = parse_pattern.regex().match(line)
                     if match and match.groups():


### PR DESCRIPTION
Added affixes to the regex pattern string, i.e., `$.*(my pattern).*$` to ensure that the searched pattern is not strictly required to start from the beginning of the string or line; it only needs to be part of the line.

This makes the definition of the pattern rules easier and makes the VTR flow log parser more robust.

(The following texts are copied from #2743)

#### Current Behaviour

The VTR flow log parser currently *only* parses/matches the regex pattern starting from:
- either the beginning of the line, e.g., `(my pattern)...`
- or the character right after one or multiple #, e.g., `#### (my pattern)...`

(Note: The parse function and a brief intro of how the VTR log parser works can be found in the appendix.)

The above assumptions can break the parser in some cases, causing chaotic failures in the regression test.

#### Problematic Situation

If someone accidentally prints a few characters at the beginning of the line or someone doesn't know the assumptions made in the log parser, the log parser will *make a hard life* to the regression testing.

PS: This guy is me. I did something stupid causing parsing issues, as mentioned in https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2720#issuecomment-2364570242 and https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2720#discussion_r1769605417.

#### Possible Solution
<!--- Not obligatory, but suggest ideas for how to implement the feature, -->
<!--- or alternative solutions you have considered. -->

Let's say we have the following script (actually derived from the real case in #2720) not capturing the value `0.70`:

```python3
import re
line='.# Routing took 0.70 seconds (max_rss 81.2 MiB, delta_rss +0.0 MiB)'
regex = re.compile(r'\s*Routing took (.*) seconds')
match = regex.match(line)
if match and match.groups():
    print(match.groups()[0])
```

We can correct this by adding affixes to the regex pattern string to indicate that the pattern is *part of* the string/line:
```python3
import re
line='.# Routing took 0.70 seconds (max_rss 81.2 MiB, delta_rss +0.0 MiB)'
regex = re.compile(r'^.*\s*Routing took (.*) seconds.*$') # Added a prefix '^.*' and a suffix '.*$'
match = regex.match(line)
if match and match.groups():
    print(match.groups()[0])
```

`^` and `$` indicate the beginning and the end of the string/line, respectively. Though the suffix can be removed, I prefer to keep it to explicitly say that our pattern only has to be *part of* the line.

Performance concerns: compared to the previous version, it is theatrically slower due to more work to do; however, since the regex pattern has been pre-compiled, the overhead should be that significant. Plus, the improved robustness is worth the overhead.

#### Appendix

The parse function can be found here:
https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/2c2af51e03cee9fcc4d479d78a6d53b099089a92/vtr_flow/scripts/python_libs/vtr/parse_vtr_flow.py#L18-L46

Regarding the `parse_pattern.regex().match(line)`, the `parse_pattern.regex()` is just a pre-compiled regex as shown in: https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/2c2af51e03cee9fcc4d479d78a6d53b099089a92/vtr_flow/scripts/python_libs/vtr/log_parse.py#L20-L43

An example of this `ParsePattern` object can be `ParsePattern('crit_path_route_time', '/path/to/vpr.crit_path.out', '\s*Routing took (.*) seconds', None)` based on this rule: https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/2c2af51e03cee9fcc4d479d78a6d53b099089a92/vtr_flow/parse/parse_config/timing/vpr.route_relaxed_chan_width.txt#L29
