### PR TITLE
Net decomposing router: hotfix

### DIFF
--- a/vpr/src/route/DecompNetlistRouter.tpp
+++ b/vpr/src/route/DecompNetlistRouter.tpp
@@ -448,11 +448,15 @@ inline bool is_close_to_cutline(RRNodeId inode, Axis cutline_axis, int cutline_p
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
+    vtr::Rect<int> tile_bb = device_ctx.grid.get_tile_bb({rr_graph.node_xlow(inode),
+                                                  rr_graph.node_ylow(inode),
+                                          rr_graph.node_layer(inode)});
+
     /* Cutlines are considered to be at x + 0.5, set a thickness of +1 here by checking for equality */
     if (cutline_axis == Axis::X) {
-        return rr_graph.node_xlow(inode) - thickness <= cutline_pos && rr_graph.node_xhigh(inode) + thickness >= cutline_pos;
+        return tile_bb.xmin() - thickness <= cutline_pos && tile_bb.xmax() + thickness >= cutline_pos;
     } else {
-        return rr_graph.node_ylow(inode) - thickness <= cutline_pos && rr_graph.node_yhigh(inode) + thickness >= cutline_pos;
+        return tile_bb.ymin() - thickness <= cutline_pos && tile_bb.ymax() + thickness >= cutline_pos;
     }
 }
 
@@ -461,10 +465,14 @@ inline bool is_close_to_bb(RRNodeId inode, const t_bb& bb, int thickness) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
-    int xlow = rr_graph.node_xlow(inode) - thickness;
-    int ylow = rr_graph.node_ylow(inode) - thickness;
-    int xhigh = rr_graph.node_xhigh(inode) + thickness;
-    int yhigh = rr_graph.node_yhigh(inode) + thickness;
+    vtr::Rect<int> tile_bb = device_ctx.grid.get_tile_bb({rr_graph.node_xlow(inode),
+                                                  rr_graph.node_ylow(inode),
+                                          rr_graph.node_layer(inode)});
+
+    int xlow = tile_bb.xmin() - thickness;
+    int ylow = tile_bb.ymin() - thickness;
+    int xhigh = tile_bb.xmax() + thickness;
+    int yhigh = tile_bb.ymax() + thickness;
 
     return (xlow <= bb.xmin && xhigh >= bb.xmin)
            || (ylow <= bb.ymin && yhigh >= bb.ymin)


### PR DESCRIPTION
Looks like sinks no longer "grow" to the size of their tile. In that case, it's better to use the tile bounding box to sample sinks for the net decomposing router.

This seems to fix the runtime blowup I started to see again with the decomp + flat router. Here is a table with "actual" route times from the flat router which I get by adding up the iteration times.

| circuit                                  | master | mine  | decomp | decomp (fixed) |
|------------------------------------------|--------|-------|--------|----------|
| gsm_switch_stratixiv_arch_timing.blif    |  113.7 |   108 |   72.2 |     63.6 |
| mes_noc_stratixiv_arch_timing.blif       |  467.7 | 254.6 |  733.6 |    655.4 |
| dart_stratixiv_arch_timing.blif          |   68.5 |  68.2 |   47.8 |     42.7 |
| denoise_stratixiv_arch_timing.blif       |  219.4 | 277.8 |   97.2 |     92.4 |
| sparcT2_core_stratixiv_arch_timing.blif  |  173.8 | 187.4 |  114.4 |    109.5 |
| cholesky_bdti_stratixiv_arch_timing.blif |  115.9 | 121.8 |   83.3 |     65.8 |
| minres_stratixiv_arch_timing.blif        |   69.7 |  69.7 |   38.2 |     35.4 |
| stap_qrd_stratixiv_arch_timing.blif      |   71.5 |    65 |  147.2 |     47.6 |
| openCV_stratixiv_arch_timing.blif        |  112.1 | 106.1 |   78.3 |     65.6 |
| bitonic_mesh_stratixiv_arch_timing.blif  |  137.3 | 131.3 |   73.9 |       72 |
| segmentation_stratixiv_arch_timing.blif  |  117.5 | 112.1 |   70.7 |     66.1 |
| SLAM_spheric_stratixiv_arch_timing.blif  |   80.1 |  78.2 |   59.7 |       57 |
| des90_stratixiv_arch_timing.blif         |   72.4 |  74.8 | 1015.1 |    102.9 |
| neuron_stratixiv_arch_timing.blif        |   28.2 |  25.8 |   17.8 |     16.1 |
| sparcT1_core_stratixiv_arch_timing.blif  |   48.7 |  45.8 |   34.6 |     32.5 |
| stereo_vision_stratixiv_arch_timing.blif |   20.9 |  23.6 |   17.2 |     16.9 |
| cholesky_mc_stratixiv_arch_timing.blif   |   39.1 |  38.1 |   27.1 |       25 |
| directrf_stratixiv_arch_timing.blif      |  710.4 | 520.7 |  385.6 |    364.2 |
| bitcoin_miner_stratixiv_arch_timing.blif |  592.1 |   577 |  477.1 |    448.3 |
| LU230_stratixiv_arch_timing.blif         |  416.5 | 418.4 |  453.6 |    287.2 |
| sparcT1_chip2_stratixiv_arch_timing.blif |    255 | 270.2 |  178.8 |    169.5 |
| LU_Network_stratixiv_arch_timing.blif    |  180.4 | 189.9 |  115.4 |    116.4 |