### PR TITLE
Update VTR 9 branch with faster check_non_configurable_edges

### DIFF
--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1641,7 +1641,7 @@ typedef t_routing_status<AtomNetId> t_atom_net_routing_status;
 
 /** Edge between two RRNodes */
 struct t_node_edge {
-    t_node_edge(RRNodeId fnode, RRNodeId tnode)
+    t_node_edge(RRNodeId fnode, RRNodeId tnode) noexcept
         : from_node(fnode)
         , to_node(tnode) {}
 
@@ -1654,10 +1654,18 @@ struct t_node_edge {
     }
 };
 
-///@brief Non-configurably connected nodes and edges in the RR graph
+/**
+ * @brief Groups of non-configurably connected nodes and edges in the RR graph.
+ * @note Each group is represented by a node set and an edge set, stored at the same index.
+ *
+ * For example, in an architecture with L-shaped wires formed by an x- and y-directed segment
+ * connected by an electrical short, each L-shaped wire corresponds to a new group. The group's
+ * index provides access to its node set (containing two RRNodeIds) and edge set (containing two
+ * directed edge in opposite directions).
+ */
 struct t_non_configurable_rr_sets {
-    std::set<std::set<RRNodeId>> node_sets;
-    std::set<std::set<t_node_edge>> edge_sets;
+    std::vector<std::set<RRNodeId>> node_sets;
+    std::vector<std::set<t_node_edge>> edge_sets;
 };
 
 ///@brief Power estimation options
@@ -1669,11 +1677,11 @@ struct t_power_opts {
  * @param max= Maximum channel width between x_max and y_max.
  * @param x_min= Minimum channel width of horizontal channels. Initialized when init_chan() is invoked in rr_graph2.cpp
  * @param y_min= Same as above but for vertical channels.
- * @param x_max= Maximum channel width of horiozntal channels. Initialized when init_chan() is invoked in rr_graph2.cpp
+ * @param x_max= Maximum channel width of horizontal channels. Initialized when init_chan() is invoked in rr_graph2.cpp
  * @param y_max= Same as above but for vertical channels.
  * @param x_list= Stores the channel width of all horizontal channels and thus goes from [0..grid.height()]
  * (imagine a 2D Cartesian grid with horizontal lines starting at every grid point on a line parallel to the y-axis)
- * @param y_list= Stores the channel width of all verical channels and thus goes from [0..grid.width()]
+ * @param y_list= Stores the channel width of all vertical channels and thus goes from [0..grid.width()]
  * (imagine a 2D Cartesian grid with vertical lines starting at every grid point on a line parallel to the x-axis)
  */
 

--- a/vpr/src/route/edge_groups.cpp
+++ b/vpr/src/route/edge_groups.cpp
@@ -52,14 +52,14 @@ t_non_configurable_rr_sets EdgeGroups::output_sets() {
         std::set<t_node_edge> edge_set;
         std::set<RRNodeId> node_set(nodes.begin(), nodes.end());
 
-        for (const auto& src : node_set) {
-            for (const auto& dest : graph_[src].edges) {
-                edge_set.emplace(t_node_edge(src, dest));
+        for (const RRNodeId src : node_set) {
+            for (const RRNodeId dest : graph_[src].edges) {
+                edge_set.emplace(src, dest);
             }
         }
 
-        sets.node_sets.emplace(std::move(node_set));
-        sets.edge_sets.emplace(std::move(edge_set));
+        sets.node_sets.emplace_back(std::move(node_set));
+        sets.edge_sets.emplace_back(std::move(edge_set));
     }
 
     return sets;

--- a/vpr/test/test_edge_groups.cpp
+++ b/vpr/test/test_edge_groups.cpp
@@ -19,12 +19,12 @@ TEST_CASE("edge_groups_create_sets", "[vpr]") {
     // Build chains from the given connected sets
     int max_node_id = 0;
     std::vector<std::pair<int, int>> edges;
-    for (auto set : connected_sets) {
+    for (const auto& set : connected_sets) {
         int last = *set.cbegin();
         std::for_each(std::next(set.cbegin()),
                       set.cend(),
                       [&](int node) {
-                          edges.push_back(std::make_pair(last, node));
+                          edges.emplace_back(last, node);
                           last = node;
                           max_node_id = std::max(max_node_id, node);
                       });
@@ -36,7 +36,7 @@ TEST_CASE("edge_groups_create_sets", "[vpr]") {
     // Initialize nodes to [0, 1, ..., max_node_id]
     std::iota(nodes.begin(), nodes.end(), 0);
 
-    // Create a Mersenne Twister psuedo-random number generator with seed 1
+    // Create a Mersenne Twister pseudo-random number generator with seed 1
     std::mt19937 g(1);
 
     // Run the test many times, the PRNG will give differently shuffled inputs
@@ -66,12 +66,12 @@ TEST_CASE("edge_groups_create_sets", "[vpr]") {
         t_non_configurable_rr_sets sets = groups.output_sets();
 
         // Check for the expected sets
-        for (auto set : connected_sets) {
+        for (const auto& set : connected_sets) {
             std::set<RRNodeId> random_set;
             for (auto elem : set) {
                 random_set.insert(RRNodeId(random_nodes[elem]));
             }
-            REQUIRE(sets.node_sets.find(random_set) != sets.node_sets.end());
+            REQUIRE(std::find(sets.node_sets.begin(), sets.node_sets.end(), random_set) != sets.node_sets.end());
         }
     }
 }


### PR DESCRIPTION
We previously checked every node in a route tree against all non-configurable RR sets, leading to O(n²) complexity. This PR limits checks to RR sets within the route tree, reducing complexity to O(n). As a result, the check_all_non_configurable_edges() function's execution time dropped from 2045s to 1.1s on the bgm benchmark in a 7-series architecture.