### PR TITLE
Clarified target_ext_pin_utilization command line option documentation

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -657,7 +657,7 @@ For people not working on CAD, you can probably leave all the options to their d
 
     .. note::
 
-        If a pin utilization target is unspecified it defaults to 1.0 (i.e. 100% utilization).
+        If some pin utilizations are specified, ``auto`` mode is turned off and the utilization target for any unspecified pin types defaults to 1.0 (i.e. 100% utilization).
 
         For example:
 


### PR DESCRIPTION
#### Description
Clarified that setting any target_ext_pin_utilization values turns off auto mode and the target pin utilization for any unspecified pin types is set to 100% in that case.

#### Related Issue
This previously confused researchers at Cornell.
