### PR TITLE
Fixed ignored y channels in computing routing channel utilization histogram.

### DIFF
--- a/vpr/src/route/channel_stats.cpp
+++ b/vpr/src/route/channel_stats.cpp
@@ -36,7 +36,7 @@ void print_channel_stats(bool is_flat) {
     for (size_t x = 0; x < device_ctx.grid.width() - 1; ++x) {
         for (size_t y = 0; y < device_ctx.grid.height() - 1; ++y) {
             float chanx_util = routing_util(chanx_usage[x][y], chanx_avail[x][y]);
-            float chany_util = routing_util(chanx_usage[x][y], chanx_avail[x][y]);
+            float chany_util = routing_util(chany_usage[x][y], chany_avail[x][y]);
 
             for (float util : {chanx_util, chany_util}) {
                 //Record peak utilization


### PR DESCRIPTION
This PR fixes a bug that ignored y channels when computing channel utilization histogram and maximum channel utilization.