### PR TITLE
[Pack] Removed Global Overfilled Partition Regions

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -6,18 +6,17 @@
 #include <mutex>
 
 #include "FlatPlacementInfo.h"
+#include "user_place_constraints.h"
+#include "user_route_constraints.h"
 #include "vpr_types.h"
-#include "vtr_ndmatrix.h"
 #include "vtr_optional.h"
 #include "vtr_vector.h"
 #include "vtr_vector_map.h"
 #include "atom_netlist.h"
 #include "clustered_netlist.h"
 #include "rr_graph_view.h"
-#include "rr_graph_storage.h"
 #include "rr_graph_builder.h"
 #include "rr_node.h"
-#include "rr_rc_data.h"
 #include "tatum/TimingGraph.hpp"
 #include "tatum/TimingConstraints.hpp"
 #include "power.h"
@@ -27,10 +26,7 @@
 #include "clock_connection_builders.h"
 #include "route_tree.h"
 #include "router_lookahead.h"
-#include "place_macro.h"
 #include "compressed_grid.h"
-#include "metadata_storage.h"
-#include "vpr_constraints.h"
 #include "noc_storage.h"
 #include "noc_traffic_flows.h"
 #include "noc_routing.h"
@@ -513,8 +509,6 @@ struct FloorplanningContext : public Context {
      *
      */
     std::vector<vtr::vector<ClusterBlockId, PartitionRegion>> compressed_cluster_constraints;
-
-    std::vector<PartitionRegion> overfull_partition_regions;
 };
 
 /**

--- a/vpr/src/pack/attraction_groups.cpp
+++ b/vpr/src/pack/attraction_groups.cpp
@@ -33,7 +33,8 @@ AttractionInfo::AttractionInfo(bool attraction_groups_on) {
     }
 }
 
-void AttractionInfo::create_att_groups_for_overfull_regions() {
+void AttractionInfo::create_att_groups_for_overfull_regions(
+            const std::vector<PartitionRegion>& overfull_partition_regions) {
     const auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
     auto& atom_ctx = g_vpr_ctx.atom();
     int num_parts = floorplanning_ctx.constraints.get_num_partitions();
@@ -48,8 +49,6 @@ void AttractionInfo::create_att_groups_for_overfull_regions() {
     atom_attraction_group.resize(num_atoms);
     fill(atom_attraction_group.begin(), atom_attraction_group.end(), AttractGroupId::INVALID());
 
-    const std::vector<PartitionRegion>& overfull_prs = floorplanning_ctx.overfull_partition_regions;
-
     /*
      * Create an attraction group for each partition that overlaps with at least one overfull partition
      */
@@ -58,7 +57,7 @@ void AttractionInfo::create_att_groups_for_overfull_regions() {
 
         const Partition& part = floorplanning_ctx.constraints.get_partition(partid);
 
-        for (const PartitionRegion& overfull_pr : overfull_prs) {
+        for (const PartitionRegion& overfull_pr : overfull_partition_regions) {
             PartitionRegion intersect_pr = intersection(part.get_part_region(), overfull_pr);
             if (!intersect_pr.empty()) {
                 AttractionGroup group_info;

--- a/vpr/src/pack/attraction_groups.h
+++ b/vpr/src/pack/attraction_groups.h
@@ -12,6 +12,9 @@
 #include "vtr_vector.h"
 #include "atom_netlist_fwd.h"
 
+// Forward declarations
+class PartitionRegion;
+
 /**
  * @file
  * @brief This file defines the AttractionInfo class, which is used to store atoms in attraction groups, which are
@@ -53,7 +56,7 @@ class AttractionInfo {
      * Create attraction groups for the partitions that contain overfull regions (i.e.
      * The region has more blocks of a certain type assigned to than are actually available).
      */
-    void create_att_groups_for_overfull_regions();
+    void create_att_groups_for_overfull_regions(const std::vector<PartitionRegion>& overfull_partition_regions);
 
     /*
      * Create attraction groups for all partitions.

--- a/vpr/src/pack/constraints_report.cpp
+++ b/vpr/src/pack/constraints_report.cpp
@@ -1,15 +1,12 @@
 #include "constraints_report.h"
 #include "cluster_legalizer.h"
-#include "globals.h"
 #include "grid_tile_lookup.h"
 
-bool floorplan_constraints_regions_overfull(const ClusterLegalizer& cluster_legalizer) {
+bool floorplan_constraints_regions_overfull(
+                        std::vector<PartitionRegion>& overfull_partition_regions,
+                        const ClusterLegalizer& cluster_legalizer,
+                        const std::vector<t_logical_block_type>& logical_block_types) {
     GridTileLookup grid_tiles;
-
-    auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
-    auto& device_ctx = g_vpr_ctx.device();
-
-    const std::vector<t_logical_block_type>& block_types = device_ctx.logical_block_types;
 
     // keep record of how many blocks of each type are assigned to each PartitionRegion
     std::unordered_map<PartitionRegion, std::vector<int>> pr_count_info;
@@ -22,7 +19,7 @@ bool floorplan_constraints_regions_overfull(const ClusterLegalizer& cluster_lega
         t_logical_block_type_ptr bt = cluster_legalizer.get_cluster_type(cluster_id);
         auto got = pr_count_info.find(pr);
         if (got == pr_count_info.end()) {
-            std::vector<int> block_type_counts(block_types.size(), 0);
+            std::vector<int> block_type_counts(logical_block_types.size(), 0);
             block_type_counts[bt->index]++;
             pr_count_info.insert({pr, block_type_counts});
         } else {
@@ -35,7 +32,7 @@ bool floorplan_constraints_regions_overfull(const ClusterLegalizer& cluster_lega
     for (const auto& [pr, block_type_counts] : pr_count_info) {
         const std::vector<Region>& regions = pr.get_regions();
 
-        for (const t_logical_block_type& block_type : block_types) {
+        for (const t_logical_block_type& block_type : logical_block_types) {
             int num_assigned_blocks = block_type_counts[block_type.index];
             int num_tiles = std::accumulate(regions.begin(), regions.end(), 0, [&grid_tiles, &block_type](int acc, const Region& reg) -> int {
                 return acc + grid_tiles.region_tile_count(reg, &block_type);
@@ -43,7 +40,7 @@ bool floorplan_constraints_regions_overfull(const ClusterLegalizer& cluster_lega
 
             if (num_assigned_blocks > num_tiles) {
                 floorplan_regions_overfull = true;
-                floorplanning_ctx.overfull_partition_regions.push_back(pr);
+                overfull_partition_regions.push_back(pr);
                 VTR_LOG("\n\nA partition including the following regions has been assigned %d blocks of type %s, "
                         "but only has %d tiles of that type\n",
                         num_assigned_blocks, block_type.name.c_str(), num_tiles);
@@ -62,3 +59,4 @@ bool floorplan_constraints_regions_overfull(const ClusterLegalizer& cluster_lega
 
     return floorplan_regions_overfull;
 }
+

--- a/vpr/src/pack/constraints_report.h
+++ b/vpr/src/pack/constraints_report.h
@@ -2,10 +2,13 @@
  * floorplan regions have been packed with too many clusters.
  */
 
-#ifndef VPR_SRC_PACK_CONSTRAINTS_REPORT_H_
-#define VPR_SRC_PACK_CONSTRAINTS_REPORT_H_
+#pragma once
+
+#include <vector>
 
 class ClusterLegalizer;
+class PartitionRegion;
+struct t_logical_block_type;
 
 /**
  * @brief Check if any constraint partition regions are overfull,
@@ -23,8 +26,12 @@ class ClusterLegalizer;
  * VPR can still work if these assumptions do not hold true, but for tight overlapping
  * partitions, the placement engine may fail to find a legal placement.
  *
+ * Adds the overfilled partition regions to the overfull_partition_regions vector.
+ *
  * @return True if there is at least one overfull partition.
  */
-bool floorplan_constraints_regions_overfull(const ClusterLegalizer& cluster_legalizer);
+bool floorplan_constraints_regions_overfull(
+                                std::vector<PartitionRegion> &overfull_partition_regions,
+                                const ClusterLegalizer& cluster_legalizer,
+                                const std::vector<t_logical_block_type>& logical_block_types);
 
-#endif /* VPR_SRC_PACK_CONSTRAINTS_REPORT_H_ */

--- a/vpr/src/pack/greedy_clusterer.cpp
+++ b/vpr/src/pack/greedy_clusterer.cpp
@@ -47,7 +47,6 @@
 #include "attraction_groups.h"
 #include "cluster_legalizer.h"
 #include "cluster_util.h"
-#include "constraints_report.h"
 #include "greedy_candidate_selector.h"
 #include "greedy_seed_selector.h"
 #include "physical_types.h"

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -2,11 +2,7 @@
 
 #include "globals.h"
 #include "arch_util.h"
-#include "rr_graph2.h"
-
-#include "vtr_assert.h"
-#include "vtr_log.h"
-#include "vtr_error.h"
+#include "rr_rc_data.h"
 
 #include <random>
 #include <math.h>

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -2,9 +2,9 @@
 
 #include "globals.h"
 
+#include "rr_rc_data.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
-#include "vtr_error.h"
 
 void static populate_segment_values(int seg_index,
                                     std::string name,

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "alloc_and_load_rr_indexed_data.h"
 #include "physical_types_util.h"
+#include "rr_rc_data.h"
 #include "vtr_assert.h"
 
 #include "vtr_util.h"

--- a/vpr/src/route/rr_graph_timing_params.cpp
+++ b/vpr/src/route/rr_graph_timing_params.cpp
@@ -1,14 +1,9 @@
 #include <cstdio>
 
-#include "vtr_memory.h"
-
-#include "vpr_types.h"
-#include "vpr_error.h"
-
 #include "globals.h"
 #include "rr_graph.h"
 #include "rr_graph_utils.h"
-#include "rr_graph2.h"
+#include "rr_rc_data.h"
 #include "rr_graph_timing_params.h"
 
 /****************** Subroutine definitions *********************************/


### PR DESCRIPTION
After each pack, the partition regions are checked to see if any of the partition regions are overfilled. During this process, the overfilled partition regions were stored in the Floorplanning context (likely for legacy reasons). This was then read from a few lines later in another function.

Since this is only used in such a localized scenario, turned this into a local variable instead of a global variable.