### PR TITLE
Change NightlyTest workflow to not run automatically

### DIFF
--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -22,8 +22,6 @@ on:
   #     - '**.md'
   #     - '**.rst'
   workflow_dispatch:
-  schedule:
-  - cron: '0 0 * * *' # daily
 
 # We want to cancel previous runs for a given PR or branch / ref if another CI
 # run is requested.


### PR DESCRIPTION
Since NightlyTest is currently not working, we should stop it from running automatically everyday. We still have the option to manually run the workflow if we need to.