### PR TITLE
7-Series Pin-Equivalent Ports

### DIFF
--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1222,17 +1222,17 @@
           output="SLICE_L[1].I[3]" />
         <mux name="cross11" input="CLB.I00[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[3]" />
-        <mux name="cross12" input="CLB.I[40] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
+        <mux name="cross12" input="CLB.I11[5] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[1].I[12]" />
         <mux name="cross13"
           input="CLB.I01[5] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[12]" />
-        <mux name="cross14" input="CLB.I[43] SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
+        <mux name="cross14" input="CLB.I11[0] SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[7]" />
         <mux name="cross15"
           input="CLB.I01[0] CLB.SR1BEG_S0_IN SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[7]" />
-        <mux name="cross16" input="CLB.I[36] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
+        <mux name="cross16" input="CLB.I11[2] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[9]" />
         <mux name="cross17"
           input="CLB.I01[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
@@ -1240,7 +1240,7 @@
         <mux name="cross18"
           input="CLB.I01[1] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[8]" />
-        <mux name="cross19" input="CLB.I[39] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+        <mux name="cross19" input="CLB.I11[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[8]" />
         <mux name="cross20" input="CLB.I[32] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[1].I[15]" />
@@ -1255,10 +1255,10 @@
         <mux name="cross24" input="CLB.I01[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[11]" />
         <mux name="cross25"
-          input="CLB.I[37] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
+          input="CLB.I11[4] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[11]" />
         <mux name="cross26"
-          input="CLB.I[30] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
+          input="CLB.I11[3] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[10]" />
         <mux name="cross27" input="CLB.I01[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[10]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -156,6 +156,10 @@
         <!-- Sub Tile Inputs -->
         <clock name="CLK" num_pins="1" />
         <input name="I" num_pins="56" />
+        <input name="I0" num_pins="6" />
+        <input name="I1" num_pins="6" />
+        <input name="I2" num_pins="6" />
+        <input name="I3" num_pins="6" />
         <input name="cin" num_pins="2" />
         <input name="NL1BEG_N3_IN" num_pins="1" />
         <input name="SR1BEG_S0_IN" num_pins="1" />
@@ -218,6 +222,47 @@
           <fc_override port_name="I" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
           <fc_override port_name="I" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
 
+          <fc_override port_name="I0" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I0" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I0" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I0" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I0" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I0" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I0" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I0" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+
+
+          <fc_override port_name="I1" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I1" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I1" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I1" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I1" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I1" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I1" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I1" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I2" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I2" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I2" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I2" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I2" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I2" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I2" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I2" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+          
+          <fc_override port_name="I3" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I3" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I3" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I3" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I3" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I3" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I3" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I3" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+
           <!-- CLB ports never connect to len18, len12, or cardinal len6 wires -->
           <fc_override segment_name="len6_y" fc_type="abs" fc_val="0" />
           <fc_override segment_name="len6y_stub" fc_type="abs" fc_val="0" />
@@ -268,13 +313,13 @@
 
         </fc>
         <pinlocations pattern="custom">
-          <loc side="left">CLB.CLK CLB.I CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
+          <loc side="left">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
             CLB.NL1BEG_N3_OUT</loc>
-          <loc side="top">CLB.CLK CLB.I CLB.O CLB.cout CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
+          <loc side="top">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.cout CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
             CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
-          <loc side="bottom">CLB.CLK CLB.I CLB.O CLB.cin CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
+          <loc side="bottom">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.cin CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
             CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
-          <loc side="right">CLB.CLK CLB.I CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
+          <loc side="right">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
             CLB.NL1BEG_N3_OUT </loc>
         </pinlocations>
         <equivalent_sites>
@@ -798,6 +843,10 @@
     <pb_type name="CLB">
       <clock name="CLK" num_pins="1" />
       <input name="I" num_pins="56" />
+      <input name="I0" num_pins="6" />
+      <input name="I1" num_pins="6" />
+      <input name="I2" num_pins="6" />
+      <input name="I3" num_pins="6" />
       <input name="cin" num_pins="2" />
       <input name="NL1BEG_N3_IN" num_pins="1" />
       <input name="SR1BEG_S0_IN" num_pins="1" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1150,28 +1150,28 @@
         <mux name="cross0" input="CLB.I[52] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[2]" />
         <mux name="cross1"
-          input="CLB.I[45] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
+          input="CLB.I0[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[2]" />
-        <mux name="cross2" input="CLB.I[54] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
+        <mux name="cross2" input="CLB.I0[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[1]" />
         <mux name="cross3" input="CLB.I[55] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[1]" />
-        <mux name="cross4" input="CLB.I[49] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
+        <mux name="cross4" input="CLB.I0[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[0].I[5]" />
         <mux name="cross5" input="CLB.I[48] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[5]" />
         <mux name="cross6" input="CLB.I[51] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[1].I[0]" />
-        <mux name="cross7" input="CLB.I[50] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
+        <mux name="cross7" input="CLB.I0[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[0].I[0]" />
-        <mux name="cross8" input="CLB.I[44] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
+        <mux name="cross8" input="CLB.I0[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[4]" />
         <mux name="cross9" input="CLB.I[53] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[4]" />
         <mux name="cross10"
           input="CLB.I[46] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[3]" />
-        <mux name="cross11" input="CLB.I[47] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+        <mux name="cross11" input="CLB.I0[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[3]" />
         <mux name="cross12" input="CLB.I[40] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[1].I[12]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1239,29 +1239,29 @@
           input="CLB.I[9] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[24]" />
         <mux name="cross38"
-          input="CLB.I[18] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+          input="CLB.I3[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[0].I[23]" />
         <mux name="cross39" input="CLB.I[19] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[23]" />
         <mux name="cross40"
-          input="CLB.I[13] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
+          input="CLB.I3[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[21]" />
         <mux name="cross41" input="CLB.I[12] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[21]" />
         <mux name="cross42" input="CLB.I[15] SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[26]" />
         <mux name="cross43"
-          input="CLB.I[14] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+          input="CLB.I3[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[26]" />
-        <mux name="cross44" input="CLB.I[8] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
+        <mux name="cross44" input="CLB.I3[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[0].I[24]" />
         <mux name="cross45"
-          input="CLB.I[17] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          input="CLB.I3[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[22]" />
         <mux name="cross46"
           input="CLB.I[10] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[25]" />
-        <mux name="cross47" input="CLB.I[11] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
+        <mux name="cross47" input="CLB.I3[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[25]" />
       </interconnect>
     </pb_type>

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1196,29 +1196,29 @@
         <!-- The bellow is correct all 48 connections apear to be here (these are the imux
           connections) The nodes that should be missing are 6,13,20,27 which are the #X equivalents. These
           nodes are indeed missing -->
-        <mux name="cross0" input="CLB.I[52] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
+        <mux name="cross0" input="CLB.I10[2] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[2]" />
         <mux name="cross1"
           input="CLB.I00[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[2]" />
         <mux name="cross2" input="CLB.I00[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[1]" />
-        <mux name="cross3" input="CLB.I[55] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+        <mux name="cross3" input="CLB.I10[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[1]" />
         <mux name="cross4" input="CLB.I00[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[0].I[5]" />
-        <mux name="cross5" input="CLB.I[48] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
+        <mux name="cross5" input="CLB.I10[5] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[5]" />
-        <mux name="cross6" input="CLB.I[51] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+        <mux name="cross6" input="CLB.I10[0] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[1].I[0]" />
         <mux name="cross7" input="CLB.I00[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[0].I[0]" />
         <mux name="cross8" input="CLB.I00[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[4]" />
-        <mux name="cross9" input="CLB.I[53] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
+        <mux name="cross9" input="CLB.I10[4] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[4]" />
         <mux name="cross10"
-          input="CLB.I[46] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
+          input="CLB.I10[3] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[3]" />
         <mux name="cross11" input="CLB.I00[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[3]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1242,15 +1242,15 @@
           output="SLICE_L[0].I[8]" />
         <mux name="cross19" input="CLB.I11[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[8]" />
-        <mux name="cross20" input="CLB.I[32] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
+        <mux name="cross20" input="CLB.I12[1] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[1].I[15]" />
         <mux name="cross21"
-          input="CLB.I[25] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
+          input="CLB.I12[3] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[17]" />
         <mux name="cross22"
           input="CLB.I02[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[0].I[16]" />
-        <mux name="cross23" input="CLB.I[35] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
+        <mux name="cross23" input="CLB.I12[2] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[16]" />
         <mux name="cross24" input="CLB.I01[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[11]" />
@@ -1268,16 +1268,16 @@
           input="CLB.I02[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[15]" />
         <mux name="cross30"
-          input="CLB.I[26] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
+          input="CLB.I12[4] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[18]" />
         <mux name="cross31" input="CLB.I02[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[18]" />
         <mux name="cross32"
           input="CLB.I02[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[0].I[14]" />
-        <mux name="cross33" input="CLB.I[20] SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
+        <mux name="cross33" input="CLB.I12[0] SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[1].I[14]" />
-        <mux name="cross34" input="CLB.I[23] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
+        <mux name="cross34" input="CLB.I12[5] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[1].I[19]" />
         <mux name="cross35"
           input="CLB.I02[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1199,7 +1199,7 @@
           input="CLB.I[25] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[17]" />
         <mux name="cross22"
-          input="CLB.I[34] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+          input="CLB.I2[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[0].I[16]" />
         <mux name="cross23" input="CLB.I[35] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[16]" />
@@ -1213,25 +1213,25 @@
           output="SLICE_L[1].I[10]" />
         <mux name="cross27" input="CLB.I1[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[10]" />
-        <mux name="cross28" input="CLB.I[24] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
+        <mux name="cross28" input="CLB.I2[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[0].I[17]" />
         <mux name="cross29"
-          input="CLB.I[33] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          input="CLB.I2[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[15]" />
         <mux name="cross30"
           input="CLB.I[26] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[18]" />
-        <mux name="cross31" input="CLB.I[27] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
+        <mux name="cross31" input="CLB.I2[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[18]" />
         <mux name="cross32"
-          input="CLB.I[21] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
+          input="CLB.I2[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[0].I[14]" />
         <mux name="cross33" input="CLB.I[20] SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[1].I[14]" />
         <mux name="cross34" input="CLB.I[23] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[1].I[19]" />
         <mux name="cross35"
-          input="CLB.I[22] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+          input="CLB.I2[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[0].I[19]" />
         <mux name="cross36" input="CLB.I[16] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[1].I[22]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1147,29 +1147,29 @@
         <!-- The bellow is correct all 48 connections apear to be here (these are the imux
           connections) The nodes that should be missing are 6,13,20,27 which are the #X equivalents. These
           nodes are indeed missing -->
-        <mux name="cross0" input="CLB.I1[2] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
+        <mux name="cross0" input="CLB.I[52] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[2]" />
         <mux name="cross1"
           input="CLB.I0[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[2]" />
         <mux name="cross2" input="CLB.I0[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[1]" />
-        <mux name="cross3" input="CLB.I1[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+        <mux name="cross3" input="CLB.I[55] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[1]" />
         <mux name="cross4" input="CLB.I0[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[0].I[5]" />
-        <mux name="cross5" input="CLB.I1[5] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
+        <mux name="cross5" input="CLB.I[48] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[5]" />
-        <mux name="cross6" input="CLB.I1[0] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+        <mux name="cross6" input="CLB.I[51] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[1].I[0]" />
         <mux name="cross7" input="CLB.I0[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[0].I[0]" />
         <mux name="cross8" input="CLB.I0[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[4]" />
-        <mux name="cross9" input="CLB.I1[4] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
+        <mux name="cross9" input="CLB.I[53] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[4]" />
         <mux name="cross10"
-          input="CLB.I1[3] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
+          input="CLB.I[46] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[3]" />
         <mux name="cross11" input="CLB.I0[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[3]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1147,29 +1147,29 @@
         <!-- The bellow is correct all 48 connections apear to be here (these are the imux
           connections) The nodes that should be missing are 6,13,20,27 which are the #X equivalents. These
           nodes are indeed missing -->
-        <mux name="cross0" input="CLB.I[52] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
+        <mux name="cross0" input="CLB.I1[2] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[2]" />
         <mux name="cross1"
           input="CLB.I0[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[2]" />
         <mux name="cross2" input="CLB.I0[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[1]" />
-        <mux name="cross3" input="CLB.I[55] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+        <mux name="cross3" input="CLB.I1[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[1]" />
         <mux name="cross4" input="CLB.I0[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[0].I[5]" />
-        <mux name="cross5" input="CLB.I[48] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
+        <mux name="cross5" input="CLB.I1[5] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[5]" />
-        <mux name="cross6" input="CLB.I[51] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+        <mux name="cross6" input="CLB.I1[0] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[1].I[0]" />
         <mux name="cross7" input="CLB.I0[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[0].I[0]" />
         <mux name="cross8" input="CLB.I0[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[4]" />
-        <mux name="cross9" input="CLB.I[53] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
+        <mux name="cross9" input="CLB.I1[4] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[4]" />
         <mux name="cross10"
-          input="CLB.I[46] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
+          input="CLB.I1[3] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[3]" />
         <mux name="cross11" input="CLB.I0[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[3]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -155,7 +155,7 @@
       <sub_tile capacity="1" name="CLB">
         <!-- Sub Tile Inputs -->
         <clock name="CLK" num_pins="1" />
-        <input name="I" num_pins="56" />
+        <input name="I" num_pins="8" />
         <input name="I00" num_pins="6" equivalent="full"/>
         <input name="I01" num_pins="6" equivalent="full"/>
         <input name="I02" num_pins="6" equivalent="full"/>
@@ -164,7 +164,7 @@
         <input name="I11" num_pins="6" equivalent="full"/>
         <input name="I12" num_pins="6" equivalent="full"/>
         <input name="I13" num_pins="6" equivalent="full"/>
-        <input name="cin" num_pins="2" equivalent="full"/>
+        <input name="cin" num_pins="2"/>
         <input name="NL1BEG_N3_IN" num_pins="1" />
         <input name="SR1BEG_S0_IN" num_pins="1" />
         <output name="O" num_pins="24" />
@@ -358,14 +358,14 @@
 
         </fc>
         <pinlocations pattern="custom">
-          <loc side="left">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
-            CLB.NL1BEG_N3_OUT</loc>
-          <loc side="top">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.cout CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
-            CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
-          <loc side="bottom">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.cin CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
-            CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
-          <loc side="right">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
-            CLB.NL1BEG_N3_OUT </loc>
+          <loc side="left">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.I10 CLB.I11 CLB.I12 CLB.I13 
+            CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
+          <loc side="top">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.I10 CLB.I11 CLB.I12 CLB.I13 
+            CLB.O CLB.cout CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
+          <loc side="bottom">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.I10 CLB.I11 CLB.I12 CLB.I13 
+            CLB.O CLB.cin CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
+          <loc side="right">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.I10 CLB.I11 CLB.I12 CLB.I13 
+            CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT </loc>
         </pinlocations>
         <equivalent_sites>
           <site pb_type="CLB" pin_mapping="direct" />
@@ -887,7 +887,7 @@
       timing but we leave this for a latter time. -->
     <pb_type name="CLB">
       <clock name="CLK" num_pins="1" />
-      <input name="I" num_pins="56" />
+      <input name="I" num_pins="8" />
       <input name="I00" num_pins="6" equivalent="full"/>
       <input name="I01" num_pins="6" equivalent="full"/>
       <input name="I02" num_pins="6" equivalent="full"/>
@@ -896,7 +896,7 @@
       <input name="I11" num_pins="6" equivalent="full"/>
       <input name="I12" num_pins="6" equivalent="full"/>
       <input name="I13" num_pins="6" equivalent="full"/>
-      <input name="cin" num_pins="2" equivalent="full"/>
+      <input name="cin" num_pins="2"/>
       <input name="NL1BEG_N3_IN" num_pins="1" />
       <input name="SR1BEG_S0_IN" num_pins="1" />
       <output name="O" num_pins="24" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1135,13 +1135,13 @@
             <direct name="D" input="fle[3].out" output="SLICE_L.O[10]" />
             <direct name="DQ" input="fle[3].outQ" output="SLICE_L.O[11]" />
             <!-- Internal inputs. Here we call D inputs the top (0) and A inputs the bottom (21). -->
-            <direct name="inA" input="SLICE_L.I[5:0]" output="fle[0].in" />
+            <complete name="inA" input="SLICE_L.I[5:0]" output="fle[0].in" />
             <direct name="AX" input="SLICE_L.I[6]" output="fle[0].inX" />
-            <direct name="inB" input="SLICE_L.I[12:7]" output="fle[1].in" />
+            <complete name="inB" input="SLICE_L.I[12:7]" output="fle[1].in" />
             <direct name="BX" input="SLICE_L.I[13]" output="fle[1].inX" />
-            <direct name="inC" input="SLICE_L.I[19:14]" output="fle[2].in" />
+            <complete name="inC" input="SLICE_L.I[19:14]" output="fle[2].in" />
             <direct name="CX" input="SLICE_L.I[20]" output="fle[2].inX" />
-            <direct name="inD" input="SLICE_L.I[26:21]" output="fle[3].in" />
+            <complete name="inD" input="SLICE_L.I[26:21]" output="fle[3].in" />
             <direct name="DX" input="SLICE_L.I[27]" output="fle[3].inX" />
           </interconnect>
         </mode>
@@ -1196,122 +1196,32 @@
         <!-- The bellow is correct all 48 connections apear to be here (these are the imux
           connections) The nodes that should be missing are 6,13,20,27 which are the #X equivalents. These
           nodes are indeed missing -->
-        <mux name="cross0" input="CLB.I10[2] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
-          output="SLICE_L[1].I[2]" />
-        <mux name="cross1"
-          input="CLB.I00[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
-          output="SLICE_L[0].I[2]" />
-        <mux name="cross2" input="CLB.I00[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
-          output="SLICE_L[0].I[1]" />
-        <mux name="cross3" input="CLB.I10[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
-          output="SLICE_L[1].I[1]" />
-        <mux name="cross4" input="CLB.I00[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
-          output="SLICE_L[0].I[5]" />
-        <mux name="cross5" input="CLB.I10[5] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
-          output="SLICE_L[1].I[5]" />
-        <mux name="cross6" input="CLB.I10[0] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
-          output="SLICE_L[1].I[0]" />
-        <mux name="cross7" input="CLB.I00[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
-          output="SLICE_L[0].I[0]" />
-        <mux name="cross8" input="CLB.I00[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
-          output="SLICE_L[0].I[4]" />
-        <mux name="cross9" input="CLB.I10[4] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
-          output="SLICE_L[1].I[4]" />
-        <mux name="cross10"
-          input="CLB.I10[3] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
-          output="SLICE_L[1].I[3]" />
-        <mux name="cross11" input="CLB.I00[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
-          output="SLICE_L[0].I[3]" />
-        <mux name="cross12" input="CLB.I11[5] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
-          output="SLICE_L[1].I[12]" />
-        <mux name="cross13"
-          input="CLB.I01[5] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
-          output="SLICE_L[0].I[12]" />
-        <mux name="cross14" input="CLB.I11[0] SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
-          output="SLICE_L[1].I[7]" />
-        <mux name="cross15"
-          input="CLB.I01[0] CLB.SR1BEG_S0_IN SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
-          output="SLICE_L[0].I[7]" />
-        <mux name="cross16" input="CLB.I11[2] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
-          output="SLICE_L[1].I[9]" />
-        <mux name="cross17"
-          input="CLB.I01[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
-          output="SLICE_L[0].I[9]" />
-        <mux name="cross18"
-          input="CLB.I01[1] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
-          output="SLICE_L[0].I[8]" />
-        <mux name="cross19" input="CLB.I11[1] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
-          output="SLICE_L[1].I[8]" />
-        <mux name="cross20" input="CLB.I12[1] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
-          output="SLICE_L[1].I[15]" />
-        <mux name="cross21"
-          input="CLB.I12[3] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
-          output="SLICE_L[1].I[17]" />
-        <mux name="cross22"
-          input="CLB.I02[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
-          output="SLICE_L[0].I[16]" />
-        <mux name="cross23" input="CLB.I12[2] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
-          output="SLICE_L[1].I[16]" />
-        <mux name="cross24" input="CLB.I01[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
-          output="SLICE_L[0].I[11]" />
-        <mux name="cross25"
-          input="CLB.I11[4] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
-          output="SLICE_L[1].I[11]" />
-        <mux name="cross26"
-          input="CLB.I11[3] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
-          output="SLICE_L[1].I[10]" />
-        <mux name="cross27" input="CLB.I01[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
-          output="SLICE_L[0].I[10]" />
-        <mux name="cross28" input="CLB.I02[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
-          output="SLICE_L[0].I[17]" />
-        <mux name="cross29"
-          input="CLB.I02[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
-          output="SLICE_L[0].I[15]" />
-        <mux name="cross30"
-          input="CLB.I12[4] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
-          output="SLICE_L[1].I[18]" />
-        <mux name="cross31" input="CLB.I02[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
-          output="SLICE_L[0].I[18]" />
-        <mux name="cross32"
-          input="CLB.I02[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
-          output="SLICE_L[0].I[14]" />
-        <mux name="cross33" input="CLB.I12[0] SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
-          output="SLICE_L[1].I[14]" />
-        <mux name="cross34" input="CLB.I12[5] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
-          output="SLICE_L[1].I[19]" />
-        <mux name="cross35"
-          input="CLB.I02[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
-          output="SLICE_L[0].I[19]" />
-        <mux name="cross36" input="CLB.I13[1] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
-          output="SLICE_L[1].I[22]" />
-        <mux name="cross37"
-          input="CLB.I13[3] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
-          output="SLICE_L[1].I[24]" />
-        <mux name="cross38"
-          input="CLB.I03[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
-          output="SLICE_L[0].I[23]" />
-        <mux name="cross39" input="CLB.I13[2] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
-          output="SLICE_L[1].I[23]" />
-        <mux name="cross40"
-          input="CLB.I03[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
-          output="SLICE_L[0].I[21]" />
-        <mux name="cross41" input="CLB.I13[0] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
-          output="SLICE_L[1].I[21]" />
-        <mux name="cross42" input="CLB.I13[5] SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
-          output="SLICE_L[1].I[26]" />
-        <mux name="cross43"
-          input="CLB.I03[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
-          output="SLICE_L[0].I[26]" />
-        <mux name="cross44" input="CLB.I03[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
-          output="SLICE_L[0].I[24]" />
-        <mux name="cross45"
-          input="CLB.I03[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
-          output="SLICE_L[0].I[22]" />
-        <mux name="cross46"
-          input="CLB.I13[4] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
-          output="SLICE_L[1].I[25]" />
-        <mux name="cross47" input="CLB.I03[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
-          output="SLICE_L[0].I[25]" />
+        <complete name="cross0"
+          input="CLB.I00 CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+          output="SLICE_L[0].I[0] SLICE_L[0].I[1] SLICE_L[0].I[2] SLICE_L[0].I[3] SLICE_L[0].I[4] SLICE_L[0].I[5]" />
+        <complete name="cross1"
+          input="CLB.I01 SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          output="SLICE_L[0].I[7] SLICE_L[0].I[8] SLICE_L[0].I[9] SLICE_L[0].I[10] SLICE_L[0].I[11] SLICE_L[0].I[12]" />
+        <complete name="cross2"
+          input="CLB.I02 SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2] SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+          output="SLICE_L[0].I[14] SLICE_L[0].I[15] SLICE_L[0].I[16] SLICE_L[0].I[17] SLICE_L[0].I[18] SLICE_L[0].I[19]" />
+        <complete name="cross3"
+          input="CLB.I03 SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1] SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+          output="SLICE_L[0].I[21] SLICE_L[0].I[22] SLICE_L[0].I[23] SLICE_L[0].I[24] SLICE_L[0].I[25] SLICE_L[0].I[26]" />
+
+
+        <complete name="cross4" 
+          input="CLB.I10 SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
+          output="SLICE_L[1].I[0] SLICE_L[1].I[1] SLICE_L[1].I[2] SLICE_L[1].I[3] SLICE_L[1].I[4] SLICE_L[1].I[5]" />
+        <complete name="cross5" 
+          input="CLB.I11 SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
+          output="SLICE_L[1].I[7] SLICE_L[1].I[8] SLICE_L[1].I[9] SLICE_L[1].I[10] SLICE_L[1].I[11] SLICE_L[1].I[12]" />
+        <complete name="cross6" 
+          input="CLB.I12 SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
+          output="SLICE_L[1].I[14] SLICE_L[1].I[15] SLICE_L[1].I[16] SLICE_L[1].I[17] SLICE_L[1].I[18] SLICE_L[1].I[19]" />
+        <complete name="cross7" 
+          input="CLB.I13 SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11] SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4] SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
+          output="SLICE_L[1].I[21] SLICE_L[1].I[22] SLICE_L[1].I[23] SLICE_L[1].I[24] SLICE_L[1].I[25] SLICE_L[1].I[26]" />
       </interconnect>
     </pb_type>
     <!-- Define general purpose logic block (CLB) ends -->

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1282,22 +1282,22 @@
         <mux name="cross35"
           input="CLB.I02[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[0].I[19]" />
-        <mux name="cross36" input="CLB.I[16] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
+        <mux name="cross36" input="CLB.I13[1] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[1].I[22]" />
         <mux name="cross37"
-          input="CLB.I[9] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
+          input="CLB.I13[3] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[24]" />
         <mux name="cross38"
           input="CLB.I03[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[0].I[23]" />
-        <mux name="cross39" input="CLB.I[19] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
+        <mux name="cross39" input="CLB.I13[2] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[23]" />
         <mux name="cross40"
           input="CLB.I03[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[21]" />
-        <mux name="cross41" input="CLB.I[12] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
+        <mux name="cross41" input="CLB.I13[0] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[21]" />
-        <mux name="cross42" input="CLB.I[15] SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
+        <mux name="cross42" input="CLB.I13[5] SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[26]" />
         <mux name="cross43"
           input="CLB.I03[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
@@ -1308,7 +1308,7 @@
           input="CLB.I03[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[22]" />
         <mux name="cross46"
-          input="CLB.I[10] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
+          input="CLB.I13[4] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[25]" />
         <mux name="cross47" input="CLB.I03[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[25]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -1176,20 +1176,20 @@
         <mux name="cross12" input="CLB.I[40] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[1].I[12]" />
         <mux name="cross13"
-          input="CLB.I[41] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          input="CLB.I1[5] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[12]" />
         <mux name="cross14" input="CLB.I[43] SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[7]" />
         <mux name="cross15"
-          input="CLB.I[42] CLB.SR1BEG_S0_IN SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
+          input="CLB.I1[0] CLB.SR1BEG_S0_IN SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[7]" />
         <mux name="cross16" input="CLB.I[36] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[9]" />
         <mux name="cross17"
-          input="CLB.I[29] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
+          input="CLB.I1[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[9]" />
         <mux name="cross18"
-          input="CLB.I[38] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
+          input="CLB.I1[1] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[8]" />
         <mux name="cross19" input="CLB.I[39] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[8]" />
@@ -1203,7 +1203,7 @@
           output="SLICE_L[0].I[16]" />
         <mux name="cross23" input="CLB.I[35] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[16]" />
-        <mux name="cross24" input="CLB.I[28] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
+        <mux name="cross24" input="CLB.I1[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[11]" />
         <mux name="cross25"
           input="CLB.I[37] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
@@ -1211,7 +1211,7 @@
         <mux name="cross26"
           input="CLB.I[30] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[10]" />
-        <mux name="cross27" input="CLB.I[31] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+        <mux name="cross27" input="CLB.I1[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[10]" />
         <mux name="cross28" input="CLB.I[24] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[0].I[17]" />

--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -156,11 +156,15 @@
         <!-- Sub Tile Inputs -->
         <clock name="CLK" num_pins="1" />
         <input name="I" num_pins="56" />
-        <input name="I0" num_pins="6" />
-        <input name="I1" num_pins="6" />
-        <input name="I2" num_pins="6" />
-        <input name="I3" num_pins="6" />
-        <input name="cin" num_pins="2" />
+        <input name="I00" num_pins="6" equivalent="full"/>
+        <input name="I01" num_pins="6" equivalent="full"/>
+        <input name="I02" num_pins="6" equivalent="full"/>
+        <input name="I03" num_pins="6" equivalent="full"/>
+        <input name="I10" num_pins="6" equivalent="full"/>
+        <input name="I11" num_pins="6" equivalent="full"/>
+        <input name="I12" num_pins="6" equivalent="full"/>
+        <input name="I13" num_pins="6" equivalent="full"/>
+        <input name="cin" num_pins="2" equivalent="full"/>
         <input name="NL1BEG_N3_IN" num_pins="1" />
         <input name="SR1BEG_S0_IN" num_pins="1" />
         <output name="O" num_pins="24" />
@@ -222,46 +226,87 @@
           <fc_override port_name="I" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
           <fc_override port_name="I" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
 
-          <fc_override port_name="I0" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I0" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I0" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I0" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
 
-          <fc_override port_name="I0" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I0" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I0" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I0" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I00" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
 
 
-          <fc_override port_name="I1" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I1" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I1" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I1" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
 
-          <fc_override port_name="I1" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I1" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I1" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I1" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I01" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
 
-          <fc_override port_name="I2" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I2" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I2" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I2" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
 
-          <fc_override port_name="I2" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I2" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I2" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I2" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I02" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
           
-          <fc_override port_name="I3" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I3" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I3" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I3" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
 
-          <fc_override port_name="I3" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I3" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I3" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
-          <fc_override port_name="I3" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I03" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I10" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I10" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I10" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I10" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I10" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I10" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I10" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I10" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+
+
+          <fc_override port_name="I11" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I11" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I11" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I11" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I11" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I11" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I11" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I11" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I12" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I12" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I12" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I12" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I12" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I12" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I12" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I12" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
+          
+          <fc_override port_name="I13" segment_name="1len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I13" segment_name="2len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I13" segment_name="3len4D_y" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I13" segment_name="4len4D_y" fc_type="abs" fc_val="0" />
+
+          <fc_override port_name="I13" segment_name="1len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I13" segment_name="2len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I13" segment_name="3len2D_x" fc_type="abs" fc_val="0" />
+          <fc_override port_name="I13" segment_name="4len2D_x" fc_type="abs" fc_val="0" />
 
           <!-- CLB ports never connect to len18, len12, or cardinal len6 wires -->
           <fc_override segment_name="len6_y" fc_type="abs" fc_val="0" />
@@ -313,13 +358,13 @@
 
         </fc>
         <pinlocations pattern="custom">
-          <loc side="left">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
+          <loc side="left">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
             CLB.NL1BEG_N3_OUT</loc>
-          <loc side="top">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.cout CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
+          <loc side="top">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.cout CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
             CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
-          <loc side="bottom">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.cin CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
+          <loc side="bottom">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.cin CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT
             CLB.NL1BEG_N3_IN CLB.NL1BEG_N3_OUT</loc>
-          <loc side="right">CLB.CLK CLB.I CLB.I0 CLB.I1 CLB.I2 CLB.I3 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
+          <loc side="right">CLB.CLK CLB.I CLB.I00 CLB.I01 CLB.I02 CLB.I03 CLB.O CLB.SR1BEG_S0_IN CLB.SR1BEG_S0_OUT CLB.NL1BEG_N3_IN
             CLB.NL1BEG_N3_OUT </loc>
         </pinlocations>
         <equivalent_sites>
@@ -843,11 +888,15 @@
     <pb_type name="CLB">
       <clock name="CLK" num_pins="1" />
       <input name="I" num_pins="56" />
-      <input name="I0" num_pins="6" />
-      <input name="I1" num_pins="6" />
-      <input name="I2" num_pins="6" />
-      <input name="I3" num_pins="6" />
-      <input name="cin" num_pins="2" />
+      <input name="I00" num_pins="6" equivalent="full"/>
+      <input name="I01" num_pins="6" equivalent="full"/>
+      <input name="I02" num_pins="6" equivalent="full"/>
+      <input name="I03" num_pins="6" equivalent="full"/>
+      <input name="I10" num_pins="6" equivalent="full"/>
+      <input name="I11" num_pins="6" equivalent="full"/>
+      <input name="I12" num_pins="6" equivalent="full"/>
+      <input name="I13" num_pins="6" equivalent="full"/>
+      <input name="cin" num_pins="2" equivalent="full"/>
       <input name="NL1BEG_N3_IN" num_pins="1" />
       <input name="SR1BEG_S0_IN" num_pins="1" />
       <output name="O" num_pins="24" />
@@ -1150,46 +1199,46 @@
         <mux name="cross0" input="CLB.I[52] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[2]" />
         <mux name="cross1"
-          input="CLB.I0[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
+          input="CLB.I00[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[2]" />
-        <mux name="cross2" input="CLB.I0[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
+        <mux name="cross2" input="CLB.I00[1] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[1]" />
         <mux name="cross3" input="CLB.I[55] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[1]" />
-        <mux name="cross4" input="CLB.I0[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
+        <mux name="cross4" input="CLB.I00[5] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[0].I[5]" />
         <mux name="cross5" input="CLB.I[48] SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[5]" />
         <mux name="cross6" input="CLB.I[51] SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[1].I[0]" />
-        <mux name="cross7" input="CLB.I0[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
+        <mux name="cross7" input="CLB.I00[0] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[0].I[0]" />
-        <mux name="cross8" input="CLB.I0[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
+        <mux name="cross8" input="CLB.I00[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[4]" />
         <mux name="cross9" input="CLB.I[53] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[4]" />
         <mux name="cross10"
           input="CLB.I[46] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[3]" />
-        <mux name="cross11" input="CLB.I0[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+        <mux name="cross11" input="CLB.I00[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[3]" />
         <mux name="cross12" input="CLB.I[40] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[1].I[12]" />
         <mux name="cross13"
-          input="CLB.I1[5] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          input="CLB.I01[5] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[12]" />
         <mux name="cross14" input="CLB.I[43] SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[7]" />
         <mux name="cross15"
-          input="CLB.I1[0] CLB.SR1BEG_S0_IN SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
+          input="CLB.I01[0] CLB.SR1BEG_S0_IN SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[7]" />
         <mux name="cross16" input="CLB.I[36] SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[1].I[9]" />
         <mux name="cross17"
-          input="CLB.I1[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
+          input="CLB.I01[2] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[0].I[9]" />
         <mux name="cross18"
-          input="CLB.I1[1] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
+          input="CLB.I01[1] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[0].I[8]" />
         <mux name="cross19" input="CLB.I[39] SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[1].I[8]" />
@@ -1199,11 +1248,11 @@
           input="CLB.I[25] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[17]" />
         <mux name="cross22"
-          input="CLB.I2[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+          input="CLB.I02[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[0].I[16]" />
         <mux name="cross23" input="CLB.I[35] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[16]" />
-        <mux name="cross24" input="CLB.I1[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
+        <mux name="cross24" input="CLB.I01[4] SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[11]" />
         <mux name="cross25"
           input="CLB.I[37] CLB.NL1BEG_N3_IN SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
@@ -1211,27 +1260,27 @@
         <mux name="cross26"
           input="CLB.I[30] CLB.NL1BEG_N3_IN SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[10]" />
-        <mux name="cross27" input="CLB.I1[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+        <mux name="cross27" input="CLB.I01[3] SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[10]" />
-        <mux name="cross28" input="CLB.I2[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
+        <mux name="cross28" input="CLB.I02[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[0].I[17]" />
         <mux name="cross29"
-          input="CLB.I2[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          input="CLB.I02[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[15]" />
         <mux name="cross30"
           input="CLB.I[26] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[18]" />
-        <mux name="cross31" input="CLB.I2[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
+        <mux name="cross31" input="CLB.I02[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[18]" />
         <mux name="cross32"
-          input="CLB.I2[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
+          input="CLB.I02[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[0].O[1] SLICE_L[1].O[2]"
           output="SLICE_L[0].I[14]" />
         <mux name="cross33" input="CLB.I[20] SLICE_L[1].O[6] SLICE_L[1].O[1] SLICE_L[0].O[2]"
           output="SLICE_L[1].I[14]" />
         <mux name="cross34" input="CLB.I[23] SLICE_L[1].O[9] SLICE_L[1].O[4] SLICE_L[0].O[5]"
           output="SLICE_L[1].I[19]" />
         <mux name="cross35"
-          input="CLB.I2[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
+          input="CLB.I02[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[0].O[4] SLICE_L[1].O[5]"
           output="SLICE_L[0].I[19]" />
         <mux name="cross36" input="CLB.I[16] SLICE_L[0].O[0] SLICE_L[0].O[7] SLICE_L[1].O[8]"
           output="SLICE_L[1].I[22]" />
@@ -1239,29 +1288,29 @@
           input="CLB.I[9] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[1].O[7] SLICE_L[0].O[8]"
           output="SLICE_L[1].I[24]" />
         <mux name="cross38"
-          input="CLB.I3[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
+          input="CLB.I03[2] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[1].O[10] SLICE_L[0].O[11]"
           output="SLICE_L[0].I[23]" />
         <mux name="cross39" input="CLB.I[19] SLICE_L[0].O[3] SLICE_L[0].O[10] SLICE_L[1].O[11]"
           output="SLICE_L[1].I[23]" />
         <mux name="cross40"
-          input="CLB.I3[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
+          input="CLB.I03[0] CLB.NL1BEG_N3_IN SLICE_L[0].O[6] SLICE_L[1].O[2] SLICE_L[0].O[1]"
           output="SLICE_L[0].I[21]" />
         <mux name="cross41" input="CLB.I[12] SLICE_L[1].O[6] SLICE_L[0].O[2] SLICE_L[1].O[1]"
           output="SLICE_L[1].I[21]" />
         <mux name="cross42" input="CLB.I[15] SLICE_L[1].O[9] SLICE_L[0].O[5] SLICE_L[1].O[4]"
           output="SLICE_L[1].I[26]" />
         <mux name="cross43"
-          input="CLB.I3[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
+          input="CLB.I03[5] CLB.NL1BEG_N3_IN SLICE_L[0].O[9] SLICE_L[1].O[5] SLICE_L[0].O[4]"
           output="SLICE_L[0].I[26]" />
-        <mux name="cross44" input="CLB.I3[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
+        <mux name="cross44" input="CLB.I03[3] SLICE_L[0].O[0] SLICE_L[1].O[8] SLICE_L[0].O[7]"
           output="SLICE_L[0].I[24]" />
         <mux name="cross45"
-          input="CLB.I3[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
+          input="CLB.I03[1] CLB.SR1BEG_S0_IN SLICE_L[1].O[0] SLICE_L[0].O[8] SLICE_L[1].O[7]"
           output="SLICE_L[0].I[22]" />
         <mux name="cross46"
           input="CLB.I[10] CLB.SR1BEG_S0_IN SLICE_L[1].O[3] SLICE_L[0].O[11] SLICE_L[1].O[10]"
           output="SLICE_L[1].I[25]" />
-        <mux name="cross47" input="CLB.I3[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
+        <mux name="cross47" input="CLB.I03[4] SLICE_L[0].O[3] SLICE_L[1].O[11] SLICE_L[0].O[10]"
           output="SLICE_L[0].I[25]" />
       </interconnect>
     </pb_type>


### PR DESCRIPTION
#### Description  
This PR updates the 7-series architecture to mark the pins connected to LUTs as pin-equivalent. 