### PR TITLE
Remove some defines in vpr types in favor of standard library constants

### DIFF
--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -93,13 +93,6 @@ constexpr bool VTR_ENABLE_DEBUG_LOGGING_CONST_EXPR = true;
 constexpr bool VTR_ENABLE_DEBUG_LOGGING_CONST_EXPR = false;
 #endif
 
-/* Values large enough to be way out of range for any data, but small enough
- * to allow a small number to be added to them without going out of range. */
-#define HUGE_POSITIVE_FLOAT 1.e30
-
-/* Used to avoid floating-point errors when comparing values close to 0 */
-#define EPSILON 1.e-15
-
 /*
  * Files
  */

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -210,7 +210,7 @@ bool get_next_primitive_list(t_intra_cluster_placement_stats* cluster_placement_
 
     // Intialize variables
     bool found_best = false;
-    lowest_cost = HUGE_POSITIVE_FLOAT;
+    lowest_cost = std::numeric_limits<float>::max();
 
     // Iterate over each primitive block type in the current cluster_placement_stats
     for (int i = 0; i < cluster_placement_stats->num_pb_types; i++) {
@@ -241,7 +241,7 @@ bool get_next_primitive_list(t_intra_cluster_placement_stats* cluster_placement_
                                                       it->second->pb_graph_node,
                                                       primitives_list,
                                                       prepacker);
-                            if (cost < HUGE_POSITIVE_FLOAT) {
+                            if (cost < std::numeric_limits<float>::max()) {
                                 cluster_placement_stats->move_primitive_to_inflight(i, it);
                                 return true;
                             } else {
@@ -481,7 +481,7 @@ static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placeme
                                 t_pb_graph_node* root,
                                 t_pb_graph_node** primitives_list,
                                 const Prepacker& prepacker) {
-    float cost = HUGE_POSITIVE_FLOAT;
+    float cost = std::numeric_limits<float>::max();
     const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
     size_t list_size = molecule.atom_block_ids.size();
 
@@ -502,7 +502,7 @@ static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placeme
                                                            primitives_list,
                                                            prepacker,
                                                            &cost)) {
-                    return HUGE_POSITIVE_FLOAT;
+                    return std::numeric_limits<float>::max();
                 }
             }
             for (size_t i = 0; i < list_size; i++) {
@@ -510,7 +510,7 @@ static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placeme
                 for (size_t j = 0; j < list_size; j++) {
                     if (i != j) {
                         if (primitives_list[i] != nullptr && primitives_list[i] == primitives_list[j]) {
-                            return HUGE_POSITIVE_FLOAT;
+                            return std::numeric_limits<float>::max();
                         }
                     }
                 }
@@ -728,4 +728,3 @@ bool exists_free_primitive_for_atom_block(t_intra_cluster_placement_stats* clust
 void reset_tried_but_unused_cluster_placements(t_intra_cluster_placement_stats* cluster_placement_stats) {
     cluster_placement_stats->flush_intermediate_queues();
 }
-

--- a/vpr/src/place/annealer.cpp
+++ b/vpr/src/place/annealer.cpp
@@ -259,7 +259,11 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
     // Get the first range limiter
     placer_state_.mutable_move().first_rlim = (float)std::max(device_ctx.grid.width() - 1, device_ctx.grid.height() - 1);
 
-    annealing_state_ = t_annealing_state(EPSILON,    // Set the temperature low to ensure that initial placement quality will be preserved
+    // In automatic schedule we do a number of random moves before starting the main annealer
+    // to get an estimate for the initial temperature. We set this temperature low
+    // to ensure that initial placement quality will be preserved
+    constexpr float pre_annealing_temp = 1.e-15f;
+    annealing_state_ = t_annealing_state(pre_annealing_temp,
                                          placer_state_.move().first_rlim,
                                          first_move_lim,
                                          first_crit_exponent);

--- a/vpr/src/timing/read_sdc.cpp
+++ b/vpr/src/timing/read_sdc.cpp
@@ -1,5 +1,6 @@
 #include "read_sdc.h"
 
+#include <limits>
 #include <regex>
 
 #include "vtr_log.h"
@@ -741,13 +742,14 @@ class SdcParseCallback : public sdcparse::Callback {
         VTR_ASSERT_MSG(capture_clock.period >= 0., "Clock period must be positive");
 
         float constraint = std::numeric_limits<float>::quiet_NaN();
-
-        if (std::fabs(launch_clock.period - capture_clock.period) < EPSILON && std::fabs(launch_clock.rise_edge - capture_clock.rise_edge) < EPSILON && std::fabs(launch_clock.fall_edge - capture_clock.fall_edge) < EPSILON) {
+        if (vtr::isclose(launch_clock.period, capture_clock.period)       &&
+            vtr::isclose(launch_clock.rise_edge, capture_clock.rise_edge) &&
+            vtr::isclose(launch_clock.fall_edge, capture_clock.fall_edge)) {
             //The source and sink domains have the same period and edges, the constraint is the common clock period.
 
             constraint = launch_clock.period;
 
-        } else if (launch_clock.period < EPSILON || capture_clock.period < EPSILON) {
+        } else if (vtr::isclose(launch_clock.period, 0.0) || vtr::isclose(capture_clock.period, 0.0)) {
             //If either period is 0, the constraint is 0
             constraint = 0.;
 


### PR DESCRIPTION
There were some legacy macro constants defined in vpr_types.h. This PR removes those and uses the standard library instead.

In particular:

- MAX_SHORT was replaced with the equivalent std::numeric_limits<short>::max()
- HUGE_POSITIVE_FLOAT was replaced with std::numeric_limits<float>::infinity(). The values are not equal but it was used similar to an infinite value. The same thing was previously done in route_common.cpp:reset_path_costs
- EPSILON was used for two different things:
  - In annealer.cpp as a generic small value. Since this could possibly change QoR it was substituted with a local constexpr variable of the same value.
  - For float comparision. Changed this to std::numeric_limits<float>::epsilon() which is \*not\* equal to 1.e-15 and is instead 1.19209e-07. The way float comparison is done in that piece of code is not safe in general, but changing this value did not result in any issues in basic and strong regression tests. We might need an "approximately equal" function for float comparisons if we want to do this properly.