### PR TITLE
[CI] Added GCC-13 on Ubuntu Noble as a Compatibility Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -471,6 +471,37 @@ jobs:
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         ./.github/scripts/build.sh
 
+  NobleCompatibility:
+    name: 'Ubuntu Noble - 24.04 Compatibility Test'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12.3
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
+
+    - name: Install Dependencies
+      run: ./.github/scripts/install_noble_dependencies.sh
+
+    - uses: hendrikmuhs/ccache-action@v1.2
+
+    - name: Test
+      env:
+        CMAKE_PARAMS: "-DVTR_ASSERT_LEVEL=3 -DCMAKE_COMPILE_WARNING_AS_ERROR=on -DVTR_IPO_BUILD=off"
+        MATRIX_EVAL: 'CC=gcc-13 && CXX=g++-13'
+        BUILD_TYPE: release
+        NUM_PROC: ${{ steps.cpu-cores.outputs.count }}
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        ./.github/scripts/build.sh
+
   Coverity:
     name: 'Coverity Scan'
     needs:

--- a/libs/EXTERNAL/libezgl/src/application.cpp
+++ b/libs/EXTERNAL/libezgl/src/application.cpp
@@ -18,6 +18,16 @@
 
 #include "ezgl/application.hpp"
 
+// GLib deprecated G_APPLICATION_FLAGS_NONE and replaced it with G_APPLICATION_DEFAULT_FLAGS,
+// however, this enum was not introduced until GLib 2.74. These lines of code allow EZGL
+// to be backwards compatible with older versions of GLib, while not using the deprecated
+// enum.
+#if GLIB_CHECK_VERSION(2, 74, 0)
+static constexpr GApplicationFlags EZGL_APPLICATION_DEFAULT_FLAGS = G_APPLICATION_DEFAULT_FLAGS;
+#else
+static constexpr GApplicationFlags EZGL_APPLICATION_DEFAULT_FLAGS = G_APPLICATION_FLAGS_NONE;
+#endif
+
 namespace ezgl {
 
 // A flag to disable event loop (default is false)
@@ -86,7 +96,7 @@ application::application(application::settings s)
     , m_window_id(s.window_identifier)
     , m_canvas_id(s.canvas_identifier)
     , m_application_id(s.application_identifier)
-    , m_application(gtk_application_new(s.application_identifier.c_str(), G_APPLICATION_FLAGS_NONE))
+    , m_application(gtk_application_new(s.application_identifier.c_str(), EZGL_APPLICATION_DEFAULT_FLAGS))
     , m_builder(gtk_builder_new())
     , m_register_callbacks(s.setup_callbacks)
 {
@@ -205,7 +215,7 @@ int application::run(setup_callback_fn initial_setup_user_callback,
     g_object_unref(m_builder);
 
     // Reconstruct the GTK application
-    m_application = (gtk_application_new(m_application_id.c_str(), G_APPLICATION_FLAGS_NONE));
+    m_application = (gtk_application_new(m_application_id.c_str(), EZGL_APPLICATION_DEFAULT_FLAGS));
     m_builder = (gtk_builder_new());
     g_signal_connect(m_application, "startup", G_CALLBACK(startup), this);
     g_signal_connect(m_application, "activate", G_CALLBACK(activate), this);


### PR DESCRIPTION
Now that the GCC-13 build on Ubuntu Noble is warning clean, adding it to the CI to maintain it. This is a stepping stone to moving the entire CI to Ubuntu Noble.