### PR TITLE
Make Nightly Tests Continue on Error

### DIFF
--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -63,37 +63,44 @@ jobs:
     # TODO: We could expose more parallelism if we had one task list which ran
     #       all of these.
     - name: 'Run Nightly Test 1'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test1
 
     - name: 'Run Nightly Test 2'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test2
 
     - name: 'Run Nightly Test 3'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test3
 
 
     - name: 'Run Nightly Test 4'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test4
 
     - name: 'Run Nightly Test 5'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test5
 
     - name: 'Run Nightly Test 6'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test6
 
     - name: 'Run Nightly Test 7'
+      if: success() || failure()
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test7


### PR DESCRIPTION
Basically the same thing as #2905 but uses a different way to do it that hopefully avoids the issue of the run being considered successful even if some tests have failed. Did it in a different PR and branch because I didn't want to mess with the origin too much.