### PR TITLE
Fix manual move

### DIFF
--- a/vpr/src/draw/manual_moves.cpp
+++ b/vpr/src/draw/manual_moves.cpp
@@ -5,7 +5,7 @@
  * @brief 	Contains the function definitions needed for manual moves feature.
  *
  * Includes the graphics/gtk function for manual moves. The Manual Move Generator class is defined  manual_move_generator.h/cpp.
- * The manual move feature allows the user to select a move by choosing the block to move, x position, y position, subtile position.
+ * The manual move feature allows the user to select a move by choosing the block to move, x position, y position, layer_position, subtile position.
  * If the placer accepts the move, the user can accept or reject the move with respect to the delta cost,
  * delta timing and delta bounding box cost displayed on the UI. The manual move feature interacts with placement through
  * the ManualMoveGenerator class in the manual_move_generator.cpp/h files and in the place.cpp file by checking
@@ -42,11 +42,13 @@ void draw_manual_moves_window(const std::string& block_id) {
 
         GtkWidget* x_position_entry = gtk_entry_new();
         GtkWidget* y_position_entry = gtk_entry_new();
+        GtkWidget* layer_position_entry = gtk_entry_new();
         GtkWidget* subtile_position_entry = gtk_entry_new();
         GtkWidget* block_label = gtk_label_new("Block ID/Block Name:");
         GtkWidget* to_label = gtk_label_new("To Location:");
         GtkWidget* x = gtk_label_new("x:");
         GtkWidget* y = gtk_label_new("y:");
+        GtkWidget* layer = gtk_label_new("layer:");
         GtkWidget* subtile = gtk_label_new("Subtile:");
 
         GtkWidget* calculate_cost_button = gtk_button_new_with_label("Calculate Costs");
@@ -59,9 +61,11 @@ void draw_manual_moves_window(const std::string& block_id) {
         gtk_grid_attach((GtkGrid*)grid, x_position_entry, 2, 1, 1, 1);
         gtk_grid_attach((GtkGrid*)grid, y, 1, 2, 1, 1);
         gtk_grid_attach((GtkGrid*)grid, y_position_entry, 2, 2, 1, 1);
-        gtk_grid_attach((GtkGrid*)grid, subtile, 1, 3, 1, 1);
-        gtk_grid_attach((GtkGrid*)grid, subtile_position_entry, 2, 3, 1, 1);
-        gtk_grid_attach((GtkGrid*)grid, calculate_cost_button, 0, 4, 3, 1); //spans three columns
+        gtk_grid_attach((GtkGrid*)grid, layer, 1, 3, 1, 1);
+        gtk_grid_attach((GtkGrid*)grid, layer_position_entry, 2, 3, 1, 1);
+        gtk_grid_attach((GtkGrid*)grid, subtile, 1, 4, 1, 1);
+        gtk_grid_attach((GtkGrid*)grid, subtile_position_entry, 2, 4, 1, 1);
+        gtk_grid_attach((GtkGrid*)grid, calculate_cost_button, 0, 5, 3, 1); //spans three columns
 
         //Set margins
         gtk_widget_set_margin_bottom(grid, 20);
@@ -88,6 +92,7 @@ void calculate_cost_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     int block_id = -1;
     int x_location = -1;
     int y_location = -1;
+    int layer_location = -1;
     int subtile_location = -1;
     bool valid_input = true;
 
@@ -108,19 +113,20 @@ void calculate_cost_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
 
     GtkWidget* x_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 1);
     GtkWidget* y_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 2);
-    GtkWidget* subtile_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 3);
+    GtkWidget* layer_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 3);
+    GtkWidget* subtile_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 4);
 
     x_location = std::atoi(gtk_entry_get_text((GtkEntry*)x_position_entry));
     y_location = std::atoi(gtk_entry_get_text((GtkEntry*)y_position_entry));
+    layer_location = std::atoi(gtk_entry_get_text((GtkEntry*)layer_position_entry));
     subtile_location = std::atoi(gtk_entry_get_text((GtkEntry*)subtile_position_entry));
 
-    if (std::string(gtk_entry_get_text((GtkEntry*)block_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)x_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)y_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)subtile_position_entry)).empty()) {
+    if (std::string(gtk_entry_get_text((GtkEntry*)block_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)x_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)y_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)layer_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)subtile_position_entry)).empty()) {
         invalid_breakpoint_entry_window("Not all fields are complete");
         valid_input = false;
     }
 
-    // TODO: When graphic is updated to support 3D, this will need to be updated
-    t_pl_loc to = t_pl_loc(x_location, y_location, subtile_location, 0);
+    t_pl_loc to = t_pl_loc(x_location, y_location, subtile_location, layer_location);
     valid_input = is_manual_move_legal(ClusterBlockId(block_id), to);
 
     if (valid_input) {
@@ -128,6 +134,7 @@ void calculate_cost_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
         draw_state->manual_moves_state.manual_move_info.blockID = block_id;
         draw_state->manual_moves_state.manual_move_info.x_pos = x_location;
         draw_state->manual_moves_state.manual_move_info.y_pos = y_location;
+        draw_state->manual_moves_state.manual_move_info.layer = layer_location;
         draw_state->manual_moves_state.manual_move_info.subtile = subtile_location;
         draw_state->manual_moves_state.manual_move_info.to_location = to;
 

--- a/vpr/src/draw/manual_moves.h
+++ b/vpr/src/draw/manual_moves.h
@@ -51,6 +51,7 @@ struct ManualMovesInfo {
     int x_pos = -1;
     int y_pos = -1;
     int subtile = 0;
+    int layer = 0;
     double delta_cost = 0;
     double delta_timing = 0;
     double delta_bounding_box = 0;

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -1351,7 +1351,7 @@ static e_move_result try_swap(const t_annealing_state* state,
         create_move_outcome = move_generator.propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
     }
 
-    if (proposed_action.logical_blk_type_index != -1) { //if the agent proposed the block type, then collect the block type stat
+    if (proposed_action.logical_blk_type_index != -1 && !manual_move_enabled) { //if the agent proposed the block type, then collect the block type stat
         ++move_type_stat.blk_type_moves[proposed_action.logical_blk_type_index][(int)proposed_action.move_type];
     }
     LOG_MOVE_STATS_PROPOSED(t, blocks_affected);
@@ -1575,7 +1575,7 @@ static e_move_result try_swap(const t_annealing_state* state,
     // move generator, so we should not calculate the reward and update
     // the move generators status since this outcome is not a direct
     // consequence of the move generator
-    if (!router_block_move) {
+    if (!manual_move_enabled && !router_block_move) {
         move_generator.calculate_reward_and_process_outcome(move_outcome_stats, delta_c, timing_bb_factor);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR is a follow-up on PR #2804 to fix a segmentation fault that happens during manual moves after the latest refactors. It also adds an widget for the layer in the manual move prompt.

#### Related Issue
The manual move was facing segmentation fault due to 2 reasons:
1.  The global instance of `BlkLocRegistry` was used instead the one stored in `placer_state_` --> fixed in PR #2804 but still after this fix, whenever the user accepts or rejects the move, it will result in a seg fault.
2. After the move, the code is trying to update the RL agent Q table and the move statistics while the move type is manual (not recognized by the agent) --> fixed in this PR

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
