### PR TITLE
[vtr_flow] Changed Triggers for Second Run

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/flow.py
+++ b/vtr_flow/scripts/python_libs/vtr/flow.py
@@ -297,8 +297,6 @@ def run(
 
             if (
                 "write_rr_graph" in vpr_args
-                or "analysis" in vpr_args
-                or "route" in vpr_args
                 or "write_router_lookahead" in vpr_args
                 or "write_intra_cluster_router_lookahead" in vpr_args
             ):


### PR DESCRIPTION
Currently, when running the VPR stage of the vtr_flow script, if you are routing at a fixed channel width and you have "--route" or "--analysis" in the command, it will run the VPR stage twice with the exact same arguments. This is unnecessary and can make some of the runs 2x longer than they need to be.

The purpose of running the VPR flow twice is that the second time would load in the temporary files produced by the first run to ensure they are the same values. It appears as though route and analysis used to be part of this check; however it is no longer being used. I checked the second run code and having the --route or --analysis flag set has no affect on the second run's arguments; so the exact same run is dispatched.

I looked through all the regression tests and only found one testcase that used either of these options; which may be the reason this was never caught.

This is useful for the AP flow since, to use the AP flow, we need to specify the --analytical_place flow which inherently does not perfrom routing. So we have to add --route to our arguments. I noticed that these runs took 2x longer than they should and found this issue.

The code that triggers the second run can be found here:
https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/12c46002b9e4235b64e28d7aa5c1b99d83054815/vtr_flow/scripts/python_libs/vtr/flow.py#L295-L338

The second run is performed here:
https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/12c46002b9e4235b64e28d7aa5c1b99d83054815/vtr_flow/scripts/python_libs/vtr/vpr/vpr.py#L276-L341

Notice that the second run's args only change based on the router lookahead and rr graph.