### PR TITLE
[CI] Sanitizer Update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,10 +288,14 @@ jobs:
         include: [
           {
             name: 'Basic',
-            params: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on -DWITH_PARMYS=OFF -DWITH_ODIN=on',
-            suite: 'vtr_reg_basic_odin'
+            params: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DWITH_BLIFEXPLORER=on',
+            suite: 'vtr_reg_basic'
+          },
+          {
+            name: 'Strong',
+            params: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DWITH_BLIFEXPLORER=on',
+            suite: 'vtr_reg_strong'
           }
-          #- { name: 'Strong', suite: 'vtr_reg_strong' } # SKIP Too long to run on GitHub Actions (max 6h)
         ]
 
 


### PR DESCRIPTION
Updated the sanitizer to use the standard VTR flow (without Odin) instead of with Odin.

Turned on the Strong tests as well to get better sanitizer coverage. This test was originally turned off since it took too long. Will use a PR to investigate how long this takes.