### PR TITLE
[Pack] Cleaned Up try_pack API

### DIFF
--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -109,12 +109,6 @@ static void free_complex_block_types();
 static void free_device(const t_det_routing_arch& routing_arch);
 static void free_circuit();
 
-static void get_intercluster_switch_fanin_estimates(const t_vpr_setup& vpr_setup,
-                                                    const t_arch& arch,
-                                                    const int wire_segment_length,
-                                                    int* opin_switch_fanin,
-                                                    int* wire_switch_fanin,
-                                                    int* ipin_switch_fanin);
 /* Local subroutines end */
 
 ///@brief Display general VPR information
@@ -641,53 +635,6 @@ bool vpr_pack_flow(t_vpr_setup& vpr_setup, const t_arch& arch) {
 bool vpr_pack(t_vpr_setup& vpr_setup, const t_arch& arch) {
     vtr::ScopedStartFinishTimer timer("Packing");
 
-    /* If needed, estimate inter-cluster delay. Assume the average routing hop goes out of
-     * a block through an opin switch to a length-4 wire, then through a wire switch to another
-     * length-4 wire, then through a wire-to-ipin-switch into another block. */
-    int wire_segment_length = 4;
-
-    float inter_cluster_delay = UNDEFINED;
-    if (vpr_setup.PackerOpts.timing_driven
-        && vpr_setup.PackerOpts.auto_compute_inter_cluster_net_delay) {
-        /* We want to determine a reasonable fan-in to the opin, wire, and ipin switches, based
-         * on which the intercluster delays can be estimated. The fan-in of a switch influences its
-         * delay.
-         *
-         * The fan-in of the switch depends on the architecture (unidirectional/bidirectional), as
-         * well as Fc_in/out and Fs */
-        int opin_switch_fanin, wire_switch_fanin, ipin_switch_fanin;
-        get_intercluster_switch_fanin_estimates(vpr_setup, arch, wire_segment_length, &opin_switch_fanin,
-                                                &wire_switch_fanin, &ipin_switch_fanin);
-
-        float Tdel_opin_switch, R_opin_switch, Cout_opin_switch;
-        float opin_switch_del = get_arch_switch_info(arch.Segments[0].arch_opin_switch, opin_switch_fanin,
-                                                     Tdel_opin_switch, R_opin_switch, Cout_opin_switch);
-
-        float Tdel_wire_switch, R_wire_switch, Cout_wire_switch;
-        float wire_switch_del = get_arch_switch_info(arch.Segments[0].arch_wire_switch, wire_switch_fanin,
-                                                     Tdel_wire_switch, R_wire_switch, Cout_wire_switch);
-
-        float Tdel_wtoi_switch, R_wtoi_switch, Cout_wtoi_switch;
-        float wtoi_switch_del = get_arch_switch_info(vpr_setup.RoutingArch.wire_to_arch_ipin_switch, ipin_switch_fanin,
-                                                     Tdel_wtoi_switch, R_wtoi_switch, Cout_wtoi_switch);
-
-        float Rmetal = arch.Segments[0].Rmetal;
-        float Cmetal = arch.Segments[0].Cmetal;
-
-        /* The delay of a wire with its driving switch is the switch delay plus the
-         * product of the equivalent resistance and capacitance experienced by the wire. */
-
-        float first_wire_seg_delay = opin_switch_del
-                                     + (R_opin_switch + Rmetal * (float)wire_segment_length / 2)
-                                           * (Cout_opin_switch + Cmetal * (float)wire_segment_length);
-        float second_wire_seg_delay = wire_switch_del
-                                      + (R_wire_switch + Rmetal * (float)wire_segment_length / 2)
-                                            * (Cout_wire_switch + Cmetal * (float)wire_segment_length);
-        inter_cluster_delay = 4
-                              * (first_wire_seg_delay + second_wire_seg_delay
-                                 + wtoi_switch_del); /* multiply by 4 to get a more conservative estimate */
-    }
-
     // Read in the flat placement if a flat placement file is provided and it
     // has not been loaded already.
     if (!vpr_setup.FileNameOpts.read_flat_place_file.empty() &&
@@ -698,8 +645,9 @@ bool vpr_pack(t_vpr_setup& vpr_setup, const t_arch& arch) {
     }
 
     return try_pack(&vpr_setup.PackerOpts, &vpr_setup.AnalysisOpts,
-                    &arch, vpr_setup.user_models,
-                    vpr_setup.library_models, inter_cluster_delay,
+                    arch, vpr_setup.RoutingArch,
+                    vpr_setup.user_models,
+                    vpr_setup.library_models,
                     vpr_setup.PackerRRGraph, g_vpr_ctx.atom().flat_placement_info);
 }
 
@@ -1210,100 +1158,6 @@ void vpr_init_server(const t_vpr_setup& vpr_setup) {
 void vpr_close_graphics(const t_vpr_setup& /*vpr_setup*/) {
     /* Close down X Display */
     free_draw_structs();
-}
-
-/**
- * Since the parameters of a switch may change as a function of its fanin,
- * to get an estimation of inter-cluster delays we need a reasonable estimation
- * of the fan-ins of switches that connect clusters together. These switches are
- * 1) opin to wire switch
- * 2) wire to wire switch
- * 3) wire to ipin switch
- * We can estimate the fan-in of these switches based on the Fc_in/Fc_out of
- * a logic block, and the switch block Fs value
- */
-static void get_intercluster_switch_fanin_estimates(const t_vpr_setup& vpr_setup,
-                                                    const t_arch& arch,
-                                                    const int wire_segment_length,
-                                                    int* opin_switch_fanin,
-                                                    int* wire_switch_fanin,
-                                                    int* ipin_switch_fanin) {
-    e_directionality directionality;
-    int Fs;
-    float Fc_in, Fc_out;
-    int W = 100; //W is unknown pre-packing, so *if* we need W here, we will assume a value of 100
-
-    directionality = vpr_setup.RoutingArch.directionality;
-    Fs = vpr_setup.RoutingArch.Fs;
-    Fc_in = 0, Fc_out = 0;
-
-    //Build a dummy 10x10 device to determine the 'best' block type to use
-    auto grid = create_device_grid(vpr_setup.device_layout, arch.grid_layouts, 10, 10);
-
-    auto type = find_most_common_tile_type(grid);
-    /* get Fc_in/out for most common block (e.g. logic blocks) */
-    VTR_ASSERT(!type->fc_specs.empty());
-
-    //Estimate the maximum Fc_in/Fc_out
-
-    for (const t_fc_specification& fc_spec : type->fc_specs) {
-        float Fc = fc_spec.fc_value;
-
-        if (fc_spec.fc_value_type == e_fc_value_type::ABSOLUTE) {
-            //Convert to estimated fractional
-            Fc /= W;
-        }
-        VTR_ASSERT_MSG(Fc >= 0 && Fc <= 1., "Fc should be fractional");
-
-        for (int ipin : fc_spec.pins) {
-            e_pin_type pin_type = get_pin_type_from_pin_physical_num(type, ipin);
-
-            if (pin_type == DRIVER) {
-                Fc_out = std::max(Fc, Fc_out);
-            } else {
-                VTR_ASSERT(pin_type == RECEIVER);
-                Fc_in = std::max(Fc, Fc_in);
-            }
-        }
-    }
-
-    /* Estimates of switch fan-in are done as follows:
-     * 1) opin to wire switch:
-     * 2 CLBs connect to a channel, each with #opins/4 pins. Each pin has Fc_out*W
-     * switches, and then we assume the switches are distributed evenly over the W wires.
-     * In the unidirectional case, all these switches are then crammed down to W/wire_segment_length wires.
-     *
-     * Unidirectional: 2 * #opins_per_side * Fc_out * wire_segment_length
-     * Bidirectional:  2 * #opins_per_side * Fc_out
-     *
-     * 2) wire to wire switch
-     * A wire segment in a switchblock connects to Fs other wires. Assuming these connections are evenly
-     * distributed, each target wire receives Fs connections as well. In the unidirectional case,
-     * source wires can only connect to W/wire_segment_length wires.
-     *
-     * Unidirectional: Fs * wire_segment_length
-     * Bidirectional:  Fs
-     *
-     * 3) wire to ipin switch
-     * An input pin of a CLB simply receives Fc_in connections.
-     *
-     * Unidirectional: Fc_in
-     * Bidirectional:  Fc_in
-     */
-
-    /* Fan-in to opin/ipin/wire switches depends on whether the architecture is unidirectional/bidirectional */
-    (*opin_switch_fanin) = 2 * type->num_drivers / 4 * Fc_out;
-    (*wire_switch_fanin) = Fs;
-    (*ipin_switch_fanin) = Fc_in;
-    if (directionality == UNI_DIRECTIONAL) {
-        /* adjustments to opin-to-wire and wire-to-wire switch fan-ins */
-        (*opin_switch_fanin) *= wire_segment_length;
-        (*wire_switch_fanin) *= wire_segment_length;
-    } else if (directionality == BI_DIRECTIONAL) {
-        /* no adjustments need to be made here */
-    } else {
-        VPR_FATAL_ERROR(VPR_ERROR_PACK, "Unrecognized directionality: %d\n", (int)directionality);
-    }
 }
 
 ///@brief Free architecture data structures

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -480,9 +480,7 @@ static void get_intercluster_switch_fanin_estimates(const t_arch& arch,
      */
 
     /* Fan-in to opin/ipin/wire switches depends on whether the architecture is unidirectional/bidirectional */
-    // FIXME This line may have precision issues. Should 2 and 4 be floats?
-    //       This should also use parenthesis to make it more clear what each term means.
-    (*opin_switch_fanin) = 2 * type->num_drivers / 4 * Fc_out;
+    (*opin_switch_fanin) = 2.f * type->num_drivers / 4.f * Fc_out;
     (*wire_switch_fanin) = routing_arch.Fs;
     (*ipin_switch_fanin) = Fc_in;
     if (routing_arch.directionality == UNI_DIRECTIONAL) {

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -23,12 +23,38 @@ static bool try_size_device_grid(const t_arch& arch,
                                  float target_device_utilization,
                                  const std::string& device_layout_name);
 
+/**
+ * Since the parameters of a switch may change as a function of its fanin,
+ * to get an estimation of inter-cluster delays we need a reasonable estimation
+ * of the fan-ins of switches that connect clusters together. These switches are
+ * 1) opin to wire switch
+ * 2) wire to wire switch
+ * 3) wire to ipin switch
+ * We can estimate the fan-in of these switches based on the Fc_in/Fc_out of
+ * a logic block, and the switch block Fs value
+ */
+static void get_intercluster_switch_fanin_estimates(const t_arch& arch,
+                                                    const t_det_routing_arch& routing_arch,
+                                                    const std::string& device_layout,
+                                                    const int wire_segment_length,
+                                                    int* opin_switch_fanin,
+                                                    int* wire_switch_fanin,
+                                                    int* ipin_switch_fanin);
+
+static float get_arch_switch_info(short switch_index, int switch_fanin,
+                                  float& Tdel_switch, float& R_switch,
+                                  float& Cout_switch);
+
+static float approximate_inter_cluster_delay(const t_arch& arch,
+                                             const t_det_routing_arch& routing_arch,
+                                             const std::string& device_layout);
+
 bool try_pack(t_packer_opts* packer_opts,
               const t_analysis_opts* analysis_opts,
-              const t_arch* arch,
+              const t_arch& arch,
+              const t_det_routing_arch& routing_arch,
               const t_model* user_models,
               const t_model* library_models,
-              float interc_delay,
               std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,
               const FlatPlacementInfo& flat_placement_info) {
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
@@ -92,6 +118,12 @@ bool try_pack(t_packer_opts* packer_opts,
     }
 
     if (packer_opts->auto_compute_inter_cluster_net_delay) {
+        float interc_delay = UNDEFINED;
+        if (packer_opts->timing_driven) {
+            interc_delay = approximate_inter_cluster_delay(arch,
+                                                           routing_arch,
+                                                           packer_opts->device_layout);
+        }
         packer_opts->inter_cluster_net_delay = interc_delay;
         VTR_LOG("Using inter-cluster delay: %g\n", packer_opts->inter_cluster_net_delay);
     }
@@ -139,7 +171,7 @@ bool try_pack(t_packer_opts* packer_opts,
     GreedyClusterer clusterer(*packer_opts,
                               *analysis_opts,
                               atom_ctx.nlist,
-                              *arch,
+                              arch,
                               high_fanout_thresholds,
                               is_clock,
                               is_global,
@@ -158,7 +190,7 @@ bool try_pack(t_packer_opts* packer_opts,
                                                           mutable_device_ctx);
 
         //Try to size/find a device
-        bool fits_on_device = try_size_device_grid(*arch, num_used_type_instances, packer_opts->target_device_utilization, packer_opts->device_layout);
+        bool fits_on_device = try_size_device_grid(arch, num_used_type_instances, packer_opts->target_device_utilization, packer_opts->device_layout);
 
         /* We use this bool to determine the cause for the clustering not being dense enough. If the clustering
          * is not dense enough and there are floorplan constraints, it is presumed that the constraints are the cause
@@ -285,7 +317,7 @@ bool try_pack(t_packer_opts* packer_opts,
     /******************** End **************************/
 
     //check clustering and output it
-    check_and_output_clustering(cluster_legalizer, *packer_opts, is_clock, arch);
+    check_and_output_clustering(cluster_legalizer, *packer_opts, is_clock, &arch);
 
     VTR_LOG("\n");
     VTR_LOG("Netlist conversion complete.\n");
@@ -294,7 +326,7 @@ bool try_pack(t_packer_opts* packer_opts,
     return true;
 }
 
-float get_arch_switch_info(short switch_index, int switch_fanin, float& Tdel_switch, float& R_switch, float& Cout_switch) {
+static float get_arch_switch_info(short switch_index, int switch_fanin, float& Tdel_switch, float& R_switch, float& Cout_switch) {
     /* Fetches delay, resistance and output capacitance of the architecture switch at switch_index.
      * Returns the total delay through the switch. Used to calculate inter-cluster net delay. */
 
@@ -380,5 +412,136 @@ static bool try_size_device_grid(const t_arch& arch,
     VTR_LOG("\n");
 
     return fits_on_device;
+}
+
+static void get_intercluster_switch_fanin_estimates(const t_arch& arch,
+                                                    const t_det_routing_arch& routing_arch,
+                                                    const std::string& device_layout,
+                                                    const int wire_segment_length,
+                                                    int* opin_switch_fanin,
+                                                    int* wire_switch_fanin,
+                                                    int* ipin_switch_fanin) {
+    // W is unknown pre-packing, so *if* we need W here, we will assume a value of 100
+    constexpr int W = 100;
+
+    //Build a dummy 10x10 device to determine the 'best' block type to use
+    auto grid = create_device_grid(device_layout, arch.grid_layouts, 10, 10);
+
+    auto type = find_most_common_tile_type(grid);
+    /* get Fc_in/out for most common block (e.g. logic blocks) */
+    VTR_ASSERT(!type->fc_specs.empty());
+
+    //Estimate the maximum Fc_in/Fc_out
+    float Fc_in = 0.f;
+    float Fc_out = 0.f;
+    for (const t_fc_specification& fc_spec : type->fc_specs) {
+        float Fc = fc_spec.fc_value;
+
+        if (fc_spec.fc_value_type == e_fc_value_type::ABSOLUTE) {
+            //Convert to estimated fractional
+            Fc /= W;
+        }
+        VTR_ASSERT_MSG(Fc >= 0 && Fc <= 1., "Fc should be fractional");
+
+        for (int ipin : fc_spec.pins) {
+            e_pin_type pin_type = get_pin_type_from_pin_physical_num(type, ipin);
+
+            if (pin_type == DRIVER) {
+                Fc_out = std::max(Fc, Fc_out);
+            } else {
+                VTR_ASSERT(pin_type == RECEIVER);
+                Fc_in = std::max(Fc, Fc_in);
+            }
+        }
+    }
+
+    /* Estimates of switch fan-in are done as follows:
+     * 1) opin to wire switch:
+     * 2 CLBs connect to a channel, each with #opins/4 pins. Each pin has Fc_out*W
+     * switches, and then we assume the switches are distributed evenly over the W wires.
+     * In the unidirectional case, all these switches are then crammed down to W/wire_segment_length wires.
+     *
+     * Unidirectional: 2 * #opins_per_side * Fc_out * wire_segment_length
+     * Bidirectional:  2 * #opins_per_side * Fc_out
+     *
+     * 2) wire to wire switch
+     * A wire segment in a switchblock connects to Fs other wires. Assuming these connections are evenly
+     * distributed, each target wire receives Fs connections as well. In the unidirectional case,
+     * source wires can only connect to W/wire_segment_length wires.
+     *
+     * Unidirectional: Fs * wire_segment_length
+     * Bidirectional:  Fs
+     *
+     * 3) wire to ipin switch
+     * An input pin of a CLB simply receives Fc_in connections.
+     *
+     * Unidirectional: Fc_in
+     * Bidirectional:  Fc_in
+     */
+
+    /* Fan-in to opin/ipin/wire switches depends on whether the architecture is unidirectional/bidirectional */
+    // FIXME This line may have precision issues. Should 2 and 4 be floats?
+    //       This should also use parenthesis to make it more clear what each term means.
+    (*opin_switch_fanin) = 2 * type->num_drivers / 4 * Fc_out;
+    (*wire_switch_fanin) = routing_arch.Fs;
+    (*ipin_switch_fanin) = Fc_in;
+    if (routing_arch.directionality == UNI_DIRECTIONAL) {
+        /* adjustments to opin-to-wire and wire-to-wire switch fan-ins */
+        (*opin_switch_fanin) *= wire_segment_length;
+        (*wire_switch_fanin) *= wire_segment_length;
+    } else if (routing_arch.directionality == BI_DIRECTIONAL) {
+        /* no adjustments need to be made here */
+    } else {
+        VPR_FATAL_ERROR(VPR_ERROR_PACK, "Unrecognized directionality: %d\n",
+                        (int)routing_arch.directionality);
+    }
+}
+
+static float approximate_inter_cluster_delay(const t_arch& arch,
+                                             const t_det_routing_arch& routing_arch,
+                                             const std::string& device_layout) {
+
+    /* If needed, estimate inter-cluster delay. Assume the average routing hop goes out of
+     * a block through an opin switch to a length-4 wire, then through a wire switch to another
+     * length-4 wire, then through a wire-to-ipin-switch into another block. */
+    constexpr int wire_segment_length = 4;
+
+    /* We want to determine a reasonable fan-in to the opin, wire, and ipin switches, based
+     * on which the intercluster delays can be estimated. The fan-in of a switch influences its
+     * delay.
+     *
+     * The fan-in of the switch depends on the architecture (unidirectional/bidirectional), as
+     * well as Fc_in/out and Fs */
+    int opin_switch_fanin, wire_switch_fanin, ipin_switch_fanin;
+    get_intercluster_switch_fanin_estimates(arch, routing_arch, device_layout, wire_segment_length, &opin_switch_fanin,
+                                            &wire_switch_fanin, &ipin_switch_fanin);
+
+    float Tdel_opin_switch, R_opin_switch, Cout_opin_switch;
+    float opin_switch_del = get_arch_switch_info(arch.Segments[0].arch_opin_switch, opin_switch_fanin,
+                                                 Tdel_opin_switch, R_opin_switch, Cout_opin_switch);
+
+    float Tdel_wire_switch, R_wire_switch, Cout_wire_switch;
+    float wire_switch_del = get_arch_switch_info(arch.Segments[0].arch_wire_switch, wire_switch_fanin,
+                                                 Tdel_wire_switch, R_wire_switch, Cout_wire_switch);
+
+    float Tdel_wtoi_switch, R_wtoi_switch, Cout_wtoi_switch;
+    float wtoi_switch_del = get_arch_switch_info(routing_arch.wire_to_arch_ipin_switch, ipin_switch_fanin,
+                                                 Tdel_wtoi_switch, R_wtoi_switch, Cout_wtoi_switch);
+
+    float Rmetal = arch.Segments[0].Rmetal;
+    float Cmetal = arch.Segments[0].Cmetal;
+
+    /* The delay of a wire with its driving switch is the switch delay plus the
+     * product of the equivalent resistance and capacitance experienced by the wire. */
+
+    float first_wire_seg_delay = opin_switch_del
+                                 + (R_opin_switch + Rmetal * (float)wire_segment_length / 2)
+                                       * (Cout_opin_switch + Cmetal * (float)wire_segment_length);
+    float second_wire_seg_delay = wire_switch_del
+                                  + (R_wire_switch + Rmetal * (float)wire_segment_length / 2)
+                                        * (Cout_wire_switch + Cmetal * (float)wire_segment_length);
+
+    /* multiply by 4 to get a more conservative estimate */
+    return 4 * (first_wire_seg_delay + second_wire_seg_delay + wtoi_switch_del);
 }
 

--- a/vpr/src/pack/pack.h
+++ b/vpr/src/pack/pack.h
@@ -8,6 +8,7 @@ class AtomNetId;
 class FlatPlacementInfo;
 struct t_analysis_opts;
 struct t_arch;
+struct t_det_routing_arch;
 struct t_lb_type_rr_node;
 struct t_model;
 struct t_packer_opts;
@@ -22,12 +23,12 @@ struct t_packer_opts;
  *              Options passed by the user to configure how analysis is
  *              performed in the packer.
  *  @param arch
- *              A pointer to the architecture to create clusters for.
+ *              The architecture to create clusters for.
+ *  @param routing_arch
  *  @param user_models
  *              A list of architecture models provided by the architecture file.
  *  @param library_models
  *              A list of architecture models provided by the library.
- *  @param interc_delay
  *  @param lb_type_rr_graphs
  *  @param flat_placement_info
  *              Flat (primitive-level) placement information that may be
@@ -36,14 +37,12 @@ struct t_packer_opts;
  */
 bool try_pack(t_packer_opts* packer_opts,
               const t_analysis_opts* analysis_opts,
-              const t_arch* arch,
+              const t_arch& arch,
+              const t_det_routing_arch& routing_arch,
               const t_model* user_models,
               const t_model* library_models,
-              float interc_delay,
               std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,
               const FlatPlacementInfo& flat_placement_info);
-
-float get_arch_switch_info(short switch_index, int switch_fanin, float& Tdel_switch, float& R_switch, float& Cout_switch);
 
 std::unordered_set<AtomNetId> alloc_and_load_is_clock();
 


### PR DESCRIPTION
The try_pack API required an approximation for the inter-cluster delay; however, this approximation was always being made the same way and did not need to be brought in externally. Inlined this into the packer itself to make the interface easier to work with.

This cleanup will help with integrating the APPack code into the AP flow.