### PR TITLE
[CI] Made Nightly Tests Continue on Error

### DIFF
--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -63,37 +63,45 @@ jobs:
     # TODO: We could expose more parallelism if we had one task list which ran
     #       all of these.
     - name: 'Run Nightly Test 1'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test1
 
     - name: 'Run Nightly Test 2'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test2
 
     - name: 'Run Nightly Test 3'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test3
 
 
     - name: 'Run Nightly Test 4'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test4
 
     - name: 'Run Nightly Test 5'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test5
 
     - name: 'Run Nightly Test 6'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test6
 
     - name: 'Run Nightly Test 7'
+      continue-on-error: true
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test7
+


### PR DESCRIPTION
Currently, the Nightly Tests will stop whenever any of the Nightly Tests fail (and will not run the following tests). So for example, if Nightly Test 1 has a QoR failure, all other Nightly tests will not be run.

Made each step in the Nightly Test manual job continue on error. This will run the following steps even if one of them fail.

I found this while running the Nightly Tests on Haydar's recent PR (PR #2897 ):
<img width="382" alt="image" src="https://github.com/user-attachments/assets/43f512b5-61db-4601-be46-f3f8294b6bc4" />

I do not think this is the intended behavior we want based on previous discussions.