### PR TITLE
[CMake] Upgrade Minimum Version to 3.10

### DIFF
--- a/libs/EXTERNAL/libezgl/CMakeLists.txt
+++ b/libs/EXTERNAL/libezgl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 # create the project
 project(

--- a/libs/EXTERNAL/libezgl/examples/basic-application/CMakeLists.txt
+++ b/libs/EXTERNAL/libezgl/examples/basic-application/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(
   basic-application

--- a/utils/route_diag/CMakeLists.txt
+++ b/utils/route_diag/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-cmake_policy(VERSION 3.9)
+cmake_policy(VERSION 3.10)
 
 project("route_diag")
 


### PR DESCRIPTION
The CI currently always runs on the latest version of CMake. I am not sure why this is, its not the best practice, but CMake is a fairly stable application so it should be fine.

CMake is deprecating version 3.9, and a few CMake files require the minimum version to be 3.9 or larger. Changed these files to be 3.10 or later.

This is currently causing the CI to fail for basically all of the tests with the following errors:
<img width="924" alt="image" src="https://github.com/user-attachments/assets/f8bd7434-f6a2-4bfe-b644-96f519659238">
