### PR TITLE
Remove place_cost_exp from documentation

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -830,47 +830,9 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
 
     **Default:** ``0.0``
 
-.. _dusty_sa_options:
-Setting any of the following 5 options selects :ref:`Dusty's annealing schedule <dusty_sa>` .
-
-.. option:: --alpha_min <float>
-
-    The minimum (starting) update factor (alpha) used.
-    Ranges between 0 and alpha_max.
-
-    **Default:** ``0.2``
-
-.. option:: --alpha_max <float>
-
-    The maximum (stopping) update factor (alpha) used after which simulated annealing will complete.
-    Ranges between alpha_min and 1.
-
-    **Default:** ``0.9``
-
-.. option:: --alpha_decay <float>
-
-    The rate at which alpha will approach 1: alpha(n) = 1 - (1 - alpha(n-1)) * alpha_decay
-    Ranges between 0 and 1.
-
-    **Default:** ``0.7``
-
-.. option:: --anneal_success_min <float>
-
-   The minimum success ratio after which the temperature will reset to maintain the target success ratio.
-   Ranges between 0 and anneal_success_target.
-
-    **Default:** ``0.1``
-
-.. option:: --anneal_success_target <float>
-
-   The temperature after each reset is selected to keep this target success ratio.
-   Ranges between anneal_success_target and 1.
-
-    **Default:** ``0.25``
-
 .. option:: --RL_agent_placement {on | off}
 
-    Uses a Reinforcement Learning (RL) agent in choosing the appropiate move type in placement.
+    Uses a Reinforcement Learning (RL) agent in choosing the appropriate move type in placement.
     It activates the RL agent placement instead of using a fixed probability for each move type.
 
     **Default:** ``on``
@@ -899,7 +861,7 @@ Setting any of the following 5 options selects :ref:`Dusty's annealing schedule 
 
     Controls how quickly the agent's memory decays. Values between [0., 1.] specify
     the fraction of weight in the exponentially weighted reward average applied to moves
-    which occured greater than moves_per_temp moves ago. Values < 0 cause the
+    which occurred greater than moves_per_temp moves ago. Values < 0 cause the
     unweighted reward sample average to be used (all samples are weighted equally)
 
     **Default:** ``0.05``
@@ -917,6 +879,8 @@ Setting any of the following 5 options selects :ref:`Dusty's annealing schedule 
     The RL Agent exploration space can be either based on only move types or also consider different block types moved.
 
     **Default:** ``move_block_type``
+
+
 
 .. option:: --placer_debug_block <int>
     
@@ -1015,7 +979,7 @@ The following options are only valid when the placement engine is in timing-driv
 
 .. option:: --place_delay_model_reducer {min, max, median, arithmean, geomean}
 
-    When calculating delta delays for the placment delay model how are multiple values combined?
+    When calculating delta delays for the placement delay model how are multiple values combined?
 
     **Default:** ``min``
 
@@ -1048,7 +1012,7 @@ The following options are only valid when the placement engine is in timing-driv
 
 .. option:: --place_tsu_abs_margin <float>
 
-    Specifies an absolute offest added to cell setup times used by the placer.
+    Specifies an absolute offset added to cell setup times used by the placer.
     This effectively controls whether the placer should try to achieve extra margin on setup paths.
     For example a value of 500e-12 corresponds to requesting an extra 500ps of setup margin.
 
@@ -1056,7 +1020,7 @@ The following options are only valid when the placement engine is in timing-driv
 
 .. option:: --post_place_timing_report <file>
 
-    Name of the post-placement timing report file to generate (not generated if unspecfied).
+    Name of the post-placement timing report file to generate (not generated if unspecified).
 
 
 .. _noc_placement_options:

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -868,14 +868,6 @@ Setting any of the following 5 options selects :ref:`Dusty's annealing schedule 
 
     **Default:** ``0.25``
 
-.. option:: --place_cost_exp <float>
-
-    Wiring cost is divided by the average channel width over a net's bounding box
-    taken to this exponent. Only impacts devices with different channel widths in 
-    different directions or regions. 
-
-    **Default:** ``1``
-
 .. option:: --RL_agent_placement {on | off}
 
     Uses a Reinforcement Learning (RL) agent in choosing the appropiate move type in placement.

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2067,7 +2067,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
 
     place_grp.add_argument<bool, ParseOnOff>(args.RL_agent_placement, "--RL_agent_placement")
         .help(
-            "Uses a Reinforcement Learning (RL) agent in choosing the appropiate move type in placement."
+            "Uses a Reinforcement Learning (RL) agent in choosing the appropriate move type in placement."
             "It activates the RL agent placement instead of using fixed probability for each move type.")
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
@@ -2082,7 +2082,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
     place_grp.add_argument<bool, ParseOnOff>(args.place_checkpointing, "--place_checkpointing")
         .help(
             "Enable Placement checkpoints. This means saving the placement and restore it if it's better than later placements."
-            "Only effective if agnet's 2nd state is activated.")
+            "Only effective if agent's 2nd state is activated.")
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
@@ -2096,7 +2096,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
     place_grp.add_argument(args.place_agent_gamma, "--place_agent_gamma")
         .help(
             "Controls how quickly the agent's memory decays. "
-            "Values between [0., 1.] specify the fraction of weight in the exponentially weighted reward average applied to moves which occured greater than moves_per_temp moves ago."
+            "Values between [0., 1.] specify the fraction of weight in the exponentially weighted reward average applied to moves which occurred greater than moves_per_temp moves ago."
             "Values < 0 cause the unweighted reward sample average to be used (all samples are weighted equally)")
         .default_value("0.05")
         .show_in(argparse::ShowIn::HELP_ONLY);
@@ -2159,13 +2159,6 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    /*
-     * place_grp.add_argument(args.place_timing_cost_func, "--place_timing_cost_func")
-     * .help(
-     * "which timing cost function to use")
-     * .default_value("0")
-     * .show_in(argparse::ShowIn::HELP_ONLY);
-     */
     place_grp.add_argument<e_agent_algorithm, ParsePlaceAgentAlgorithm>(args.place_agent_algorithm, "--place_agent_algorithm")
         .help("Controls which placement RL agent is used")
         .default_value("softmax")
@@ -2219,13 +2212,13 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_timing_grp.add_argument(args.inner_loop_recompute_divider, "--inner_loop_recompute_divider")
-        .help("Controls how many timing analysies are perform per temperature during placement")
+        .help("Controls how many timing analyses are performed per temperature during placement")
         .default_value("0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_timing_grp.add_argument(args.quench_recompute_divider, "--quench_recompute_divider")
         .help(
-            "Controls how many timing analysies are perform during the final placement quench (t=0)."
+            "Controls how many timing analyses are performed during the final placement quench (t=0)."
             " If unspecified, uses the value from --inner_loop_recompute_divider")
         .default_value("0")
         .show_in(argparse::ShowIn::HELP_ONLY);

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -991,11 +991,6 @@ enum class e_move_type;
  *   @param timing_tradeoff
  *              When in CRITICALITY_TIMING_PLACE mode, what is the
  *              tradeoff between timing and wiring costs.
- *   @param place_cost_exp
- *              Wiring cost is divided by the average channel width over
- *              a net's bounding box taken to this exponent.
- *              Only impacts devices with different channel widths in 
- *              different directions or regions. (Default: 1)
  *   @param place_chan_width
  *              The channel width assumed if only one placement is performed.
  *   @param pad_loc_type

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -253,8 +253,7 @@ class NetCostHandler {
      * @details This is only useful for the cost function that takes the length of the net bounding box in each
      * dimension divided by the average number of tracks in that direction. For other cost functions, you don't
      * have to bother calling this routine; when using the cost function described above, however, you must always
-     * call this routine before you do any placement cost determination. The place_cost_exp factor specifies to
-     * what power the width of the channel should be taken -- larger numbers make narrower channels more expensive.
+     * call this routine before you do any placement cost determination.
      */
     void alloc_and_load_chan_w_factors_for_place_cost_();
 
@@ -262,8 +261,7 @@ class NetCostHandler {
     * @brief Allocates and loads acc_tile_num_inter_die_conn_ which contains the accumulative number of inter-die
     * conntections.
     *
-    * @details This is only useful for multi-die FPGAs. The place_cost_exp factor specifies to
-    * what power the average number of inter-die connections should be take -- larger numbers make narrower channels more expensive.
+    * @details This is only useful for multi-die FPGAs.
     */
     void alloc_and_load_for_fast_vertical_cost_update_();
 


### PR DESCRIPTION
place_cost_exp was set to 1 by default. This option was removed in #2799. This PR removes this command line option from documentation.