### PR TITLE
Add Z Cost to Placement Cost Function [WIP]

### DIFF
--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -1395,6 +1395,8 @@ double NetCostHandler::get_net_cube_bb_cost_(ClusterNetId net_id, bool use_ts) {
 
     const t_bb& bb = use_ts ? ts_bb_coord_new_[net_id] : placer_state_.move().bb_coords[net_id];
 
+    const bool is_multi_layer = (g_vpr_ctx.device().grid.get_num_layers() > 1);
+
     double crossing = wirelength_crossing_count(cluster_ctx.clb_nlist.net_pins(net_id).size());
 
     /* Could insert a check for xmin == xmax.  In that case, assume  *
@@ -1413,6 +1415,9 @@ double NetCostHandler::get_net_cube_bb_cost_(ClusterNetId net_id, bool use_ts) {
     double ncost;
     ncost = (bb.xmax - bb.xmin + 1) * crossing * chanx_place_cost_fac_[bb.ymax][bb.ymin - 1];
     ncost += (bb.ymax - bb.ymin + 1) * crossing * chany_place_cost_fac_[bb.xmax][bb.xmin - 1];
+    if (is_multi_layer) {
+        ncost += (bb.layer_max - bb.layer_min) * crossing * chanz_place_cost_fac_[bb.xmax][bb.ymax][bb.xmin][bb.ymin];
+    }
 
     return ncost;
 }

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -240,6 +240,16 @@ static void alloc_and_load_for_fast_vertical_cost_update(float place_cost_exp, v
     const auto& rr_graph = device_ctx.rr_graph;
     vtr::NdMatrix<float, 2> tile_num_inter_die_conn({device_ctx.grid.width(),
                                                      device_ctx.grid.height()}, 0);
+    
+    const int grid_height = device_ctx.grid.height();
+    const int grid_width = device_ctx.grid.width();
+
+
+    chanz_place_cost_fac = vtr::NdOffsetMatrix<float, 4>({{{0, grid_width-1}, 
+                                                         {0, grid_height-1}, 
+                                                         {0, grid_width-1}, 
+                                                         {0, grid_height-1}}}
+                                                        );                                    
 
     for (const auto& src_rr_node : rr_graph.nodes()) {
         for (const auto& rr_edge_idx : rr_graph.configurable_edges(src_rr_node)) {
@@ -265,10 +275,10 @@ static void alloc_and_load_for_fast_vertical_cost_update(float place_cost_exp, v
         }
     }
 
-    for (int x_high = 1; x_high < (int)device_ctx.grid.width(); x_high++) {
-        for (int y_high = 1; y_high < (int)device_ctx.grid.height(); y_high++) {
-                for (int x_low = 0; x_low < x_high; x_low++) {
-                    for (int y_low = 0; y_low < y_high; y_low++) {
+    for (int x_high = 0; x_high < (int)device_ctx.grid.width(); x_high++) {
+        for (int y_high = 0; y_high < (int)device_ctx.grid.height(); y_high++) {
+                for (int x_low = 0; x_low <= x_high; x_low++) {
+                    for (int y_low = 0; y_low <= y_high; y_low++) {
                         int num_inter_die_conn = 0;
                         for (int x = x_low; x <= x_high; x++) {
                             for (int y = y_low; y <= y_high; y++) {

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -237,8 +237,8 @@ void NetCostHandler::alloc_and_load_for_fast_vertical_cost_update_(float place_c
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
     
-    const int grid_height = device_ctx.grid.height();
-    const int grid_width = device_ctx.grid.width();
+    const size_t grid_height = device_ctx.grid.height();
+    const size_t grid_width = device_ctx.grid.width();
 
 
     chanz_place_cost_fac_ = vtr::NdMatrix<float, 4>({grid_width, grid_height, grid_width, grid_height}, 0.);

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -195,6 +195,7 @@ class NetCostHandler {
      */
     vtr::NdOffsetMatrix<float, 2> chanx_place_cost_fac_; // [-1...device_ctx.grid.width()-1]
     vtr::NdOffsetMatrix<float, 2> chany_place_cost_fac_; // [-1...device_ctx.grid.height()-1]
+    vtr::NdOffsetMatrix<float, 2> chanz_place_cost_fac_; // [-1...device_ctx.grid.get_num_layers()-1]
 
 
   private:

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -195,7 +195,7 @@ class NetCostHandler {
      */
     vtr::NdOffsetMatrix<float, 2> chanx_place_cost_fac_; // [-1...device_ctx.grid.width()-1]
     vtr::NdOffsetMatrix<float, 2> chany_place_cost_fac_; // [-1...device_ctx.grid.height()-1]
-    vtr::NdOffsetMatrix<float, 2> chanz_place_cost_fac_; // [-1...device_ctx.grid.get_num_layers()-1]
+    vtr::NdOffsetMatrix<float, 4> chanz_place_cost_fac_; // [-1...device_ctx.grid.get_num_layers()-1]
 
 
   private:

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -195,7 +195,13 @@ class NetCostHandler {
      */
     vtr::NdOffsetMatrix<float, 2> chanx_place_cost_fac_; // [-1...device_ctx.grid.width()-1]
     vtr::NdOffsetMatrix<float, 2> chany_place_cost_fac_; // [-1...device_ctx.grid.height()-1]
-    vtr::NdOffsetMatrix<float, 4> chanz_place_cost_fac_; // [0...device_ctx.grid.width()-1][0...device_ctx.grid.height()-1][0...device_ctx.grid.width()-1][0...device_ctx.grid.height()-1]
+    /**
+      @brief This data structure functions similarly to the matrices described above 
+      but is applied to 3D connections linking different FPGA layers. It is used in the 
+      placement cost function calculation, where the height of the bounding box is divided 
+      by the average number of inter-die connections within the bounding box.
+     */
+    vtr::NdMatrix<float, 4> chanz_place_cost_fac_; // [0...device_ctx.grid.width()-1][0...device_ctx.grid.height()-1][0...device_ctx.grid.width()-1][0...device_ctx.grid.height()-1]
 
 
   private:
@@ -249,6 +255,18 @@ class NetCostHandler {
      * a higher value would favour wider channels more over narrower channels during placement (usually we use 1).
      */
     void alloc_and_load_chan_w_factors_for_place_cost_(float place_cost_exp);
+
+    /**
+    * @brief Allocates and loads the chanz_place_cost_fac array with the inverse of
+    * the average number of inter-die connections between [subhigh] and [sublow].
+    *
+    * @details This is only useful for multi-die FPGAs. The place_cost_exp factor specifies to
+    * what power the average number of inter-die connections should be take -- larger numbers make narrower channels more expensive.
+    *
+    * @param place_cost_exp It is an exponent to which you take the average number of inter-die connections;
+    * a higher value would favour areas with more inter-die connections over areas with less of those during placement (usually we use 1).
+    */
+    void alloc_and_load_for_fast_vertical_cost_update_(float place_cost_exp);
 
     /**
      * @brief Calculate the new connection delay and timing cost of all the

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -195,7 +195,7 @@ class NetCostHandler {
      */
     vtr::NdOffsetMatrix<float, 2> chanx_place_cost_fac_; // [-1...device_ctx.grid.width()-1]
     vtr::NdOffsetMatrix<float, 2> chany_place_cost_fac_; // [-1...device_ctx.grid.height()-1]
-    vtr::NdOffsetMatrix<float, 4> chanz_place_cost_fac_; // [-1...device_ctx.grid.get_num_layers()-1]
+    vtr::NdOffsetMatrix<float, 4> chanz_place_cost_fac_; // [0...device_ctx.grid.width()-1][0...device_ctx.grid.height()-1][0...device_ctx.grid.width()-1][0...device_ctx.grid.height()-1]
 
 
   private:


### PR DESCRIPTION
When using 3D architectures, two types of bounding boxes are available: per-layer and cube bounding boxes. For the cube bounding box, the cost function previously depended only on the bounding box's dx and dy dimensions, with dz being ignored. In this PR, we added chanz_place_cost_fac_ to the NetCostHandler class, which contains the inverse of the average number of inter-die connections for each [subheight][sublow] pair. This data structure is multiplied by the bounding box’s dz and added to the placement cost.
QoR:
3D SIV without Z cost vs 3D SIV with Z cost:
<img width="499" alt="3d" src="https://github.com/user-attachments/assets/204816c2-1e05-4478-a0dd-1d02a4d90baf">
