### PR TITLE
[Place] Moved PlaceMacros Out of BlkLocRegistry

### DIFF
--- a/vpr/src/analytical_place/full_legalizer.cpp
+++ b/vpr/src/analytical_place/full_legalizer.cpp
@@ -467,7 +467,16 @@ void NaiveFullLegalizer::legalize(const PartialPlacement& p_placement) {
     // Get the clustering from the global context.
     // TODO: Eventually should be returned from the create_clusters method.
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    const PlaceMacros& place_macros = *g_vpr_ctx.clustering().place_macros;
+
+    // Alloc and load the placement macros.
+    VTR_ASSERT(!g_vpr_ctx.placement().place_macros);
+    g_vpr_ctx.mutable_placement().place_macros = std::make_unique<PlaceMacros>(g_vpr_ctx.device().arch->directs,
+                                                                               g_vpr_ctx.device().physical_tile_types,
+                                                                               g_vpr_ctx.clustering().clb_nlist,
+                                                                               g_vpr_ctx.atom().nlist,
+                                                                               g_vpr_ctx.atom().lookup);
+
+    const PlaceMacros& place_macros = *g_vpr_ctx.placement().place_macros;
 
     // Place the clusters based on where the atoms want to be placed.
     place_clusters(clb_nlist, place_macros, p_placement);
@@ -533,9 +542,7 @@ void APPack::legalize(const PartialPlacement& p_placement) {
     // TODO: This should only be the initial placer. Running the full SA would
     //       be more of a Detailed Placer.
     const auto& placement_net_list = (const Netlist<>&)clb_nlist;
-    const PlaceMacros& place_macros = *g_vpr_ctx.clustering().place_macros;
     try_place(placement_net_list,
-              place_macros,
               vpr_setup_.PlacerOpts,
               vpr_setup_.RouterOpts,
               vpr_setup_.AnalysisOpts,

--- a/vpr/src/analytical_place/full_legalizer.h
+++ b/vpr/src/analytical_place/full_legalizer.h
@@ -19,6 +19,7 @@ class AtomNetlist;
 class ClusteredNetlist;
 class DeviceGrid;
 class PartialPlacement;
+class PlaceMacros;
 class Prepacker;
 struct t_arch;
 struct t_logical_block_type;
@@ -125,6 +126,7 @@ private:
      *        placement.
      */
     void place_clusters(const ClusteredNetlist& clb_nlist,
+                        const PlaceMacros& place_macros,
                         const PartialPlacement& p_placement);
 
 };

--- a/vpr/src/base/blk_loc_registry.cpp
+++ b/vpr/src/base/blk_loc_registry.cpp
@@ -45,14 +45,6 @@ int BlkLocRegistry::net_pin_to_tile_pin_index(const ClusterNetId net_id, int net
     return this->tile_pin_index(pin_id);
 }
 
-const PlaceMacros& BlkLocRegistry::place_macros() const {
-    return place_macros_;
-}
-
-PlaceMacros& BlkLocRegistry::mutable_place_macros() {
-    return  place_macros_;
-}
-
 void BlkLocRegistry::set_block_location(ClusterBlockId blk_id, const t_pl_loc& location) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -289,3 +281,4 @@ t_physical_tile_loc BlkLocRegistry::get_coordinate_of_pin(ClusterPinId pin) cons
 
     return tile_loc;
 }
+

--- a/vpr/src/base/blk_loc_registry.h
+++ b/vpr/src/base/blk_loc_registry.h
@@ -5,7 +5,6 @@
 #include "vtr_vector_map.h"
 #include "vpr_types.h"
 #include "grid_block.h"
-#include "place_macro.h"
 
 struct t_block_loc;
 struct t_pl_blocks_to_be_moved;
@@ -37,13 +36,6 @@ class BlkLocRegistry {
     ///@brief Clustered pin placement mapping with physical pin
     vtr::vector_map<ClusterPinId, int> physical_pins_;
 
-    /**
-     * @brief Contains information about placement macros.
-     * A placement macro is a set of clustered blocks that must be placed
-     * in a way that is compliant with relative locations specified by the macro.
-     */
-    PlaceMacros place_macros_;
-
     /// @brief Stores ClusterBlockId of all movable clustered blocks
     /// (blocks that are not locked down to a single location)
     std::vector<ClusterBlockId> movable_blocks_;
@@ -66,12 +58,6 @@ class BlkLocRegistry {
 
     ///@brief Returns the physical pin of the tile, related to the given ClusterNedId, and the net pin index.
     int net_pin_to_tile_pin_index(const ClusterNetId net_id, int net_pin_index) const;
-
-    ///@brief Returns a constant reference to placement macros.
-    const PlaceMacros& place_macros() const;
-
-    ///@brief Returns a mutable reference to placement macros.
-    PlaceMacros& mutable_place_macros();
 
     /// @brief Returns a constant reference to the vector of ClusterBlockIds of all movable clustered blocks.
     const std::vector<ClusterBlockId>& movable_blocks() const { return movable_blocks_; }
@@ -170,3 +156,4 @@ class BlkLocRegistry {
 
     e_expected_transaction expected_transaction_;
 };
+

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 #include "FlatPlacementInfo.h"
+#include "place_macro.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
 
@@ -45,6 +46,7 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
                                   const t_noc_opts& noc_opts,
                                   const t_file_name_opts& filename_opts,
                                   const t_arch* arch,
+                                  const PlaceMacros& place_macros,
                                   bool verify_binary_search,
                                   int min_chan_width_hint,
                                   t_det_routing_arch* det_routing_arch,
@@ -166,6 +168,7 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
         if (placer_opts.place_freq == PLACE_ALWAYS) {
             placer_opts.place_chan_width = current;
             try_place(placement_net_list,
+                      place_macros,
                       placer_opts,
                       router_opts,
                       analysis_opts,
@@ -310,7 +313,7 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
                 break;
             if (placer_opts.place_freq == PLACE_ALWAYS) {
                 placer_opts.place_chan_width = current;
-                try_place(placement_net_list, placer_opts, router_opts, analysis_opts, noc_opts,
+                try_place(placement_net_list, place_macros, placer_opts, router_opts, analysis_opts, noc_opts,
                           arch->Chans, det_routing_arch, segment_inf,
                           arch->directs,
                           FlatPlacementInfo(),  // Pass empty flat placement info.

--- a/vpr/src/base/place_and_route.cpp
+++ b/vpr/src/base/place_and_route.cpp
@@ -46,7 +46,6 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
                                   const t_noc_opts& noc_opts,
                                   const t_file_name_opts& filename_opts,
                                   const t_arch* arch,
-                                  const PlaceMacros& place_macros,
                                   bool verify_binary_search,
                                   int min_chan_width_hint,
                                   t_det_routing_arch* det_routing_arch,
@@ -168,7 +167,6 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
         if (placer_opts.place_freq == PLACE_ALWAYS) {
             placer_opts.place_chan_width = current;
             try_place(placement_net_list,
-                      place_macros,
                       placer_opts,
                       router_opts,
                       analysis_opts,
@@ -313,7 +311,7 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
                 break;
             if (placer_opts.place_freq == PLACE_ALWAYS) {
                 placer_opts.place_chan_width = current;
-                try_place(placement_net_list, place_macros, placer_opts, router_opts, analysis_opts, noc_opts,
+                try_place(placement_net_list, placer_opts, router_opts, analysis_opts, noc_opts,
                           arch->Chans, det_routing_arch, segment_inf,
                           arch->directs,
                           FlatPlacementInfo(),  // Pass empty flat placement info.

--- a/vpr/src/base/place_and_route.h
+++ b/vpr/src/base/place_and_route.h
@@ -11,6 +11,8 @@
 #include "RoutingDelayCalculator.h"
 #include "rr_graph.h"
 
+class PlaceMacros;
+
 struct t_fmap_cell {
     int fs;         ///<at this fs
     int fc;         ///<at this fc
@@ -27,6 +29,7 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
                                   const t_noc_opts& noc_opts,
                                   const t_file_name_opts& filename_opts,
                                   const t_arch* arch,
+                                  const PlaceMacros& place_macros,
                                   bool verify_binary_search,
                                   int min_chan_width_hint,
                                   t_det_routing_arch* det_routing_arch,

--- a/vpr/src/base/place_and_route.h
+++ b/vpr/src/base/place_and_route.h
@@ -11,8 +11,6 @@
 #include "RoutingDelayCalculator.h"
 #include "rr_graph.h"
 
-class PlaceMacros;
-
 struct t_fmap_cell {
     int fs;         ///<at this fs
     int fc;         ///<at this fc
@@ -29,7 +27,6 @@ int binary_search_place_and_route(const Netlist<>& placement_net_list,
                                   const t_noc_opts& noc_opts,
                                   const t_file_name_opts& filename_opts,
                                   const t_arch* arch,
-                                  const PlaceMacros& place_macros,
                                   bool verify_binary_search,
                                   int min_chan_width_hint,
                                   t_det_routing_arch* det_routing_arch,

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -15,9 +15,11 @@
 #include <cstring>
 #include <cmath>
 #include <memory>
+#include <vector>
 
 #include "FlatPlacementInfo.h"
 #include "cluster_util.h"
+#include "physical_types.h"
 #include "place_macro.h"
 #include "verify_placement.h"
 #include "vpr_context.h"
@@ -394,8 +396,7 @@ bool vpr_flow(t_vpr_setup& vpr_setup, t_arch& arch) {
 
     { //Place
         const auto& placement_net_list = (const Netlist<>&)g_vpr_ctx.clustering().clb_nlist;
-        const PlaceMacros& place_macros = *g_vpr_ctx.clustering().place_macros;
-        bool place_success = vpr_place_flow(placement_net_list, vpr_setup, arch, place_macros);
+        bool place_success = vpr_place_flow(placement_net_list, vpr_setup, arch);
 
         if (!place_success) {
             return false; //Unimplementable
@@ -420,10 +421,9 @@ bool vpr_flow(t_vpr_setup& vpr_setup, t_arch& arch) {
 
     bool is_flat = vpr_setup.RouterOpts.flat_routing;
     const Netlist<>& router_net_list = is_flat ? (const Netlist<>&)g_vpr_ctx.atom().nlist : (const Netlist<>&)g_vpr_ctx.clustering().clb_nlist;
-    const PlaceMacros& place_macros = *g_vpr_ctx.clustering().place_macros;
     RouteStatus route_status;
     { //Route
-        route_status = vpr_route_flow(router_net_list, vpr_setup, arch, place_macros, is_flat);
+        route_status = vpr_route_flow(router_net_list, vpr_setup, arch, is_flat);
     }
     { //Analysis
         vpr_analysis_flow(router_net_list, vpr_setup, arch, route_status, is_flat);
@@ -709,13 +709,6 @@ void vpr_load_packing(const t_vpr_setup& vpr_setup, const t_arch& arch) {
     // print the total number of used physical blocks for each
     // physical block type after finishing the packing stage
     print_pb_type_count(g_vpr_ctx.clustering().clb_nlist);
-
-    // Alloc and load the placement macros.
-    cluster_ctx.place_macros = std::make_unique<PlaceMacros>(arch.directs,
-                                                             g_vpr_ctx.device().physical_tile_types,
-                                                             cluster_ctx.clb_nlist,
-                                                             g_vpr_ctx.atom().nlist,
-                                                             g_vpr_ctx.atom().lookup);
 }
 
 bool vpr_load_flat_placement(t_vpr_setup& vpr_setup, const t_arch& arch) {
@@ -754,8 +747,7 @@ bool vpr_load_flat_placement(t_vpr_setup& vpr_setup, const t_arch& arch) {
 
 bool vpr_place_flow(const Netlist<>& net_list,
                     t_vpr_setup& vpr_setup,
-                    const t_arch& arch,
-                    const PlaceMacros& place_macros) {
+                    const t_arch& arch) {
     VTR_LOG("\n");
     const auto& placer_opts = vpr_setup.PlacerOpts;
     const auto& filename_opts = vpr_setup.FileNameOpts;
@@ -764,13 +756,13 @@ bool vpr_place_flow(const Netlist<>& net_list,
     } else {
         if (placer_opts.doPlacement == STAGE_DO) {
             //Do the actual placement
-            vpr_place(net_list, vpr_setup, arch, place_macros);
+            vpr_place(net_list, vpr_setup, arch);
 
         } else {
             VTR_ASSERT(placer_opts.doPlacement == STAGE_LOAD);
 
             //Load a previous placement
-            vpr_load_placement(vpr_setup);
+            vpr_load_placement(vpr_setup, arch.directs);
         }
 
         post_place_sync();
@@ -797,8 +789,7 @@ bool vpr_place_flow(const Netlist<>& net_list,
 
 void vpr_place(const Netlist<>& net_list,
                t_vpr_setup& vpr_setup,
-               const t_arch& arch,
-               const PlaceMacros& place_macros) {
+               const t_arch& arch) {
     bool is_flat = false;
     if (vpr_setup.PlacerOpts.place_algorithm.is_timing_driven()) {
         // Prime lookahead cache to avoid adding lookahead computation cost to
@@ -823,7 +814,6 @@ void vpr_place(const Netlist<>& net_list,
     }
 
     try_place(net_list,
-              place_macros,
               vpr_setup.PlacerOpts,
               vpr_setup.RouterOpts,
               vpr_setup.AnalysisOpts,
@@ -846,7 +836,8 @@ void vpr_place(const Netlist<>& net_list,
                                block_locs);
 }
 
-void vpr_load_placement(t_vpr_setup& vpr_setup) {
+void vpr_load_placement(t_vpr_setup& vpr_setup,
+                        const std::vector<t_direct_inf> directs) {
     vtr::ScopedStartFinishTimer timer("Load Placement");
 
     const auto& device_ctx = g_vpr_ctx.device();
@@ -856,6 +847,13 @@ void vpr_load_placement(t_vpr_setup& vpr_setup) {
 
     //Initialize placement data structures, which will be filled when loading placement
     init_placement_context(blk_loc_registry);
+
+    // Alloc and load the placement macros.
+    place_ctx.place_macros = std::make_unique<PlaceMacros>(directs,
+                                                           device_ctx.physical_tile_types,
+                                                           g_vpr_ctx.clustering().clb_nlist,
+                                                           g_vpr_ctx.atom().nlist,
+                                                           g_vpr_ctx.atom().lookup);
 
     //Load an existing placement from a file
     place_ctx.placement_id = read_place(filename_opts.NetFile.c_str(), filename_opts.PlaceFile.c_str(),
@@ -878,7 +876,6 @@ void vpr_load_placement(t_vpr_setup& vpr_setup) {
 RouteStatus vpr_route_flow(const Netlist<>& net_list,
                            t_vpr_setup& vpr_setup,
                            const t_arch& arch,
-                           const PlaceMacros& place_macros,
                            bool is_flat) {
     VTR_LOG("\n");
 
@@ -925,7 +922,7 @@ RouteStatus vpr_route_flow(const Netlist<>& net_list,
             //Do the actual routing
             if (NO_FIXED_CHANNEL_WIDTH == chan_width) {
                 //Find minimum channel width
-                route_status = vpr_route_min_W(net_list, vpr_setup, arch, timing_info, routing_delay_calc, net_delay, place_macros, is_flat);
+                route_status = vpr_route_min_W(net_list, vpr_setup, arch, timing_info, routing_delay_calc, net_delay, is_flat);
             } else {
                 //Route at specified channel width
                 route_status = vpr_route_fixed_W(net_list, vpr_setup, arch, chan_width, timing_info, routing_delay_calc, net_delay, is_flat);
@@ -1055,7 +1052,6 @@ RouteStatus vpr_route_min_W(const Netlist<>& net_list,
                             std::shared_ptr<SetupHoldTimingInfo> timing_info,
                             std::shared_ptr<RoutingDelayCalculator> delay_calc,
                             NetPinsMatrix<float>& net_delay,
-                            const PlaceMacros& place_macros,
                             bool is_flat) {
     // Note that lookahead cache is not primed here because
     // binary_search_place_and_route will change the channel width, and result
@@ -1072,7 +1068,6 @@ RouteStatus vpr_route_min_W(const Netlist<>& net_list,
                                               vpr_setup.NocOpts,
                                               vpr_setup.FileNameOpts,
                                               &arch,
-                                              place_macros,
                                               router_opts.verify_binary_search,
                                               router_opts.min_channel_width_hint,
                                               &vpr_setup.RoutingArch,

--- a/vpr/src/base/vpr_api.h
+++ b/vpr/src/base/vpr_api.h
@@ -41,6 +41,8 @@
 
 #include "vpr_error.h"
 
+class PlaceMacros;
+
 /*
  * Main VPR Operations
  */
@@ -71,13 +73,19 @@ bool vpr_load_flat_placement(t_vpr_setup& vpr_setup, const t_arch& arch);
 /* Placement */
 
 ///@brief Perform, load or skip the placement stage
-bool vpr_place_flow(const Netlist<>& net_list, t_vpr_setup& vpr_setup, const t_arch& arch);
+bool vpr_place_flow(const Netlist<>& net_list,
+                    t_vpr_setup& vpr_setup,
+                    const t_arch& arch,
+                    const PlaceMacros& place_macros);
 
 ///@brief Perform placement
-void vpr_place(const Netlist<>& net_list, t_vpr_setup& vpr_setup, const t_arch& arch);
+void vpr_place(const Netlist<>& net_list,
+               t_vpr_setup& vpr_setup,
+               const t_arch& arch,
+               const PlaceMacros& place_macros);
 
 ///@brief Loads a previous placement
-void vpr_load_placement(t_vpr_setup& vpr_setup, const t_arch& arch);
+void vpr_load_placement(t_vpr_setup& vpr_setup);
 
 /* Routing */
 
@@ -85,6 +93,7 @@ void vpr_load_placement(t_vpr_setup& vpr_setup, const t_arch& arch);
 RouteStatus vpr_route_flow(const Netlist<>& net_list,
                            t_vpr_setup& vpr_setup,
                            const t_arch& arch,
+                           const PlaceMacros& place_macros,
                            bool is_flat);
 
 ///@brief Perform routing at a fixed channel width)
@@ -104,6 +113,7 @@ RouteStatus vpr_route_min_W(const Netlist<>& net_list,
                             std::shared_ptr<SetupHoldTimingInfo> timing_info,
                             std::shared_ptr<RoutingDelayCalculator> delay_calc,
                             NetPinsMatrix<float>& net_delay,
+                            const PlaceMacros& place_macros,
                             bool is_flat);
 
 ///@brief Loads a previous routing

--- a/vpr/src/base/vpr_api.h
+++ b/vpr/src/base/vpr_api.h
@@ -41,8 +41,6 @@
 
 #include "vpr_error.h"
 
-class PlaceMacros;
-
 /*
  * Main VPR Operations
  */
@@ -75,17 +73,16 @@ bool vpr_load_flat_placement(t_vpr_setup& vpr_setup, const t_arch& arch);
 ///@brief Perform, load or skip the placement stage
 bool vpr_place_flow(const Netlist<>& net_list,
                     t_vpr_setup& vpr_setup,
-                    const t_arch& arch,
-                    const PlaceMacros& place_macros);
+                    const t_arch& arch);
 
 ///@brief Perform placement
 void vpr_place(const Netlist<>& net_list,
                t_vpr_setup& vpr_setup,
-               const t_arch& arch,
-               const PlaceMacros& place_macros);
+               const t_arch& arch);
 
 ///@brief Loads a previous placement
-void vpr_load_placement(t_vpr_setup& vpr_setup);
+void vpr_load_placement(t_vpr_setup& vpr_setup,
+                        const std::vector<t_direct_inf> directs);
 
 /* Routing */
 
@@ -93,7 +90,6 @@ void vpr_load_placement(t_vpr_setup& vpr_setup);
 RouteStatus vpr_route_flow(const Netlist<>& net_list,
                            t_vpr_setup& vpr_setup,
                            const t_arch& arch,
-                           const PlaceMacros& place_macros,
                            bool is_flat);
 
 ///@brief Perform routing at a fixed channel width)
@@ -113,7 +109,6 @@ RouteStatus vpr_route_min_W(const Netlist<>& net_list,
                             std::shared_ptr<SetupHoldTimingInfo> timing_info,
                             std::shared_ptr<RoutingDelayCalculator> delay_calc,
                             NetPinsMatrix<float>& net_delay,
-                            const PlaceMacros& place_macros,
                             bool is_flat);
 
 ///@brief Loads a previous routing

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -6,6 +6,7 @@
 #include <mutex>
 
 #include "FlatPlacementInfo.h"
+#include "place_macro.h"
 #include "user_place_constraints.h"
 #include "user_route_constraints.h"
 #include "vpr_types.h"
@@ -300,6 +301,14 @@ struct ClusteringContext : public Context {
     ///        clustered block [0 .. num_clustered_blocks-1]
     /// This is populated when the packing is loaded.
     vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>> atoms_lookup;
+
+    /// @brief Collection of all the placement macros in the netlist. A placement
+    ///        macro is a set of clustered blocks that must be placed in a way
+    ///        that is compliant with relative locations specified by the macro.
+    ///        Macros are used during placement and are not modified after they
+    ///        are created.
+    /// This is created when the packing is loaded.
+    std::unique_ptr<PlaceMacros> place_macros;
 };
 
 /**

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -301,14 +301,6 @@ struct ClusteringContext : public Context {
     ///        clustered block [0 .. num_clustered_blocks-1]
     /// This is populated when the packing is loaded.
     vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>> atoms_lookup;
-
-    /// @brief Collection of all the placement macros in the netlist. A placement
-    ///        macro is a set of clustered blocks that must be placed in a way
-    ///        that is compliant with relative locations specified by the macro.
-    ///        Macros are used during placement and are not modified after they
-    ///        are created.
-    /// This is created when the packing is loaded.
-    std::unique_ptr<PlaceMacros> place_macros;
 };
 
 /**
@@ -370,6 +362,16 @@ struct PlacementContext : public Context {
      * make the block location information accessible for subsequent stages.
      */
     void unlock_loc_vars() { VTR_ASSERT_SAFE(!loc_vars_are_accessible_); loc_vars_are_accessible_ = true; }
+
+    /**
+     * @brief Collection of all the placement macros in the netlist. A placement
+     *        macro is a set of clustered blocks that must be placed in a way
+     *        that is compliant with relative locations specified by the macro.
+     *        Macros are used during placement and are not modified after they
+     *        are created.
+     * This is created at the start of placement.
+     */
+    std::unique_ptr<PlaceMacros> place_macros;
 
     /**
      * @brief Compressed grid space for each block type

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -569,7 +569,7 @@ void init_draw_coords(float clb_width, const BlkLocRegistry& blk_loc_registry) {
             draw_state->draw_rr_node[inode].node_highlighted = false;
         }
     }
-    draw_coords->tile_width = clb_width;
+    draw_coords->set_tile_width(clb_width);
     draw_coords->pin_size = 0.3;
     for (const auto& type : device_ctx.physical_tile_types) {
         auto num_pins = type.num_pins;

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -776,7 +776,9 @@ void draw_placement_macros(ezgl::renderer* g) {
     t_draw_coords* draw_coords = get_draw_coords_vars();
 
     const auto& block_locs = draw_state->get_graphics_blk_loc_registry_ref().block_locs();
-    const auto& place_macros = draw_state->get_graphics_blk_loc_registry_ref().place_macros();
+
+    VTR_ASSERT(g_vpr_ctx.clustering().place_macros);
+    const PlaceMacros& place_macros = *g_vpr_ctx.clustering().place_macros;
 
     for (const t_pl_macro& pl_macro : place_macros.macros()) {
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -777,8 +777,8 @@ void draw_placement_macros(ezgl::renderer* g) {
 
     const auto& block_locs = draw_state->get_graphics_blk_loc_registry_ref().block_locs();
 
-    VTR_ASSERT(g_vpr_ctx.clustering().place_macros);
-    const PlaceMacros& place_macros = *g_vpr_ctx.clustering().place_macros;
+    VTR_ASSERT(g_vpr_ctx.placement().place_macros);
+    const PlaceMacros& place_macros = *g_vpr_ctx.placement().place_macros;
 
     for (const t_pl_macro& pl_macro : place_macros.macros()) {
 

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -410,6 +410,11 @@ struct t_draw_coords {
     ///@brief constructor
     t_draw_coords();
 
+    ///@brief Sets the tile width
+    inline void set_tile_width(float new_tile_width) {
+        tile_width = new_tile_width;
+    }
+
     ///@brief returns tile width
     float get_tile_width();
 

--- a/vpr/src/draw/manual_moves.cpp
+++ b/vpr/src/draw/manual_moves.cpp
@@ -18,6 +18,7 @@
 #include "draw_searchbar.h"
 #include "buttons.h"
 #include "physical_types_util.h"
+#include "place_macro.h"
 
 #ifndef NO_GRAPHICS
 
@@ -319,13 +320,14 @@ e_create_move manual_move_display_and_propose(ManualMoveGenerator& manual_move_g
                                               t_pl_blocks_to_be_moved& blocks_affected,
                                               e_move_type& move_type,
                                               float rlim,
+                                              const PlaceMacros& place_macros,
                                               const t_placer_opts& placer_opts,
                                               const PlacerCriticalities* criticalities) {
     draw_manual_moves_window("");
     update_screen(ScreenUpdatePriority::MAJOR, " ", PLACEMENT, nullptr);
     move_type = e_move_type::MANUAL_MOVE;
     t_propose_action proposed_action{move_type, -1}; //no need to specify block type in manual move "propose_move" function
-    return manual_move_generator.propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
+    return manual_move_generator.propose_move(blocks_affected, proposed_action, rlim, place_macros, placer_opts, criticalities);
 }
 
 #endif /*NO_GRAPHICS*/

--- a/vpr/src/draw/manual_moves.cpp
+++ b/vpr/src/draw/manual_moves.cpp
@@ -18,7 +18,6 @@
 #include "draw_searchbar.h"
 #include "buttons.h"
 #include "physical_types_util.h"
-#include "place_macro.h"
 
 #ifndef NO_GRAPHICS
 
@@ -320,14 +319,13 @@ e_create_move manual_move_display_and_propose(ManualMoveGenerator& manual_move_g
                                               t_pl_blocks_to_be_moved& blocks_affected,
                                               e_move_type& move_type,
                                               float rlim,
-                                              const PlaceMacros& place_macros,
                                               const t_placer_opts& placer_opts,
                                               const PlacerCriticalities* criticalities) {
     draw_manual_moves_window("");
     update_screen(ScreenUpdatePriority::MAJOR, " ", PLACEMENT, nullptr);
     move_type = e_move_type::MANUAL_MOVE;
     t_propose_action proposed_action{move_type, -1}; //no need to specify block type in manual move "propose_move" function
-    return manual_move_generator.propose_move(blocks_affected, proposed_action, rlim, place_macros, placer_opts, criticalities);
+    return manual_move_generator.propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
 }
 
 #endif /*NO_GRAPHICS*/

--- a/vpr/src/draw/manual_moves.h
+++ b/vpr/src/draw/manual_moves.h
@@ -25,6 +25,8 @@
 #    include <algorithm>
 #    include <iostream>
 
+class PlaceMacros;
+
 /**
  * @brief ManualMovesInfo struct
  *
@@ -160,6 +162,7 @@ e_create_move manual_move_display_and_propose(ManualMoveGenerator& manual_move_g
                                               t_pl_blocks_to_be_moved& blocks_affected,
                                               e_move_type& move_type,
                                               float rlim,
+                                              const PlaceMacros& place_macros,
                                               const t_placer_opts& placer_opts,
                                               const PlacerCriticalities* criticalities);
 

--- a/vpr/src/draw/manual_moves.h
+++ b/vpr/src/draw/manual_moves.h
@@ -25,8 +25,6 @@
 #    include <algorithm>
 #    include <iostream>
 
-class PlaceMacros;
-
 /**
  * @brief ManualMovesInfo struct
  *
@@ -162,7 +160,6 @@ e_create_move manual_move_display_and_propose(ManualMoveGenerator& manual_move_g
                                               t_pl_blocks_to_be_moved& blocks_affected,
                                               e_move_type& move_type,
                                               float rlim,
-                                              const PlaceMacros& place_macros,
                                               const t_placer_opts& placer_opts,
                                               const PlacerCriticalities* criticalities);
 

--- a/vpr/src/place/RL_agent_util.cpp
+++ b/vpr/src/place/RL_agent_util.cpp
@@ -1,9 +1,8 @@
 #include "RL_agent_util.h"
 
+#include "simpleRL_move_generator.h"
 #include "static_move_generator.h"
-#include "manual_move_generator.h"
 #include "placer_state.h"
-
 
 std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create_move_generators(PlacerState& placer_state,
                                                                                                  const t_placer_opts& placer_opts,

--- a/vpr/src/place/RL_agent_util.cpp
+++ b/vpr/src/place/RL_agent_util.cpp
@@ -1,10 +1,12 @@
 #include "RL_agent_util.h"
 
+#include "place_macro.h"
 #include "simpleRL_move_generator.h"
 #include "static_move_generator.h"
 #include "placer_state.h"
 
 std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create_move_generators(PlacerState& placer_state,
+                                                                                                 const PlaceMacros& place_macros,
                                                                                                  const t_placer_opts& placer_opts,
                                                                                                  int move_lim,
                                                                                                  double noc_attraction_weight,
@@ -24,8 +26,8 @@ std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create
                     move_name.c_str(),
                     placer_opts.place_static_move_prob[move_type]);
         }
-        move_generators.first = std::make_unique<StaticMoveGenerator>(placer_state, reward_fun, rng, placer_opts.place_static_move_prob);
-        move_generators.second = std::make_unique<StaticMoveGenerator>(placer_state, reward_fun, rng, placer_opts.place_static_move_prob);
+        move_generators.first = std::make_unique<StaticMoveGenerator>(placer_state, place_macros, reward_fun, rng, placer_opts.place_static_move_prob);
+        move_generators.second = std::make_unique<StaticMoveGenerator>(placer_state, place_macros, reward_fun, rng, placer_opts.place_static_move_prob);
     } else { //RL based placement
         /* For the non timing driven placement: the agent has a single state   *
          *     - Available moves are (Uniform / Median / Centroid)             *
@@ -89,6 +91,7 @@ std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create
             }
             karmed_bandit_agent1->set_step(placer_opts.place_agent_gamma, move_lim);
             move_generators.first = std::make_unique<SimpleRLMoveGenerator>(placer_state,
+                                                                            place_macros,
                                                                             reward_fun,
                                                                             rng,
                                                                             karmed_bandit_agent1,
@@ -102,6 +105,7 @@ std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create
                                                                         num_movable_blocks_per_type);
             karmed_bandit_agent2->set_step(placer_opts.place_agent_gamma, move_lim);
             move_generators.second = std::make_unique<SimpleRLMoveGenerator>(placer_state,
+                                                                             place_macros,
                                                                              reward_fun,
                                                                              rng,
                                                                              karmed_bandit_agent2,
@@ -125,6 +129,7 @@ std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create
             }
             karmed_bandit_agent1->set_step(placer_opts.place_agent_gamma, move_lim);
             move_generators.first = std::make_unique<SimpleRLMoveGenerator>(placer_state,
+                                                                            place_macros,
                                                                             reward_fun,
                                                                             rng,
                                                                             karmed_bandit_agent1,
@@ -137,6 +142,7 @@ std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create
                                                                   num_movable_blocks_per_type);
             karmed_bandit_agent2->set_step(placer_opts.place_agent_gamma, move_lim);
             move_generators.second = std::make_unique<SimpleRLMoveGenerator>(placer_state,
+                                                                             place_macros,
                                                                              reward_fun,
                                                                              rng,
                                                                              karmed_bandit_agent2,

--- a/vpr/src/place/RL_agent_util.h
+++ b/vpr/src/place/RL_agent_util.h
@@ -3,6 +3,8 @@
 
 #include "move_generator.h"
 
+class PlaceMacros;
+
 //enum represents the available agent states
 enum class e_agent_state {
     EARLY_IN_THE_ANNEAL,
@@ -27,6 +29,7 @@ enum class e_agent_state {
  *
  */
 std::pair<std::unique_ptr<MoveGenerator>, std::unique_ptr<MoveGenerator>> create_move_generators(PlacerState& placer_state,
+                                                                                                 const PlaceMacros& place_macros,
                                                                                                  const t_placer_opts& placer_opts,
                                                                                                  int move_lim,
                                                                                                  double noc_attraction_weight,

--- a/vpr/src/place/analytic_placer.cpp
+++ b/vpr/src/place/analytic_placer.cpp
@@ -1,3 +1,4 @@
+#include "place_macro.h"
 #ifdef ENABLE_ANALYTIC_PLACE
 
 #    include "analytic_placer.h"
@@ -122,8 +123,9 @@ constexpr int HEAP_STALLED_ITERATIONS_STOP = 15;
  * Placement & device info is accessed via g_vpr_ctx
  */
 
-AnalyticPlacer::AnalyticPlacer(BlkLocRegistry& blk_loc_registry)
-    : blk_loc_registry_ref_(blk_loc_registry) {
+AnalyticPlacer::AnalyticPlacer(BlkLocRegistry& blk_loc_registry,
+                               const PlaceMacros& place_macros)
+    : blk_loc_registry_ref_(blk_loc_registry), place_macros_(place_macros) {
     //Eigen::initParallel();
 
     // TODO: PlacerHeapCfg should be externally configured & supplied
@@ -297,7 +299,6 @@ void AnalyticPlacer::build_legal_locations() {
 void AnalyticPlacer::init() {
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     auto& init_block_locs = blk_loc_registry_ref_.block_locs();
-    auto& place_macros = blk_loc_registry_ref_.place_macros();
 
     for (auto blk_id : clb_nlist.blocks()) {
         blk_locs.insert(blk_id, BlockLocation{});
@@ -319,7 +320,7 @@ void AnalyticPlacer::init() {
         if (!init_block_locs[blk_id].is_fixed && has_connections(blk_id))
             // not fixed and has connections
             // matrix equation is formulated based on connections, so requires at least one connection
-            if (place_macros.get_imacro_from_iblk(blk_id) == NO_MACRO || place_macros.macro_head(blk_id) == blk_id) {
+            if (place_macros_.get_imacro_from_iblk(blk_id) == NO_MACRO || place_macros_.macro_head(blk_id) == blk_id) {
                 // not in macro or head of macro
                 // for macro, only the head (base) block of the macro is a free variable, the location of other macro
                 // blocks can be calculated using offset of the head. They are not free variables in the equation system
@@ -379,7 +380,6 @@ int AnalyticPlacer::total_hpwl() {
  */
 void AnalyticPlacer::setup_solve_blks(t_logical_block_type_ptr blkTypes) {
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    const auto& place_macros = blk_loc_registry_ref_.place_macros();
 
     int row = 0;
     solve_blks.clear();
@@ -395,9 +395,9 @@ void AnalyticPlacer::setup_solve_blks(t_logical_block_type_ptr blkTypes) {
         }
     }
     // update row_num of macro members
-    for (auto& macro : blk_loc_registry_ref_.place_macros().macros()) {
+    for (auto& macro : place_macros_.macros()) {
         for (auto& member : macro.members) {
-            row_num[member.blk_index] = row_num[place_macros.macro_head(member.blk_index)];
+            row_num[member.blk_index] = row_num[place_macros_.macro_head(member.blk_index)];
         }
     }
 }
@@ -408,7 +408,7 @@ void AnalyticPlacer::setup_solve_blks(t_logical_block_type_ptr blkTypes) {
  * when formulating the matrix equations), an update for members is necessary
  */
 void AnalyticPlacer::update_macros() {
-    for (auto& macro : blk_loc_registry_ref_.place_macros().macros()) {
+    for (auto& macro : place_macros_.macros()) {
         ClusterBlockId head_id = macro.members[0].blk_index;
         bool mac_can_be_placed = macro_can_be_placed(macro, blk_locs[head_id].loc, true, blk_loc_registry_ref_);
 
@@ -471,8 +471,6 @@ void AnalyticPlacer::stamp_weight_on_matrix(EquationSystem<double>& es,
                                             ClusterBlockId var,
                                             ClusterBlockId eqn,
                                             double weight) {
-    const auto& place_macros = blk_loc_registry_ref_.place_macros();
-
     // Return the x or y position of a block
     auto blk_p = [&](ClusterBlockId blk_id) { return dir ? blk_locs[blk_id].loc.y : blk_locs[blk_id].loc.x; };
 
@@ -486,8 +484,8 @@ void AnalyticPlacer::stamp_weight_on_matrix(EquationSystem<double>& es,
     } else { // var is not movable, stamp weight on rhs vector
         es.add_rhs(eqn_row, -v_pos * weight);
     }
-    if (place_macros.get_imacro_from_iblk(var) != NO_MACRO) { // var is part of a macro, stamp on rhs vector
-        auto& members = place_macros[place_macros.get_imacro_from_iblk(var)].members;
+    if (place_macros_.get_imacro_from_iblk(var) != NO_MACRO) { // var is part of a macro, stamp on rhs vector
+        auto& members = place_macros_[place_macros_.get_imacro_from_iblk(var)].members;
         for (auto& member : members) { // go through macro members to find the right member block
             if (member.blk_index == var)
                 es.add_rhs(eqn_row, -(dir ? member.offset.y : member.offset.x) * weight);

--- a/vpr/src/place/analytic_placer.h
+++ b/vpr/src/place/analytic_placer.h
@@ -85,6 +85,8 @@
 #    include "vpr_context.h"
 #    include "PlacementDelayCalculator.h"
 
+class PlaceMacros;
+
 /*
  * @brief Templated struct for constructing and solving matrix equations in analytic placer
  * Eigen library is used in EquationSystem::solve()
@@ -106,7 +108,7 @@ class AnalyticPlacer {
      * To tune these parameters, change directly in constructor
      */
     AnalyticPlacer() = delete;
-    explicit AnalyticPlacer(BlkLocRegistry& blk_loc_registry);
+    explicit AnalyticPlacer(BlkLocRegistry& blk_loc_registry, const PlaceMacros& place_macros);
 
     /*
      * @brief main function of analytic placement
@@ -166,6 +168,9 @@ class AnalyticPlacer {
 
     // reference to the placement location variables
     BlkLocRegistry& blk_loc_registry_ref_;
+
+    // Reference to the placement macros.
+    const PlaceMacros& place_macros_;
 
     /*
      * The set of blks of different types to be placed by AnalyticPlacement process,

--- a/vpr/src/place/annealer.cpp
+++ b/vpr/src/place/annealer.cpp
@@ -6,6 +6,7 @@
 
 #include "globals.h"
 #include "draw_global.h"
+#include "place_macro.h"
 #include "vpr_types.h"
 #include "place_util.h"
 #include "placer_state.h"
@@ -189,6 +190,7 @@ void t_annealing_state::update_crit_exponent(const t_placer_opts& placer_opts) {
 
 PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
                                      PlacerState& placer_state,
+                                     const PlaceMacros& place_macros,
                                      t_placer_costs& costs,
                                      NetCostHandler& net_cost_handler,
                                      std::optional<NocCostHandler>& noc_cost_handler,
@@ -204,6 +206,7 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
                                      int move_lim)
     : placer_opts_(placer_opts)
     , placer_state_(placer_state)
+    , place_macros_(place_macros)
     , costs_(costs)
     , net_cost_handler_(net_cost_handler)
     , noc_cost_handler_(noc_cost_handler)
@@ -388,16 +391,16 @@ e_move_result PlacementAnnealer::try_swap_(MoveGenerator& move_generator,
     if (manual_move_enabled) {
 #ifndef NO_GRAPHICS
         create_move_outcome = manual_move_display_and_propose(manual_move_generator_, blocks_affected_,
-                                                              proposed_action.move_type, rlim, placer_opts_,
-                                                              criticalities_);
+                                                              proposed_action.move_type, rlim, place_macros_,
+                                                              placer_opts_, criticalities_);
 #endif //NO_GRAPHICS
     } else if (router_block_move) {
         // generate a move where two random router blocks are swapped
-        create_move_outcome = propose_router_swap(blocks_affected_, rlim, blk_loc_registry, rng_);
+        create_move_outcome = propose_router_swap(blocks_affected_, rlim, blk_loc_registry, place_macros_, rng_);
         proposed_action.move_type = e_move_type::UNIFORM;
     } else {
         //Generate a new move (perturbation) used to explore the space of possible placements
-        create_move_outcome = move_generator.propose_move(blocks_affected_, proposed_action, rlim, placer_opts_, criticalities_);
+        create_move_outcome = move_generator.propose_move(blocks_affected_, proposed_action, rlim, place_macros_, placer_opts_, criticalities_);
     }
 
     move_type_stats_.incr_blk_type_moves(proposed_action);

--- a/vpr/src/place/annealer.cpp
+++ b/vpr/src/place/annealer.cpp
@@ -214,7 +214,7 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
     , rng_(rng)
     , move_generator_1_(std::move(move_generator_1))
     , move_generator_2_(std::move(move_generator_2))
-    , manual_move_generator_(placer_state, rng)
+    , manual_move_generator_(placer_state, place_macros, rng)
     , agent_state_(e_agent_state::EARLY_IN_THE_ANNEAL)
     , delay_model_(delay_model)
     , criticalities_(criticalities)
@@ -391,7 +391,7 @@ e_move_result PlacementAnnealer::try_swap_(MoveGenerator& move_generator,
     if (manual_move_enabled) {
 #ifndef NO_GRAPHICS
         create_move_outcome = manual_move_display_and_propose(manual_move_generator_, blocks_affected_,
-                                                              proposed_action.move_type, rlim, place_macros_,
+                                                              proposed_action.move_type, rlim,
                                                               placer_opts_, criticalities_);
 #endif //NO_GRAPHICS
     } else if (router_block_move) {
@@ -400,7 +400,7 @@ e_move_result PlacementAnnealer::try_swap_(MoveGenerator& move_generator,
         proposed_action.move_type = e_move_type::UNIFORM;
     } else {
         //Generate a new move (perturbation) used to explore the space of possible placements
-        create_move_outcome = move_generator.propose_move(blocks_affected_, proposed_action, rlim, place_macros_, placer_opts_, criticalities_);
+        create_move_outcome = move_generator.propose_move(blocks_affected_, proposed_action, rlim, placer_opts_, criticalities_);
     }
 
     move_type_stats_.incr_blk_type_moves(proposed_action);

--- a/vpr/src/place/annealer.h
+++ b/vpr/src/place/annealer.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <tuple>
 
+class PlaceMacros;
 class PlacerState;
 class t_placer_costs;
 struct t_placer_opts;
@@ -171,6 +172,7 @@ class PlacementAnnealer {
   public:
     PlacementAnnealer(const t_placer_opts& placer_opts,
                       PlacerState& placer_state,
+                      const PlaceMacros& place_macros,
                       t_placer_costs& costs,
                       NetCostHandler& net_cost_handler,
                       std::optional<NocCostHandler>& noc_cost_handler,
@@ -269,6 +271,7 @@ class PlacementAnnealer {
   private:
     const t_placer_opts& placer_opts_;
     PlacerState& placer_state_;
+    const PlaceMacros& place_macros_;
     /// Stores different placement cost terms
     t_placer_costs& costs_;
     /// Computes bounding box for each cluster net

--- a/vpr/src/place/cut_spreader.cpp
+++ b/vpr/src/place/cut_spreader.cpp
@@ -1,3 +1,4 @@
+#include "place_macro.h"
 #ifdef ENABLE_ANALYTIC_PLACE
 
 #    include "cut_spreader.h"
@@ -112,7 +113,7 @@ void CutSpreader::cutSpread() {
 // setup CutSpreader data structures using information from AnalyticPlacer
 void CutSpreader::init() {
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
 
     size_t max_x = g_vpr_ctx.device().grid.width();
     size_t max_y = g_vpr_ctx.device().grid.height();
@@ -407,7 +408,7 @@ void CutSpreader::expand_regions() {
 std::pair<int, int> CutSpreader::cut_region(SpreaderRegion& r, bool dir) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
 
     // TODO: CutSpreader is not compatible with 3D FPGA
     VTR_ASSERT(device_ctx.grid.get_num_layers() == 1);
@@ -619,7 +620,7 @@ int CutSpreader::initial_source_cut(SpreaderRegion& r,
                                     bool dir,
                                     int& clearance_l,
                                     int& clearance_r) {
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
 
     // pivot is the midpoint of cut_blks in terms of total block size (counting macro members)
     // this ensures the initial partitions have similar number of blocks
@@ -672,7 +673,7 @@ int CutSpreader::initial_target_cut(SpreaderRegion& r,
                                     int& right_blks_n,
                                     int& left_tiles_n,
                                     int& right_tiles_n) {
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
 
     // To achieve smallest difference in utilization, first move all tiles to right partition
     left_blks_n = 0, right_blks_n = 0;
@@ -808,7 +809,7 @@ void CutSpreader::linear_spread_subarea(std::vector<ClusterBlockId>& cut_blks,
 void CutSpreader::strict_legalize() {
     auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     const auto& block_locs = ap->blk_loc_registry_ref_.block_locs();
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
     int max_x = g_vpr_ctx.device().grid.width();
     int max_y = g_vpr_ctx.device().grid.height();
 
@@ -1035,7 +1036,7 @@ bool CutSpreader::try_place_blk(ClusterBlockId blk,
                                 std::priority_queue<std::pair<int, ClusterBlockId>>& remaining) {
     const auto& grid_blocks = ap->blk_loc_registry_ref_.grid_blocks();
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
 
     // iteration at current radius has exceeded exploration limit, and a candidate sub_tile (best_subtile) is found
     // then blk is placed in best_subtile
@@ -1112,7 +1113,7 @@ bool CutSpreader::try_place_macro(ClusterBlockId blk,
                                   int nx,
                                   int ny,
                                   std::priority_queue<std::pair<int, ClusterBlockId>>& remaining) {
-    const auto& place_macros = ap->blk_loc_registry_ref_.place_macros();
+    const auto& place_macros = ap->place_macros_;
     const auto& grid_blocks = ap->blk_loc_registry_ref_.grid_blocks();
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
 

--- a/vpr/src/place/initial_noc_placement.cpp
+++ b/vpr/src/place/initial_noc_placement.cpp
@@ -1,6 +1,7 @@
 
 #include "initial_noc_placment.h"
 
+#include "place_macro.h"
 #include "vpr_types.h"
 #include "initial_placement.h"
 #include "noc_place_utils.h"
@@ -66,6 +67,7 @@ static void place_noc_routers_randomly(std::vector<ClusterBlockId>& unfixed_rout
  */
 static void noc_routers_anneal(const t_noc_opts& noc_opts,
                                BlkLocRegistry& blk_loc_registry,
+                               const PlaceMacros& place_macros,
                                NocCostHandler& noc_cost_handler,
                                vtr::RngContainer& rng);
 
@@ -210,6 +212,7 @@ static void place_noc_routers_randomly(std::vector<ClusterBlockId>& unfixed_rout
 
 static void noc_routers_anneal(const t_noc_opts& noc_opts,
                                BlkLocRegistry& blk_loc_registry,
+                               const PlaceMacros& place_macros,
                                NocCostHandler& noc_cost_handler,
                                vtr::RngContainer& rng) {
     auto& noc_ctx = g_vpr_ctx.noc();
@@ -276,6 +279,7 @@ static void noc_routers_anneal(const t_noc_opts& noc_opts,
         e_create_move create_move_outcome = propose_router_swap(blocks_affected,
                                                                 r_lim_decayed,
                                                                 blk_loc_registry,
+                                                                place_macros,
                                                                 rng);
 
         if (create_move_outcome != e_create_move::ABORT) {
@@ -311,6 +315,7 @@ static void noc_routers_anneal(const t_noc_opts& noc_opts,
 
 void initial_noc_placement(const t_noc_opts& noc_opts,
                            BlkLocRegistry& blk_loc_registry,
+                           const PlaceMacros& place_macros,
                            NocCostHandler& noc_cost_handler,
                            vtr::RngContainer& rng) {
 	vtr::ScopedStartFinishTimer timer("Initial NoC Placement");
@@ -343,7 +348,7 @@ void initial_noc_placement(const t_noc_opts& noc_opts,
     noc_cost_handler.initial_noc_routing({});
 
     // Run the simulated annealing optimizer for NoC routers
-    noc_routers_anneal(noc_opts, blk_loc_registry, noc_cost_handler, rng);
+    noc_routers_anneal(noc_opts, blk_loc_registry, place_macros, noc_cost_handler, rng);
 
     // check if there is any cycles
     bool has_cycle = noc_cost_handler.noc_routing_has_cycle();

--- a/vpr/src/place/initial_noc_placment.h
+++ b/vpr/src/place/initial_noc_placment.h
@@ -5,6 +5,7 @@
 struct t_noc_opts;
 struct t_placer_opts;
 class BlkLocRegistry;
+class PlaceMacros;
 class NocCostHandler;
 
 namespace vtr {
@@ -22,6 +23,7 @@ class RngContainer;
  */
 void initial_noc_placement(const t_noc_opts& noc_opts,
                            BlkLocRegistry& blk_loc_registry,
+                           const PlaceMacros& place_macros,
                            NocCostHandler& noc_cost_handler,
                            vtr::RngContainer& rng);
 

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -238,6 +238,7 @@ static void place_all_blocks(const t_placer_opts& placer_opts,
                              e_pad_loc_type pad_loc_type,
                              const char* constraints_file,
                              BlkLocRegistry& blk_loc_registry,
+                             const PlaceMacros& place_macros,
                              const FlatPlacementInfo& flat_placement_info,
                              vtr::RngContainer& rng);
 
@@ -1072,11 +1073,11 @@ static void place_all_blocks(const t_placer_opts& placer_opts,
                              enum e_pad_loc_type pad_loc_type,
                              const char* constraints_file,
                              BlkLocRegistry& blk_loc_registry,
+                             const PlaceMacros& place_macros,
                              const FlatPlacementInfo& flat_placement_info,
                              vtr::RngContainer& rng) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
     const auto& device_ctx = g_vpr_ctx.device();
-    const auto& place_macros = blk_loc_registry.place_macros();
     auto blocks = cluster_ctx.clb_nlist.blocks();
 
     int number_of_unplaced_blks_in_curr_itr;
@@ -1138,6 +1139,7 @@ static void place_all_blocks(const t_placer_opts& placer_opts,
                                                 &blk_types_empty_locs_in_grid[blk_id_type->index],
                                                 &block_scores,
                                                 blk_loc_registry,
+                                                place_macros,
                                                 flat_placement_info,
                                                 rng);
 
@@ -1180,10 +1182,10 @@ bool place_one_block(const ClusterBlockId blk_id,
                      std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid,
                      vtr::vector<ClusterBlockId, t_block_score>* block_scores,
                      BlkLocRegistry& blk_loc_registry,
+                     const PlaceMacros& place_macros,
                      const FlatPlacementInfo& flat_placement_info,
                      vtr::RngContainer& rng) {
     const auto& block_locs = blk_loc_registry.block_locs();
-    const auto& place_macros = blk_loc_registry.place_macros();
 
     //Check if block has already been placed
     if (is_block_placed(blk_id, block_locs)) {
@@ -1243,11 +1245,11 @@ void initial_placement(const t_placer_opts& placer_opts,
                        const char* constraints_file,
                        const t_noc_opts& noc_opts,
                        BlkLocRegistry& blk_loc_registry,
+                       const PlaceMacros& place_macros,
                        std::optional<NocCostHandler>& noc_cost_handler,
                        const FlatPlacementInfo& flat_placement_info,
                        vtr::RngContainer& rng) {
     vtr::ScopedStartFinishTimer timer("Initial Placement");
-    const auto& place_macros = blk_loc_registry.place_macros();
 
     /* Initialize the grid blocks to empty.
      * Initialize all the blocks to unplaced.
@@ -1277,7 +1279,7 @@ void initial_placement(const t_placer_opts& placer_opts,
     } else {
         if (noc_opts.noc) {
             // NoC routers are placed before other blocks
-            initial_noc_placement(noc_opts, blk_loc_registry, noc_cost_handler.value(), rng);
+            initial_noc_placement(noc_opts, blk_loc_registry, place_macros, noc_cost_handler.value(), rng);
             propagate_place_constraints(place_macros);
         }
 
@@ -1286,7 +1288,7 @@ void initial_placement(const t_placer_opts& placer_opts,
 
         //Place all blocks
         place_all_blocks(placer_opts, block_scores, placer_opts.pad_loc_type,
-                         constraints_file, blk_loc_registry,
+                         constraints_file, blk_loc_registry, place_macros,
                          flat_placement_info, rng);
     }
 

--- a/vpr/src/place/initial_placement.h
+++ b/vpr/src/place/initial_placement.h
@@ -148,6 +148,7 @@ void initial_placement(const t_placer_opts& placer_opts,
                        const char* constraints_file,
                        const t_noc_opts& noc_opts,
                        BlkLocRegistry& blk_loc_registry,
+                       const PlaceMacros& place_macros,
                        std::optional<NocCostHandler>& noc_cost_handler,
                        const FlatPlacementInfo& flat_placement_info,
                        vtr::RngContainer& rng);
@@ -170,6 +171,7 @@ bool place_one_block(const ClusterBlockId blk_id,
                      std::vector<t_grid_empty_locs_block_type>* blk_types_empty_locs_in_grid,
                      vtr::vector<ClusterBlockId, t_block_score>* block_scores,
                      BlkLocRegistry& blk_loc_registry,
+                     const PlaceMacros& place_macros,
                      const FlatPlacementInfo& flat_placement_info,
                      vtr::RngContainer& rng);
 

--- a/vpr/src/place/move_generators/centroid_move_generator.cpp
+++ b/vpr/src/place/move_generators/centroid_move_generator.cpp
@@ -1,5 +1,6 @@
 #include "centroid_move_generator.h"
 #include "physical_types_util.h"
+#include "place_macro.h"
 #include "vpr_types.h"
 #include "globals.h"
 #include "place_constraints.h"
@@ -32,6 +33,7 @@ CentroidMoveGenerator::CentroidMoveGenerator(PlacerState& placer_state,
 e_create_move CentroidMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                   t_propose_action& proposed_action,
                                                   float rlim,
+                                                  const PlaceMacros& place_macros,
                                                   const t_placer_opts& placer_opts,
                                                   const PlacerCriticalities* criticalities) {
     auto& placer_state = placer_state_.get();
@@ -84,7 +86,7 @@ e_create_move CentroidMoveGenerator::propose_move(t_pl_blocks_to_be_moved& block
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/centroid_move_generator.cpp
+++ b/vpr/src/place/move_generators/centroid_move_generator.cpp
@@ -10,19 +10,21 @@
 #include <queue>
 
 CentroidMoveGenerator::CentroidMoveGenerator(PlacerState& placer_state,
+                                             const PlaceMacros& place_macros,
                                              e_reward_function reward_function,
                                              vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, reward_function, rng)
+    : MoveGenerator(placer_state, place_macros, reward_function, rng)
     , weighted_(false)
     , noc_attraction_weight_(0.0f)
     , noc_attraction_enabled_(false) {}
 
 CentroidMoveGenerator::CentroidMoveGenerator(PlacerState& placer_state,
+                                             const PlaceMacros& place_macros,
                                              e_reward_function reward_function,
                                              vtr::RngContainer& rng,
                                              float noc_attraction_weight,
                                              size_t high_fanout_net)
-    : MoveGenerator(placer_state, reward_function, rng)
+    : MoveGenerator(placer_state, place_macros, reward_function, rng)
     , noc_attraction_weight_(noc_attraction_weight)
     , noc_attraction_enabled_(true) {
     VTR_ASSERT(noc_attraction_weight > 0.0 && noc_attraction_weight <= 1.0);
@@ -33,7 +35,6 @@ CentroidMoveGenerator::CentroidMoveGenerator(PlacerState& placer_state,
 e_create_move CentroidMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                   t_propose_action& proposed_action,
                                                   float rlim,
-                                                  const PlaceMacros& place_macros,
                                                   const t_placer_opts& placer_opts,
                                                   const PlacerCriticalities* criticalities) {
     auto& placer_state = placer_state_.get();
@@ -86,7 +87,7 @@ e_create_move CentroidMoveGenerator::propose_move(t_pl_blocks_to_be_moved& block
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/centroid_move_generator.h
+++ b/vpr/src/place/move_generators/centroid_move_generator.h
@@ -3,6 +3,8 @@
 
 #include "move_generator.h"
 
+class PlaceMacros;
+
 /**
  * @file
  * @author M. Elgammal
@@ -74,6 +76,7 @@ class CentroidMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* /*criticalities*/) override;
 

--- a/vpr/src/place/move_generators/centroid_move_generator.h
+++ b/vpr/src/place/move_generators/centroid_move_generator.h
@@ -32,6 +32,7 @@ class CentroidMoveGenerator : public MoveGenerator {
      * of the RL agent.
      */
     CentroidMoveGenerator(PlacerState& placer_state,
+                          const PlaceMacros& place_macros,
                           e_reward_function reward_function,
                           vtr::RngContainer& rng);
 
@@ -51,6 +52,7 @@ class CentroidMoveGenerator : public MoveGenerator {
      * ignored when forming NoC groups.
      */
     CentroidMoveGenerator(PlacerState& placer_state,
+                          const PlaceMacros& place_macros,
                           e_reward_function reward_function,
                           vtr::RngContainer& rng,
                           float noc_attraction_weight,
@@ -76,7 +78,6 @@ class CentroidMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* /*criticalities*/) override;
 

--- a/vpr/src/place/move_generators/critical_uniform_move_generator.cpp
+++ b/vpr/src/place/move_generators/critical_uniform_move_generator.cpp
@@ -4,6 +4,7 @@
 #include "globals.h"
 #include "physical_types_util.h"
 #include "place_constraints.h"
+#include "place_macro.h"
 #include "placer_state.h"
 #include "move_utils.h"
 
@@ -15,6 +16,7 @@ CriticalUniformMoveGenerator::CriticalUniformMoveGenerator(PlacerState& placer_s
 e_create_move CriticalUniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                          t_propose_action& proposed_action,
                                                          float rlim,
+                                                         const PlaceMacros& place_macros,
                                                          const t_placer_opts& placer_opts,
                                                          const PlacerCriticalities* criticalities) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -52,7 +54,7 @@ e_create_move CriticalUniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/critical_uniform_move_generator.cpp
+++ b/vpr/src/place/move_generators/critical_uniform_move_generator.cpp
@@ -9,14 +9,14 @@
 #include "move_utils.h"
 
 CriticalUniformMoveGenerator::CriticalUniformMoveGenerator(PlacerState& placer_state,
+                                                           const PlaceMacros& place_macros,
                                                            e_reward_function reward_function,
                                                            vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, reward_function, rng) {}
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {}
 
 e_create_move CriticalUniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                          t_propose_action& proposed_action,
                                                          float rlim,
-                                                         const PlaceMacros& place_macros,
                                                          const t_placer_opts& placer_opts,
                                                          const PlacerCriticalities* criticalities) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -54,7 +54,7 @@ e_create_move CriticalUniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/critical_uniform_move_generator.h
+++ b/vpr/src/place/move_generators/critical_uniform_move_generator.h
@@ -1,6 +1,9 @@
 #ifndef VPR_CRITICAL_UNIFORM_MOVE_GEN_H
 #define VPR_CRITICAL_UNIFORM_MOVE_GEN_H
+
 #include "move_generator.h"
+
+class PlaceMacros;
 
 /**
  * @file 
@@ -24,6 +27,7 @@ class CriticalUniformMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& /*placer_opts*/,
                                const PlacerCriticalities* /*criticalities*/) override;
 };

--- a/vpr/src/place/move_generators/critical_uniform_move_generator.h
+++ b/vpr/src/place/move_generators/critical_uniform_move_generator.h
@@ -20,6 +20,7 @@ class CriticalUniformMoveGenerator : public MoveGenerator {
   public:
     CriticalUniformMoveGenerator() = delete;
     CriticalUniformMoveGenerator(PlacerState& placer_state,
+                                 const PlaceMacros& place_macros,
                                  e_reward_function reward_function,
                                  vtr::RngContainer& rng);
 
@@ -27,7 +28,6 @@ class CriticalUniformMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& /*placer_opts*/,
                                const PlacerCriticalities* /*criticalities*/) override;
 };

--- a/vpr/src/place/move_generators/feasible_region_move_generator.cpp
+++ b/vpr/src/place/move_generators/feasible_region_move_generator.cpp
@@ -3,6 +3,7 @@
 #include "globals.h"
 #include "physical_types_util.h"
 #include "place_constraints.h"
+#include "place_macro.h"
 #include "placer_state.h"
 #include "move_utils.h"
 
@@ -17,6 +18,7 @@ FeasibleRegionMoveGenerator::FeasibleRegionMoveGenerator(PlacerState& placer_sta
 e_create_move FeasibleRegionMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                         t_propose_action& proposed_action,
                                                         float rlim,
+                                                        const PlaceMacros& place_macros,
                                                         const t_placer_opts& placer_opts,
                                                         const PlacerCriticalities* criticalities) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -143,7 +145,7 @@ e_create_move FeasibleRegionMoveGenerator::propose_move(t_pl_blocks_to_be_moved&
             return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/feasible_region_move_generator.cpp
+++ b/vpr/src/place/move_generators/feasible_region_move_generator.cpp
@@ -11,14 +11,14 @@
 #include <cmath>
 
 FeasibleRegionMoveGenerator::FeasibleRegionMoveGenerator(PlacerState& placer_state,
+                                                         const PlaceMacros& place_macros,
                                                          e_reward_function reward_function,
                                                          vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, reward_function, rng) {}
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {}
 
 e_create_move FeasibleRegionMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                         t_propose_action& proposed_action,
                                                         float rlim,
-                                                        const PlaceMacros& place_macros,
                                                         const t_placer_opts& placer_opts,
                                                         const PlacerCriticalities* criticalities) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -145,7 +145,7 @@ e_create_move FeasibleRegionMoveGenerator::propose_move(t_pl_blocks_to_be_moved&
             return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/feasible_region_move_generator.h
+++ b/vpr/src/place/move_generators/feasible_region_move_generator.h
@@ -1,6 +1,9 @@
 #ifndef VPR_FEASIBLE_REGION_MOVE_GEN_H
 #define VPR_FEASIBLE_REGION_MOVE_GEN_H
+
 #include "move_generator.h"
+
+class PlaceMacros;
 
 /**
  * @brief Feasible Region (FR) move generator
@@ -28,6 +31,7 @@ class FeasibleRegionMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 };

--- a/vpr/src/place/move_generators/feasible_region_move_generator.h
+++ b/vpr/src/place/move_generators/feasible_region_move_generator.h
@@ -24,6 +24,7 @@ class FeasibleRegionMoveGenerator : public MoveGenerator {
   public:
     FeasibleRegionMoveGenerator() = delete;
     FeasibleRegionMoveGenerator(PlacerState& placer_state,
+                                const PlaceMacros& place_macros,
                                 e_reward_function reward_function,
                                 vtr::RngContainer& rng);
 
@@ -31,7 +32,6 @@ class FeasibleRegionMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 };

--- a/vpr/src/place/move_generators/manual_move_generator.cpp
+++ b/vpr/src/place/move_generators/manual_move_generator.cpp
@@ -13,6 +13,7 @@
 #include "manual_move_generator.h"
 #include "manual_moves.h"
 #include "physical_types_util.h"
+#include "place_macro.h"
 #include "placer_state.h"
 
 #ifndef NO_GRAPHICS
@@ -26,6 +27,7 @@ ManualMoveGenerator::ManualMoveGenerator(PlacerState& placer_state, vtr::RngCont
 e_create_move ManualMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                 t_propose_action& /*proposed_action*/,
                                                 float /*rlim*/,
+                                                const PlaceMacros& place_macros,
                                                 const t_placer_opts& /*placer_opts*/,
                                                 const PlacerCriticalities* /*criticalities*/) {
     const auto& place_ctx = g_vpr_ctx.placement();
@@ -67,7 +69,7 @@ e_create_move ManualMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
     return create_move;
 }
 

--- a/vpr/src/place/move_generators/manual_move_generator.cpp
+++ b/vpr/src/place/move_generators/manual_move_generator.cpp
@@ -20,14 +20,15 @@
 #    include "draw.h"
 #endif //NO_GRAPHICS
 
-ManualMoveGenerator::ManualMoveGenerator(PlacerState& placer_state, vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, e_reward_function::UNDEFINED_REWARD, rng) {}
+ManualMoveGenerator::ManualMoveGenerator(PlacerState& placer_state,
+                                         const PlaceMacros& place_macros,
+                                         vtr::RngContainer& rng)
+    : MoveGenerator(placer_state, place_macros, e_reward_function::UNDEFINED_REWARD, rng) {}
 
 //Manual Move Generator function
 e_create_move ManualMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                 t_propose_action& /*proposed_action*/,
                                                 float /*rlim*/,
-                                                const PlaceMacros& place_macros,
                                                 const t_placer_opts& /*placer_opts*/,
                                                 const PlacerCriticalities* /*criticalities*/) {
     const auto& place_ctx = g_vpr_ctx.placement();
@@ -69,7 +70,7 @@ e_create_move ManualMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
     return create_move;
 }
 

--- a/vpr/src/place/move_generators/manual_move_generator.h
+++ b/vpr/src/place/move_generators/manual_move_generator.h
@@ -9,15 +9,8 @@
 #define VPR_MANUAL_MOVE_GEN_H
 
 #include "move_generator.h"
-#include "median_move_generator.h"
-#include "weighted_median_move_generator.h"
-#include "weighted_centroid_move_generator.h"
-#include "feasible_region_move_generator.h"
-#include "uniform_move_generator.h"
-#include "critical_uniform_move_generator.h"
-#include "centroid_move_generator.h"
-#include "simpleRL_move_generator.h"
-#include <numeric>
+
+class PlaceMacros;
 
 /**
  * @brief Manual Moves Generator, inherits from MoveGenerator class.
@@ -33,6 +26,7 @@ class ManualMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& /*proposed_action*/,
                                float /*rlim*/,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& /*placer_opts*/,
                                const PlacerCriticalities* /*criticalities*/) override;
 };

--- a/vpr/src/place/move_generators/manual_move_generator.h
+++ b/vpr/src/place/move_generators/manual_move_generator.h
@@ -20,13 +20,14 @@ class PlaceMacros;
 class ManualMoveGenerator : public MoveGenerator {
   public:
     ManualMoveGenerator() = delete;
-    ManualMoveGenerator(PlacerState& placer_state, vtr::RngContainer& rng);
+    ManualMoveGenerator(PlacerState& placer_state,
+                        const PlaceMacros& place_macros,
+                        vtr::RngContainer& rng);
 
     //Evaluates if move is successful and legal or unable to do.
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& /*proposed_action*/,
                                float /*rlim*/,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& /*placer_opts*/,
                                const PlacerCriticalities* /*criticalities*/) override;
 };

--- a/vpr/src/place/move_generators/median_move_generator.cpp
+++ b/vpr/src/place/move_generators/median_move_generator.cpp
@@ -3,6 +3,7 @@
 #include "globals.h"
 #include "physical_types_util.h"
 #include "place_constraints.h"
+#include "place_macro.h"
 #include "placer_state.h"
 #include "move_utils.h"
 
@@ -16,6 +17,7 @@ MedianMoveGenerator::MedianMoveGenerator(PlacerState& placer_state,
 e_create_move MedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                 t_propose_action& proposed_action,
                                                 float rlim,
+                                                const PlaceMacros& place_macros,
                                                 const t_placer_opts& placer_opts,
                                                 const PlacerCriticalities* /*criticalities*/) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -167,7 +169,7 @@ e_create_move MedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/median_move_generator.cpp
+++ b/vpr/src/place/move_generators/median_move_generator.cpp
@@ -10,14 +10,14 @@
 #include <algorithm>
 
 MedianMoveGenerator::MedianMoveGenerator(PlacerState& placer_state,
+                                         const PlaceMacros& place_macros,
                                          e_reward_function reward_function,
                                          vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, reward_function, rng) {}
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {}
 
 e_create_move MedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                 t_propose_action& proposed_action,
                                                 float rlim,
-                                                const PlaceMacros& place_macros,
                                                 const t_placer_opts& placer_opts,
                                                 const PlacerCriticalities* /*criticalities*/) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -169,7 +169,7 @@ e_create_move MedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/median_move_generator.h
+++ b/vpr/src/place/move_generators/median_move_generator.h
@@ -1,6 +1,9 @@
 #ifndef VPR_MEDIAN_MOVE_GEN_H
 #define VPR_MEDIAN_MOVE_GEN_H
+
 #include "move_generator.h"
+
+class PlaceMacros;
 
 /**
  * @brief Median move generator
@@ -26,6 +29,7 @@ class MedianMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* /*criticalities*/) override;
 

--- a/vpr/src/place/move_generators/median_move_generator.h
+++ b/vpr/src/place/move_generators/median_move_generator.h
@@ -22,6 +22,7 @@ class MedianMoveGenerator : public MoveGenerator {
   public:
     MedianMoveGenerator() = delete;
     MedianMoveGenerator(PlacerState& placer_state,
+                        const PlaceMacros& place_macros,
                         e_reward_function reward_function,
                         vtr::RngContainer& rng);
 
@@ -29,7 +30,6 @@ class MedianMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* /*criticalities*/) override;
 

--- a/vpr/src/place/move_generators/move_generator.h
+++ b/vpr/src/place/move_generators/move_generator.h
@@ -7,6 +7,7 @@
 
 #include <limits>
 
+class PlaceMacros;
 class PlacerState;
 
 struct MoveOutcomeStats {
@@ -124,6 +125,7 @@ class MoveGenerator {
     virtual e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                        t_propose_action& proposed_action,
                                        float rlim,
+                                       const PlaceMacros& place_macros,
                                        const t_placer_opts& placer_opts,
                                        const PlacerCriticalities* criticalities) = 0;
 

--- a/vpr/src/place/move_generators/move_generator.h
+++ b/vpr/src/place/move_generators/move_generator.h
@@ -5,6 +5,7 @@
 #include "move_utils.h"
 #include "PlacerCriticalities.h"
 
+#include <functional>
 #include <limits>
 
 class PlaceMacros;
@@ -93,12 +94,18 @@ class MoveGenerator {
      *
      * @param placer_state A mutable reference to the placement state which will
      * be stored in this object.
+     * @param place_macros An immutable reference to the placement macros which
+     * will be stored in this object.
      * @param reward_function Specifies the reward function to update q-tables
      * of the RL agent.
      * @param rng A random number generator to be used for block and location selection.
      */
-    MoveGenerator(PlacerState& placer_state, e_reward_function reward_function, vtr::RngContainer& rng)
+    MoveGenerator(PlacerState& placer_state,
+                  const PlaceMacros& place_macros,
+                  e_reward_function reward_function,
+                  vtr::RngContainer& rng)
         : placer_state_(placer_state)
+        , place_macros_(place_macros)
         , reward_func_(reward_function)
         , rng_(rng) {}
 
@@ -125,7 +132,6 @@ class MoveGenerator {
     virtual e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                        t_propose_action& proposed_action,
                                        float rlim,
-                                       const PlaceMacros& place_macros,
                                        const t_placer_opts& placer_opts,
                                        const PlacerCriticalities* criticalities) = 0;
 
@@ -154,6 +160,7 @@ class MoveGenerator {
 
   protected:
     std::reference_wrapper<PlacerState> placer_state_;
+    const PlaceMacros& place_macros_;
     e_reward_function reward_func_;
     vtr::RngContainer& rng_;
 };

--- a/vpr/src/place/move_generators/simpleRL_move_generator.cpp
+++ b/vpr/src/place/move_generators/simpleRL_move_generator.cpp
@@ -2,6 +2,7 @@
 #include "simpleRL_move_generator.h"
 
 #include "globals.h"
+#include "place_macro.h"
 #include "vtr_random.h"
 #include "vtr_time.h"
 
@@ -22,10 +23,11 @@ static float scaled_clipped_exp(float x) { return std::exp(std::min(1000 * x, fl
 e_create_move SimpleRLMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                   t_propose_action& proposed_action,
                                                   float rlim,
+                                                  const PlaceMacros& place_macros,
                                                   const t_placer_opts& placer_opts,
                                                   const PlacerCriticalities* criticalities) {
     proposed_action = karmed_bandit_agent->propose_action();
-    return all_moves[proposed_action.move_type]->propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
+    return all_moves[proposed_action.move_type]->propose_move(blocks_affected, proposed_action, rlim, place_macros, placer_opts, criticalities);
 }
 
 void SimpleRLMoveGenerator::process_outcome(double reward, e_reward_function reward_fun) {

--- a/vpr/src/place/move_generators/simpleRL_move_generator.cpp
+++ b/vpr/src/place/move_generators/simpleRL_move_generator.cpp
@@ -2,7 +2,6 @@
 #include "simpleRL_move_generator.h"
 
 #include "globals.h"
-#include "place_macro.h"
 #include "vtr_random.h"
 #include "vtr_time.h"
 
@@ -23,11 +22,10 @@ static float scaled_clipped_exp(float x) { return std::exp(std::min(1000 * x, fl
 e_create_move SimpleRLMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                   t_propose_action& proposed_action,
                                                   float rlim,
-                                                  const PlaceMacros& place_macros,
                                                   const t_placer_opts& placer_opts,
                                                   const PlacerCriticalities* criticalities) {
     proposed_action = karmed_bandit_agent->propose_action();
-    return all_moves[proposed_action.move_type]->propose_move(blocks_affected, proposed_action, rlim, place_macros, placer_opts, criticalities);
+    return all_moves[proposed_action.move_type]->propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
 }
 
 void SimpleRLMoveGenerator::process_outcome(double reward, e_reward_function reward_fun) {

--- a/vpr/src/place/move_generators/simpleRL_move_generator.h
+++ b/vpr/src/place/move_generators/simpleRL_move_generator.h
@@ -9,6 +9,8 @@
 #include "critical_uniform_move_generator.h"
 #include "centroid_move_generator.h"
 
+class PlaceMacros;
+
 /**
  * @brief KArmedBanditAgent is the base class for RL agents that target the k-armed bandit problems
  */
@@ -245,6 +247,7 @@ class SimpleRLMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 

--- a/vpr/src/place/move_generators/simpleRL_move_generator.h
+++ b/vpr/src/place/move_generators/simpleRL_move_generator.h
@@ -237,6 +237,7 @@ class SimpleRLMoveGenerator : public MoveGenerator {
     template<class T,
              class = typename std::enable_if<std::is_same<T, EpsilonGreedyAgent>::value || std::is_same<T, SoftmaxAgent>::value>::type>
     explicit SimpleRLMoveGenerator(PlacerState& placer_state,
+                                   const PlaceMacros& place_macros,
                                    e_reward_function reward_function,
                                    vtr::RngContainer& rng,
                                    std::unique_ptr<T>& agent,
@@ -247,7 +248,6 @@ class SimpleRLMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 
@@ -257,27 +257,28 @@ class SimpleRLMoveGenerator : public MoveGenerator {
 
 template<class T, class>
 SimpleRLMoveGenerator::SimpleRLMoveGenerator(PlacerState& placer_state,
+                                             const PlaceMacros& place_macros,
                                              e_reward_function reward_function,
                                              vtr::RngContainer& rng,
                                              std::unique_ptr<T>& agent,
                                              float noc_attraction_weight,
                                              size_t high_fanout_thresh)
-    : MoveGenerator(placer_state, reward_function, rng) {
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {
     if (noc_attraction_weight > 0.0f) {
         all_moves.resize((int)e_move_type::NUMBER_OF_AUTO_MOVES);
     } else {
         all_moves.resize((int)e_move_type::NUMBER_OF_AUTO_MOVES - 1);
     }
 
-    all_moves[e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::CENTROID] = std::make_unique<CentroidMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::W_CENTROID] = std::make_unique<WeightedCentroidMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::W_MEDIAN] = std::make_unique<WeightedMedianMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::CRIT_UNIFORM] = std::make_unique<CriticalUniformMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::FEASIBLE_REGION] = std::make_unique<FeasibleRegionMoveGenerator>(placer_state, reward_function, rng);
+    all_moves[e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::CENTROID] = std::make_unique<CentroidMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::W_CENTROID] = std::make_unique<WeightedCentroidMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::W_MEDIAN] = std::make_unique<WeightedMedianMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::CRIT_UNIFORM] = std::make_unique<CriticalUniformMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::FEASIBLE_REGION] = std::make_unique<FeasibleRegionMoveGenerator>(placer_state, place_macros_, reward_function, rng);
     if (noc_attraction_weight > 0.0f) {
-        all_moves[e_move_type::NOC_ATTRACTION_CENTROID] = std::make_unique<CentroidMoveGenerator>(placer_state, reward_function, rng,
+        all_moves[e_move_type::NOC_ATTRACTION_CENTROID] = std::make_unique<CentroidMoveGenerator>(placer_state, place_macros_, reward_function, rng,
                                                                                                   noc_attraction_weight, high_fanout_thresh);
     }
 

--- a/vpr/src/place/move_generators/static_move_generator.cpp
+++ b/vpr/src/place/move_generators/static_move_generator.cpp
@@ -2,6 +2,7 @@
 #include "static_move_generator.h"
 
 #include "median_move_generator.h"
+#include "place_macro.h"
 #include "weighted_median_move_generator.h"
 #include "weighted_centroid_move_generator.h"
 #include "feasible_region_move_generator.h"
@@ -46,6 +47,7 @@ void StaticMoveGenerator::initialize_move_prob(const vtr::vector<e_move_type, fl
 e_create_move StaticMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                 t_propose_action& proposed_action,
                                                 float rlim,
+                                                const PlaceMacros& place_macros,
                                                 const t_placer_opts& placer_opts,
                                                 const PlacerCriticalities* criticalities) {
     float rand_num = rng_.frand() * total_prob;
@@ -53,7 +55,7 @@ e_create_move StaticMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_
     for (auto move_type : cumm_move_probs.keys()) {
         if (rand_num <= cumm_move_probs[move_type]) {
             proposed_action.move_type = move_type;
-            return all_moves[move_type]->propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
+            return all_moves[move_type]->propose_move(blocks_affected, proposed_action, rlim, place_macros, placer_opts, criticalities);
         }
     }
 

--- a/vpr/src/place/move_generators/static_move_generator.cpp
+++ b/vpr/src/place/move_generators/static_move_generator.cpp
@@ -14,19 +14,20 @@
 #include "vtr_assert.h"
 
 StaticMoveGenerator::StaticMoveGenerator(PlacerState& placer_state,
+                                         const PlaceMacros& place_macros,
                                          e_reward_function reward_function,
                                          vtr::RngContainer& rng,
                                          const vtr::vector<e_move_type, float>& move_probs)
-    : MoveGenerator(placer_state, reward_function, rng) {
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {
     all_moves.resize((int)e_move_type::NUMBER_OF_AUTO_MOVES);
 
-    all_moves[e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::CENTROID] = std::make_unique<CentroidMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::W_CENTROID] = std::make_unique<WeightedCentroidMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::W_MEDIAN] = std::make_unique<WeightedMedianMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::CRIT_UNIFORM] = std::make_unique<CriticalUniformMoveGenerator>(placer_state, reward_function, rng);
-    all_moves[e_move_type::FEASIBLE_REGION] = std::make_unique<FeasibleRegionMoveGenerator>(placer_state, reward_function, rng);
+    all_moves[e_move_type::UNIFORM] = std::make_unique<UniformMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::MEDIAN] = std::make_unique<MedianMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::CENTROID] = std::make_unique<CentroidMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::W_CENTROID] = std::make_unique<WeightedCentroidMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::W_MEDIAN] = std::make_unique<WeightedMedianMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::CRIT_UNIFORM] = std::make_unique<CriticalUniformMoveGenerator>(placer_state, place_macros_, reward_function, rng);
+    all_moves[e_move_type::FEASIBLE_REGION] = std::make_unique<FeasibleRegionMoveGenerator>(placer_state, place_macros_, reward_function, rng);
 
     initialize_move_prob(move_probs);
 }
@@ -47,7 +48,6 @@ void StaticMoveGenerator::initialize_move_prob(const vtr::vector<e_move_type, fl
 e_create_move StaticMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                 t_propose_action& proposed_action,
                                                 float rlim,
-                                                const PlaceMacros& place_macros,
                                                 const t_placer_opts& placer_opts,
                                                 const PlacerCriticalities* criticalities) {
     float rand_num = rng_.frand() * total_prob;
@@ -55,7 +55,7 @@ e_create_move StaticMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_
     for (auto move_type : cumm_move_probs.keys()) {
         if (rand_num <= cumm_move_probs[move_type]) {
             proposed_action.move_type = move_type;
-            return all_moves[move_type]->propose_move(blocks_affected, proposed_action, rlim, place_macros, placer_opts, criticalities);
+            return all_moves[move_type]->propose_move(blocks_affected, proposed_action, rlim, placer_opts, criticalities);
         }
     }
 

--- a/vpr/src/place/move_generators/static_move_generator.h
+++ b/vpr/src/place/move_generators/static_move_generator.h
@@ -3,6 +3,8 @@
 
 #include "move_generator.h"
 
+class PlaceMacros;
+
 /**
  * @brief a special move generator class that controls the different move types by assigning a fixed probability for each move type
  *
@@ -26,6 +28,7 @@ class StaticMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 };

--- a/vpr/src/place/move_generators/static_move_generator.h
+++ b/vpr/src/place/move_generators/static_move_generator.h
@@ -21,6 +21,7 @@ class StaticMoveGenerator : public MoveGenerator {
   public:
     StaticMoveGenerator() = delete;
     StaticMoveGenerator(PlacerState& placer_state,
+                        const PlaceMacros& place_macros,
                         e_reward_function reward_function,
                         vtr::RngContainer& rng,
                         const vtr::vector<e_move_type, float>& move_probs);
@@ -28,7 +29,6 @@ class StaticMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 };

--- a/vpr/src/place/move_generators/uniform_move_generator.cpp
+++ b/vpr/src/place/move_generators/uniform_move_generator.cpp
@@ -3,6 +3,7 @@
 #include "globals.h"
 #include "physical_types_util.h"
 #include "place_constraints.h"
+#include "place_macro.h"
 #include "placer_state.h"
 #include "move_utils.h"
 
@@ -14,6 +15,7 @@ UniformMoveGenerator::UniformMoveGenerator(PlacerState& placer_state,
 e_create_move UniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                  t_propose_action& proposed_action,
                                                  float rlim,
+                                                 const PlaceMacros& place_macros,
                                                  const t_placer_opts& placer_opts,
                                                  const PlacerCriticalities* /*criticalities*/) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -62,7 +64,7 @@ e_create_move UniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks
     VTR_LOG("\n");
 #endif
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/uniform_move_generator.cpp
+++ b/vpr/src/place/move_generators/uniform_move_generator.cpp
@@ -8,14 +8,14 @@
 #include "move_utils.h"
 
 UniformMoveGenerator::UniformMoveGenerator(PlacerState& placer_state,
+                                           const PlaceMacros& place_macros,
                                            e_reward_function reward_function,
                                            vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, reward_function, rng) {}
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {}
 
 e_create_move UniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                  t_propose_action& proposed_action,
                                                  float rlim,
-                                                 const PlaceMacros& place_macros,
                                                  const t_placer_opts& placer_opts,
                                                  const PlacerCriticalities* /*criticalities*/) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -64,7 +64,7 @@ e_create_move UniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks
     VTR_LOG("\n");
 #endif
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/uniform_move_generator.h
+++ b/vpr/src/place/move_generators/uniform_move_generator.h
@@ -1,6 +1,9 @@
 #ifndef VPR_UNIFORM_MOVE_GEN_H
 #define VPR_UNIFORM_MOVE_GEN_H
+
 #include "move_generator.h"
+
+class PlaceMacros;
 
 /**
  * @brief The classic VPR move generator
@@ -19,6 +22,7 @@ class UniformMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& /*placer_opts*/,
                                const PlacerCriticalities* /*criticalities*/) override;
 };

--- a/vpr/src/place/move_generators/uniform_move_generator.h
+++ b/vpr/src/place/move_generators/uniform_move_generator.h
@@ -15,6 +15,7 @@ class UniformMoveGenerator : public MoveGenerator {
   public:
     UniformMoveGenerator() = delete;
     UniformMoveGenerator(PlacerState& placer_state,
+                         const PlaceMacros& place_macros,
                          e_reward_function reward_function,
                          vtr::RngContainer& rng);
 
@@ -22,7 +23,6 @@ class UniformMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& /*placer_opts*/,
                                const PlacerCriticalities* /*criticalities*/) override;
 };

--- a/vpr/src/place/move_generators/weighted_centroid_move_generator.cpp
+++ b/vpr/src/place/move_generators/weighted_centroid_move_generator.cpp
@@ -1,8 +1,10 @@
 #include "weighted_centroid_move_generator.h"
+#include "place_macro.h"
 
 WeightedCentroidMoveGenerator::WeightedCentroidMoveGenerator(PlacerState& placer_state,
+                                                             const PlaceMacros& place_macros,
                                                              e_reward_function reward_function,
                                                              vtr::RngContainer& rng)
-    : CentroidMoveGenerator(placer_state, reward_function, rng) {
+    : CentroidMoveGenerator(placer_state, place_macros, reward_function, rng) {
     weighted_ = true;
 }

--- a/vpr/src/place/move_generators/weighted_centroid_move_generator.h
+++ b/vpr/src/place/move_generators/weighted_centroid_move_generator.h
@@ -3,6 +3,8 @@
 
 #include "centroid_move_generator.h"
 
+class PlaceMacros;
+
 /**
  * @brief Weighted Centroid move generator
  *
@@ -18,6 +20,7 @@ class WeightedCentroidMoveGenerator : public CentroidMoveGenerator {
   public:
     WeightedCentroidMoveGenerator() = delete;
     WeightedCentroidMoveGenerator(PlacerState& placer_state,
+                                  const PlaceMacros& place_macros,
                                   e_reward_function reward_function,
                                   vtr::RngContainer& rng);
 };

--- a/vpr/src/place/move_generators/weighted_median_move_generator.cpp
+++ b/vpr/src/place/move_generators/weighted_median_move_generator.cpp
@@ -3,6 +3,7 @@
 #include "globals.h"
 #include "physical_types_util.h"
 #include "place_constraints.h"
+#include "place_macro.h"
 #include "placer_state.h"
 #include "move_utils.h"
 
@@ -19,6 +20,7 @@ WeightedMedianMoveGenerator::WeightedMedianMoveGenerator(PlacerState& placer_sta
 e_create_move WeightedMedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                         t_propose_action& proposed_action,
                                                         float rlim,
+                                                        const PlaceMacros& place_macros,
                                                         const t_placer_opts& placer_opts,
                                                         const PlacerCriticalities* criticalities) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -144,7 +146,7 @@ e_create_move WeightedMedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved&
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/weighted_median_move_generator.cpp
+++ b/vpr/src/place/move_generators/weighted_median_move_generator.cpp
@@ -13,14 +13,14 @@
 #define CRIT_MULT_FOR_W_MEDIAN 10
 
 WeightedMedianMoveGenerator::WeightedMedianMoveGenerator(PlacerState& placer_state,
+                                                         const PlaceMacros& place_macros,
                                                          e_reward_function reward_function,
                                                          vtr::RngContainer& rng)
-    : MoveGenerator(placer_state, reward_function, rng) {}
+    : MoveGenerator(placer_state, place_macros, reward_function, rng) {}
 
 e_create_move WeightedMedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                                         t_propose_action& proposed_action,
                                                         float rlim,
-                                                        const PlaceMacros& place_macros,
                                                         const t_placer_opts& placer_opts,
                                                         const PlacerCriticalities* criticalities) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
@@ -146,7 +146,7 @@ e_create_move WeightedMedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved&
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros_);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/move_generators/weighted_median_move_generator.h
+++ b/vpr/src/place/move_generators/weighted_median_move_generator.h
@@ -3,6 +3,8 @@
 
 #include "move_generator.h"
 
+class PlaceMacros;
+
 /**
  * @brief The weighted median move generator
  *
@@ -23,6 +25,7 @@ class WeightedMedianMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
+                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 

--- a/vpr/src/place/move_generators/weighted_median_move_generator.h
+++ b/vpr/src/place/move_generators/weighted_median_move_generator.h
@@ -18,6 +18,7 @@ class WeightedMedianMoveGenerator : public MoveGenerator {
   public:
     WeightedMedianMoveGenerator() = delete;
     WeightedMedianMoveGenerator(PlacerState& placer_state,
+                                const PlaceMacros& place_macros,
                                 e_reward_function reward_function,
                                 vtr::RngContainer& rng);
 
@@ -25,7 +26,6 @@ class WeightedMedianMoveGenerator : public MoveGenerator {
     e_create_move propose_move(t_pl_blocks_to_be_moved& blocks_affected,
                                t_propose_action& proposed_action,
                                float rlim,
-                               const PlaceMacros& place_macros,
                                const t_placer_opts& placer_opts,
                                const PlacerCriticalities* criticalities) override;
 

--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -7,6 +7,7 @@
 
 class PlacerState;
 class BlkLocRegistry;
+class PlaceMacros;
 class PlacerCriticalities;
 namespace vtr {
 class RngContainer;
@@ -98,7 +99,8 @@ struct t_range_limiters {
 e_create_move create_move(t_pl_blocks_to_be_moved& blocks_affected,
                           ClusterBlockId b_from,
                           t_pl_loc to,
-                          const BlkLocRegistry& blk_loc_registry);
+                          const BlkLocRegistry& blk_loc_registry,
+                          const PlaceMacros& place_macros);
 
 /**
  * @brief Find the blocks that will be affected by a move of b_from to to_loc
@@ -111,7 +113,8 @@ e_create_move create_move(t_pl_blocks_to_be_moved& blocks_affected,
 e_block_move_result find_affected_blocks(t_pl_blocks_to_be_moved& blocks_affected,
                                          ClusterBlockId b_from,
                                          t_pl_loc to,
-                                         const BlkLocRegistry& blk_loc_registry);
+                                         const BlkLocRegistry& blk_loc_registry,
+                                         const PlaceMacros& place_macros);
 
 e_block_move_result record_single_block_swap(t_pl_blocks_to_be_moved& blocks_affected,
                                              ClusterBlockId b_from,
@@ -122,7 +125,8 @@ e_block_move_result record_macro_swaps(t_pl_blocks_to_be_moved& blocks_affected,
                                        const int imacro_from,
                                        int& imember_from,
                                        t_pl_offset swap_offset,
-                                       const BlkLocRegistry& blk_loc_registry);
+                                       const BlkLocRegistry& blk_loc_registry,
+                                       const PlaceMacros& place_macros);
 
 e_block_move_result record_macro_macro_swaps(t_pl_blocks_to_be_moved& blocks_affected,
                                              const int imacro_from,
@@ -130,24 +134,28 @@ e_block_move_result record_macro_macro_swaps(t_pl_blocks_to_be_moved& blocks_aff
                                              const int imacro_to,
                                              ClusterBlockId blk_to,
                                              t_pl_offset swap_offset,
-                                             const BlkLocRegistry& blk_loc_registry);
+                                             const BlkLocRegistry& blk_loc_registry,
+                                             const PlaceMacros& pl_macros);
 
 e_block_move_result record_macro_move(t_pl_blocks_to_be_moved& blocks_affected,
                                       std::vector<ClusterBlockId>& displaced_blocks,
                                       const int imacro,
                                       t_pl_offset swap_offset,
-                                      const BlkLocRegistry& blk_loc_registry);
+                                      const BlkLocRegistry& blk_loc_registry,
+                                      const PlaceMacros& place_macros);
 
 e_block_move_result identify_macro_self_swap_affected_macros(std::vector<int>& macros,
                                                              const int imacro,
                                                              t_pl_offset swap_offset,
                                                              const BlkLocRegistry& blk_loc_registry,
+                                                             const PlaceMacros& place_macros,
                                                              MoveAbortionLogger& move_abortion_logger);
 
 e_block_move_result record_macro_self_swaps(t_pl_blocks_to_be_moved& blocks_affected,
                                             const int imacro,
                                             t_pl_offset swap_offset,
-                                            const BlkLocRegistry& blk_loc_registry);
+                                            const BlkLocRegistry& blk_loc_registry,
+                                            const PlaceMacros& place_macros);
 
 /**
  * @brief Check whether the "to" location is legal for the given "blk"

--- a/vpr/src/place/noc_place_utils.cpp
+++ b/vpr/src/place/noc_place_utils.cpp
@@ -3,6 +3,7 @@
 
 #include "globals.h"
 #include "physical_types_util.h"
+#include "place_macro.h"
 #include "vtr_log.h"
 #include "vtr_assert.h"
 #include "vtr_random.h"
@@ -872,6 +873,7 @@ static bool select_random_router_cluster(ClusterBlockId& b_from,
 e_create_move propose_router_swap(t_pl_blocks_to_be_moved& blocks_affected,
                                   float rlim,
                                   const BlkLocRegistry& blk_loc_registry,
+                                  const PlaceMacros& place_macros,
                                   vtr::RngContainer& rng) {
     // block ID for the randomly selected router cluster
     ClusterBlockId b_from;
@@ -899,7 +901,7 @@ e_create_move propose_router_swap(t_pl_blocks_to_be_moved& blocks_affected,
         return e_create_move::ABORT;
     }
 
-    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry);
+    e_create_move create_move = ::create_move(blocks_affected, b_from, to, blk_loc_registry, place_macros);
 
     //Check that all the blocks affected by the move would still be in a legal floorplan region after the swap
     if (!floorplan_legal(blocks_affected)) {

--- a/vpr/src/place/noc_place_utils.h
+++ b/vpr/src/place/noc_place_utils.h
@@ -5,6 +5,8 @@
 #include "move_utils.h"
 #include "place_util.h"
 
+class PlaceMacros;
+
 /**
  * @class NocCostHandler is responsible for computing NoC-related costs terms.
  *
@@ -662,6 +664,7 @@ bool check_for_router_swap(int user_supplied_noc_router_swap_percentage,
 e_create_move propose_router_swap(t_pl_blocks_to_be_moved& blocks_affected,
                                   float rlim,
                                   const BlkLocRegistry& blk_loc_registry,
+                                  const PlaceMacros& place_macros,
                                   vtr::RngContainer& rng);
 
 /**

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 
 #include "FlatPlacementInfo.h"
+#include "place_macro.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
 #include "vtr_time.h"
@@ -11,17 +12,9 @@
 #include "globals.h"
 #include "place.h"
 #include "annealer.h"
-#include "read_xml_arch_file.h"
 #include "echo_files.h"
-#include "histogram.h"
 #include "PlacementDelayModelCreator.h"
-#include "move_utils.h"
-#include "buttons.h"
 
-#include "VprTimingGraphResolver.h"
-#include "tatum/TimingReporter.hpp"
-
-#include "RL_agent_util.h"
 #include "placer.h"
 
 /********************* Static subroutines local to place.c *******************/
@@ -40,6 +33,7 @@ static bool is_cube_bb(const e_place_bounding_box_mode place_bb_mode,
 
 /*****************************************************************************/
 void try_place(const Netlist<>& net_list,
+               const PlaceMacros& place_macros,
                const t_placer_opts& placer_opts,
                const t_router_opts& router_opts,
                const t_analysis_opts& analysis_opts,
@@ -107,8 +101,8 @@ void try_place(const Netlist<>& net_list,
     // Enables fast look-up of atom pins connect to CLB pins
     ClusteredPinAtomPinsLookup netlist_pin_lookup(cluster_ctx.clb_nlist, atom_ctx.nlist, pb_gpin_lookup);
 
-    Placer placer(net_list, placer_opts, analysis_opts, noc_opts, pb_gpin_lookup, netlist_pin_lookup,
-                  directs, flat_placement_info, place_delay_model, cube_bb, is_flat, /*quiet=*/false);
+    Placer placer(net_list, place_macros, placer_opts, analysis_opts, noc_opts, pb_gpin_lookup, netlist_pin_lookup,
+                  flat_placement_info, place_delay_model, cube_bb, is_flat, /*quiet=*/false);
 
     placer.place();
 

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -33,7 +33,6 @@ static bool is_cube_bb(const e_place_bounding_box_mode place_bb_mode,
 
 /*****************************************************************************/
 void try_place(const Netlist<>& net_list,
-               const PlaceMacros& place_macros,
                const t_placer_opts& placer_opts,
                const t_router_opts& router_opts,
                const t_analysis_opts& analysis_opts,
@@ -91,6 +90,13 @@ void try_place(const Netlist<>& net_list,
     place_ctx.lock_loc_vars();
     place_ctx.compressed_block_grids = create_compressed_block_grids();
 
+    // Alloc and load the placement macros.
+    place_ctx.place_macros = std::make_unique<PlaceMacros>(directs,
+                                                           device_ctx.physical_tile_types,
+                                                           cluster_ctx.clb_nlist,
+                                                           atom_ctx.nlist,
+                                                           atom_ctx.lookup);
+
     /* Start measuring placement time. The measured execution time will be printed
      * when this object goes out of scope at the end of this function.
      */
@@ -101,7 +107,7 @@ void try_place(const Netlist<>& net_list,
     // Enables fast look-up of atom pins connect to CLB pins
     ClusteredPinAtomPinsLookup netlist_pin_lookup(cluster_ctx.clb_nlist, atom_ctx.nlist, pb_gpin_lookup);
 
-    Placer placer(net_list, place_macros, placer_opts, analysis_opts, noc_opts, pb_gpin_lookup, netlist_pin_lookup,
+    Placer placer(net_list, placer_opts, analysis_opts, noc_opts, pb_gpin_lookup, netlist_pin_lookup,
                   flat_placement_info, place_delay_model, cube_bb, is_flat, /*quiet=*/false);
 
     placer.place();

--- a/vpr/src/place/place.h
+++ b/vpr/src/place/place.h
@@ -4,8 +4,10 @@
 #include "vpr_types.h"
 
 class FlatPlacementInfo;
+class PlaceMacros;
 
 void try_place(const Netlist<>& net_list,
+               const PlaceMacros& place_macros,
                const t_placer_opts& placer_opts,
                const t_router_opts& router_opts,
                const t_analysis_opts& analysis_opts,

--- a/vpr/src/place/place.h
+++ b/vpr/src/place/place.h
@@ -4,10 +4,8 @@
 #include "vpr_types.h"
 
 class FlatPlacementInfo;
-class PlaceMacros;
 
 void try_place(const Netlist<>& net_list,
-               const PlaceMacros& place_macros,
                const t_placer_opts& placer_opts,
                const t_router_opts& router_opts,
                const t_analysis_opts& analysis_opts,

--- a/vpr/src/place/place_macro.h
+++ b/vpr/src/place/place_macro.h
@@ -125,6 +125,9 @@
 #include "physical_types.h"
 #include "vpr_types.h"
 
+class AtomLookup;
+class AtomNetlist;
+
 /**
  * @struct t_pl_macro_member
  * @brief The placement macro structure.
@@ -143,8 +146,6 @@ struct t_pl_macro {
 
 class PlaceMacros {
   public:
-    PlaceMacros() = default;
-
     /**
      * @brief Allocates and loads the placement macros.
      * @details The following steps are taken in this methodL
@@ -162,7 +163,11 @@ class PlaceMacros {
      * carry_in's is connected to the netlist which has only 1 SINK.
      * @param directs
      */
-    void alloc_and_load_placement_macros(const std::vector<t_direct_inf>& directs);
+    PlaceMacros(const std::vector<t_direct_inf>& directs,
+                const std::vector<t_physical_tile_type>& physical_tile_types,
+                const ClusteredNetlist& clb_nlist,
+                const AtomNetlist& atom_nlist,
+                const AtomLookup& atom_lookup);
 
     /**
      * @brief Returns the placement macro index to which the given block belongs.
@@ -222,15 +227,23 @@ class PlaceMacros {
     std::vector<t_pl_macro> pl_macros_;
 
   private:
-    int find_all_the_macro_(std::vector<int>& pl_macro_idirect,
+    int find_all_the_macro_(const ClusteredNetlist& clb_nlist,
+                            const AtomNetlist& atom_nlist,
+                            const AtomLookup& atom_lookup,
+                            std::vector<int>& pl_macro_idirect,
                             std::vector<int>& pl_macro_num_members,
                             std::vector<std::vector<ClusterBlockId>>& pl_macro_member_blk_num);
 
-    void alloc_and_load_imacro_from_iblk_(const std::vector<t_pl_macro>& macros);
+    void alloc_and_load_imacro_from_iblk_(const std::vector<t_pl_macro>& macros,
+                                          const ClusteredNetlist& clb_nlist);
 
-    void write_place_macros_(std::string filename, const std::vector<t_pl_macro>& macros);
+    void write_place_macros_(std::string filename,
+                             const std::vector<t_pl_macro>& macros,
+                             const std::vector<t_physical_tile_type>& physical_tile_types,
+                             const ClusteredNetlist& clb_nlist);
 
-    bool net_is_driven_by_direct_(ClusterNetId clb_net);
+    bool net_is_driven_by_direct_(ClusterNetId clb_net,
+                                  const ClusteredNetlist& clb_nlist);
 
     /**
      * @brief Allocates and loads idirect_from_blk_pin and direct_type_from_blk_pin arrays.
@@ -247,7 +260,8 @@ class PlaceMacros {
      * chain connection.
      * @param directs Contains information about all direct connections in the architecture.
      */
-    void alloc_and_load_idirect_from_blk_pin_(const std::vector<t_direct_inf>& directs);
+    void alloc_and_load_idirect_from_blk_pin_(const std::vector<t_direct_inf>& directs,
+                                              const std::vector<t_physical_tile_type>& physical_tile_types);
 };
 
 #endif

--- a/vpr/src/place/place_macro.h
+++ b/vpr/src/place/place_macro.h
@@ -259,6 +259,7 @@ class PlaceMacros {
      * the arch file, OPEN (-1) is stored for pins that could not be part of a direct
      * chain connection.
      * @param directs Contains information about all direct connections in the architecture.
+     * @param physical_tile_types A list of the physical tile types on the device.
      */
     void alloc_and_load_idirect_from_blk_pin_(const std::vector<t_direct_inf>& directs,
                                               const std::vector<t_physical_tile_type>& physical_tile_types);

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -19,13 +19,11 @@
  */
 static GridBlock init_grid_blocks();
 
-void init_placement_context(BlkLocRegistry& blk_loc_registry,
-                            const std::vector<t_direct_inf>& directs) {
+void init_placement_context(BlkLocRegistry& blk_loc_registry) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
 
     auto& block_locs = blk_loc_registry.mutable_block_locs();
     auto& grid_blocks = blk_loc_registry.mutable_grid_blocks();
-    auto& place_macros = blk_loc_registry.mutable_place_macros();
 
     /* Initialize the lookup of CLB block positions */
     block_locs.clear();
@@ -33,8 +31,6 @@ void init_placement_context(BlkLocRegistry& blk_loc_registry,
 
     /* Initialize the reverse lookup of CLB block positions */
     grid_blocks = init_grid_blocks();
-
-    place_macros.alloc_and_load_placement_macros(directs);
 }
 
 static GridBlock init_grid_blocks() {

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -25,6 +25,8 @@ constexpr double PL_INCREMENTAL_COST_TOLERANCE = .01;
 class t_placer_costs;
 class BlkLocRegistry;
 
+struct t_pl_macro;
+
 /**
  * @brief Data structure that stores different cost terms for NoC placement.
  * This data structure can also be used to store normalization and weighting
@@ -203,8 +205,7 @@ class t_placer_statistics {
  *
  * Initialize both of them to empty states.
  */
-void init_placement_context(BlkLocRegistry& blk_loc_registry,
-                            const std::vector<t_direct_inf>& directs);
+void init_placement_context(BlkLocRegistry& blk_loc_registry);
 
 /**
  * @brief Get the initial limit for inner loop block move attempt limit.

--- a/vpr/src/place/placement_log_printer.cpp
+++ b/vpr/src/place/placement_log_printer.cpp
@@ -1,6 +1,7 @@
 
 #include "placement_log_printer.h"
 
+#include "place_macro.h"
 #include "vtr_log.h"
 #include "annealer.h"
 #include "place_util.h"
@@ -196,13 +197,14 @@ void PlacementLogPrinter::print_initial_placement_stats() const {
     }
 
     const BlkLocRegistry& blk_loc_registry = placer_.placer_state_.blk_loc_registry();
+    const PlaceMacros& place_macros = placer_.place_macros_;
     size_t num_macro_members = 0;
-    for (const t_pl_macro& macro : blk_loc_registry.place_macros().macros()) {
+    for (const t_pl_macro& macro : place_macros.macros()) {
         num_macro_members += macro.members.size();
     }
     VTR_LOG("Placement contains %zu placement macros involving %zu blocks (average macro size %f)\n",
-            blk_loc_registry.place_macros().macros().size(), num_macro_members,
-            float(num_macro_members) / blk_loc_registry.place_macros().macros().size());
+            place_macros.macros().size(), num_macro_members,
+            float(num_macro_members) / place_macros.macros().size());
     VTR_LOG("\n");
 
     sprintf(msg_.data(),

--- a/vpr/src/place/placement_log_printer.cpp
+++ b/vpr/src/place/placement_log_printer.cpp
@@ -197,7 +197,7 @@ void PlacementLogPrinter::print_initial_placement_stats() const {
     }
 
     const BlkLocRegistry& blk_loc_registry = placer_.placer_state_.blk_loc_registry();
-    const PlaceMacros& place_macros = placer_.place_macros_;
+    const PlaceMacros& place_macros = *g_vpr_ctx.placement().place_macros;
     size_t num_macro_members = 0;
     for (const t_pl_macro& macro : place_macros.macros()) {
         num_macro_members += macro.members.size();

--- a/vpr/src/place/placer.cpp
+++ b/vpr/src/place/placer.cpp
@@ -85,7 +85,7 @@ Placer::Placer(const Netlist<>& net_list,
 
     const int move_lim = (int)(placer_opts.anneal_sched.inner_num * pow(net_list.blocks().size(), 1.3333));
     //create the move generator based on the chosen placement strategy
-    auto [move_generator, move_generator2] = create_move_generators(placer_state_, placer_opts, move_lim, noc_opts.noc_centroid_weight, rng_);
+    auto [move_generator, move_generator2] = create_move_generators(placer_state_, place_macros, placer_opts, move_lim, noc_opts.noc_centroid_weight, rng_);
 
     if (!placer_opts.write_initial_place_file.empty()) {
         print_place(nullptr, nullptr, placer_opts.write_initial_place_file.c_str(), placer_state_.block_locs());

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -31,6 +31,7 @@
 #include "NetPinTimingInvalidator.h"
 
 class FlatPlacementInfo;
+class PlaceMacros;
 class PlacementAnnealer;
 namespace vtr{
 class ScopedStartFinishTimer;
@@ -39,12 +40,12 @@ class ScopedStartFinishTimer;
 class Placer {
   public:
     Placer(const Netlist<>& net_list,
+           const PlaceMacros& place_macros,
            const t_placer_opts& placer_opts,
            const t_analysis_opts& analysis_opts,
            const t_noc_opts& noc_opts,
            const IntraLbPbPinLookup& pb_gpin_lookup,
            const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
-           const std::vector<t_direct_inf>& directs,
            const FlatPlacementInfo& flat_placement_info,
            std::shared_ptr<PlaceDelayModel> place_delay_model,
            bool cube_bb,
@@ -71,6 +72,7 @@ class Placer {
     void copy_locs_to_global_state(PlacementContext& place_ctx);
 
   private:
+    const PlaceMacros& place_macros_;
     /// Holds placement algorithm parameters
     const t_placer_opts& placer_opts_;
     /// Holds timing analysis parameters

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -31,7 +31,6 @@
 #include "NetPinTimingInvalidator.h"
 
 class FlatPlacementInfo;
-class PlaceMacros;
 class PlacementAnnealer;
 namespace vtr{
 class ScopedStartFinishTimer;
@@ -40,7 +39,6 @@ class ScopedStartFinishTimer;
 class Placer {
   public:
     Placer(const Netlist<>& net_list,
-           const PlaceMacros& place_macros,
            const t_placer_opts& placer_opts,
            const t_analysis_opts& analysis_opts,
            const t_noc_opts& noc_opts,
@@ -72,7 +70,6 @@ class Placer {
     void copy_locs_to_global_state(PlacementContext& place_ctx);
 
   private:
-    const PlaceMacros& place_macros_;
     /// Holds placement algorithm parameters
     const t_placer_opts& placer_opts_;
     /// Holds timing analysis parameters

--- a/vpr/src/place/verify_placement.cpp
+++ b/vpr/src/place/verify_placement.cpp
@@ -172,8 +172,8 @@ static unsigned check_block_placement_consistency(const BlkLocRegistry& blk_loc_
  *
  *  @return The number of errors in the macro placement.
  */
-static unsigned check_macro_placement_consistency(const BlkLocRegistry& blk_loc_registry) {
-    const PlaceMacros& pl_macros = blk_loc_registry.place_macros();
+static unsigned check_macro_placement_consistency(const BlkLocRegistry& blk_loc_registry,
+                                                  const PlaceMacros& pl_macros) {
     const auto& block_locs = blk_loc_registry.block_locs();
     const auto& grid_blocks = blk_loc_registry.grid_blocks();
 
@@ -248,6 +248,7 @@ static unsigned check_placement_floorplanning(const BlkLocRegistry& blk_loc_regi
 }
 
 unsigned verify_placement(const BlkLocRegistry& blk_loc_registry,
+                          const PlaceMacros& place_macros,
                           const ClusteredNetlist& clb_nlist,
                           const DeviceGrid& device_grid,
                           const vtr::vector<ClusterBlockId, PartitionRegion>& cluster_constraints) {
@@ -265,7 +266,7 @@ unsigned verify_placement(const BlkLocRegistry& blk_loc_registry,
     // FIXME: Should we be checking the macro consistency at all? Does the
     //        router use the pl_macros? If not this should be removed from this
     //        method and only used when the macro placement is actually used.
-    num_errors += check_macro_placement_consistency(blk_loc_registry);
+    num_errors += check_macro_placement_consistency(blk_loc_registry, place_macros);
 
     // Check that the floorplanning is observed.
     num_errors += check_placement_floorplanning(blk_loc_registry,
@@ -278,6 +279,7 @@ unsigned verify_placement(const BlkLocRegistry& blk_loc_registry,
 unsigned verify_placement(const VprContext& ctx) {
     // Verify the placement within the given context.
     return verify_placement(ctx.placement().blk_loc_registry(),
+                            *ctx.clustering().place_macros,
                             ctx.clustering().clb_nlist,
                             ctx.device().grid,
                             ctx.floorplanning().cluster_constraints);

--- a/vpr/src/place/verify_placement.cpp
+++ b/vpr/src/place/verify_placement.cpp
@@ -279,7 +279,7 @@ unsigned verify_placement(const BlkLocRegistry& blk_loc_registry,
 unsigned verify_placement(const VprContext& ctx) {
     // Verify the placement within the given context.
     return verify_placement(ctx.placement().blk_loc_registry(),
-                            *ctx.clustering().place_macros,
+                            *ctx.placement().place_macros,
                             ctx.clustering().clb_nlist,
                             ctx.device().grid,
                             ctx.floorplanning().cluster_constraints);

--- a/vpr/src/place/verify_placement.h
+++ b/vpr/src/place/verify_placement.h
@@ -22,6 +22,7 @@ class ClusterBlockId;
 class ClusteredNetlist;
 class DeviceGrid;
 class PartitionRegion;
+class PlaceMacros;
 class VprContext;
 
 /**
@@ -61,6 +62,7 @@ class VprContext;
  *          log messages for each error found.
  */
 unsigned verify_placement(const BlkLocRegistry& blk_loc_registry,
+                          const PlaceMacros& place_macros,
                           const ClusteredNetlist& clb_nlist,
                           const DeviceGrid& device_grid,
                           const vtr::vector<ClusterBlockId, PartitionRegion>& cluster_constraints);

--- a/vpr/src/place/verify_placement.h
+++ b/vpr/src/place/verify_placement.h
@@ -53,6 +53,7 @@ class VprContext;
  *
  *  @param blk_loc_registry     A registry containing the current placement of
  *                              the clusters.
+ *  @param place_macros         The place macros for the clustered netlist.
  *  @param clb_nlist            The clustered netlist being verified.
  *  @param device_grid          The device grid being verified over.
  *  @param cluster_constraints  The constrained regions that each cluster is


### PR DESCRIPTION
The PlaceMacros only require the Clustering and atom/arch info to be constructed; after which they are never modified. Since they are unchanged by the placement, they were out of place in the BlkLocRegistry.

Moved them to the placement context.

This will make it easier to separate out the initial placement from the SA placer.