### PR TITLE
Update docs for parallel router

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1284,13 +1284,17 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
     This option attempts to verify the minimum by routing at successively lower channel widths until two consecutive routing failures are observed.
 
-.. option:: --router_algorithm {parallel | timing_driven}
+.. option:: --router_algorithm {timing_driven | parallel | parallel_decomp}
 
-    Selects which router algorithm to use.
+    Selects which router algorithm to use. 
 
-    .. warning::
+    * ``timing_driven`` is the default single-threaded PathFinder algorithm.
 
-        The ``parallel`` router is experimental. (TODO: more explanation)
+    * ``parallel`` partitions the device to route non-overlapping nets in parallel. Use with the ``-j`` option to specify the number of threads.
+
+    * ``parallel_decomp`` decomposes nets for aggressive parallelization :cite:`kosar2024parallel`. This imposes additional constraints and may result in worse QoR for difficult circuits.
+
+    Note that both ``parallel`` and ``parallel_decomp`` are timing-driven routers.
 
     **Default:** ``timing_driven``
 

--- a/doc/src/z_references.bib
+++ b/doc/src/z_references.bib
@@ -430,3 +430,9 @@
   year={2021}
 }
 
+@inproceedings{kosar2024parallel,
+  title={Parallel FPGA Routing with On-the-Fly Net Decomposition},
+  author={Kosar, Fahrican and Stojilovic, Mirjana and Betz, Vaughn},
+  booktitle={The 23rd International Conference on Field-Programmable Technology},
+  year={2024}
+}


### PR DESCRIPTION
Adds documentation for the net decomposing and baseline parallel routers and removes the experimental warning.