### PR TITLE
Added dependency installer script for Fedora

### DIFF
--- a/doc/src/quickstart/index.rst
+++ b/doc/src/quickstart/index.rst
@@ -24,11 +24,17 @@ If you cloned the repository, you will need to set up the git submodules (if you
     > git submodule init
     > git submodule update
     
-VTR requires several system packages and Python packages to build and run the flow.  You can install the required system packages using the following command (this works on Ubuntu 18.04, 20.04 and 22.04, but you may require different packages on other Linux distributions). Our CI testing is on Ubuntu 22.04, so that is the best tested platform and recommended for development.
+VTR requires several system packages and Python packages to build and run the flow. Ubuntu users can install the required system packages using the following command (this works on Ubuntu 18.04, 20.04 and 22.04, but you may require different packages on other Linux distributions). Our CI testing is on Ubuntu 22.04, so that is the best tested platform and recommended for development.
 
 .. code-block:: bash
 
     > ./install_apt_packages.sh
+
+Fedora and RHEL users may use the following command to install the required system packages.
+
+.. code-block:: bash
+
+    > ./install_dnf_packages.sh
 
 Then, to install the required Python packages (optionally within a new Python virtual environment):
 

--- a/doc/src/quickstart/index.rst
+++ b/doc/src/quickstart/index.rst
@@ -24,7 +24,7 @@ If you cloned the repository, you will need to set up the git submodules (if you
     > git submodule init
     > git submodule update
     
-VTR requires several system packages and Python packages to build and run the flow. Ubuntu users can install the required system packages using the following command (this works on Ubuntu 18.04, 20.04 and 22.04, but you may require different packages on other Linux distributions). Our CI testing is on Ubuntu 22.04, so that is the best tested platform and recommended for development.
+VTR requires several system packages and Python packages to build and run the flow. Ubuntu users can install the required system packages using the following command (this works on Ubuntu 18.04, 20.04, 22.04 and 24.04, but you may require different packages on other Linux distributions). Our CI testing is on Ubuntu 24.04, so that is the best tested platform and recommended for development.
 
 .. code-block:: bash
 

--- a/install_dnf_packages.sh
+++ b/install_dnf_packages.sh
@@ -1,0 +1,52 @@
+sudo dnf upgrade --refresh
+
+# Base packages to compile and run basic regression tests
+sudo dnf install -y \
+    make \
+    cmake \
+    automake \
+    gcc \
+    gcc-c++ \
+    kernel-devel \
+    pkg-config \
+    bison \
+    flex \
+    python3-devel \
+    tbb-devel
+# Required for graphics
+sudo dnf install -y \
+    gtk3-devel \
+    libX11
+
+# Required for parmys front-end from https://github.com/YosysHQ/yosys
+sudo dnf install -y \
+    make \
+    automake \
+    gcc \
+    gcc-c++ \
+    kernel-devel \
+    clang \
+    bison \
+    flex \
+    readline-devel \
+    gawk \
+    tcl-devel \
+    libffi-devel \
+    git \
+    graphviz \
+    python-xdot \
+    pkg-config \
+    python3-devel \
+    boost-system \
+    boost-python3 \
+    boost-filesystem \
+    zlib-ng-devel
+
+# Required to build the documentation
+sudo dnf install -y \
+    python3-sphinx \
+    python-sphinx-doc
+
+# Required to run the analytical placement flow
+sudo dnf install -y \
+    eigen3-devel


### PR DESCRIPTION
Added a script that installs all needed packages to run vtr on Fedora/RHEL distributions and updated the documentation showing how to use it. This is analogous to the 'install_apt_packages.sh' script that does the same for Ubuntu/Debian. This commit didn't really change anything in the actual code but to be safe I ran the basic and strong test and didn't see any failures.