### PR TITLE
[Place] Cleaned Up Placement Context Initialization

### DIFF
--- a/vpr/src/base/blk_loc_registry.cpp
+++ b/vpr/src/base/blk_loc_registry.cpp
@@ -7,18 +7,12 @@
 #include "physical_types_util.h"
 #include "vpr_context.h"
 
-/**
- * @brief Initialize `grid_blocks`, the inverse structure of `block_locs`.
- *
- * The container at each grid block location should have a length equal to the
- * subtile capacity of that block. Unused subtile would be marked ClusterBlockId::INVALID().
- */
-static GridBlock init_grid_blocks(const DeviceGrid& device_grid);
-
 BlkLocRegistry::BlkLocRegistry()
     : expected_transaction_(e_expected_transaction::APPLY) {}
 
-void BlkLocRegistry::init(const ClusteredNetlist& clb_nlist, const DeviceGrid& device_grid) {
+void BlkLocRegistry::init() {
+    const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
+    const DeviceGrid& device_grid = g_vpr_ctx.device().grid;
     auto& block_locs = mutable_block_locs();
     auto& grid_blocks = mutable_grid_blocks();
 
@@ -27,33 +21,12 @@ void BlkLocRegistry::init(const ClusteredNetlist& clb_nlist, const DeviceGrid& d
     block_locs.resize(clb_nlist.blocks().size());
 
     /* Initialize the reverse lookup of CLB block positions */
-    grid_blocks = init_grid_blocks(device_grid);
+    grid_blocks.init_grid_blocks(device_grid);
 
     /* Initialize the grid blocks to empty.
      * Initialize all the blocks to unplaced.
      */
     clear_all_grid_locs();
-}
-
-static GridBlock init_grid_blocks(const DeviceGrid& device_grid) {
-    size_t grid_width = device_grid.width();
-    size_t grid_height = device_grid.height();
-    int num_layers = device_grid.get_num_layers();
-
-    /* Structure should have the same dimensions as the grid. */
-    auto grid_blocks = GridBlock(grid_width, grid_height, num_layers);
-
-    for (int layer_num = 0; layer_num < num_layers; layer_num++) {
-        for (size_t x = 0; x < grid_width; x++) {
-            for (size_t y = 0; y < grid_height; y++) {
-                const t_physical_tile_loc tile_loc({(int)x, (int)y, layer_num});
-                auto type = device_grid.get_physical_type(tile_loc);
-                grid_blocks.initialized_grid_block_at_location(tile_loc, type->capacity);
-            }
-        }
-    }
-
-    return grid_blocks;
 }
 
 const vtr::vector_map<ClusterBlockId, t_block_loc>& BlkLocRegistry::block_locs() const {

--- a/vpr/src/base/blk_loc_registry.h
+++ b/vpr/src/base/blk_loc_registry.h
@@ -26,6 +26,10 @@ class BlkLocRegistry {
     BlkLocRegistry(BlkLocRegistry&&) = delete;
     BlkLocRegistry& operator=(BlkLocRegistry&&) = delete;
 
+    /// @brief Initialize the block loc registry's internal data. Must be called
+    ///        before any other method is called.
+    void init(const ClusteredNetlist& clb_nlist, const DeviceGrid& device_grid);
+
   private:
     ///@brief Clustered block placement locations
     vtr::vector_map<ClusterBlockId, t_block_loc> block_locs_;

--- a/vpr/src/base/blk_loc_registry.h
+++ b/vpr/src/base/blk_loc_registry.h
@@ -28,7 +28,7 @@ class BlkLocRegistry {
 
     /// @brief Initialize the block loc registry's internal data. Must be called
     ///        before any other method is called.
-    void init(const ClusteredNetlist& clb_nlist, const DeviceGrid& device_grid);
+    void init();
 
   private:
     ///@brief Clustered block placement locations

--- a/vpr/src/base/grid_block.cpp
+++ b/vpr/src/base/grid_block.cpp
@@ -1,7 +1,28 @@
 
 #include "grid_block.h"
 
+#include "device_grid.h"
 #include "globals.h"
+#include "physical_types.h"
+
+void GridBlock::init_grid_blocks(const DeviceGrid& device_grid) {
+    size_t grid_width = device_grid.width();
+    size_t grid_height = device_grid.height();
+    size_t num_layers = device_grid.get_num_layers();
+
+    /* Structure should have the same dimensions as the grid. */
+    grid_blocks_.resize({num_layers, grid_width, grid_height});
+
+    for (size_t layer_num = 0; layer_num < num_layers; layer_num++) {
+        for (size_t x = 0; x < grid_width; x++) {
+            for (size_t y = 0; y < grid_height; y++) {
+                const t_physical_tile_loc tile_loc({(int)x, (int)y, (int)layer_num});
+                auto type = device_grid.get_physical_type(tile_loc);
+                initialized_grid_block_at_location(tile_loc, type->capacity);
+            }
+        }
+    }
+}
 
 void GridBlock::zero_initialize() {
     auto& device_ctx = g_vpr_ctx.device();

--- a/vpr/src/base/grid_block.h
+++ b/vpr/src/base/grid_block.h
@@ -38,6 +38,14 @@ class GridBlock {
         grid_blocks_.resize({layers, width, height});
     }
 
+    /**
+     * @brief Initialize `grid_blocks`, the inverse structure of `block_locs`.
+     *
+     * The container at each grid block location should have a length equal to the
+     * subtile capacity of that block. Unused subtiles would be marked ClusterBlockId::INVALID().
+     */
+    void init_grid_blocks(const DeviceGrid& device_grid);
+
     inline void initialized_grid_block_at_location(const t_physical_tile_loc& loc, int num_sub_tiles) {
         grid_blocks_[loc.layer_num][loc.x][loc.y].blocks.resize(num_sub_tiles, ClusterBlockId::INVALID());
     }

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -69,7 +69,6 @@
 #include "atom_netlist_utils.h"
 #include "output_clustering.h"
 #include "vpr_constraints_reader.h"
-#include "place_constraints.h"
 #include "place_util.h"
 #include "timing_fail_error.h"
 #include "analytical_placement_flow.h"
@@ -683,8 +682,9 @@ void vpr_load_packing(const t_vpr_setup& vpr_setup, const t_arch& arch) {
         report_packing_pin_usage(ofs, g_vpr_ctx);
     }
 
-    // Load cluster_constraints data structure.
-    load_cluster_constraints();
+    // Ater the clustered netlist has been loaded, update the floorplanning
+    // constraints with the new information.
+    g_vpr_ctx.mutable_floorplanning().update_floorplanning_context_post_pack();
 
     /* Sanity check the resulting netlist */
     check_netlist(vpr_setup.PackerOpts.pack_verbosity);
@@ -844,7 +844,7 @@ void vpr_load_placement(t_vpr_setup& vpr_setup,
     const auto& filename_opts = vpr_setup.FileNameOpts;
 
     //Initialize the block location registry, which will be filled when loading placement
-    blk_loc_registry.init(g_vpr_ctx.clustering().clb_nlist, device_ctx.grid);
+    blk_loc_registry.init();
 
     // Alloc and load the placement macros.
     place_ctx.place_macros = std::make_unique<PlaceMacros>(directs,

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -843,8 +843,8 @@ void vpr_load_placement(t_vpr_setup& vpr_setup,
     auto& blk_loc_registry = place_ctx.mutable_blk_loc_registry();
     const auto& filename_opts = vpr_setup.FileNameOpts;
 
-    //Initialize placement data structures, which will be filled when loading placement
-    init_placement_context(blk_loc_registry);
+    //Initialize the block location registry, which will be filled when loading placement
+    blk_loc_registry.init(g_vpr_ctx.clustering().clb_nlist, device_ctx.grid);
 
     // Alloc and load the placement macros.
     place_ctx.place_macros = std::make_unique<PlaceMacros>(directs,

--- a/vpr/src/base/vpr_context.cpp
+++ b/vpr/src/base/vpr_context.cpp
@@ -1,0 +1,103 @@
+/**
+ * @file
+ * @author  Alex Singer
+ * @date    February 2025
+ * @brief   Implementation of the more complicated context member functions.
+ *          These are methods used to initialize / clean the contexts.
+ */
+
+#include "vpr_context.h"
+#include <memory>
+#include "compressed_grid.h"
+#include "globals.h"
+#include "physical_types.h"
+#include "place_constraints.h"
+#include "place_macro.h"
+#include "vpr_types.h"
+#include "vtr_memory.h"
+
+/**
+ * @brief determine the type of the bounding box used by the placer to predict
+ * the wirelength.
+ *
+ * @param place_bb_mode The bounding box mode passed by the CLI
+ * @param rr_graph The routing resource graph
+ */
+static bool is_cube_bb(const e_place_bounding_box_mode place_bb_mode,
+                       const RRGraphView& rr_graph);
+
+void FloorplanningContext::update_floorplanning_context_post_pack() {
+    // Initialize the cluster_constraints using the constraints loaded from the
+    // user and clustering generated from packing.
+    load_cluster_constraints();
+}
+
+void FloorplanningContext::update_floorplanning_context_pre_place(
+                                    const PlaceMacros& place_macros) {
+    // Go through cluster blocks to calculate the tightest placement
+    // floorplan constraint for each constrained block.
+    propagate_place_constraints(place_macros);
+
+    // Compute and store compressed floorplanning constraints.
+    alloc_and_load_compressed_cluster_constraints();
+}
+
+void FloorplanningContext::clean_floorplanning_context_post_place() {
+    // The cluster constraints are loaded in propagate_place_constraints and are
+    // not used outside of placement.
+    vtr::release_memory(cluster_constraints);
+
+    // The compressed cluster constraints are loaded in alloc_and_laod_compressed
+    // cluster_constraints and are not used outside of placement.
+    vtr::release_memory(compressed_cluster_constraints);
+}
+
+void PlacementContext::init_placement_context(
+                                    const t_placer_opts& placer_opts,
+                                    const std::vector<t_direct_inf>& directs) {
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+
+    cube_bb = is_cube_bb(placer_opts.place_bounding_box_mode, device_ctx.rr_graph);
+
+    compressed_block_grids = create_compressed_block_grids();
+
+    // Alloc and load the placement macros.
+    place_macros = std::make_unique<PlaceMacros>(directs,
+                                                 device_ctx.physical_tile_types,
+                                                 cluster_ctx.clb_nlist,
+                                                 atom_ctx.nlist,
+                                                 atom_ctx.lookup);
+}
+
+static bool is_cube_bb(const e_place_bounding_box_mode place_bb_mode,
+                       const RRGraphView& rr_graph) {
+    bool cube_bb;
+    const int number_layers = g_vpr_ctx.device().grid.get_num_layers();
+
+    if (place_bb_mode == e_place_bounding_box_mode::AUTO_BB) {
+        // If the auto_bb is used, we analyze the RR graph to see whether is there any inter-layer connection that is not
+        // originated from OPIN. If there is any, cube BB is chosen, otherwise, per-layer bb is chosen.
+        if (number_layers > 1 && inter_layer_connections_limited_to_opin(rr_graph)) {
+            cube_bb = false;
+        } else {
+            cube_bb = true;
+        }
+    } else if (place_bb_mode == e_place_bounding_box_mode::CUBE_BB) {
+        // The user has specifically asked for CUBE_BB
+        cube_bb = true;
+    } else {
+        // The user has specifically asked for PER_LAYER_BB
+        VTR_ASSERT_SAFE(place_bb_mode == e_place_bounding_box_mode::PER_LAYER_BB);
+        cube_bb = false;
+    }
+
+    return cube_bb;
+}
+
+void PlacementContext::clean_placement_context_post_place() {
+    // The compressed block grids are currently only used during placement.
+    vtr::release_memory(compressed_block_grids);
+}
+

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -1298,7 +1298,7 @@ void initial_placement(const t_placer_opts& placer_opts,
     vtr::ScopedStartFinishTimer timer("Initial Placement");
 
     // Initialize the block loc registry.
-    blk_loc_registry.init(g_vpr_ctx.clustering().clb_nlist, g_vpr_ctx.device().grid);
+    blk_loc_registry.init();
 
     /*Mark the blocks that have already been locked to one spot via floorplan constraints
      * as fixed, so they do not get moved during initial placement or later during the simulated annealing stage of placement*/

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -1297,22 +1297,12 @@ void initial_placement(const t_placer_opts& placer_opts,
                        vtr::RngContainer& rng) {
     vtr::ScopedStartFinishTimer timer("Initial Placement");
 
-    /* Initialize the grid blocks to empty.
-     * Initialize all the blocks to unplaced.
-     */
-    blk_loc_registry.clear_all_grid_locs();
-
-    /* Go through cluster blocks to calculate the tightest placement
-     * floorplan constraint for each constrained block
-     */
-    propagate_place_constraints(place_macros);
+    // Initialize the block loc registry.
+    blk_loc_registry.init(g_vpr_ctx.clustering().clb_nlist, g_vpr_ctx.device().grid);
 
     /*Mark the blocks that have already been locked to one spot via floorplan constraints
      * as fixed, so they do not get moved during initial placement or later during the simulated annealing stage of placement*/
     mark_fixed_blocks(blk_loc_registry);
-
-    // Compute and store compressed floorplanning constraints
-    alloc_and_load_compressed_cluster_constraints();
 
     // read the constraint file and place fixed blocks
     if (strlen(constraints_file) != 0) {

--- a/vpr/src/place/place.h
+++ b/vpr/src/place/place.h
@@ -4,7 +4,6 @@
 #include "vpr_types.h"
 
 class FlatPlacementInfo;
-class PlacementContext;
 
 void try_place(const Netlist<>& net_list,
                const t_placer_opts& placer_opts,
@@ -17,33 +16,4 @@ void try_place(const Netlist<>& net_list,
                const std::vector<t_direct_inf>& directs,
                const FlatPlacementInfo& flat_placement_info,
                bool is_flat);
-
-/**
- * @brief Initialize the variables stored within the placement context. This
- *        must be called before using the Placer class.
- *
- *  @param place_ctx
- *      The placement context to initialize.
- *  @param placer_opts
- *      The options passed into the placer.
- *  @param noc_opts
- *      The options passed into the placer for NoCs.
- *  @param directs
- *      A list of the direct connections in the architecture.
- */
-void init_placement_context(PlacementContext& place_ctx,
-                            const t_placer_opts& placer_opts,
-                            const t_noc_opts& noc_opts,
-                            const std::vector<t_direct_inf>& directs);
-
-/**
- * @brief Clean variables from the placement context which are not used outside
- *        of placement.
- *
- * These are some variables that are stored in the placement context and are
- * only used in placement; while there are some that are used outside of
- * placement. This method frees up the memory of the variables used only within
- * placement.
- */
-void clean_placement_context(PlacementContext& place_ctx);
 

--- a/vpr/src/place/place.h
+++ b/vpr/src/place/place.h
@@ -4,6 +4,7 @@
 #include "vpr_types.h"
 
 class FlatPlacementInfo;
+class PlacementContext;
 
 void try_place(const Netlist<>& net_list,
                const t_placer_opts& placer_opts,
@@ -16,4 +17,33 @@ void try_place(const Netlist<>& net_list,
                const std::vector<t_direct_inf>& directs,
                const FlatPlacementInfo& flat_placement_info,
                bool is_flat);
+
+/**
+ * @brief Initialize the variables stored within the placement context. This
+ *        must be called before using the Placer class.
+ *
+ *  @param place_ctx
+ *      The placement context to initialize.
+ *  @param placer_opts
+ *      The options passed into the placer.
+ *  @param noc_opts
+ *      The options passed into the placer for NoCs.
+ *  @param directs
+ *      A list of the direct connections in the architecture.
+ */
+void init_placement_context(PlacementContext& place_ctx,
+                            const t_placer_opts& placer_opts,
+                            const t_noc_opts& noc_opts,
+                            const std::vector<t_direct_inf>& directs);
+
+/**
+ * @brief Clean variables from the placement context which are not used outside
+ *        of placement.
+ *
+ * These are some variables that are stored in the placement context and are
+ * only used in placement; while there are some that are used outside of
+ * placement. This method frees up the memory of the variables used only within
+ * placement.
+ */
+void clean_placement_context(PlacementContext& place_ctx);
 

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -6,51 +6,9 @@
 
 #include "place_util.h"
 #include "globals.h"
-#include "draw_global.h"
 #include "physical_types_util.h"
 #include "place_constraints.h"
 #include "noc_place_utils.h"
-
-/**
- * @brief Initialize `grid_blocks`, the inverse structure of `block_locs`.
- *
- * The container at each grid block location should have a length equal to the
- * subtile capacity of that block. Unused subtile would be marked ClusterBlockId::INVALID().
- */
-static GridBlock init_grid_blocks();
-
-void init_placement_context(BlkLocRegistry& blk_loc_registry) {
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-
-    auto& block_locs = blk_loc_registry.mutable_block_locs();
-    auto& grid_blocks = blk_loc_registry.mutable_grid_blocks();
-
-    /* Initialize the lookup of CLB block positions */
-    block_locs.clear();
-    block_locs.resize(cluster_ctx.clb_nlist.blocks().size());
-
-    /* Initialize the reverse lookup of CLB block positions */
-    grid_blocks = init_grid_blocks();
-}
-
-static GridBlock init_grid_blocks() {
-    auto& device_ctx = g_vpr_ctx.device();
-    int num_layers = device_ctx.grid.get_num_layers();
-
-    /* Structure should have the same dimensions as the grid. */
-    auto grid_blocks = GridBlock(device_ctx.grid.width(), device_ctx.grid.height(), num_layers);
-
-    for (int layer_num = 0; layer_num < num_layers; ++layer_num) {
-        for (int x = 0; x < (int)device_ctx.grid.width(); ++x) {
-            for (int y = 0; y < (int)device_ctx.grid.height(); ++y) {
-                auto type = device_ctx.grid.get_physical_type({x, y, layer_num});
-                grid_blocks.initialized_grid_block_at_location({x, y, layer_num}, type->capacity);
-            }
-        }
-    }
-
-    return grid_blocks;
-}
 
 void t_placer_costs::update_norm_factors() {
     if (place_algorithm.is_timing_driven()) {

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -197,17 +197,6 @@ class t_placer_statistics {
 };
 
 /**
- * @brief Initialize the placer's block-grid dual direction mapping.
- *
- * Forward direction - block to grid: place_ctx.block_locs.
- * Reverse direction - grid to block: place_ctx.grid_blocks.
- * Allocates and load placement macros.
- *
- * Initialize both of them to empty states.
- */
-void init_placement_context(BlkLocRegistry& blk_loc_registry);
-
-/**
  * @brief Get the initial limit for inner loop block move attempt limit.
  *
  * There are two ways to scale the move limit.

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -30,6 +31,7 @@
 #include "PlacerCriticalities.h"
 #include "NetPinTimingInvalidator.h"
 
+class BlkLocRegistry;
 class FlatPlacementInfo;
 class PlacementAnnealer;
 namespace vtr{
@@ -39,6 +41,7 @@ class ScopedStartFinishTimer;
 class Placer {
   public:
     Placer(const Netlist<>& net_list,
+           const std::optional<const std::reference_wrapper<BlkLocRegistry>> init_place,
            const t_placer_opts& placer_opts,
            const t_analysis_opts& analysis_opts,
            const t_noc_opts& noc_opts,


### PR DESCRIPTION
Cleaned up how the variables in the placement context were initialized to make it easier to initialize the placement context outside of the placement stage (Analytical Placement).

Added an optional argument to the Placer class to allow an initial placement to be passed in. This allows a different initial placement to be used without having to pull the initial placer out of the Placer class.

With this change, it should be easier to create the Detailed Placer in Analytical Placement.