### PR TITLE
[Warnings] Resolved Basic Warnings for GCC13

### DIFF
--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
@@ -4360,7 +4360,7 @@ inline void attr_error(std::bitset<N> astate, const char * const *lookup, const 
 }
 
 inline void get_line_number(const char *filename, std::ptrdiff_t target_offset, int * line, int * col) {
-	std::unique_ptr<FILE,decltype(&fclose)> f(fopen(filename, "rb"), fclose);
+	std::unique_ptr<FILE,int(*)(FILE*)> f(fopen(filename, "rb"), fclose);
 
 	if (!f) {
 		throw std::runtime_error(std::string("Failed to open file") + filename);

--- a/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
+++ b/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
@@ -1207,7 +1207,7 @@ inline void attr_error(std::bitset<N> astate, const char* const* lookup, const s
 }
 
 inline void get_line_number(const char* filename, std::ptrdiff_t target_offset, int* line, int* col) {
-    std::unique_ptr<FILE, decltype(&fclose)> f(fopen(filename, "rb"), fclose);
+    std::unique_ptr<FILE,int(*)(FILE*)> f(fopen(filename, "rb"), fclose);
 
     if (!f) {
         throw std::runtime_error(std::string("Failed to open file") + filename);

--- a/vpr/src/draw/draw_rr.cpp
+++ b/vpr/src/draw/draw_rr.cpp
@@ -902,8 +902,7 @@ void draw_get_rr_pin_coords(const t_rr_node& node, float* xcen, float* ycen, con
 
         default:
             vpr_throw(VPR_ERROR_OTHER, __FILE__, __LINE__,
-                      "in draw_get_rr_pin_coords: Unexpected side %s.\n",
-                      TOTAL_2D_SIDE_STRINGS[pin_side]);
+                      "in draw_get_rr_pin_coords: Unexpected side.\n");
             break;
     }
 

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -157,7 +157,9 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
             warning_dialog_box("Invalid Net Name");
             return; //name not exist
         }
-        for(auto clb_net_id: atom_ctx.lookup.clb_nets(atom_net_id).value()){
+
+        const auto clb_nets = atom_ctx.lookup.clb_nets(atom_net_id);
+        for(auto clb_net_id: clb_nets.value()){
             highlight_nets(clb_net_id);
         }
     }


### PR DESCRIPTION
Resolved a warning in search_bar.cpp which warned about a reference to a temporary. Simply fixed by splitting the statement into two lines.

Resolved a warning in draw_rr.cpp where a print statement was trying to access an invalid location in an array. The print statement did not make sense, it was trying to print an undefined side. This was removed.

Resolved a warning in the automatically generated vpr_constraints file. This was an interesting warning due to the decltype method returning the attributes of the FILE pointer, but this was passed into a template which discards the attributes (this generates a warning). Resolved this manually locally and raised a PR on the uxsdcxx repo with this fix: https://github.com/SymbiFlow/uxsdcxx/pull/53