### PR TITLE
[Git] Resolved Error in Dependabot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "libs/EXTERNAL/libcatch2"]
 	path = libs/EXTERNAL/libcatch2
 	url = https://github.com/catchorg/Catch2.git
+
+# fork where in branch v1.0.0_no_complication_warnings there are compilation warnings fixes for upstream tag v1.0.0 of sockpp
 [submodule "libs/EXTERNAL/sockpp"]
 	path = libs/EXTERNAL/sockpp
-	url = https://github.com/w0lek/sockpp.git # fork where in branch v1.0.0_no_complication_warnings there are compilation warnings fixes for upstream tag v1.0.0 of sockpp
+	url = https://github.com/w0lek/sockpp.git


### PR DESCRIPTION
Dependabot was having issues with our gitmodules file since we put a comment in the same line as the URL for a git submodule:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/815c1193-d13d-406e-b130-2a080c7b3ce4" />

This was easily resolved by moving the comment to another line.