### PR TITLE
[Warnings] Fixed Minor Warnings

### DIFF
--- a/libs/libvtrutil/src/specrand.cpp
+++ b/libs/libvtrutil/src/specrand.cpp
@@ -119,7 +119,7 @@ unsigned long SpecRandomNumberGenerator::spec_genrand_int32_() {
             y = (mt[kk] & UPPER_MASK) | (mt[kk + 1] & LOWER_MASK);
             mt[kk] = mt[kk + M] ^ (y >> 1) ^ mag01[y & 0x1UL];
         }
-        for (size_t kk; kk < N - 1; kk++) {
+        for (size_t kk = 0; kk < N - 1; kk++) {
             y = (mt[kk] & UPPER_MASK) | (mt[kk + 1] & LOWER_MASK);
             mt[kk] = mt[kk + (M - N)] ^ (y >> 1) ^ mag01[y & 0x1UL];
         }

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -2263,7 +2263,7 @@ class MergedNetlistWriterVisitor : public NetlistWriterVisitor {
         return io_name;
     }
 
-    void print_primary_io(int depth) {
+    void print_primary_io(int depth) override {
         //Primary Inputs
         for (auto iter = inputs_.begin(); iter != inputs_.end(); ++iter) {
             //verilog_os_ << indent(depth + 1) << "input " << escape_verilog_identifier(*iter);
@@ -2292,7 +2292,7 @@ class MergedNetlistWriterVisitor : public NetlistWriterVisitor {
         }
     }
 
-    void print_assignments(int depth) {
+    void print_assignments(int depth) override {
         verilog_os_ << "\n";
         verilog_os_ << indent(depth + 1) << "//IO assignments\n";
         for (auto& assign : assignments_) {


### PR DESCRIPTION
Fixed a warning with a loop induction variable not being initialized.

Fixed a warning where a method overrides the base class, but was not explicitly declared as override.

Resolves #2831 