### PR TITLE
Add initial nightly test workflow

### DIFF
--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -1,0 +1,71 @@
+name: NightlyTestManual
+
+# This workflow can only be dispatched.
+on:
+  workflow_dispatch:
+
+# We want to cancel previous runs for a given PR or branch / ref if another CI
+# run is requested.
+# See: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # default compiler for all non-compatibility tests
+  MATRIX_EVAL: "CC=gcc-11 && CXX=g++-11"
+
+jobs:
+  Run-tests:
+    # Prevents from running on forks where no custom runners are available
+    if: ${{ github.repository_owner == 'verilog-to-routing' }}
+
+    name: 'Nightly Tests Manual Run'
+    # This workflow is expected to take around 19 hours. Giving it 24 hours
+    # before timing out.
+    timeout-minutes: 1440
+    runs-on: [self-hosted, Linux, X64, SAVI]
+
+    steps:
+    # Clean previous runs of this workflow.
+    - name: 'Cleanup build folder'
+      run: |
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+
+    # Checkout the VTR repo.
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+
+    # Get the extra benchmarks
+    - name: 'Get Extra Benchmarks'
+      run: |
+        make get_titan_benchmarks
+        make get_ispd_benchmarks
+        ./dev/upgrade_vtr_archs.sh
+        make get_symbiflow_benchmarks
+
+    # Build VTR using the default build options.
+    - name: 'Build VTR'
+      run: |
+        make -j12
+        make env
+        source .venv/bin/activate
+        pip install -r requirements.txt
+
+    # Run all of the nightly tests.
+    # TODO: We could expose more parallelism if we had one task list which ran
+    #       all of these.
+    - name: 'Run Nightly Tests'
+      run: |
+        source .venv/bin/activate
+        ./run_reg_test.py -j12 \
+            vtr_reg_nightly_test1 \
+            vtr_reg_nightly_test2 \
+            vtr_reg_nightly_test3 \
+            vtr_reg_nightly_test4 \
+            vtr_reg_nightly_test5 \
+            vtr_reg_nightly_test6 \
+            vtr_reg_nightly_test7
+

--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   # default compiler for all non-compatibility tests
-  MATRIX_EVAL: "CC=gcc-11 && CXX=g++-11"
+  MATRIX_EVAL: "CC=gcc-13 && CXX=g++-13"
 
 jobs:
   Run-tests:


### PR DESCRIPTION
This commit adds the new nightly test workflow to the list of workflows. Unfortunately to test GitHub actions workflows there has to be a version of it in the master branch, but after this PR is merged we can debug and resolve any issues in the "savi_nightly_test" branch so thankfully we don't have to test on master. This workflow can only be manually dispatched so there shouldn't be any automatic runs that could overwhelm the SAVI machines while we're working on the workflow and fixing any potential issues.