### PR TITLE
convert switch id check with architecture to warning instead of error

### DIFF
--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -534,7 +534,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             }
         }
         if (!found_arch_name) {
-            VTR_LOG("Switch name '%s' found in RR graph input from file but not in the architecture file creating it.\n", string_name.c_str());
+            VTR_LOG("Switch name '%s' found in RR graph input from file but not in the architecture file; creating it.\n", string_name.c_str());
         }
         sw->intra_tile = is_internal_sw;
         sw->name = string_name;

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -534,7 +534,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             }
         }
         if (!found_arch_name) {
-            VTR_LOG_WARN("Switch name '%s' not found in architecture\n", string_name.c_str());
+            VTR_LOG("Switch name '%s' found in RR graph input from file but not in the architecture file creating it.\n", string_name.c_str());
         }
         sw->intra_tile = is_internal_sw;
         sw->name = string_name;

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -534,7 +534,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             }
         }
         if (!found_arch_name) {
-            report_error("Switch name '%s' not found in architecture\n", string_name.c_str());
+            VTR_LOG_WARN("Switch name '%s' not found in architecture\n", string_name.c_str());
         }
         sw->intra_tile = is_internal_sw;
         sw->name = string_name;


### PR DESCRIPTION
This PR converts the switch error check with the architecture to a warning. 

@vaughnbetz 
