### PR TITLE
Increase read buffer to reduce total syscalls

### DIFF
--- a/libs/libpugiutil/src/pugixml_loc.cpp
+++ b/libs/libpugiutil/src/pugixml_loc.cpp
@@ -30,7 +30,7 @@ void loc_data::build_loc_data() {
 
     std::ptrdiff_t offset = 0;
 
-    char buffer[1024];
+    char buffer[1048576];
     std::size_t size;
 
     while ((size = fread(buffer, 1, sizeof(buffer), f)) > 0) {

--- a/libs/libvtrutil/src/vtr_digest.cpp
+++ b/libs/libvtrutil/src/vtr_digest.cpp
@@ -21,7 +21,7 @@ std::string secure_digest_stream(std::istream& is) {
     //Read the stream in chunks and calculate the SHA256 digest
     picosha2::hash256_one_by_one hasher;
 
-    std::array<char, 1024> buf;
+    std::array<char, 1048576> buf;
     while (!is.eof()) {
         //Process a chunk
         is.read(buf.data(), buf.size());


### PR DESCRIPTION
This patch reduces read syscalls by 96%. `strace` showed that we were doing small incremental reads of large files:

```
openat(AT_FDCWD, "stratixiv_arch.timing.xml", O_RDONLY) = 5
read(5, "<architecture>\n  <models>\n    <!"..., 8191) = 8191
read(5, "sink_ports=\"eccstatus portbdatao"..., 8191) = 8191
read(5, "rtbdataout\" clock=\"clk_portbout\""..., 8191) = 8191
read(5, "ortbdataout\"/>\n        <port nam"..., 8191) = 8191
read(5, "ombinational_sink_ports=\"eccstat"..., 8191) = 8191
read(5, "nal_sink_ports=\"eccstatus portbd"..., 8191) = 8191
...
```
This might have been fine 20 years ago, but we can modernize it. Increasing the buffer size reduces the total number of syscalls, which helps in scale-out scenarios with many copies of vpr running on the same system. With this patch, strace looks like:
```
openat(AT_FDCWD, "stratixiv_arch.timing.xml", O_RDONLY) = 5
read(5, "<architecture>\n  <models>\n    <!"..., 1048576) = 1048576
```

Another win comes with in libblifparse, which is reading in large blif files. I was able to modify my generated yacc output, however I cannot figure out the correct way to capture this upstream in the build:
```
--- a/src/vtr-vpr/libs/EXTERNAL/libblifparse/src/blif_lexer.gen.cpp
+++ b/src/vtr-vpr/libs/EXTERNAL/libblifparse/src/blif_lexer.gen.cpp
@@ -971,12 +971,7 @@ static int input ( yyscan_t yyscanner );
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
-#ifdef __ia64__
-/* On IA-64, the buffer size is 16k, not 8k */
-#define YY_READ_BUF_SIZE 16384
-#else
-#define YY_READ_BUF_SIZE 8192
-#endif /* __ia64__ */
+#define YY_READ_BUF_SIZE 1048576
 #endif
```
Just set all the buffer sizes to 1MB, not sure why ia64 has to be different.