### PR TITLE
Partial update of the code base to be consistent with rules in .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -68,10 +68,10 @@ IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
-IndentPPDirectives: AfterHash
+IndentPPDirectives: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1

--- a/libs/librtlnumber/src/include/rtl_utils.hpp
+++ b/libs/librtlnumber/src/include/rtl_utils.hpp
@@ -16,7 +16,7 @@
 #include <stdint.h>
 
 #ifndef FILE_NAME
-#    define FILE_NAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define FILE_NAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #endif
 
 /* Enable Debug Messages for libRTLNumber: Un-Comment to Enable Debug Messages:
@@ -24,22 +24,22 @@
 // #define ENABLE_DEBUG_MESSAGES
 
 #ifdef ENABLE_DEBUG_MESSAGES
-#    define DEBUG_MSG(debugMsg) std::cerr << "DEBUG: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" \
-                                          << ": " << debugMsg << std::endl
+#define DEBUG_MSG(debugMsg) std::cerr << "DEBUG: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" \
+                                      << ": " << debugMsg << std::endl
 #else
-#    define DEBUG_MSG(debugMsg) /* No-Op */
+#define DEBUG_MSG(debugMsg) /* No-Op */
 #endif
 
 #ifndef WARN_MSG
-#    define WARN_MSG(warnMSG) std::cerr << "WARNING: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" \
-                                        << ": " << warnMSG << "!" << std::endl
+#define WARN_MSG(warnMSG) std::cerr << "WARNING: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" \
+                                    << ": " << warnMSG << "!" << std::endl
 #endif
 
 #ifndef ERR_MSG
-#    define ERR_MSG(errMsg) std::cerr << std::endl                                                            \
-                                      << "ERROR: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" \
-                                      << ": " << errMsg << "!" << std::endl                                   \
-                                      << std::endl
+#define ERR_MSG(errMsg) std::cerr << std::endl                                                            \
+                                  << "ERROR: " << FILE_NAME << ":" << __LINE__ << " " << __func__ << "()" \
+                                  << ": " << errMsg << "!" << std::endl                                   \
+                                  << std::endl
 #endif
 
 std::string string_of_radix_to_bitstring(std::string orig_string, size_t radix);

--- a/libs/libvtrutil/src/specrand.cpp
+++ b/libs/libvtrutil/src/specrand.cpp
@@ -112,7 +112,7 @@ unsigned long SpecRandomNumberGenerator::spec_genrand_int32_() {
 
     if (mti >= N) { /* generate N words at one time */
 
-        if (mti == N + 1)              /* if init_genrand() has not been called, */
+        if (mti == N + 1)               /* if init_genrand() has not been called, */
             spec_init_genrand_(5489UL); /* a default initial seed is used */
 
         for (size_t kk = 0; kk < N - M; kk++) {

--- a/libs/libvtrutil/src/specrand.h
+++ b/libs/libvtrutil/src/specrand.h
@@ -114,7 +114,6 @@ class SpecRandomNumberGenerator : public vtr::RandomNumberGeneratorInterface {
     size_t mti = N + 1;
     /// the array for the state vector
     unsigned long mt[N];
-
 };
 
 #endif

--- a/libs/libvtrutil/src/tl_optional.hpp
+++ b/libs/libvtrutil/src/tl_optional.hpp
@@ -32,78 +32,78 @@
 #include <utility>
 
 #if (defined(_MSC_VER) && _MSC_VER == 1900)
-#    define TL_OPTIONAL_MSVC2015
+#define TL_OPTIONAL_MSVC2015
 #endif
 
 #if (defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 && !defined(__clang__))
-#    define TL_OPTIONAL_GCC49
+#define TL_OPTIONAL_GCC49
 #endif
 
 #if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 4 && !defined(__clang__))
-#    define TL_OPTIONAL_GCC54
+#define TL_OPTIONAL_GCC54
 #endif
 
 #if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 5 && !defined(__clang__))
-#    define TL_OPTIONAL_GCC55
+#define TL_OPTIONAL_GCC55
 #endif
 
 #if (defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 && !defined(__clang__))
 // GCC < 5 doesn't support overloading on const&& for member functions
-#    define TL_OPTIONAL_NO_CONSTRR
+#define TL_OPTIONAL_NO_CONSTRR
 
 // GCC < 5 doesn't support some standard C++11 type traits
-#    define TL_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) \
-        std::has_trivial_copy_constructor<T>::value
-#    define TL_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) std::has_trivial_copy_assign<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) \
+    std::has_trivial_copy_constructor<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) std::has_trivial_copy_assign<T>::value
 
 // This one will be different for GCC 5.7 if it's ever supported
-#    define TL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE(T) std::is_trivially_destructible<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE(T) std::is_trivially_destructible<T>::value
 
 // GCC 5 < v < 8 has a bug in is_trivially_copy_constructible which breaks std::vector
 // for non-copyable types
 #elif (defined(__GNUC__) && __GNUC__ < 8 && !defined(__clang__))
-#    ifndef TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
-#        define TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
+#ifndef TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
+#define TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
 namespace tl {
 namespace detail {
 template<class T>
 struct is_trivially_copy_constructible : std::is_trivially_copy_constructible<T> {};
-#        ifdef _GLIBCXX_VECTOR
+#ifdef _GLIBCXX_VECTOR
 template<class T, class A>
 struct is_trivially_copy_constructible<std::vector<T, A>>
     : std::is_trivially_copy_constructible<T> {};
-#        endif
+#endif
 } // namespace detail
 } // namespace tl
-#    endif
+#endif
 
-#    define TL_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) \
-        tl::detail::is_trivially_copy_constructible<T>::value
-#    define TL_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
-        std::is_trivially_copy_assignable<T>::value
-#    define TL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE(T) std::is_trivially_destructible<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) \
+    tl::detail::is_trivially_copy_constructible<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
+    std::is_trivially_copy_assignable<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE(T) std::is_trivially_destructible<T>::value
 #else
-#    define TL_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) \
-        std::is_trivially_copy_constructible<T>::value
-#    define TL_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
-        std::is_trivially_copy_assignable<T>::value
-#    define TL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE(T) std::is_trivially_destructible<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) \
+    std::is_trivially_copy_constructible<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
+    std::is_trivially_copy_assignable<T>::value
+#define TL_OPTIONAL_IS_TRIVIALLY_DESTRUCTIBLE(T) std::is_trivially_destructible<T>::value
 #endif
 
 #if __cplusplus > 201103L
-#    define TL_OPTIONAL_CXX14
+#define TL_OPTIONAL_CXX14
 #endif
 
 // constexpr implies const in C++11, not C++14
 #if (__cplusplus == 201103L || defined(TL_OPTIONAL_MSVC2015) || defined(TL_OPTIONAL_GCC49))
-#    define TL_OPTIONAL_11_CONSTEXPR
+#define TL_OPTIONAL_11_CONSTEXPR
 #else
-#    define TL_OPTIONAL_11_CONSTEXPR constexpr
+#define TL_OPTIONAL_11_CONSTEXPR constexpr
 #endif
 
 namespace tl {
 #ifndef TL_MONOSTATE_INPLACE_MUTEX
-#    define TL_MONOSTATE_INPLACE_MUTEX
+#define TL_MONOSTATE_INPLACE_MUTEX
 /// Used to represent an optional with no data; essentially a bool
 class monostate {};
 
@@ -120,7 +120,7 @@ class optional;
 
 namespace detail {
 #ifndef TL_TRAITS_MUTEX
-#    define TL_TRAITS_MUTEX
+#define TL_TRAITS_MUTEX
 // C++14-style aliases for brevity
 template<class T>
 using remove_const_t = typename std::remove_const<T>::type;
@@ -142,14 +142,14 @@ template<class B, class... Bs>
 struct conjunction<B, Bs...>
     : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
 
-#    if defined(_LIBCPP_VERSION) && __cplusplus == 201103L
-#        define TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
-#    endif
+#if defined(_LIBCPP_VERSION) && __cplusplus == 201103L
+#define TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+#endif
 
 // In C++11 mode, there's an issue in libc++'s std::mem_fn
 // which results in a hard-error when using it in a noexcept expression
 // in some cases. This is a check to workaround the common failing case.
-#    ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
 template<class T>
 struct is_pointer_to_non_const_member_func : std::false_type {};
 template<class T, class Ret, class... Args>
@@ -171,14 +171,14 @@ template<class T>
 struct is_const_or_const_ref<T const&> : std::true_type {};
 template<class T>
 struct is_const_or_const_ref<T const> : std::true_type {};
-#    endif
+#endif
 
 // std::invoke from C++17
 // https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
 template<typename Fn, typename... Args,
-#    ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
          typename = enable_if_t<!(is_pointer_to_non_const_member_func<Fn>::value && is_const_or_const_ref<Args...>::value)>,
-#    endif
+#endif
          typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>::value>,
          int = 0>
 constexpr auto invoke(Fn&& f, Args&&... args) noexcept(
@@ -212,14 +212,14 @@ using invoke_result = invoke_result_impl<F, void, Us...>;
 template<class F, class... Us>
 using invoke_result_t = typename invoke_result<F, Us...>::type;
 
-#    if defined(_MSC_VER) && _MSC_VER <= 1900
+#if defined(_MSC_VER) && _MSC_VER <= 1900
 // TODO make a version which works with MSVC 2015
 template<class T, class U = T>
 struct is_swappable : std::true_type {};
 
 template<class T, class U = T>
 struct is_nothrow_swappable : std::true_type {};
-#    else
+#else
 // https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
 namespace swap_adl_tests {
 // if swap ADL finds this then it would call std::swap otherwise (same
@@ -276,7 +276,7 @@ struct is_nothrow_swappable
           bool,
           is_swappable<T, U>::value && ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value && detail::swap_adl_tests::is_std_swap_noexcept<T>::value) || (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value && detail::swap_adl_tests::is_adl_swap_noexcept<T, U>::value))> {
 };
-#    endif
+#endif
 #endif
 
 // std::void_t from C++17
@@ -719,7 +719,7 @@ class optional : private detail::optional_move_assign_base<T>,
                            : result(nullopt);
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr auto and_then(F&& f) const&& {
         using result = detail::invoke_result_t<F, const T&&>;
@@ -729,7 +729,7 @@ class optional : private detail::optional_move_assign_base<T>,
         return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                            : result(nullopt);
     }
-#    endif
+#endif
 #else
     /// Carries out some operation which returns an optional on the stored
     /// object if there is one.
@@ -763,7 +763,7 @@ class optional : private detail::optional_move_assign_base<T>,
                            : result(nullopt);
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr detail::invoke_result_t<F, const T&&> and_then(F&& f) const&& {
         using result = detail::invoke_result_t<F, const T&&>;
@@ -773,7 +773,7 @@ class optional : private detail::optional_move_assign_base<T>,
         return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
                            : result(nullopt);
     }
-#    endif
+#endif
 #endif
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) && !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
@@ -820,14 +820,14 @@ class optional : private detail::optional_move_assign_base<T>,
         return optional_map_impl(*this, std::forward<F>(f));
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr decltype(optional_map_impl(std::declval<const optional&&>(),
                                          std::declval<F&&>()))
     map(F&& f) const&& {
         return optional_map_impl(std::move(*this), std::forward<F>(f));
     }
-#    endif
+#endif
 #endif
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) && !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
@@ -874,14 +874,14 @@ class optional : private detail::optional_move_assign_base<T>,
         return optional_map_impl(*this, std::forward<F>(f));
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr decltype(optional_map_impl(std::declval<const optional&&>(),
                                          std::declval<F&&>()))
     transform(F&& f) const&& {
         return optional_map_impl(std::move(*this), std::forward<F>(f));
     }
-#    endif
+#endif
 #endif
 
     /// Calls `f` if the optional is empty
@@ -1593,7 +1593,7 @@ class optional<T&> {
                            : result(nullopt);
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr auto and_then(F&& f) const&& {
         using result = detail::invoke_result_t<F, const T&>;
@@ -1603,7 +1603,7 @@ class optional<T&> {
         return has_value() ? detail::invoke(std::forward<F>(f), **this)
                            : result(nullopt);
     }
-#    endif
+#endif
 #else
     /// Carries out some operation which returns an optional on the stored
     /// object if there is one.
@@ -1637,7 +1637,7 @@ class optional<T&> {
                            : result(nullopt);
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr detail::invoke_result_t<F, const T&> and_then(F&& f) const&& {
         using result = detail::invoke_result_t<F, const T&>;
@@ -1647,7 +1647,7 @@ class optional<T&> {
         return has_value() ? detail::invoke(std::forward<F>(f), **this)
                            : result(nullopt);
     }
-#    endif
+#endif
 #endif
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) && !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
@@ -1694,14 +1694,14 @@ class optional<T&> {
         return detail::optional_map_impl(*this, std::forward<F>(f));
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr decltype(detail::optional_map_impl(std::declval<const optional&&>(),
                                                  std::declval<F&&>()))
     map(F&& f) const&& {
         return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
     }
-#    endif
+#endif
 #endif
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) && !defined(TL_OPTIONAL_GCC54) && !defined(TL_OPTIONAL_GCC55)
@@ -1750,14 +1750,14 @@ class optional<T&> {
         return detail::optional_map_impl(*this, std::forward<F>(f));
     }
 
-#    ifndef TL_OPTIONAL_NO_CONSTRR
+#ifndef TL_OPTIONAL_NO_CONSTRR
     template<class F>
     constexpr decltype(detail::optional_map_impl(std::declval<const optional&&>(),
                                                  std::declval<F&&>()))
     transform(F&& f) const&& {
         return detail::optional_map_impl(std::move(*this), std::forward<F>(f));
     }
-#    endif
+#endif
 #endif
 
     /// Calls `f` if the optional is empty

--- a/libs/libvtrutil/src/vpr_error.h
+++ b/libs/libvtrutil/src/vpr_error.h
@@ -78,12 +78,12 @@ void vpr_throw_opt(enum e_vpr_error type, const char* psz_func_pretty_name, cons
 // information, so we prefer to use it if possible
 #define VPR_THROW_FUNCTION __func__
 #ifdef __GNUC__
-#    ifdef __GNUC_MINOR__
-#        if __GNUC__ >= 2 && __GNUC_MINOR__ > 6
-#            undef VPR_THROW_FUNCTION
-#            define VPR_THROW_FUNCTION __PRETTY_FUNCTION__
-#        endif
-#    endif
+#ifdef __GNUC_MINOR__
+#if __GNUC__ >= 2 && __GNUC_MINOR__ > 6
+#undef VPR_THROW_FUNCTION
+#define VPR_THROW_FUNCTION __PRETTY_FUNCTION__
+#endif
+#endif
 #endif
 
 /*

--- a/libs/libvtrutil/src/vtr_assert.h
+++ b/libs/libvtrutil/src/vtr_assert.h
@@ -29,57 +29,57 @@
 
 // Set a default assertion level if none is specified
 #ifndef VTR_ASSERT_LEVEL
-#    define VTR_ASSERT_LEVEL 2
+#define VTR_ASSERT_LEVEL 2
 #endif
 
 // Enable the assertions based on the specified level
 #if VTR_ASSERT_LEVEL >= 4
-#    define VTR_ASSERT_DEBUG_ENABLED
+#define VTR_ASSERT_DEBUG_ENABLED
 #endif
 
 #if VTR_ASSERT_LEVEL >= 3
-#    define VTR_ASSERT_SAFE_ENABLED
+#define VTR_ASSERT_SAFE_ENABLED
 #endif
 
 #if VTR_ASSERT_LEVEL >= 2
-#    define VTR_ASSERT_ENABLED
+#define VTR_ASSERT_ENABLED
 #endif
 
 #if VTR_ASSERT_LEVEL >= 1
-#    define VTR_ASSERT_OPT_ENABLED
+#define VTR_ASSERT_OPT_ENABLED
 #endif
 
 // Define the user assertion macros
 #ifdef VTR_ASSERT_DEBUG_ENABLED
-#    define VTR_ASSERT_DEBUG(expr) VTR_ASSERT_IMPL(expr, nullptr)
-#    define VTR_ASSERT_DEBUG_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
+#define VTR_ASSERT_DEBUG(expr) VTR_ASSERT_IMPL(expr, nullptr)
+#define VTR_ASSERT_DEBUG_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
 #else
-#    define VTR_ASSERT_DEBUG(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
-#    define VTR_ASSERT_DEBUG_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
+#define VTR_ASSERT_DEBUG(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
+#define VTR_ASSERT_DEBUG_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
 #endif
 
 #ifdef VTR_ASSERT_SAFE_ENABLED
-#    define VTR_ASSERT_SAFE(expr) VTR_ASSERT_IMPL(expr, nullptr)
-#    define VTR_ASSERT_SAFE_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
+#define VTR_ASSERT_SAFE(expr) VTR_ASSERT_IMPL(expr, nullptr)
+#define VTR_ASSERT_SAFE_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
 #else
-#    define VTR_ASSERT_SAFE(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
-#    define VTR_ASSERT_SAFE_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
+#define VTR_ASSERT_SAFE(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
+#define VTR_ASSERT_SAFE_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
 #endif
 
 #ifdef VTR_ASSERT_ENABLED
-#    define VTR_ASSERT(expr) VTR_ASSERT_IMPL(expr, nullptr)
-#    define VTR_ASSERT_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
+#define VTR_ASSERT(expr) VTR_ASSERT_IMPL(expr, nullptr)
+#define VTR_ASSERT_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
 #else
-#    define VTR_ASSERT(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
-#    define VTR_ASSERT_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
+#define VTR_ASSERT(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
+#define VTR_ASSERT_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
 #endif
 
 #ifdef VTR_ASSERT_OPT_ENABLED
-#    define VTR_ASSERT_OPT(expr) VTR_ASSERT_IMPL(expr, nullptr)
-#    define VTR_ASSERT_OPT_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
+#define VTR_ASSERT_OPT(expr) VTR_ASSERT_IMPL(expr, nullptr)
+#define VTR_ASSERT_OPT_MSG(expr, msg) VTR_ASSERT_IMPL(expr, msg)
 #else
-#    define VTR_ASSERT_OPT(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
-#    define VTR_ASSERT_OPT_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
+#define VTR_ASSERT_OPT(expr) VTR_ASSERT_IMPL_NOP(expr, nullptr)
+#define VTR_ASSERT_OPT_MSG(expr, msg) VTR_ASSERT_IMPL_NOP(expr, msg)
 #endif
 
 /**
@@ -124,12 +124,12 @@
  */
 #define VTR_ASSERT_FUNCTION __func__
 #ifdef __GNUC__
-#    ifdef __GNUC_MINOR__
-#        if __GNUC__ >= 2 && __GNUC_MINOR__ > 6
-#            undef VTR_ASSERT_FUNCTION
-#            define VTR_ASSERT_FUNCTION __PRETTY_FUNCTION__
-#        endif
-#    endif
+#ifdef __GNUC_MINOR__
+#if __GNUC__ >= 2 && __GNUC_MINOR__ > 6
+#undef VTR_ASSERT_FUNCTION
+#define VTR_ASSERT_FUNCTION __PRETTY_FUNCTION__
+#endif
+#endif
 #endif
 
 namespace vtr {

--- a/libs/libvtrutil/src/vtr_log.h
+++ b/libs/libvtrutil/src/vtr_log.h
@@ -120,11 +120,11 @@
 
 // Debug logging macros
 #ifdef VTR_ENABLE_DEBUG_LOGGING //Enable
-#    define VTR_LOG_DEBUG(...) VTR_LOG(__VA_ARGS__)
-#    define VTR_LOGV_DEBUG(expr, ...) VTR_LOGV(expr, __VA_ARGS__)
+#define VTR_LOG_DEBUG(...) VTR_LOG(__VA_ARGS__)
+#define VTR_LOGV_DEBUG(expr, ...) VTR_LOGV(expr, __VA_ARGS__)
 #else //Disable
-#    define VTR_LOG_DEBUG(...) VTR_LOG_NOP(__VA_ARGS__)
-#    define VTR_LOGV_DEBUG(expr, ...) VTR_LOGV_NOP(expr, __VA_ARGS__)
+#define VTR_LOG_DEBUG(...) VTR_LOG_NOP(__VA_ARGS__)
+#define VTR_LOGV_DEBUG(expr, ...) VTR_LOGV_NOP(expr, __VA_ARGS__)
 #endif
 
 namespace vtr {

--- a/libs/libvtrutil/src/vtr_logic.h
+++ b/libs/libvtrutil/src/vtr_logic.h
@@ -4,12 +4,12 @@
 #define VTR_LOGIC_H
 
 #ifdef FALSE
-#    undef FALSE
+#undef FALSE
 #endif
 #define FALSE FALSE
 
 #ifdef TRUE
-#    undef TRUE
+#undef TRUE
 #endif
 #define TRUE TRUE
 

--- a/libs/libvtrutil/src/vtr_memory.cpp
+++ b/libs/libvtrutil/src/vtr_memory.cpp
@@ -10,9 +10,9 @@
 #include "vtr_log.h"
 
 #ifndef __GLIBC__
-#    include <stdlib.h>
+#include <stdlib.h>
 #else
-#    include <malloc.h>
+#include <malloc.h>
 #endif
 
 namespace vtr {

--- a/libs/libvtrutil/src/vtr_memory.h
+++ b/libs/libvtrutil/src/vtr_memory.h
@@ -5,8 +5,8 @@
 #include <new>
 
 #ifdef _WIN32
-#    include <cerrno>
-#    include <malloc.h>
+#include <cerrno>
+#include <malloc.h>
 #endif
 
 namespace vtr {

--- a/libs/libvtrutil/src/vtr_ndmatrix.h
+++ b/libs/libvtrutil/src/vtr_ndmatrix.h
@@ -387,10 +387,10 @@ class NdMatrix : public NdMatrixBase<T, N> {
 
         // Peel off the first dimension
         return NdMatrixProxy<T, N - 1>(
-            this->dim_sizes_.data() + 1,                        //Pass the dimension information
-            this->dim_strides_.data() + 1,                      //Pass the stride for the next dimension
-            this->dim_strides_[0] * index,                      //Advance to index in this dimension
-            this->data_);                                       //Pass the base pointer
+            this->dim_sizes_.data() + 1,   //Pass the dimension information
+            this->dim_strides_.data() + 1, //Pass the stride for the next dimension
+            this->dim_strides_[0] * index, //Advance to index in this dimension
+            this->data_);                  //Pass the base pointer
     }
 
     /**
@@ -438,4 +438,3 @@ using Matrix = NdMatrix<T, 2>;
 
 } // namespace vtr
 #endif
-

--- a/libs/libvtrutil/src/vtr_random.cpp
+++ b/libs/libvtrutil/src/vtr_random.cpp
@@ -23,7 +23,7 @@ int RandomNumberGenerator::irand(int imax) {
 
     // state = (state * IA + IC) % IM;
     random_state_ = random_state_ * IA + IC; // Use overflow to wrap
-    ival = random_state_ & (IM - 1); // Modulus
+    ival = random_state_ & (IM - 1);         // Modulus
     ival = (int)((float)ival * (float)(imax + 0.999) / (float)IM);
 
     if constexpr (CHECK_RAND_CONSTEXPR) {
@@ -42,7 +42,7 @@ int RandomNumberGenerator::irand(int imax) {
 
 float RandomNumberGenerator::frand() {
     random_state_ = random_state_ * IA + IC; /* Use overflow to wrap */
-    int ival = random_state_ & (IM - 1);        /* Modulus */
+    int ival = random_state_ & (IM - 1);     /* Modulus */
     float fval = (float)ival / (float)IM;
 
     if constexpr (CHECK_RAND_CONSTEXPR) {

--- a/libs/libvtrutil/src/vtr_random.h
+++ b/libs/libvtrutil/src/vtr_random.h
@@ -53,7 +53,6 @@ class RandomNumberGenerator : public RandomNumberGeneratorInterface {
     state_t random_state_ = 0;
 };
 
-
 class RngContainer : public RandomNumberGeneratorInterface {
   public:
     RngContainer(const RngContainer&) = delete;
@@ -67,7 +66,6 @@ class RngContainer : public RandomNumberGeneratorInterface {
     inline virtual float frand() override { return rng_->frand(); }
 
   private:
-
     std::unique_ptr<RandomNumberGeneratorInterface> rng_;
 
 #ifdef SPEC_CPU

--- a/libs/libvtrutil/src/vtr_rusage.cpp
+++ b/libs/libvtrutil/src/vtr_rusage.cpp
@@ -1,8 +1,8 @@
 #include "vtr_rusage.h"
 
 #ifdef __unix__
-#    include <sys/time.h>
-#    include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 #endif
 
 namespace vtr {

--- a/libs/libvtrutil/src/vtr_strong_id_range.h
+++ b/libs/libvtrutil/src/vtr_strong_id_range.h
@@ -78,9 +78,9 @@ class StrongIdIterator {
     ///@brief Post-increment operator
     StrongIdIterator operator++(int) {
         VTR_ASSERT_SAFE(bool(id_));
-        StrongIdIterator temp = *this;  // Create a copy of the current object
-        ++(*this);                      // Use the pre-increment operator to increment
-        return temp;                    // Return the copy
+        StrongIdIterator temp = *this; // Create a copy of the current object
+        ++(*this);                     // Use the pre-increment operator to increment
+        return temp;                   // Return the copy
     }
 
     ///@brief Decremment operator

--- a/libs/libvtrutil/src/vtr_util.cpp
+++ b/libs/libvtrutil/src/vtr_util.cpp
@@ -12,7 +12,7 @@
 #include "vtr_error.h"
 
 #if defined(__unix__)
-#    include <unistd.h> //For getpid()
+#include <unistd.h> //For getpid()
 #endif
 
 namespace vtr {
@@ -396,7 +396,7 @@ char* getline(char*& _lineptr, FILE* _stream) {
 #if defined(__unix__)
     nread = getdelim(&_lineptr, &_n, '\n', _stream);
 #elif defined(_WIN32)
-#    define __WIN_NLTK "\r\n"
+#define __WIN_NLTK "\r\n"
     nread = getdelim(&_lineptr, &_n, __WIN_NLTK, _stream);
 #endif
 

--- a/libs/libvtrutil/test/test_prefix_sum.cpp
+++ b/libs/libvtrutil/test/test_prefix_sum.cpp
@@ -96,4 +96,3 @@ TEST_CASE("PrefixSum2D", "[vtr_prefix_sum/PrefixSum2D]") {
         REQUIRE(prefix_sum.get_sum(1, 2, 2, 3) == 16.f);
     }
 }
-

--- a/odin_ii/src/ast/ast_loop_unroll.cpp
+++ b/odin_ii/src/ast/ast_loop_unroll.cpp
@@ -342,7 +342,6 @@ post_condition_function resolve_binary_operation(ast_node_t* node) {
     }
 }
 
-
 /*
  *  (function: resolve_post_condition)
  *  return a lambda which gives the next value

--- a/vpr/src/analytical_place/analytical_placement_flow.cpp
+++ b/vpr/src/analytical_place/analytical_placement_flow.cpp
@@ -68,7 +68,7 @@ static void print_ap_netlist_stats(const APNetlist& netlist) {
  *  @param p_placement            The partial placement to be updated which is assumend
  * to be generated on ap_netlist or have the same blocks.
  */
-static void convert_flat_to_partial_placement(const FlatPlacementInfo& flat_placement_info, const APNetlist& ap_netlist, const Prepacker& prepacker, PartialPlacement& p_placement){
+static void convert_flat_to_partial_placement(const FlatPlacementInfo& flat_placement_info, const APNetlist& ap_netlist, const Prepacker& prepacker, PartialPlacement& p_placement) {
     for (APBlockId ap_blk_id : ap_netlist.blocks()) {
         // Get the molecule that AP block represents
         PackMoleculeId mol_id = ap_netlist.block_molecule(ap_blk_id);
@@ -78,7 +78,7 @@ static void convert_flat_to_partial_placement(const FlatPlacementInfo& flat_plac
         float atom_loc_x, atom_loc_y, atom_loc_layer;
         int atom_loc_sub_tile;
         bool found_valid_atom = false;
-        for (AtomBlockId atom_blk_id: mol.atom_block_ids) {
+        for (AtomBlockId atom_blk_id : mol.atom_block_ids) {
             if (!atom_blk_id.is_valid())
                 continue;
             float current_loc_x = flat_placement_info.blk_x_pos[atom_blk_id];
@@ -87,11 +87,12 @@ static void convert_flat_to_partial_placement(const FlatPlacementInfo& flat_plac
             int current_loc_sub_tile = flat_placement_info.blk_sub_tile[atom_blk_id];
             if (found_valid_atom) {
                 if (current_loc_x != atom_loc_x || current_loc_y != atom_loc_y || current_loc_layer != atom_loc_layer || current_loc_sub_tile != atom_loc_sub_tile)
-                    VPR_FATAL_ERROR(VPR_ERROR_AP, "Molecule of ID %zu contains atom %s (ID: %zu) with a location (%g, %g, layer: %g, subtile: %d) "
-                                                  "that conflicts the location of other atoms in this molecule of (%g, %g, layer: %g, subtile: %d).",
-                                                  mol_id, g_vpr_ctx.atom().netlist().block_name(atom_blk_id).c_str(), atom_blk_id,
-                                                  current_loc_x, current_loc_y, current_loc_layer, current_loc_sub_tile,
-                                                  atom_loc_x, atom_loc_y, atom_loc_layer, atom_loc_sub_tile);
+                    VPR_FATAL_ERROR(VPR_ERROR_AP,
+                                    "Molecule of ID %zu contains atom %s (ID: %zu) with a location (%g, %g, layer: %g, subtile: %d) "
+                                    "that conflicts the location of other atoms in this molecule of (%g, %g, layer: %g, subtile: %d).",
+                                    mol_id, g_vpr_ctx.atom().netlist().block_name(atom_blk_id).c_str(), atom_blk_id,
+                                    current_loc_x, current_loc_y, current_loc_layer, current_loc_sub_tile,
+                                    atom_loc_x, atom_loc_y, atom_loc_layer, atom_loc_sub_tile);
             } else {
                 atom_loc_x = current_loc_x;
                 atom_loc_y = current_loc_y;
@@ -201,4 +202,3 @@ void run_analytical_placement_flow(t_vpr_setup& vpr_setup) {
     g_vpr_ctx.mutable_placement().clean_placement_context_post_place();
     g_vpr_ctx.mutable_floorplanning().clean_floorplanning_context_post_place();
 }
-

--- a/vpr/src/analytical_place/analytical_placement_flow.h
+++ b/vpr/src/analytical_place/analytical_placement_flow.h
@@ -16,4 +16,3 @@ struct t_vpr_setup;
  *  @param vpr_setup    The setup options provided by the user.
  */
 void run_analytical_placement_flow(t_vpr_setup& vpr_setup);
-

--- a/vpr/src/analytical_place/analytical_solver.cpp
+++ b/vpr/src/analytical_place/analytical_solver.cpp
@@ -57,9 +57,9 @@ std::unique_ptr<AnalyticalSolver> make_analytical_solver(e_analytical_solver sol
 }
 
 AnalyticalSolver::AnalyticalSolver(const APNetlist& netlist)
-    : netlist_(netlist),
-      blk_id_to_row_id_(netlist.blocks().size(), APRowId::INVALID()),
-      row_id_to_blk_id_(netlist.blocks().size(), APBlockId::INVALID()) {
+    : netlist_(netlist)
+    , blk_id_to_row_id_(netlist.blocks().size(), APRowId::INVALID())
+    , row_id_to_blk_id_(netlist.blocks().size(), APBlockId::INVALID()) {
     // Get the number of moveable blocks in the netlist and create a unique
     // row ID from [0, num_moveable_blocks) for each moveable block in the
     // netlist.
@@ -261,16 +261,15 @@ void QPHybridSolver::init_linear_system() {
  *  @param row_id_to_blk_id     Lookup for the row id from the APBlock Id.
  *  @param iteration        The current iteration of the Global Placer.
  */
-static inline void update_linear_system_with_anchors(
-                               Eigen::SparseMatrix<double> &A_sparse_diff,
-                               Eigen::VectorXd &b_x_diff,
-                               Eigen::VectorXd &b_y_diff,
-                               PartialPlacement& p_placement,
-                               size_t num_moveable_blocks,
-                               vtr::vector<APRowId, APBlockId> row_id_to_blk_id,
-                               unsigned iteration) {
+static inline void update_linear_system_with_anchors(Eigen::SparseMatrix<double>& A_sparse_diff,
+                                                     Eigen::VectorXd& b_x_diff,
+                                                     Eigen::VectorXd& b_y_diff,
+                                                     PartialPlacement& p_placement,
+                                                     size_t num_moveable_blocks,
+                                                     vtr::vector<APRowId, APBlockId> row_id_to_blk_id,
+                                                        unsigned iteration) {
     // Anchor weights grow exponentially with iteration.
-    double coeff_pseudo_anchor = 0.01 * std::exp((double)iteration/5);
+    double coeff_pseudo_anchor = 0.01 * std::exp((double)iteration / 5);
     for (size_t row_id_idx = 0; row_id_idx < num_moveable_blocks; row_id_idx++) {
         APRowId row_id = APRowId(row_id_idx);
         APBlockId blk_id = row_id_to_blk_id[row_id];
@@ -281,7 +280,7 @@ static inline void update_linear_system_with_anchors(
     }
 }
 
-void QPHybridSolver::solve(unsigned iteration, PartialPlacement &p_placement) {
+void QPHybridSolver::solve(unsigned iteration, PartialPlacement& p_placement) {
     // Create a temporary linear system which will contain the original linear
     // system which may be updated to include the anchor points.
     Eigen::SparseMatrix<double> A_sparse_diff = Eigen::SparseMatrix<double>(A_sparse);
@@ -304,7 +303,7 @@ void QPHybridSolver::solve(unsigned iteration, PartialPlacement &p_placement) {
     //  - This tolerance may need to be a function of the number of nets.
     //  - Instead of normalizing the fixed blocks, the tolerance can be scaled
     //    by the size of the device.
-    Eigen::ConjugateGradient<Eigen::SparseMatrix<double>, Eigen::Lower|Eigen::Upper> cg;
+    Eigen::ConjugateGradient<Eigen::SparseMatrix<double>, Eigen::Lower | Eigen::Upper> cg;
     cg.compute(A_sparse_diff);
     VTR_ASSERT(cg.info() == Eigen::Success && "Conjugate Gradient failed at compute!");
     // Use the solver to solve for x and y using the constant vectors
@@ -330,4 +329,3 @@ void QPHybridSolver::solve(unsigned iteration, PartialPlacement &p_placement) {
 }
 
 #endif // EIGEN_INSTALLED
-

--- a/vpr/src/analytical_place/analytical_solver.h
+++ b/vpr/src/analytical_place/analytical_solver.h
@@ -24,7 +24,7 @@
 
 // Pop the GCC diagnostics state back to what it was before.
 #pragma GCC diagnostic pop
-#endif  // EIGEN_INSTALLED
+#endif // EIGEN_INSTALLED
 
 // Forward declarations
 class PartialPlacement;
@@ -36,7 +36,7 @@ class APNetlist;
  * NOTE: More are coming.
  */
 enum class e_analytical_solver {
-    QP_HYBRID       // A solver which optimizes the quadratic HPWL of the design.
+    QP_HYBRID // A solver which optimizes the quadratic HPWL of the design.
 };
 
 /**
@@ -58,7 +58,7 @@ typedef vtr::StrongId<ap_row_id_tag, size_t> APRowId;
  * compare different solvers.
  */
 class AnalyticalSolver {
-public:
+  public:
     virtual ~AnalyticalSolver() {}
 
     /**
@@ -67,7 +67,7 @@ public:
      * Initializes the internal data members of the base class which are useful
      * for all solvers.
      */
-    AnalyticalSolver(const APNetlist &netlist);
+    AnalyticalSolver(const APNetlist& netlist);
 
     /**
      * @brief Run an iteration of the solver using the given partial placement
@@ -87,10 +87,9 @@ public:
      *  @param p_placement  A "hint" to a legal solution that the solver should
      *                      try and be like.
      */
-    virtual void solve(unsigned iteration, PartialPlacement &p_placement) = 0;
+    virtual void solve(unsigned iteration, PartialPlacement& p_placement) = 0;
 
-protected:
-
+  protected:
     /// @brief The APNetlist the solver is optimizing over. It is implied that
     ///        the netlist is not being modified during global placement.
     const APNetlist& netlist_;
@@ -115,7 +114,7 @@ protected:
  * @brief A factory method which creates an Analytical Solver of the given type.
  */
 std::unique_ptr<AnalyticalSolver> make_analytical_solver(e_analytical_solver solver_type,
-                                                         const APNetlist &netlist);
+                                                         const APNetlist& netlist);
 
 // The Eigen library is used to solve matrix equations in the following solvers.
 // The solver cannot be built if Eigen is not installed.
@@ -145,7 +144,7 @@ std::unique_ptr<AnalyticalSolver> make_analytical_solver(e_analytical_solver sol
  *          https://doi.org/10.1109/TCAD.2005.846365
  */
 class QPHybridSolver : public AnalyticalSolver {
-private:
+  private:
     /// @brief The threshold for the number of pins a net will have to use the
     ///        Star or Clique net models. If the number of pins is larger
     ///        than this number, a star node will be created.
@@ -182,14 +181,14 @@ private:
     /// @brief The constant vector in the y dimension for the linear system.
     Eigen::VectorXd b_y;
 
-public:
-
+  public:
     /**
      * @brief Constructor of the QPHybridSolver
      *
      * Initializes internal data and constructs the initial linear system.
      */
-    QPHybridSolver(const APNetlist& netlist) : AnalyticalSolver(netlist) {
+    QPHybridSolver(const APNetlist& netlist)
+        : AnalyticalSolver(netlist) {
         // Initializing the linear system only depends on the netlist and fixed
         // block locations. Both are provided by the netlist, allowing this to
         // be initialized in the constructor.
@@ -216,8 +215,7 @@ public:
      *  @param p_placement  A "guess" solution. The result will be written into
      *                      this object.
      */
-    void solve(unsigned iteration, PartialPlacement &p_placement) final;
+    void solve(unsigned iteration, PartialPlacement& p_placement) final;
 };
 
 #endif // EIGEN_INSTALLED
-

--- a/vpr/src/analytical_place/ap_flow_enums.h
+++ b/vpr/src/analytical_place/ap_flow_enums.h
@@ -26,8 +26,8 @@ enum class e_ap_global_placer {
  * enum can select between these different Full Legalizers.
  */
 enum class e_ap_full_legalizer {
-    Naive,  ///< The Naive Full Legalizer, which clusters atoms placed in the same tile and tries to place them in that tile according to the flat placement.
-    APPack,  ///< The APPack Full Legalizer, which uses the flat placement to improve the Packer and Placer.
+    Naive,                ///< The Naive Full Legalizer, which clusters atoms placed in the same tile and tries to place them in that tile according to the flat placement.
+    APPack,               ///< The APPack Full Legalizer, which uses the flat placement to improve the Packer and Placer.
     Basic_Min_Disturbance ///< The Basic Min. Disturbance Full Legalizer, which tries to reconstruct a clustered placement that is as close to the incoming flat placement as it can.
 };
 
@@ -38,7 +38,6 @@ enum class e_ap_full_legalizer {
  * enum can select between these different Detailed Placers.
  */
 enum class e_ap_detailed_placer {
-    Identity,           ///< The Identity Detailed Placer, which does not perform any optimizations on the legalized placement. Needed as a placeholder.
-    Annealer            ///< The Annealer Detailed Placer, which runs the annealer found in the Place part of the VPR flow (using the same options as the Placement stage).
+    Identity, ///< The Identity Detailed Placer, which does not perform any optimizations on the legalized placement. Needed as a placeholder.
+    Annealer  ///< The Annealer Detailed Placer, which runs the annealer found in the Place part of the VPR flow (using the same options as the Placement stage).
 };
-

--- a/vpr/src/analytical_place/ap_netlist.h
+++ b/vpr/src/analytical_place/ap_netlist.h
@@ -49,8 +49,8 @@ struct APFixedBlockLoc {
  *       block ids.
  */
 enum class APBlockMobility : bool {
-    MOVEABLE,   // The block is not constrained in any dimension.
-    FIXED       // The block is fixed.
+    MOVEABLE, // The block is not constrained in any dimension.
+    FIXED     // The block is fixed.
 };
 
 /**
@@ -62,7 +62,7 @@ enum class APBlockMobility : bool {
  * APBlocks. These need not have physical meaning.
  */
 class APNetlist : public Netlist<APBlockId, APPortId, APPinId, APNetId> {
-public:
+  public:
     /**
      * @brief Constructs a netlist
      *
@@ -70,12 +70,13 @@ public:
      *  @param id   A unique identifier for the netlist (e.g. a secure digest of
      *              the input file)
      */
-    APNetlist(std::string name = "", std::string id = "") : Netlist(name, id) {}
+    APNetlist(std::string name = "", std::string id = "")
+        : Netlist(name, id) {}
 
     APNetlist(const APNetlist& rhs) = default;
     APNetlist& operator=(const APNetlist& rhs) = default;
 
-public: // Public Accessors
+  public: // Public Accessors
     /*
      * Blocks
      */
@@ -90,7 +91,7 @@ public: // Public Accessors
     ///        This method should not be used if the block is moveable.
     const APFixedBlockLoc& block_loc(const APBlockId id) const;
 
-public: // Public Mutators
+  public: // Public Mutators
     /*
      * Note: all create_*() functions will silently return the appropriate ID
      * if it has already been created.
@@ -141,7 +142,7 @@ public: // Public Mutators
      */
     APNetId create_net(const std::string& name);
 
-private: // Private Members
+  private: // Private Members
     /*
      * Netlist compression / optimization
      */
@@ -178,7 +179,7 @@ private: // Private Members
     bool validate_pin_sizes_impl(size_t num_pins) const override;
     bool validate_net_sizes_impl(size_t num_nets) const override;
 
-private: // Private Data
+  private: // Private Data
     /// @brief Molecule of each block
     vtr::vector_map<APBlockId, PackMoleculeId> block_molecules_;
     /// @brief Type of each block
@@ -187,4 +188,3 @@ private: // Private Data
     ///        NOTE: This vector will likely be quite sparse.
     vtr::vector_map<APBlockId, APFixedBlockLoc> block_locs_;
 };
-

--- a/vpr/src/analytical_place/ap_netlist_fwd.h
+++ b/vpr/src/analytical_place/ap_netlist_fwd.h
@@ -26,7 +26,7 @@ class APNetlist;
  * @brief A unique identifier for a block in the AP netlist
  */
 class APBlockId : public ParentBlockId {
-public:
+  public:
     static constexpr APBlockId INVALID() { return APBlockId(); }
     using ParentBlockId::ParentBlockId;
 
@@ -37,7 +37,7 @@ public:
  * @brief A unique identifier for a net in the AP netlist
  */
 class APNetId : public ParentNetId {
-public:
+  public:
     static constexpr APNetId INVALID() { return APNetId(); }
     using ParentNetId::ParentNetId;
 
@@ -48,7 +48,7 @@ public:
  * @brief A unique identifier for a port in the AP netlist
  */
 class APPortId : public ParentPortId {
-public:
+  public:
     static constexpr APPortId INVALID() { return APPortId(); }
     using ParentPortId::ParentPortId;
 
@@ -59,7 +59,7 @@ public:
  * @brief A unique identifier for a pin in the AP netlist
  */
 class APPinId : public ParentPinId {
-public:
+  public:
     static constexpr APPinId INVALID() { return APPinId(); }
     using ParentPinId::ParentPinId;
 
@@ -101,4 +101,3 @@ struct hash<APPinId> {
     }
 };
 } // namespace std
-

--- a/vpr/src/analytical_place/flat_placement_density_manager.h
+++ b/vpr/src/analytical_place/flat_placement_density_manager.h
@@ -57,7 +57,7 @@ struct t_physical_tile_type;
  *       may allow us to trade off quality and runtime.
  */
 class FlatPlacementDensityManager {
-public:
+  public:
     /**
      * @brief Construct the density manager.
      *
@@ -233,7 +233,7 @@ public:
      */
     void print_bin_grid() const;
 
-private:
+  private:
     /// @brief The AP netlist of blocks which are filling the bins.
     const APNetlist& ap_netlist_;
 
@@ -268,4 +268,3 @@ private:
     /// @brief The verbosity of log messages in this class.
     const int log_verbosity_;
 };
-

--- a/vpr/src/analytical_place/flat_placement_mass_calculator.h
+++ b/vpr/src/analytical_place/flat_placement_mass_calculator.h
@@ -39,7 +39,7 @@ struct t_physical_tile_type;
  * mass that the tile should aim to hold.
  */
 class FlatPlacementMassCalculator {
-public:
+  public:
     /**
      * @brief Construct the mass calculator.
      *
@@ -97,7 +97,7 @@ public:
         return block_mass_[blk_id];
     }
 
-private:
+  private:
     /// @brief The capacity of each physical tile type, indexed by the index
     ///        of the physical_tile_type.
     std::vector<PrimitiveVector> physical_tile_type_capacity_;
@@ -112,4 +112,3 @@ private:
     /// @brief The verbosity of log messages in the mass calculator.
     const int log_verbosity_;
 };
-

--- a/vpr/src/base/FlatPlacementInfo.h
+++ b/vpr/src/base/FlatPlacementInfo.h
@@ -18,7 +18,7 @@
  * any information that may be used by the packer to better create clusters.
  */
 class FlatPlacementInfo {
-public:
+  public:
     /// @brief Identifier for an undefined position.
     static constexpr float UNDEFINED_POS = -1.f;
     /// @brief Identifier for an undefined sub tile.
@@ -61,7 +61,8 @@ public:
      * Initializes the data structure to invalid so it can be easily checked to
      * be uninitialized.
      */
-    FlatPlacementInfo() : valid(false) {}
+    FlatPlacementInfo()
+        : valid(false) {}
 
     /**
      * @brief Constructs the flat placement with undefined positions for each
@@ -74,11 +75,10 @@ public:
      *              The netlist of atom blocks in the circuit.
      */
     FlatPlacementInfo(const AtomNetlist& atom_netlist)
-        : blk_x_pos(atom_netlist.blocks().size(), UNDEFINED_POS),
-          blk_y_pos(atom_netlist.blocks().size(), UNDEFINED_POS),
-          blk_layer(atom_netlist.blocks().size(), UNDEFINED_POS),
-          blk_sub_tile(atom_netlist.blocks().size(), UNDEFINED_SUB_TILE),
-          blk_site_idx(atom_netlist.blocks().size(), UNDEFINED_SITE_IDX),
-          valid(true) {}
+        : blk_x_pos(atom_netlist.blocks().size(), UNDEFINED_POS)
+        , blk_y_pos(atom_netlist.blocks().size(), UNDEFINED_POS)
+        , blk_layer(atom_netlist.blocks().size(), UNDEFINED_POS)
+        , blk_sub_tile(atom_netlist.blocks().size(), UNDEFINED_SUB_TILE)
+        , blk_site_idx(atom_netlist.blocks().size(), UNDEFINED_SITE_IDX)
+        , valid(true) {}
 };
-

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -362,7 +362,7 @@ static void SetupSwitches(const t_arch& Arch,
     auto& device_ctx = g_vpr_ctx.mutable_device();
 
     int switches_to_copy = (int)arch_switches.size();
-    int num_arch_switches = (int)arch_switches.size();;
+    int num_arch_switches = (int)arch_switches.size();
 
     find_ipin_cblock_switch_index(Arch, RoutingArch->wire_to_arch_ipin_switch, RoutingArch->wire_to_arch_ipin_switch_between_dice);
 
@@ -571,7 +571,7 @@ void SetupPackerOpts(const t_options& Options,
     }
 
     //TODO: document?
-    PackerOpts->global_clocks = true;       /* DEFAULT */
+    PackerOpts->global_clocks = true; /* DEFAULT */
 
     PackerOpts->allow_unrelated_clustering = Options.allow_unrelated_clustering;
     PackerOpts->connection_driven = Options.connection_driven_clustering;
@@ -764,8 +764,6 @@ static void SetupNocOpts(const t_options& Options, t_noc_opts* NocOpts) {
     }
     NocOpts->noc_sat_routing_log_search_progress = Options.noc_sat_routing_log_search_progress;
     NocOpts->noc_placement_file_name = Options.noc_placement_file_name;
-
-
 }
 
 static void SetupServerOpts(const t_options& Options, t_server_opts* ServerOpts) {

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -631,7 +631,7 @@ static void ShowAnalyticalPlacerOpts(const t_ap_opts& APOpts) {
             VTR_LOG("annealer\n");
             break;
         default:
-             VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown detailed_placer_type\n");
+            VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown detailed_placer_type\n");
     }
 
     VTR_LOG("AnalyticalPlacerOpts.log_verbosity: %d\n", APOpts.log_verbosity);

--- a/vpr/src/base/atom_lookup.cpp
+++ b/vpr/src/base/atom_lookup.cpp
@@ -112,8 +112,8 @@ void AtomLookup::add_atom_clb_net(const AtomNetId atom_net, const ClusterNetId c
     clb_net_to_atom_net_[clb_net] = atom_net;
 }
 
-void AtomLookup::remove_clb_net(const ClusterNetId clb_net){
-    if(!clb_net_to_atom_net_.count(clb_net))
+void AtomLookup::remove_clb_net(const ClusterNetId clb_net) {
+    if (!clb_net_to_atom_net_.count(clb_net))
         return;
 
     auto atom_net = clb_net_to_atom_net_[clb_net];
@@ -124,11 +124,11 @@ void AtomLookup::remove_clb_net(const ClusterNetId clb_net){
 
 /* Remove mapping for given atom net */
 void AtomLookup::remove_atom_net(const AtomNetId atom_net) {
-    if(!atom_net_to_clb_nets_.count(atom_net))
+    if (!atom_net_to_clb_nets_.count(atom_net))
         return;
 
     auto cluster_nets = atom_net_to_clb_nets_[atom_net];
-    for(auto c: cluster_nets){
+    for (auto c : cluster_nets) {
         clb_net_to_atom_net_.erase(c);
     }
     atom_net_to_clb_nets_.erase(atom_net);

--- a/vpr/src/base/blk_loc_registry.cpp
+++ b/vpr/src/base/blk_loc_registry.cpp
@@ -56,11 +56,11 @@ void BlkLocRegistry::alloc_and_load_movable_blocks() {
 }
 
 const vtr::vector_map<ClusterBlockId, t_block_loc>& BlkLocRegistry::block_locs() const {
-    return  block_locs_;
+    return block_locs_;
 }
 
 vtr::vector_map<ClusterBlockId, t_block_loc>& BlkLocRegistry::mutable_block_locs() {
-    return  block_locs_;
+    return block_locs_;
 }
 
 const GridBlock& BlkLocRegistry::grid_blocks() const {
@@ -241,9 +241,9 @@ void BlkLocRegistry::apply_move_blocks(const t_pl_blocks_to_be_moved& blocks_aff
         block_locs_[blk].loc = new_loc;
 
         // get physical tile type of the old location
-        t_physical_tile_type_ptr old_type = device_ctx.grid.get_physical_type({old_loc.x,old_loc.y,old_loc.layer});
+        t_physical_tile_type_ptr old_type = device_ctx.grid.get_physical_type({old_loc.x, old_loc.y, old_loc.layer});
         // get physical tile type of the new location
-        t_physical_tile_type_ptr new_type = device_ctx.grid.get_physical_type({new_loc.x,new_loc.y, new_loc.layer});
+        t_physical_tile_type_ptr new_type = device_ctx.grid.get_physical_type({new_loc.x, new_loc.y, new_loc.layer});
 
         // if physical tile type of old location does not equal physical tile type of new location, sync the new physical pins
         if (old_type != new_type) {
@@ -328,4 +328,3 @@ t_physical_tile_loc BlkLocRegistry::get_coordinate_of_pin(ClusterPinId pin) cons
 
     return tile_loc;
 }
-

--- a/vpr/src/base/blk_loc_registry.h
+++ b/vpr/src/base/blk_loc_registry.h
@@ -50,7 +50,6 @@ class BlkLocRegistry {
     std::vector<ClusterBlockId> movable_blocks_;
 
   public:
-
     ///@brief Stores ClusterBlockId of all movable clustered blocks of each block type
     std::vector<std::vector<ClusterBlockId>> movable_blocks_per_type_;
     const vtr::vector_map<ClusterBlockId, t_block_loc>& block_locs() const;
@@ -165,4 +164,3 @@ class BlkLocRegistry {
 
     e_expected_transaction expected_transaction_;
 };
-

--- a/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
+++ b/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
@@ -122,9 +122,9 @@ typedef const uint64_t __attribute__((aligned(1))) triehash_uu64;
 static_assert(alignof(triehash_uu32) == 1, "Unaligned 32-bit access not found.");
 static_assert(alignof(triehash_uu64) == 1, "Unaligned 64-bit access not found.");
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#    define onechar(c, s, l) (((uint64_t)(c)) << (s))
+#define onechar(c, s, l) (((uint64_t)(c)) << (s))
 #else
-#    define onechar(c, s, l) (((uint64_t)(c)) << (l - 8 - s))
+#define onechar(c, s, l) (((uint64_t)(c)) << (l - 8 - s))
 #endif
 
 /* Tokens for attribute and node names. */
@@ -1207,7 +1207,7 @@ inline void attr_error(std::bitset<N> astate, const char* const* lookup, const s
 }
 
 inline void get_line_number(const char* filename, std::ptrdiff_t target_offset, int* line, int* col) {
-    std::unique_ptr<FILE,int(*)(FILE*)> f(fopen(filename, "rb"), fclose);
+    std::unique_ptr<FILE, int (*)(FILE*)> f(fopen(filename, "rb"), fclose);
 
     if (!f) {
         throw std::runtime_error(std::string("Failed to open file") + filename);

--- a/vpr/src/base/setup_noc.cpp
+++ b/vpr/src/base/setup_noc.cpp
@@ -38,7 +38,7 @@ void setup_noc(const t_arch& arch) {
         VPR_FATAL_ERROR(VPR_ERROR_OTHER,
                         "The Provided NoC topology information in the architecture file "
                         "uses less number of routers than what is available in the FPGA device.");
-    } else if (noc_router_tiles.empty()) {  // case where no physical router tiles were found
+    } else if (noc_router_tiles.empty()) { // case where no physical router tiles were found
         VPR_FATAL_ERROR(VPR_ERROR_OTHER,
                         "No physical NoC routers were found on the FPGA device. "
                         "Either the provided name for the physical router tile was incorrect or the FPGA device has no routers.");
@@ -169,7 +169,7 @@ void create_noc_routers(const t_noc_inf& noc_info,
                 error_case_physical_router_index_1 = closest_physical_router;
                 error_case_physical_router_index_2 = curr_physical_router_index;
 
-            // case where the current logical router is closest to the physical router tile
+                // case where the current logical router is closest to the physical router tile
             } else if (curr_calculated_distance < shortest_distance) {
                 // update the shortest distance and then the closest router
                 shortest_distance = curr_calculated_distance;

--- a/vpr/src/base/vpr_constraints_writer.cpp
+++ b/vpr/src/base/vpr_constraints_writer.cpp
@@ -181,7 +181,7 @@ void setup_vpr_floorplan_constraints_cutpoints(VprConstraints& constraints,
             }
         }
 
-        Region current_reg(xminimum, yminimum, xmaximum, ymaximum, 0, n_layers-1);
+        Region current_reg(xminimum, yminimum, xmaximum, ymaximum, 0, n_layers - 1);
         // This function has not been tested for multi-layer grids. An assertion is used earlier to make sure that the grid has only one layer
 
         auto got = region_atoms.find(current_reg);

--- a/vpr/src/base/vpr_signal_handler.cpp
+++ b/vpr/src/base/vpr_signal_handler.cpp
@@ -21,7 +21,7 @@
 #include <atomic>
 
 #ifdef VPR_USE_SIGACTION
-#    include <csignal>
+#include <csignal>
 #endif
 
 void vpr_signal_handler(int signal);

--- a/vpr/src/base/vpr_types.cpp
+++ b/vpr/src/base/vpr_types.cpp
@@ -452,4 +452,3 @@ BitIndex t_pb::atom_pin_bit_index(const t_pb_graph_pin* gpin) const {
 void t_pb::set_atom_pin_bit_index(const t_pb_graph_pin* gpin, BitIndex atom_pin_bit_idx) {
     pin_rotations_[gpin] = atom_pin_bit_idx;
 }
-

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -105,7 +105,7 @@ constexpr bool VTR_ENABLE_DEBUG_LOGGING_CONST_EXPR = false;
 #define NOT_VALID (-10000) /* Marks gains that aren't valid */
 /* Ensure no gain can ever be this negative! */
 #ifndef UNDEFINED
-#    define UNDEFINED (-1)
+#define UNDEFINED (-1)
 #endif
 
 ///@brief Router lookahead types.
@@ -355,7 +355,6 @@ struct t_pb_route {
     std::vector<int> sink_pb_pin_ids;             ///<The pb_pin id's of the pb_pins driven by this node
     const t_pb_graph_pin* pb_graph_pin = nullptr; ///<The graph pin associated with this node
 };
-
 
 /******************************************************************
  * Timing data types
@@ -962,7 +961,7 @@ enum class e_move_type;
 struct t_placer_opts {
     t_place_algorithm place_algorithm;
     t_place_algorithm place_quench_algorithm;
-    t_annealing_sched anneal_sched;  ///<Placement option annealing schedule
+    t_annealing_sched anneal_sched; ///<Placement option annealing schedule
     float timing_tradeoff;
     int place_chan_width;
     enum e_pad_loc_type pad_loc_type;
@@ -1037,7 +1036,6 @@ struct t_placer_opts {
      */
     bool enable_analytic_placer;
 };
-
 
 /******************************************************************
  * Analytical Placer data types

--- a/vpr/src/draw/buttons.cpp
+++ b/vpr/src/draw/buttons.cpp
@@ -10,16 +10,16 @@
  * Last updated: Aug 2019
  */
 
-#    include "draw_global.h"
-#    include "draw.h"
-#    include "draw_toggle_functions.h"
-#    include "buttons.h"
-#    include "intra_logic_block.h"
-#    include "clustered_netlist.h"
+#include "draw_global.h"
+#include "draw.h"
+#include "draw_toggle_functions.h"
+#include "buttons.h"
+#include "intra_logic_block.h"
+#include "clustered_netlist.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 
 //location of spin buttons, combo boxes, and labels on grid
 gint box_width = 1;

--- a/vpr/src/draw/draw_debug.h
+++ b/vpr/src/draw/draw_debug.h
@@ -9,19 +9,19 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "breakpoint.h"
-#    include "draw_global.h"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "breakpoint.h"
+#include "draw_global.h"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 
-#    include <cstdio>
-#    include <cfloat>
-#    include <cstring>
-#    include <cmath>
-#    include <algorithm>
-#    include <sstream>
-#    include <array>
-#    include <iostream>
+#include <cstdio>
+#include <cfloat>
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+#include <sstream>
+#include <array>
+#include <iostream>
 
 /** debugger functions **/
 void draw_debug_window();

--- a/vpr/src/draw/draw_floorplanning.h
+++ b/vpr/src/draw/draw_floorplanning.h
@@ -6,11 +6,11 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 
 ///@brief Iterates through all partitions described in the constraints file and highlights their respective partitions
 void highlight_all_regions(ezgl::renderer* g);

--- a/vpr/src/draw/draw_global.cpp
+++ b/vpr/src/draw/draw_global.cpp
@@ -12,8 +12,8 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
-#    include "draw_types.h"
+#include "draw_global.h"
+#include "draw_types.h"
 
 /*************************** Variables Definition ***************************/
 

--- a/vpr/src/draw/draw_global.h
+++ b/vpr/src/draw/draw_global.h
@@ -15,13 +15,13 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_types.h"
+#include "draw_types.h"
 
 constexpr float DEFAULT_ARROW_SIZE = 0.3;
 
 // a very small area, in (screen pixels)^2
 // used for level of detail culling
-#    define MIN_VISIBLE_AREA 3.0
+#define MIN_VISIBLE_AREA 3.0
 
 t_draw_coords* get_draw_coords_vars();
 

--- a/vpr/src/draw/draw_mux.cpp
+++ b/vpr/src/draw/draw_mux.cpp
@@ -14,9 +14,9 @@
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
 //#define TIME_DRAWSCREEN /* Enable if want to track runtime for drawscreen() */
 

--- a/vpr/src/draw/draw_mux.h
+++ b/vpr/src/draw/draw_mux.h
@@ -31,11 +31,11 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 
 /**
  * @brief Draws a mux with width = height * 0.4 and scale (slope of the muxes sides) = 0.6, labelled with its size.

--- a/vpr/src/draw/draw_noc.cpp
+++ b/vpr/src/draw/draw_noc.cpp
@@ -1,12 +1,12 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_basic.h"
-#    include "draw_noc.h"
-#    include "globals.h"
-#    include "noc_storage.h"
-#    include "physical_types_util.h"
-#    include "vtr_math.h"
+#include "draw_basic.h"
+#include "draw_noc.h"
+#include "globals.h"
+#include "noc_storage.h"
+#include "physical_types_util.h"
+#include "vtr_math.h"
 
 void draw_noc(ezgl::renderer* g) {
     t_draw_state* draw_state = get_draw_state_vars();

--- a/vpr/src/draw/draw_noc.h
+++ b/vpr/src/draw/draw_noc.h
@@ -29,7 +29,7 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw.h"
+#include "draw.h"
 
 // defines the area of the marker that represents connection points between links
 // area is equivalent to the %x of the area of the router

--- a/vpr/src/draw/draw_rr.cpp
+++ b/vpr/src/draw/draw_rr.cpp
@@ -28,12 +28,12 @@
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
 /****************************** Define Macros *******************************/
-#    define DEFAULT_RR_NODE_COLOR ezgl::BLACK
+#define DEFAULT_RR_NODE_COLOR ezgl::BLACK
 
 //The arrow head position for turning/straight-thru connections in a switch box
 constexpr float SB_EDGE_TURN_ARROW_POSITION = 0.2;

--- a/vpr/src/draw/draw_rr.h
+++ b/vpr/src/draw/draw_rr.h
@@ -32,20 +32,20 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
-#    include "draw_color.h"
-#    include "search_bar.h"
-#    include "draw_debug.h"
-#    include "manual_moves.h"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
+#include "draw_color.h"
+#include "search_bar.h"
+#include "draw_debug.h"
+#include "manual_moves.h"
 
-#    include "rr_graph.h"
-#    include "route_utilization.h"
-#    include "place_macro.h"
-#    include "buttons.h"
+#include "rr_graph.h"
+#include "route_utilization.h"
+#include "place_macro.h"
+#include "buttons.h"
 
 /* Draws the routing resources that exist in the FPGA, if the user wants *
  * them drawn. */

--- a/vpr/src/draw/draw_rr_edges.cpp
+++ b/vpr/src/draw/draw_rr_edges.cpp
@@ -19,9 +19,9 @@
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
 void draw_chany_to_chany_edge(RRNodeId from_node, RRNodeId to_node, short switch_type, ezgl::renderer* g) {
     t_draw_state* draw_state = get_draw_state_vars();

--- a/vpr/src/draw/draw_rr_edges.h
+++ b/vpr/src/draw/draw_rr_edges.h
@@ -32,20 +32,20 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
-#    include "draw_color.h"
-#    include "search_bar.h"
-#    include "draw_debug.h"
-#    include "manual_moves.h"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
+#include "draw_color.h"
+#include "search_bar.h"
+#include "draw_debug.h"
+#include "manual_moves.h"
 
-#    include "rr_graph.h"
-#    include "route_utilization.h"
-#    include "place_macro.h"
-#    include "buttons.h"
+#include "rr_graph.h"
+#include "route_utilization.h"
+#include "place_macro.h"
+#include "buttons.h"
 
 void draw_chany_to_chany_edge(RRNodeId from_node, RRNodeId to_node, short switch_type, ezgl::renderer* g);
 void draw_chanx_to_chanx_edge(RRNodeId from_node, RRNodeId to_node, short switch_type, ezgl::renderer* g);

--- a/vpr/src/draw/draw_searchbar.cpp
+++ b/vpr/src/draw/draw_searchbar.cpp
@@ -18,13 +18,13 @@
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
 /****************************** Define Macros *******************************/
 
-#    define DEFAULT_RR_NODE_COLOR ezgl::BLACK
+#define DEFAULT_RR_NODE_COLOR ezgl::BLACK
 
 /* This function computes and returns the boundary coordinates of a channel
  * wire segment. This can be used for drawing a wire or determining if a

--- a/vpr/src/draw/draw_searchbar.h
+++ b/vpr/src/draw/draw_searchbar.h
@@ -33,20 +33,20 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
-#    include "draw_color.h"
-#    include "search_bar.h"
-#    include "draw_debug.h"
-#    include "manual_moves.h"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
+#include "draw_color.h"
+#include "search_bar.h"
+#include "draw_debug.h"
+#include "manual_moves.h"
 
-#    include "rr_graph.h"
-#    include "route_utilization.h"
-#    include "place_macro.h"
-#    include "buttons.h"
+#include "rr_graph.h"
+#include "route_utilization.h"
+#include "place_macro.h"
+#include "buttons.h"
 
 /* This function computes and returns the boundary coordinates of a channel
  * wire segment. This can be used for drawing a wire or determining if a

--- a/vpr/src/draw/draw_toggle_functions.cpp
+++ b/vpr/src/draw/draw_toggle_functions.cpp
@@ -18,9 +18,9 @@
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
 //The arrow head position for turning/straight-thru connections in a switch box
 constexpr float SB_EDGE_TURN_ARROW_POSITION = 0.2;

--- a/vpr/src/draw/draw_toggle_functions.h
+++ b/vpr/src/draw/draw_toggle_functions.h
@@ -38,20 +38,20 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
-#    include "draw_color.h"
-#    include "search_bar.h"
-#    include "draw_debug.h"
-#    include "manual_moves.h"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
+#include "draw_color.h"
+#include "search_bar.h"
+#include "draw_debug.h"
+#include "manual_moves.h"
 
-#    include "rr_graph.h"
-#    include "route_utilization.h"
-#    include "place_macro.h"
-#    include "buttons.h"
+#include "rr_graph.h"
+#include "route_utilization.h"
+#include "place_macro.h"
+#include "buttons.h"
 
 /* Callback function for main.ui created toggle_nets button in ui_setup.cpp. Controls whether or not nets are visualized.
  * Toggles value of draw_state->show_nets.*/

--- a/vpr/src/draw/draw_triangle.cpp
+++ b/vpr/src/draw/draw_triangle.cpp
@@ -7,14 +7,13 @@
 #include "draw_triangle.h"
 #include "draw_global.h"
 
-
 #ifndef NO_GRAPHICS
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
 /**
  * Retrieves the current zoom level based on the visible world and screen dimensions.

--- a/vpr/src/draw/draw_triangle.h
+++ b/vpr/src/draw/draw_triangle.h
@@ -33,20 +33,20 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
-#    include "draw_color.h"
-#    include "search_bar.h"
-#    include "draw_debug.h"
-#    include "manual_moves.h"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
+#include "draw_color.h"
+#include "search_bar.h"
+#include "draw_debug.h"
+#include "manual_moves.h"
 
-#    include "rr_graph.h"
-#    include "route_utilization.h"
-#    include "place_macro.h"
-#    include "buttons.h"
+#include "rr_graph.h"
+#include "route_utilization.h"
+#include "place_macro.h"
+#include "buttons.h"
 
 /**
  * Retrieves the current zoom level based on the visible world and screen dimensions.

--- a/vpr/src/draw/draw_types.cpp
+++ b/vpr/src/draw/draw_types.cpp
@@ -1,11 +1,11 @@
 #ifndef NO_GRAPHICS
 
-#    include "draw.h"
-#    include "draw_global.h"
-#    include "draw_types.h"
-#    include "globals.h"
-#    include "physical_types_util.h"
-#    include "vpr_utils.h"
+#include "draw.h"
+#include "draw_global.h"
+#include "draw_types.h"
+#include "globals.h"
+#include "physical_types_util.h"
+#include "vpr_utils.h"
 
 /*******************************************
  * begin t_draw_state function definitions *

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -20,20 +20,20 @@
 
 #ifndef NO_GRAPHICS
 
-#    include <vector>
-#    include <memory>
-#    include "clustered_netlist.h"
-#    include "timing_info_fwd.h"
-#    include "vtr_util.h"
-#    include "vpr_types.h"
-#    include "vtr_color_map.h"
-#    include "vtr_vector.h"
-#    include "breakpoint.h"
-#    include "manual_moves.h"
+#include <vector>
+#include <memory>
+#include "clustered_netlist.h"
+#include "timing_info_fwd.h"
+#include "vtr_util.h"
+#include "vpr_types.h"
+#include "vtr_color_map.h"
+#include "vtr_vector.h"
+#include "breakpoint.h"
+#include "manual_moves.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/rectangle.hpp"
-#    include "ezgl/color.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/rectangle.hpp"
+#include "ezgl/color.hpp"
 
 enum e_draw_crit_path {
     DRAW_NO_CRIT_PATH,

--- a/vpr/src/draw/save_graphics.cpp
+++ b/vpr/src/draw/save_graphics.cpp
@@ -1,10 +1,10 @@
 #ifndef NO_GRAPHICS
 
-#    include <cstdio>
+#include <cstdio>
 
-#    include "draw.h"
-#    include "save_graphics.h"
-#    include "search_bar.h"
+#include "draw.h"
+#include "save_graphics.h"
+#include "search_bar.h"
 
 extern ezgl::rectangle initial_world;
 

--- a/vpr/src/draw/save_graphics.h
+++ b/vpr/src/draw/save_graphics.h
@@ -9,11 +9,11 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 
 void save_graphics(std::string extension, std::string file_name);
 void save_graphics_dialog_box(GtkWidget* /*widget*/, ezgl::application* /*app*/);

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -15,42 +15,42 @@
 
 #include "physical_types.h"
 #ifndef NO_GRAPHICS
-#    include <cstdio>
-#    include <sstream>
+#include <cstdio>
+#include <sstream>
 
-#    include "vtr_assert.h"
-#    include "vtr_ndoffsetmatrix.h"
-#    include "vtr_memory.h"
-#    include "vtr_log.h"
-#    include "vtr_color_map.h"
+#include "vtr_assert.h"
+#include "vtr_ndoffsetmatrix.h"
+#include "vtr_memory.h"
+#include "vtr_log.h"
+#include "vtr_color_map.h"
 
-#    include "vpr_utils.h"
-#    include "vpr_error.h"
+#include "vpr_utils.h"
+#include "vpr_error.h"
 
-#    include "globals.h"
-#    include "draw_color.h"
-#    include "draw.h"
-#    include "draw_basic.h"
-#    include "draw_rr.h"
-#    include "draw_searchbar.h"
-#    include "read_xml_arch_file.h"
-#    include "draw_global.h"
-#    include "intra_logic_block.h"
-#    include "atom_netlist.h"
-#    include "tatum/report/TimingPathCollector.hpp"
-#    include "hsl.h"
-#    include "route_export.h"
-#    include "search_bar.h"
+#include "globals.h"
+#include "draw_color.h"
+#include "draw.h"
+#include "draw_basic.h"
+#include "draw_rr.h"
+#include "draw_searchbar.h"
+#include "read_xml_arch_file.h"
+#include "draw_global.h"
+#include "intra_logic_block.h"
+#include "atom_netlist.h"
+#include "tatum/report/TimingPathCollector.hpp"
+#include "hsl.h"
+#include "route_export.h"
+#include "search_bar.h"
 
 //To process key presses we need the X11 keysym definitions,
 //which are unavailable when building with MINGW
-#    if defined(X11) && !defined(__MINGW32__)
-#        include <X11/keysym.h>
-#    endif
+#if defined(X11) && !defined(__MINGW32__)
+#include <X11/keysym.h>
+#endif
 
-#    include "rr_graph.h"
-#    include "route_utilization.h"
-#    include "place_macro.h"
+#include "rr_graph.h"
+#include "route_utilization.h"
+#include "place_macro.h"
 
 extern std::string rr_highlight_message;
 
@@ -159,7 +159,7 @@ void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app) {
         }
 
         const auto clb_nets = atom_ctx.lookup().clb_nets(atom_net_id);
-        for(auto clb_net_id: clb_nets.value()){
+        for (auto clb_net_id : clb_nets.value()) {
             highlight_nets(clb_net_id);
         }
     }

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -12,12 +12,12 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
-#    include "draw_color.h"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
+#include "draw_color.h"
 
 void search_and_highlight(GtkWidget* /*widget*/, ezgl::application* app);
 bool highlight_rr_nodes(RRNodeId hit_node);

--- a/vpr/src/draw/ui_setup.cpp
+++ b/vpr/src/draw/ui_setup.cpp
@@ -10,18 +10,18 @@
  * Each function here initializes a different set of ui buttons, connecting their callback functions
  */
 
-#    include "draw_global.h"
-#    include "draw.h"
-#    include "draw_toggle_functions.h"
-#    include "buttons.h"
-#    include "intra_logic_block.h"
-#    include "clustered_netlist.h"
-#    include "ui_setup.h"
-#    include "save_graphics.h"
+#include "draw_global.h"
+#include "draw.h"
+#include "draw_toggle_functions.h"
+#include "buttons.h"
+#include "intra_logic_block.h"
+#include "clustered_netlist.h"
+#include "ui_setup.h"
+#include "save_graphics.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 void basic_button_setup(ezgl::application* app) {
     //button to enter window_mode, created in main.ui
     GtkButton* window = (GtkButton*)app->get_object("Window");

--- a/vpr/src/draw/ui_setup.h
+++ b/vpr/src/draw/ui_setup.h
@@ -14,11 +14,11 @@
 
 #ifndef NO_GRAPHICS
 
-#    include "draw_global.h"
+#include "draw_global.h"
 
-#    include "ezgl/point.hpp"
-#    include "ezgl/application.hpp"
-#    include "ezgl/graphics.hpp"
+#include "ezgl/point.hpp"
+#include "ezgl/application.hpp"
+#include "ezgl/graphics.hpp"
 
 /**
  * @brief configures basic buttons

--- a/vpr/src/noc/sat_routing.h
+++ b/vpr/src/noc/sat_routing.h
@@ -66,6 +66,5 @@ struct hash<std::pair<NocTrafficFlowId, NocLinkId>> {
 };
 } // namespace std
 
-
 #endif
 #endif

--- a/vpr/src/noc/turn_model_routing.cpp
+++ b/vpr/src/noc/turn_model_routing.cpp
@@ -78,12 +78,12 @@ void TurnModelRouting::route_flow(NocRouterId src_router_id,
             flow_route.push_back(next_link);
             prev_dir = next_step_direction;
         } else {
-            VPR_FATAL_ERROR(VPR_ERROR_OTHER, "No route could be found from starting router with ID:'%d' "
+            VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                            "No route could be found from starting router with ID:'%d' "
                             "and the destination router with ID:'%d' using the XY-Routing algorithm.",
                             src_router.get_router_user_id(),
                             dst_router.get_router_user_id());
         }
-
     }
 }
 
@@ -200,7 +200,7 @@ uint32_t TurnModelRouting::murmur3_32(const std::vector<uint32_t>& key, uint32_t
     // A swap is *not* necessary here because the preceding loop already
     // places the low bytes in the low places according to whatever endianness
     // we use. Swaps only apply when the memory is copied in a chunk.
-//    h ^= murmur_32_scramble(0);
+    //    h ^= murmur_32_scramble(0);
     /* Finalize. */
     h ^= key.size() * 4;
     h ^= h >> 16;
@@ -324,7 +324,6 @@ TurnModelRouting::Direction TurnModelRouting::select_next_direction(const std::v
     const int manhattan_dist = delta_x + delta_y + delta_z;
 
     int hash_val_remainder = hash_val % manhattan_dist;
-
 
     TurnModelRouting::Direction selected_direction = TurnModelRouting::Direction::INVALID;
 

--- a/vpr/src/noc/xy_routing.cpp
+++ b/vpr/src/noc/xy_routing.cpp
@@ -23,7 +23,7 @@ const std::vector<TurnModelRouting::Direction>& XYRouting::get_legal_directions(
      * the current router has the same x-coordinate as the
      * destination. Then we start moving along the y-axis.
      * Finally, we move along the z-axis.
-    */
+     */
 
     if (dst_router_pos.x > curr_router_pos.x) {
         return east_direction;

--- a/vpr/src/noc/xy_routing.h
+++ b/vpr/src/noc/xy_routing.h
@@ -87,7 +87,6 @@
 
 #include "turn_model_routing.h"
 
-
 class XYRouting : public TurnModelRouting {
   public:
     ~XYRouting() override;
@@ -111,13 +110,12 @@ class XYRouting : public TurnModelRouting {
 
   private:
     const std::vector<TurnModelRouting::Direction> east_direction{TurnModelRouting::Direction::EAST};
-    const std::vector<TurnModelRouting::Direction> west_direction {TurnModelRouting::Direction::WEST};
-    const std::vector<TurnModelRouting::Direction> north_direction {TurnModelRouting::Direction::NORTH};
-    const std::vector<TurnModelRouting::Direction> south_direction {TurnModelRouting::Direction::SOUTH};
-    const std::vector<TurnModelRouting::Direction> up_direction {TurnModelRouting::Direction::UP};
-    const std::vector<TurnModelRouting::Direction> down_direction {TurnModelRouting::Direction::DOWN};
-    const std::vector<TurnModelRouting::Direction> no_direction {};
-
+    const std::vector<TurnModelRouting::Direction> west_direction{TurnModelRouting::Direction::WEST};
+    const std::vector<TurnModelRouting::Direction> north_direction{TurnModelRouting::Direction::NORTH};
+    const std::vector<TurnModelRouting::Direction> south_direction{TurnModelRouting::Direction::SOUTH};
+    const std::vector<TurnModelRouting::Direction> up_direction{TurnModelRouting::Direction::UP};
+    const std::vector<TurnModelRouting::Direction> down_direction{TurnModelRouting::Direction::DOWN};
+    const std::vector<TurnModelRouting::Direction> no_direction{};
 };
 
 #endif

--- a/vpr/src/pack/attraction_groups.cpp
+++ b/vpr/src/pack/attraction_groups.cpp
@@ -33,8 +33,7 @@ AttractionInfo::AttractionInfo(bool attraction_groups_on) {
     }
 }
 
-void AttractionInfo::create_att_groups_for_overfull_regions(
-            const std::vector<PartitionRegion>& overfull_partition_regions) {
+void AttractionInfo::create_att_groups_for_overfull_regions(const std::vector<PartitionRegion>& overfull_partition_regions) {
     const auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
     auto& atom_ctx = g_vpr_ctx.atom();
     int num_parts = floorplanning_ctx.constraints.get_num_partitions();

--- a/vpr/src/pack/cluster_legalizer.h
+++ b/vpr/src/pack/cluster_legalizer.h
@@ -66,18 +66,18 @@ struct t_clustering_chain_info {
 /// Allows the user of the API to select how thorough the legalizer should be
 /// when adding molecules into clusters.
 enum class ClusterLegalizationStrategy {
-    FULL,                   // Run the full legalizer (including intra-lb routing)
-    SKIP_INTRA_LB_ROUTE     // Do all legality checks except intra-lb routing
+    FULL,               // Run the full legalizer (including intra-lb routing)
+    SKIP_INTRA_LB_ROUTE // Do all legality checks except intra-lb routing
 };
 
 /// @brief The status of the cluster legalization.
 enum class e_block_pack_status {
-    BLK_PASSED,                 // Passed legalization.
-    BLK_FAILED_FEASIBLE,        // Failed due to block not feasibly being able to go in the cluster.
-    BLK_FAILED_ROUTE,           // Failed due to intra-lb routing failure.
-    BLK_FAILED_FLOORPLANNING,   // Failed due to not being compatible with the cluster's current PartitionRegion.
-    BLK_FAILED_NOC_GROUP,       // Failed due to not being compatible with the cluster's NoC group.
-    BLK_STATUS_UNDEFINED        // Undefined status. Something went wrong.
+    BLK_PASSED,               // Passed legalization.
+    BLK_FAILED_FEASIBLE,      // Failed due to block not feasibly being able to go in the cluster.
+    BLK_FAILED_ROUTE,         // Failed due to intra-lb routing failure.
+    BLK_FAILED_FLOORPLANNING, // Failed due to not being compatible with the cluster's current PartitionRegion.
+    BLK_FAILED_NOC_GROUP,     // Failed due to not being compatible with the cluster's NoC group.
+    BLK_STATUS_UNDEFINED      // Undefined status. Something went wrong.
 };
 
 /*
@@ -191,15 +191,14 @@ struct LegalizationCluster {
  * // new_cluster_id now contains a fully legalized cluster.
  */
 class ClusterLegalizer {
-public:
+  public:
     // Iterator for the legalization cluster IDs
     typedef typename vtr::vector_map<LegalizationClusterId, LegalizationClusterId>::const_iterator cluster_iterator;
 
     // Range for the legalization cluster IDs
     typedef typename vtr::Range<cluster_iterator> cluster_range;
 
-private:
-
+  private:
     /*
      * @brief Helper method that tries to pack the given molecule into a cluster.
      *
@@ -235,8 +234,7 @@ private:
      */
     void reset_molecule_info(PackMoleculeId mol_id);
 
-public:
-
+  public:
     // Explicitly deleted default constructor. Need to use other constructor to
     // initialize state correctly.
     ClusterLegalizer() = delete;
@@ -518,7 +516,7 @@ public:
     /// @brief Destructor of the class. Frees allocated data.
     ~ClusterLegalizer();
 
-private:
+  private:
     /// @brief A vector of the legalization cluster IDs. If any of them are
     ///        invalid, then that means that the cluster has been destroyed.
     vtr::vector_map<LegalizationClusterId, LegalizationClusterId> legalization_cluster_ids_;
@@ -583,4 +581,3 @@ private:
     ///        legalized into clusters.
     const Prepacker& prepacker_;
 };
-

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -150,7 +150,7 @@ void t_intra_cluster_placement_stats::free_primitives() {
 }
 
 t_intra_cluster_placement_stats* alloc_and_load_cluster_placement_stats(t_logical_block_type_ptr cluster_type,
-                                                                  int cluster_mode) {
+                                                                        int cluster_mode) {
     t_intra_cluster_placement_stats* cluster_placement_stats = new t_intra_cluster_placement_stats;
     *cluster_placement_stats = t_intra_cluster_placement_stats();
     // TODO: This initialization may be able to be made more efficient.
@@ -728,4 +728,3 @@ bool exists_free_primitive_for_atom_block(t_intra_cluster_placement_stats* clust
 void reset_tried_but_unused_cluster_placements(t_intra_cluster_placement_stats* cluster_placement_stats) {
     cluster_placement_stats->flush_intermediate_queues();
 }
-

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -21,9 +21,9 @@ class AtomBlockId;
  */
 class t_intra_cluster_placement_stats {
   public:
-    int num_pb_types;                     ///<num primitive pb_types inside complex block
-    bool has_long_chain;                  ///<specifies if this cluster has a molecule placed in it that belongs to a long chain (a chain that spans more than one cluster)
-    PackMoleculeId curr_molecule;         ///<current molecule being considered for packing
+    int num_pb_types;             ///<num primitive pb_types inside complex block
+    bool has_long_chain;          ///<specifies if this cluster has a molecule placed in it that belongs to a long chain (a chain that spans more than one cluster)
+    PackMoleculeId curr_molecule; ///<current molecule being considered for packing
 
     // Vector of size num_pb_types [0.. num_pb_types-1]. Each element is an unordered_map of the cluster_placement_primitives that are of this pb_type
     // Each cluster_placement_primitive is associated with and index (key of the map) for easier lookup, insertion and deletion.
@@ -135,7 +135,7 @@ class t_intra_cluster_placement_stats {
  * The pointer returned by this method must be freed.
  */
 t_intra_cluster_placement_stats* alloc_and_load_cluster_placement_stats(t_logical_block_type_ptr cluster_type,
-                                                                  int cluster_mode);
+                                                                        int cluster_mode);
 
 /**
  * @brief Frees the cluster placement stats of a cluster.

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -163,8 +163,7 @@ void print_pack_status(int tot_num_molecules,
 
     int num_clusters_created = cluster_legalizer.clusters().size();
 
-    if (mols_since_last_print >= int_molecule_increment ||
-        num_molecules_processed == tot_num_molecules) {
+    if (mols_since_last_print >= int_molecule_increment || num_molecules_processed == tot_num_molecules) {
         VTR_LOG(
             "%6d/%-6d  %3d%%   "
             "%26d   "
@@ -461,4 +460,3 @@ void init_clb_atoms_lookup(vtr::vector<ClusterBlockId, std::unordered_set<AtomBl
         atoms_lookup[clb_index].insert(atom_blk_id);
     }
 }
-

--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -1,8 +1,8 @@
 /**
-* @file sync_netlists_to_routing_flat.cpp
-*
-* @brief Implementation for \see sync_netlists_to_routing_flat().
-*/
+ * @file sync_netlists_to_routing_flat.cpp
+ *
+ * @brief Implementation for \see sync_netlists_to_routing_flat().
+ */
 
 #include "clustered_netlist_fwd.h"
 #include "logic_types.h"
@@ -40,20 +40,19 @@ static void sync_clustered_netlist_to_routing(void);
  * (i.e. the primitive has equivalent input pins and flat routing used a different pin) */
 static void fixup_atom_pb_graph_pin_mapping(void);
 
-
 /* Function definitions */
 
 /** Is the clock net found in the routing results?
  * (If not, clock_modeling is probably ideal and we should preserve clock routing while rebuilding.) */
-inline bool is_clock_net_routed(void){
+inline bool is_clock_net_routed(void) {
     auto& atom_ctx = g_vpr_ctx.atom();
     auto& route_ctx = g_vpr_ctx.routing();
 
-    for(auto net_id: atom_ctx.netlist().nets()){
+    for (auto net_id : atom_ctx.netlist().nets()) {
         auto& tree = route_ctx.route_trees[net_id];
-        if(!tree)
+        if (!tree)
             continue;
-        if(route_ctx.is_clock_net[net_id]) /* Clock net has routing */
+        if (route_ctx.is_clock_net[net_id]) /* Clock net has routing */
             return true;
     }
 
@@ -61,7 +60,7 @@ inline bool is_clock_net_routed(void){
 }
 
 /** Get the ClusterBlockId for a given RRNodeId. */
-inline ClusterBlockId get_cluster_block_from_rr_node(RRNodeId inode){
+inline ClusterBlockId get_cluster_block_from_rr_node(RRNodeId inode) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& place_ctx = g_vpr_ctx.placement();
     auto& rr_graph = device_ctx.rr_graph;
@@ -81,38 +80,36 @@ inline ClusterBlockId get_cluster_block_from_rr_node(RRNodeId inode){
     int width_offset = device_ctx.grid.get_width_offset(node_phy_tile_loc);
     int height_offset = device_ctx.grid.get_height_offset(node_phy_tile_loc);
 
-    ClusterBlockId clb = place_ctx.grid_blocks().block_at_location({
-        rr_graph.node_xlow(inode) - width_offset,
-        rr_graph.node_ylow(inode) - height_offset,
-        subtile,
-        rr_graph.node_layer(inode)
-    });
+    ClusterBlockId clb = place_ctx.grid_blocks().block_at_location({rr_graph.node_xlow(inode) - width_offset,
+                                                                    rr_graph.node_ylow(inode) - height_offset,
+                                                                    subtile,
+                                                                    rr_graph.node_layer(inode)});
 
     return clb;
 }
 
-static void get_intra_cluster_connections(const RouteTree& tree, std::vector<std::pair<RRNodeId, RRNodeId>>& out_connections){
+static void get_intra_cluster_connections(const RouteTree& tree, std::vector<std::pair<RRNodeId, RRNodeId>>& out_connections) {
     auto& rr_graph = g_vpr_ctx.device().rr_graph;
 
-    for(auto& node: tree.all_nodes()){
+    for (auto& node : tree.all_nodes()) {
         const auto& parent = node.parent();
-        if(!parent) /* Root */
+        if (!parent) /* Root */
             continue;
 
         /* Find the case where both nodes are IPIN/OPINs and on the same block */
         auto type = rr_graph.node_type(node.inode);
         auto parent_type = rr_graph.node_type(parent->inode);
 
-        if((type == IPIN || type == OPIN) && (parent_type == IPIN || parent_type == OPIN)){
+        if ((type == IPIN || type == OPIN) && (parent_type == IPIN || parent_type == OPIN)) {
             auto clb = get_cluster_block_from_rr_node(node.inode);
             auto parent_clb = get_cluster_block_from_rr_node(parent->inode);
-            if(clb == parent_clb)
+            if (clb == parent_clb)
                 out_connections.push_back({parent->inode, node.inode});
         }
     }
 }
 
-static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_pb_graph_pin* sink_pin, AtomNetId net_id, t_pb* out_pb){
+static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_pb_graph_pin* sink_pin, AtomNetId net_id, t_pb* out_pb) {
     std::unordered_set<const t_pb_graph_pin*> visited;
     std::deque<const t_pb_graph_pin*> queue;
     std::unordered_map<const t_pb_graph_pin*, const t_pb_graph_pin*> prev;
@@ -122,19 +119,19 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
     queue.push_back(source_pin);
     prev[source_pin] = NULL;
 
-    while(!queue.empty()){
+    while (!queue.empty()) {
         const t_pb_graph_pin* cur_pin = queue.front();
         queue.pop_front();
-        if(visited.count(cur_pin))
+        if (visited.count(cur_pin))
             continue;
         visited.insert(cur_pin);
 
         /* Backtrack and return */
-        if(cur_pin == sink_pin){
+        if (cur_pin == sink_pin) {
             break;
         }
 
-        for(auto& edge: cur_pin->output_edges){
+        for (auto& edge : cur_pin->output_edges) {
             VTR_ASSERT(edge->num_output_pins == 1);
             queue.push_back(edge->output_pins[0]);
             prev[edge->output_pins[0]] = cur_pin;
@@ -146,7 +143,7 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
     /* Collect path: we need to build pb_routes from source to sink */
     std::vector<const t_pb_graph_pin*> path;
     const t_pb_graph_pin* cur_pin = sink_pin;
-    while(cur_pin != source_pin){
+    while (cur_pin != source_pin) {
         path.push_back(cur_pin);
         cur_pin = prev[cur_pin];
     }
@@ -154,25 +151,24 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
 
     /* Output the path into out_pb, starting from source. This is where the pb_route is updated */
     int prev_pin_id = -1;
-    for(auto it = path.rbegin(); it != path.rend(); ++it){
+    for (auto it = path.rbegin(); it != path.rend(); ++it) {
         cur_pin = *it;
         int cur_pin_id = cur_pin->pin_count_in_cluster;
         t_pb_route* cur_pb_route;
 
-        if(out_pb_routes.count(cur_pin_id))
+        if (out_pb_routes.count(cur_pin_id))
             cur_pb_route = &out_pb_routes[cur_pin_id];
         else {
             t_pb_route pb_route = {
                 net_id,
                 -1,
                 {},
-                cur_pin
-            };
+                cur_pin};
             out_pb_routes.insert(std::make_pair<>(cur_pin_id, pb_route));
             cur_pb_route = &out_pb_routes[cur_pin_id];
         }
 
-        if(prev_pin_id != -1){
+        if (prev_pin_id != -1) {
             t_pb_route& prev_pb_route = out_pb_routes[prev_pin_id];
             prev_pb_route.sink_pb_pin_ids.push_back(cur_pin_id);
             cur_pb_route->driver_pb_pin_id = prev_pb_route.pb_graph_pin->pin_count_in_cluster;
@@ -182,7 +178,7 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
     }
 }
 
-static void sync_pb_routes_to_routing(void){
+static void sync_pb_routes_to_routing(void) {
     auto& device_ctx = g_vpr_ctx.device();
     auto& atom_ctx = g_vpr_ctx.atom();
     auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
@@ -198,20 +194,20 @@ static void sync_pb_routes_to_routing(void){
          * Otherwise we won't have data to rebuild them */
         std::vector<int> pins_to_erase;
         auto& pb_routes = cluster_ctx.clb_nlist.block_pb(clb_blk_id)->pb_route;
-        for(auto& [pin, pb_route]: pb_routes){
-            if(clock_net_is_routed || !route_ctx.is_clock_net[pb_route.atom_net_id])
+        for (auto& [pin, pb_route] : pb_routes) {
+            if (clock_net_is_routed || !route_ctx.is_clock_net[pb_route.atom_net_id])
                 pins_to_erase.push_back(pin);
         }
 
-        for(int pin: pins_to_erase){
+        for (int pin : pins_to_erase) {
             pb_routes.erase(pin);
         }
     }
 
     /* Go through each route tree and rebuild the pb_routes */
-    for(ParentNetId net_id: atom_ctx.netlist().nets()){
+    for (ParentNetId net_id : atom_ctx.netlist().nets()) {
         auto& tree = route_ctx.route_trees[net_id];
-        if(!tree)
+        if (!tree)
             continue; /* No routing at this ParentNetId */
 
         /* Get all intrablock connections */
@@ -219,26 +215,24 @@ static void sync_pb_routes_to_routing(void){
         get_intra_cluster_connections(tree.value(), conns_to_restore);
 
         /* Restore the connections */
-        for(auto [source_inode, sink_inode]: conns_to_restore){
+        for (auto [source_inode, sink_inode] : conns_to_restore) {
             ClusterBlockId clb = get_cluster_block_from_rr_node(source_inode);
-            auto physical_tile = device_ctx.grid.get_physical_type({
-                rr_graph.node_xlow(source_inode),
-                rr_graph.node_ylow(source_inode),
-                rr_graph.node_layer(source_inode)
-            });
+            auto physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(source_inode),
+                                                                    rr_graph.node_ylow(source_inode),
+                                                                    rr_graph.node_layer(source_inode)});
             int source_pin = rr_graph.node_pin_num(source_inode);
             int sink_pin = rr_graph.node_pin_num(sink_inode);
 
             /* Look up pb graph pins from pb type if pin is not on tile, look up from block otherwise */
-            const t_pb_graph_pin* source_pb_graph_pin, *sink_pb_graph_pin;
-            if(is_pin_on_tile(physical_tile, sink_pin)){
+            const t_pb_graph_pin *source_pb_graph_pin, *sink_pb_graph_pin;
+            if (is_pin_on_tile(physical_tile, sink_pin)) {
                 sink_pb_graph_pin = get_pb_graph_node_pin_from_block_pin(clb, sink_pin);
-            }else{
+            } else {
                 sink_pb_graph_pin = get_pb_pin_from_pin_physical_num(physical_tile, sink_pin);
             }
-            if(is_pin_on_tile(physical_tile, source_pin)){
+            if (is_pin_on_tile(physical_tile, source_pin)) {
                 source_pb_graph_pin = get_pb_graph_node_pin_from_block_pin(clb, source_pin);
-            }else{
+            } else {
                 source_pb_graph_pin = get_pb_pin_from_pin_physical_num(physical_tile, source_pin);
             }
 
@@ -253,18 +247,18 @@ static void sync_pb_routes_to_routing(void){
 /** Rebuild the ClusterNetId <-> AtomNetId lookup after compressing the ClusterNetlist.
  * Needs the old ClusterNetIds in atom_ctx.lookup(). Won't work after calling compress() twice,
  * since we won't have access to the old IDs in the IdRemapper anywhere. */
-inline void rebuild_atom_nets_lookup(ClusteredNetlist::IdRemapper& remapped){
+inline void rebuild_atom_nets_lookup(ClusteredNetlist::IdRemapper& remapped) {
     auto& atom_ctx = g_vpr_ctx.mutable_atom();
     auto& atom_lookup = atom_ctx.mutable_lookup();
 
-    for(auto parent_net_id: atom_ctx.netlist().nets()){
+    for (auto parent_net_id : atom_ctx.netlist().nets()) {
         auto atom_net_id = convert_to_atom_net_id(parent_net_id);
         auto old_clb_nets_opt = atom_lookup.clb_nets(atom_net_id);
-        if(!old_clb_nets_opt)
+        if (!old_clb_nets_opt)
             continue;
         std::vector<ClusterNetId> old_clb_nets = old_clb_nets_opt.value();
         atom_lookup.remove_atom_net(atom_net_id);
-        for(auto old_clb_net: old_clb_nets){
+        for (auto old_clb_net : old_clb_nets) {
             ClusterNetId new_clb_net = remapped.new_net_id(old_clb_net);
             atom_lookup.add_atom_clb_net(atom_net_id, new_clb_net);
         }
@@ -272,7 +266,7 @@ inline void rebuild_atom_nets_lookup(ClusteredNetlist::IdRemapper& remapped){
 }
 
 /** Regenerate clustered netlist nets from routing results */
-static void sync_clustered_netlist_to_routing(void){
+static void sync_clustered_netlist_to_routing(void) {
     auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
     auto& place_ctx = g_vpr_ctx.mutable_placement();
     auto& route_ctx = g_vpr_ctx.routing();
@@ -291,25 +285,25 @@ static void sync_clustered_netlist_to_routing(void){
     std::vector<ClusterPinId> pins_to_remove;
     std::vector<ClusterPortId> ports_to_remove;
 
-    for(auto net_id: clb_netlist.nets()){
+    for (auto net_id : clb_netlist.nets()) {
         auto atom_net_id = atom_lookup.atom_net(net_id);
-        if(!clock_net_is_routed && route_ctx.is_clock_net[atom_net_id])
+        if (!clock_net_is_routed && route_ctx.is_clock_net[atom_net_id])
             continue;
 
         nets_to_remove.push_back(net_id);
     }
-    for(auto pin_id: clb_netlist.pins()){
+    for (auto pin_id : clb_netlist.pins()) {
         ClusterNetId clb_net_id = clb_netlist.pin_net(pin_id);
         auto atom_net_id = atom_lookup.atom_net(clb_net_id);
-        if(!clock_net_is_routed && atom_net_id && route_ctx.is_clock_net[atom_net_id])
+        if (!clock_net_is_routed && atom_net_id && route_ctx.is_clock_net[atom_net_id])
             continue;
 
         pins_to_remove.push_back(pin_id);
     }
-    for(auto port_id: clb_netlist.ports()){
+    for (auto port_id : clb_netlist.ports()) {
         ClusterNetId clb_net_id = clb_netlist.port_net(port_id, 0);
         auto atom_net_id = atom_lookup.atom_net(clb_net_id);
-        if(!clock_net_is_routed && atom_net_id && route_ctx.is_clock_net[atom_net_id])
+        if (!clock_net_is_routed && atom_net_id && route_ctx.is_clock_net[atom_net_id])
             continue;
 
         ports_to_remove.push_back(port_id);
@@ -317,14 +311,14 @@ static void sync_clustered_netlist_to_routing(void){
 
     /* ClusteredNetlist's iterators rely on internal lookups, so we mark for removal
      * while iterating, then remove in bulk */
-    for(auto net_id: nets_to_remove){
+    for (auto net_id : nets_to_remove) {
         clb_netlist.remove_net(net_id);
         atom_ctx.mutable_lookup().remove_clb_net(net_id);
     }
-    for(auto pin_id: pins_to_remove){
+    for (auto pin_id : pins_to_remove) {
         clb_netlist.remove_pin(pin_id);
     }
-    for(auto port_id: ports_to_remove){
+    for (auto port_id : ports_to_remove) {
         clb_netlist.remove_port(port_id);
     }
 
@@ -334,34 +328,32 @@ static void sync_clustered_netlist_to_routing(void){
 
     /* 3. Walk each routing in the atom netlist. If a node is on the tile, add a ClusterPinId for it.
      * Add the associated net and port too if they don't exist */
-    for(auto parent_net_id: atom_ctx.netlist().nets()){
+    for (auto parent_net_id : atom_ctx.netlist().nets()) {
         auto& tree = route_ctx.route_trees[parent_net_id];
         AtomNetId atom_net_id = convert_to_atom_net_id(parent_net_id);
 
         ClusterNetId clb_net_id;
         int clb_nets_so_far = 0;
-        for(auto& rt_node: tree->all_nodes()){
+        for (auto& rt_node : tree->all_nodes()) {
             auto node_type = rr_graph.node_type(rt_node.inode);
-            if(node_type != IPIN && node_type != OPIN)
+            if (node_type != IPIN && node_type != OPIN)
                 continue;
 
-            auto physical_tile = device_ctx.grid.get_physical_type({
-                rr_graph.node_xlow(rt_node.inode),
-                rr_graph.node_ylow(rt_node.inode),
-                rr_graph.node_layer(rt_node.inode)
-            });
+            auto physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(rt_node.inode),
+                                                                    rr_graph.node_ylow(rt_node.inode),
+                                                                    rr_graph.node_layer(rt_node.inode)});
 
             int pin_index = rr_graph.node_pin_num(rt_node.inode);
 
             ClusterBlockId clb = get_cluster_block_from_rr_node(rt_node.inode);
 
-            if(!is_pin_on_tile(physical_tile, pin_index))
+            if (!is_pin_on_tile(physical_tile, pin_index))
                 continue;
 
             /* OPIN on the tile: create a new clb_net_id and add all ports & pins into here
              * Due to how the route tree is traversed, all nodes until the next OPIN on the tile will
              * be under this OPIN, so this is valid (we don't need to get the branch explicitly) */
-            if(node_type == OPIN){
+            if (node_type == OPIN) {
                 std::string net_name;
                 net_name = atom_ctx.netlist().net_name(parent_net_id) + "_" + std::to_string(clb_nets_so_far);
                 clb_net_id = clb_netlist.create_net(net_name);
@@ -372,13 +364,13 @@ static void sync_clustered_netlist_to_routing(void){
             t_pb_graph_pin* pb_graph_pin = get_pb_graph_node_pin_from_block_pin(clb, pin_index);
 
             ClusterPortId port_id = clb_netlist.find_port(clb, pb_graph_pin->port->name);
-            if(!port_id){
+            if (!port_id) {
                 PortType port_type;
-                if(pb_graph_pin->port->is_clock)
+                if (pb_graph_pin->port->is_clock)
                     port_type = PortType::CLOCK;
-                else if(pb_graph_pin->port->type == IN_PORT)
+                else if (pb_graph_pin->port->type == IN_PORT)
                     port_type = PortType::INPUT;
-                else if(pb_graph_pin->port->type == OUT_PORT)
+                else if (pb_graph_pin->port->type == OUT_PORT)
                     port_type = PortType::OUTPUT;
                 else
                     VTR_ASSERT_MSG(false, "Unsupported port type");
@@ -398,38 +390,38 @@ static void sync_clustered_netlist_to_routing(void){
     auto& blk_loc_registry = place_ctx.mutable_blk_loc_registry();
     auto& physical_pins = place_ctx.mutable_physical_pins();
     physical_pins.clear();
-    for(auto clb: clb_netlist.blocks()){
+    for (auto clb : clb_netlist.blocks()) {
         blk_loc_registry.place_sync_external_block_connections(clb);
     }
 }
 
-static void fixup_atom_pb_graph_pin_mapping(void){
+static void fixup_atom_pb_graph_pin_mapping(void) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& atom_ctx = g_vpr_ctx.mutable_atom();
 
-    for(ClusterBlockId clb: cluster_ctx.clb_nlist.blocks()){
+    for (ClusterBlockId clb : cluster_ctx.clb_nlist.blocks()) {
         /* Collect all innermost pb routes */
         std::vector<int> sink_pb_route_ids;
         t_pb* clb_pb = cluster_ctx.clb_nlist.block_pb(clb);
-        for(auto [pb_route_id, pb_route]: clb_pb->pb_route){
-            if(pb_route.sink_pb_pin_ids.empty())
+        for (auto [pb_route_id, pb_route] : clb_pb->pb_route) {
+            if (pb_route.sink_pb_pin_ids.empty())
                 sink_pb_route_ids.push_back(pb_route_id);
         }
 
-        for(int sink_pb_route_id: sink_pb_route_ids){
+        for (int sink_pb_route_id : sink_pb_route_ids) {
             t_pb_route& pb_route = clb_pb->pb_route.at(sink_pb_route_id);
 
             const t_pb_graph_pin* atom_pbg_pin = pb_route.pb_graph_pin;
             t_pb* atom_pb = clb_pb->find_mutable_pb(atom_pbg_pin->parent_node);
             AtomBlockId atb = atom_ctx.lookup().pb_atom(atom_pb);
-            if(!atb)
+            if (!atb)
                 continue;
 
             /* Find atom port from pbg pin's model port */
             AtomPortId atom_port = atom_ctx.netlist().find_atom_port(atb, atom_pbg_pin->port->model_port);
-            for(AtomPinId atom_pin: atom_ctx.netlist().port_pins(atom_port)){
+            for (AtomPinId atom_pin : atom_ctx.netlist().port_pins(atom_port)) {
                 /* Match net IDs from pb_route and atom netlist and connect in lookup */
-                if(pb_route.atom_net_id == atom_ctx.netlist().pin_net(atom_pin)){
+                if (pb_route.atom_net_id == atom_ctx.netlist().pin_net(atom_pin)) {
                     atom_ctx.mutable_lookup().set_atom_pin_pb_graph_pin(atom_pin, atom_pbg_pin);
                     atom_pb->set_atom_pin_bit_index(atom_pbg_pin, atom_ctx.netlist().pin_port_bit(atom_pin));
                 }

--- a/vpr/src/pack/sync_netlists_to_routing_flat.h
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.h
@@ -1,6 +1,6 @@
 #include "netlist.h"
 
- /********************************************************************
+/********************************************************************
  * Top-level function to synchronize packing results to routing results.
  * Flat routing invalidates the ClusteredNetlist since nets may be routed
  * inside or outside a block and changes virtually all intrablock routing.

--- a/vpr/src/pack/verify_clustering.h
+++ b/vpr/src/pack/verify_clustering.h
@@ -82,4 +82,3 @@ unsigned verify_clustering(const ClusteredNetlist& clb_nlist,
  *          log messages for each error found.
  */
 unsigned verify_clustering(const VprContext& ctx);
-

--- a/vpr/src/pack/verify_flat_placement.h
+++ b/vpr/src/pack/verify_flat_placement.h
@@ -35,4 +35,3 @@ class Prepacker;
 unsigned verify_flat_placement_for_packing(const FlatPlacementInfo& flat_placement_info,
                                            const AtomNetlist& atom_netlist,
                                            const Prepacker& prepacker);
-

--- a/vpr/src/place/analytic_placer.cpp
+++ b/vpr/src/place/analytic_placer.cpp
@@ -1,30 +1,30 @@
 #include "place_macro.h"
 #ifdef ENABLE_ANALYTIC_PLACE
 
-#    include "analytic_placer.h"
+#include "analytic_placer.h"
 
 // The eigen library contains a warning in GCC13 for a null dereference. This
 // causes the CI build to fail due to the warning. Ignoring the warning for
 // these include files. Using push to return to the state of GCC diagnostics.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference"
-#    include <Eigen/Core>
-#    include <Eigen/IterativeLinearSolvers>
+#include <Eigen/Core>
+#include <Eigen/IterativeLinearSolvers>
 // Pop the GCC diagnostics state back to what it was before.
 #pragma GCC diagnostic pop
 
-#    include <iostream>
-#    include <vector>
-#    include <cstdint>
+#include <iostream>
+#include <vector>
+#include <cstdint>
 
-#    include "vpr_types.h"
-#    include "vtr_time.h"
-#    include "read_place.h"
-#    include "globals.h"
-#    include "vtr_log.h"
-#    include "cut_spreader.h"
-#    include "vpr_utils.h"
-#    include "place_util.h"
+#include "vpr_types.h"
+#include "vtr_time.h"
+#include "read_place.h"
+#include "globals.h"
+#include "vtr_log.h"
+#include "cut_spreader.h"
+#include "vpr_utils.h"
+#include "place_util.h"
 
 // Templated struct for constructing and solving matrix equations in analytic placer
 template<typename T>
@@ -125,7 +125,8 @@ constexpr int HEAP_STALLED_ITERATIONS_STOP = 15;
 
 AnalyticPlacer::AnalyticPlacer(BlkLocRegistry& blk_loc_registry,
                                const PlaceMacros& place_macros)
-    : blk_loc_registry_ref_(blk_loc_registry), place_macros_(place_macros) {
+    : blk_loc_registry_ref_(blk_loc_registry)
+    , place_macros_(place_macros) {
     //Eigen::initParallel();
 
     // TODO: PlacerHeapCfg should be externally configured & supplied
@@ -303,7 +304,7 @@ void AnalyticPlacer::init() {
     for (auto blk_id : clb_nlist.blocks()) {
         blk_locs.insert(blk_id, BlockLocation{});
         blk_locs[blk_id].loc = init_block_locs[blk_id].loc; // transfer of initial placement
-        row_num.insert(blk_id, DONT_SOLVE);                      // no blocks are moved by default, until they are setup in setup_solve_blks()
+        row_num.insert(blk_id, DONT_SOLVE);                 // no blocks are moved by default, until they are setup in setup_solve_blks()
     }
 
     // only blocks with connections are considered

--- a/vpr/src/place/analytic_placer.h
+++ b/vpr/src/place/analytic_placer.h
@@ -82,8 +82,8 @@
  * https://github.com/YosysHQ/nextpnr
  */
 
-#    include "vpr_context.h"
-#    include "PlacementDelayCalculator.h"
+#include "vpr_context.h"
+#include "PlacementDelayCalculator.h"
 
 class PlaceMacros;
 
@@ -99,7 +99,6 @@ extern int DONT_SOLVE;
 
 // sentinel for blks not part of a placement macro
 extern int NO_MACRO;
-
 
 class AnalyticPlacer {
   public:

--- a/vpr/src/place/annealer.cpp
+++ b/vpr/src/place/annealer.cpp
@@ -138,7 +138,6 @@ bool t_annealing_state::outer_loop_update(float success_rate,
     auto& cluster_ctx = g_vpr_ctx.clustering();
     float t_exit = 0.005 * costs.cost / cluster_ctx.clb_nlist.nets().size();
 
-
     VTR_ASSERT_SAFE(placer_opts.anneal_sched.type == e_sched_type::AUTO_SCHED);
     // Automatically adjust alpha according to success rate.
     if (success_rate > 0.96) {
@@ -224,8 +223,7 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
     , move_stats_file_(nullptr, vtr::fclose)
     , outer_crit_iter_count_(1)
     , blocks_affected_(placer_state.block_locs().size())
-    , quench_started_(false)
-{
+    , quench_started_(false) {
     const auto& device_ctx = g_vpr_ctx.device();
 
     float first_crit_exponent;
@@ -372,7 +370,6 @@ e_move_result PlacementAnnealer::try_swap_(MoveGenerator& move_generator,
     double delta_c = 0;        //Change in cost due to this swap.
     double bb_delta_c = 0;     //Change in the bounding box (wiring) cost.
     double timing_delta_c = 0; //Change in the timing cost (delay * criticality).
-
 
     /* Allow some fraction of moves to not be restricted by rlim,
      * in the hopes of better escaping local minima. */
@@ -562,7 +559,7 @@ e_move_result PlacementAnnealer::try_swap_(MoveGenerator& move_generator,
             // Update clb data structures since we kept the move.
             blk_loc_registry.commit_move_blocks(blocks_affected_);
 
-            if (noc_opts_.noc){
+            if (noc_opts_.noc) {
                 noc_cost_handler_->commit_noc_costs();
                 costs_ += noc_delta_c;
             }
@@ -641,7 +638,6 @@ e_move_result PlacementAnnealer::try_swap_(MoveGenerator& move_generator,
     stop_placement_and_check_breakpoints(blocks_affected_, move_outcome, delta_c, bb_delta_c, timing_delta_c);
 #endif
 
-
     // Clear the data structure containing block move info
     blocks_affected_.clear_move_blocks();
 
@@ -655,8 +651,7 @@ void PlacementAnnealer::outer_loop_update_timing_info() {
     if (placer_opts_.place_algorithm.is_timing_driven()) {
         /* At each temperature change we update these values to be used
          * for normalizing the tradeoff between timing and wirelength (bb) */
-        if (outer_crit_iter_count_ >= placer_opts_.recompute_crit_iter ||
-            placer_opts_.inner_loop_recompute_divider != 0) {
+        if (outer_crit_iter_count_ >= placer_opts_.recompute_crit_iter || placer_opts_.inner_loop_recompute_divider != 0) {
 
             PlaceCritParams crit_params{annealing_state_.crit_exponent,
                                         placer_opts_.place_crit_limit};
@@ -755,9 +750,7 @@ void PlacementAnnealer::placement_inner_loop() {
 
     // update the RL agent's state
     if (!quench_started_) {
-        if (placer_opts_.place_algorithm.is_timing_driven() &&
-            placer_opts_.place_agent_multistate &&
-            agent_state_ == e_agent_state::EARLY_IN_THE_ANNEAL) {
+        if (placer_opts_.place_algorithm.is_timing_driven() && placer_opts_.place_agent_multistate && agent_state_ == e_agent_state::EARLY_IN_THE_ANNEAL) {
             if (annealing_state_.alpha < 0.85 && annealing_state_.alpha > 0.6) {
                 agent_state_ = e_agent_state::LATE_IN_THE_ANNEAL;
                 VTR_LOG("Agent's 2nd state: \n");
@@ -768,7 +761,6 @@ void PlacementAnnealer::placement_inner_loop() {
     tot_iter_ += annealing_state_.move_lim;
     ++annealing_state_.num_temps;
 }
-
 
 int PlacementAnnealer::get_total_iteration() const {
     return tot_iter_;
@@ -851,8 +843,7 @@ void PlacementAnnealer::LOG_MOVE_STATS_PROPOSED() {
     }
 }
 
-void PlacementAnnealer::LOG_MOVE_STATS_OUTCOME(double delta_cost, double delta_bb_cost, double delta_td_cost,
-                                               const char* outcome, const char* reason) {
+void PlacementAnnealer::LOG_MOVE_STATS_OUTCOME(double delta_cost, double delta_bb_cost, double delta_td_cost, const char* outcome, const char* reason) {
     if (move_stats_file_) {
         fprintf(move_stats_file_.get(),
                 "%g,%g,%g,"

--- a/vpr/src/place/compressed_grid.cpp
+++ b/vpr/src/place/compressed_grid.cpp
@@ -18,7 +18,6 @@
 static t_compressed_block_grid create_compressed_block_grid(const std::vector<std::vector<vtr::Point<int>>>& locations,
                                                             int num_layers);
 
-
 std::vector<t_compressed_block_grid> create_compressed_block_grids() {
     /* Measure how long it takes to allocate and initialize compressed grid.
      * The measured execution time is printed when this object goes out of scope
@@ -44,7 +43,7 @@ std::vector<t_compressed_block_grid> create_compressed_block_grids() {
                 int width_offset = grid.get_width_offset({x, y, layer_num});
                 int height_offset = grid.get_height_offset(t_physical_tile_loc(x, y, layer_num));
 
-                if (width_offset == 0 && height_offset == 0) {  // the bottom left corner of a tile
+                if (width_offset == 0 && height_offset == 0) { // the bottom left corner of a tile
                     const auto& type = grid.get_physical_type({x, y, layer_num});
                     auto equivalent_sites = get_equivalent_sites_set(type);
 

--- a/vpr/src/place/cut_spreader.cpp
+++ b/vpr/src/place/cut_spreader.cpp
@@ -1,19 +1,19 @@
 #include "place_macro.h"
 #ifdef ENABLE_ANALYTIC_PLACE
 
-#    include "cut_spreader.h"
-#    include <iostream>
-#    include <vector>
-#    include <queue>
-#    include <cstdlib>
+#include "cut_spreader.h"
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <cstdlib>
 
-#    include "analytic_placer.h"
-#    include "vpr_types.h"
-#    include "vtr_time.h"
-#    include "globals.h"
-#    include "vtr_log.h"
-#    include "place_util.h"
-#    include "grid_block.h"
+#include "analytic_placer.h"
+#include "vpr_types.h"
+#include "vtr_time.h"
+#include "globals.h"
+#include "vtr_log.h"
+#include "place_util.h"
+#include "grid_block.h"
 
 // sentinel for base case in CutSpreader (i.e. only 1 block left in region)
 constexpr std::pair<int, int> BASE_CASE = {-2, -2};
@@ -1043,7 +1043,7 @@ bool CutSpreader::try_place_blk(ClusterBlockId blk,
     if (exceeds_explore_limit && best_subtile != t_pl_loc{}) {
         // find the logic block bound to (placed on) best_subtile
         ClusterBlockId bound_blk = grid_blocks.block_at_location(best_subtile);
-        if (bound_blk) {   // if best_subtile has a logic block
+        if (bound_blk) {                     // if best_subtile has a logic block
             unbind_tile(best_subtile);       // clear bound_block and best_subtile's placement info
             remaining.emplace(1, bound_blk); // put bound_blk back into remaining blocks to place
         }
@@ -1052,7 +1052,7 @@ bool CutSpreader::try_place_blk(ClusterBlockId blk,
     }
 
     // if exploration limit is not met or a candidate sub_tile is not found yet
-    for (auto sub_t : subtiles_at_location[nx][ny]) {                              // for each available sub_tile at random location
+    for (auto sub_t : subtiles_at_location[nx][ny]) {                    // for each available sub_tile at random location
         ClusterBlockId bound_blk = grid_blocks.block_at_location(sub_t); // logic blk at [nx, ny]
         if (bound_blk == ClusterBlockId::INVALID()
             || ripup_radius_met

--- a/vpr/src/place/cut_spreader.h
+++ b/vpr/src/place/cut_spreader.h
@@ -107,8 +107,8 @@
  * https://github.com/YosysHQ/nextpnr
  *
  */
-#    include "vpr_context.h"
-#    include <queue>
+#include "vpr_context.h"
+#include <queue>
 
 // declaration of used types;
 class AnalyticPlacer;

--- a/vpr/src/place/delay_model/simple_delay_model.cpp
+++ b/vpr/src/place/delay_model/simple_delay_model.cpp
@@ -2,12 +2,12 @@
 #include "simple_delay_model.h"
 
 #ifdef VTR_ENABLE_CAPNPROTO
-#    include "capnp/serialize.h"
-#    include "place_delay_model.capnp.h"
-#    include "ndmatrix_serdes.h"
-#    include "mmap_file.h"
-#    include "serdes_utils.h"
-#endif  // VTR_ENABLE_CAPNPROTO
+#include "capnp/serialize.h"
+#include "place_delay_model.capnp.h"
+#include "ndmatrix_serdes.h"
+#include "mmap_file.h"
+#include "serdes_utils.h"
+#endif // VTR_ENABLE_CAPNPROTO
 
 void SimpleDelayModel::compute(RouterDelayProfiler& route_profiler,
                                const t_placer_opts& /*placer_opts*/,

--- a/vpr/src/place/move_generators/centroid_move_generator.h
+++ b/vpr/src/place/move_generators/centroid_move_generator.h
@@ -58,7 +58,6 @@ class CentroidMoveGenerator : public MoveGenerator {
                           float noc_attraction_weight,
                           size_t high_fanout_net);
 
-
     /**
      * Returns all NoC routers that are in the NoC group with a given ID.
      * @param noc_grp_id The NoC group ID whose NoC routers are requested.

--- a/vpr/src/place/move_generators/critical_uniform_move_generator.cpp
+++ b/vpr/src/place/move_generators/critical_uniform_move_generator.cpp
@@ -63,4 +63,3 @@ e_create_move CriticalUniformMoveGenerator::propose_move(t_pl_blocks_to_be_moved
 
     return create_move;
 }
-

--- a/vpr/src/place/move_generators/simpleRL_move_generator.cpp
+++ b/vpr/src/place/move_generators/simpleRL_move_generator.cpp
@@ -9,7 +9,6 @@
 #include <numeric>
 #include <utility>
 
-
 /* File-scope routines */
 //a scaled and clipped exponential function
 static float scaled_clipped_exp(float x) { return std::exp(std::min(1000 * x, float(3.0))); }

--- a/vpr/src/place/move_generators/simpleRL_move_generator.h
+++ b/vpr/src/place/move_generators/simpleRL_move_generator.h
@@ -89,14 +89,14 @@ class KArmedBanditAgent {
     inline int agent_to_phy_blk_type(int idx);
 
   protected:
-    float exp_alpha_ = -1;                      //Step size for q_ updates (< 0 implies use incremental average)
-    std::vector<e_move_type> available_moves_;  //All available moves from which the agent can choose
-    size_t num_available_types_;                //Number of block types that exist in the netlist. Agent may not choose the block type.
-    size_t num_available_actions_;              //Total number of available actions
-    bool propose_blk_type_ = false;             //Check if agent should propose both move and block type or only move type
-    std::vector<size_t> num_action_chosen_;     //Number of times each arm has been pulled (n)
-    std::vector<float> q_;                      //Estimated value of each arm (Q)
-    size_t last_action_;                        //type of the last action (move type) proposed
+    float exp_alpha_ = -1;                     //Step size for q_ updates (< 0 implies use incremental average)
+    std::vector<e_move_type> available_moves_; //All available moves from which the agent can choose
+    size_t num_available_types_;               //Number of block types that exist in the netlist. Agent may not choose the block type.
+    size_t num_available_actions_;             //Total number of available actions
+    bool propose_blk_type_ = false;            //Check if agent should propose both move and block type or only move type
+    std::vector<size_t> num_action_chosen_;    //Number of times each arm has been pulled (n)
+    std::vector<float> q_;                     //Estimated value of each arm (Q)
+    size_t last_action_;                       //type of the last action (move type) proposed
     /* Ratios of the average runtime to calculate each move type              */
     /* These ratios are useful for different reward functions                 *
      * The vector is calculated by averaging many runs on different circuits  */

--- a/vpr/src/place/move_generators/static_move_generator.cpp
+++ b/vpr/src/place/move_generators/static_move_generator.cpp
@@ -36,7 +36,7 @@ void StaticMoveGenerator::initialize_move_prob(const vtr::vector<e_move_type, fl
     cumm_move_probs.resize((int)e_move_type::NUMBER_OF_AUTO_MOVES);
     std::fill(cumm_move_probs.begin(), cumm_move_probs.end(), 0.0f);
 
-    for(auto move_type : move_probs.keys()) {
+    for (auto move_type : move_probs.keys()) {
         cumm_move_probs[move_type] = move_probs[move_type];
     }
 

--- a/vpr/src/place/move_generators/static_move_generator.h
+++ b/vpr/src/place/move_generators/static_move_generator.h
@@ -12,9 +12,9 @@ class PlaceMacros;
  */
 class StaticMoveGenerator : public MoveGenerator {
   private:
-    vtr::vector<e_move_type, std::unique_ptr<MoveGenerator>> all_moves;     // list of pointers to the different available move type generators
-    vtr::vector<e_move_type, float> cumm_move_probs;                        // accumulative probabilities for different move types
-    float total_prob;                                                       // sum of the input probabilities from the use
+    vtr::vector<e_move_type, std::unique_ptr<MoveGenerator>> all_moves; // list of pointers to the different available move type generators
+    vtr::vector<e_move_type, float> cumm_move_probs;                    // accumulative probabilities for different move types
+    float total_prob;                                                   // sum of the input probabilities from the use
 
     void initialize_move_prob(const vtr::vector<e_move_type, float>& move_probs);
 

--- a/vpr/src/place/move_generators/weighted_median_move_generator.cpp
+++ b/vpr/src/place/move_generators/weighted_median_move_generator.cpp
@@ -157,9 +157,9 @@ e_create_move WeightedMedianMoveGenerator::propose_move(t_pl_blocks_to_be_moved&
 }
 
 bool WeightedMedianMoveGenerator::get_bb_cost_for_net_excluding_block(ClusterNetId net_id,
-                                         ClusterPinId moving_pin_id,
-                                         const PlacerCriticalities* criticalities,
-                                         t_bb_cost* coords) {
+                                                                      ClusterPinId moving_pin_id,
+                                                                      const PlacerCriticalities* criticalities,
+                                                                      t_bb_cost* coords) {
     const auto& blk_loc_registry = placer_state_.get().blk_loc_registry();
     const auto& cluster_ctx = g_vpr_ctx.clustering();
 
@@ -257,4 +257,3 @@ bool WeightedMedianMoveGenerator::get_bb_cost_for_net_excluding_block(ClusterNet
 
     return skip_net;
 }
-

--- a/vpr/src/place/verify_placement.cpp
+++ b/vpr/src/place/verify_placement.cpp
@@ -64,8 +64,7 @@ static unsigned check_block_placement_consistency(const BlkLocRegistry& blk_loc_
                 // and that it has no valid clusters placed at this location.
                 // TODO: Eventually it should be made impossible to place blocks
                 //       at these locations.
-                if (device_grid.get_width_offset(tile_loc) != 0 ||
-                    device_grid.get_height_offset(tile_loc) != 0) {
+                if (device_grid.get_width_offset(tile_loc) != 0 || device_grid.get_height_offset(tile_loc) != 0) {
                     // Usage must be 0
                     if (grid_blocks.get_usage(tile_loc) != 0) {
                         VTR_LOG_ERROR(
@@ -205,7 +204,7 @@ static unsigned check_macro_placement_consistency(const BlkLocRegistry& blk_loc_
                 num_errors++;
             }
         } // Finish going through all the members
-    } // Finish going through all the macros
+    }     // Finish going through all the macros
 
     return num_errors;
 }
@@ -284,4 +283,3 @@ unsigned verify_placement(const VprContext& ctx) {
                             ctx.device().grid,
                             ctx.floorplanning().cluster_constraints);
 }
-

--- a/vpr/src/place/verify_placement.h
+++ b/vpr/src/place/verify_placement.h
@@ -81,4 +81,3 @@ unsigned verify_placement(const BlkLocRegistry& blk_loc_registry,
  *  @param ctx  The global VPR context variable found in g_vpr_ctx.
  */
 unsigned verify_placement(const VprContext& ctx);
-

--- a/vpr/src/route/annotate_routing.cpp
+++ b/vpr/src/route/annotate_routing.cpp
@@ -14,8 +14,8 @@
 #include "annotate_routing.h"
 
 vtr::vector<RRNodeId, ClusterNetId> annotate_rr_node_nets(const ClusteringContext& cluster_ctx,
-                                                         const DeviceContext& device_ctx,
-                                                         const bool& verbose) {
+                                                          const DeviceContext& device_ctx,
+                                                          const bool& verbose) {
     size_t counter = 0;
     vtr::ScopedStartFinishTimer timer("Annotating rr_node with routed nets");
 
@@ -35,7 +35,7 @@ vtr::vector<RRNodeId, ClusterNetId> annotate_rr_node_nets(const ClusteringContex
         }
 
         auto& tree = get_route_tree_from_cluster_net_id(net_id);
-        if(!tree)
+        if (!tree)
             continue;
 
         for (auto& rt_node : tree->all_nodes()) {

--- a/vpr/src/route/annotate_routing.h
+++ b/vpr/src/route/annotate_routing.h
@@ -11,7 +11,7 @@
  * - Unmapped rr_node will use invalid ids
  *******************************************************************/
 vtr::vector<RRNodeId, ClusterNetId> annotate_rr_node_nets(const ClusteringContext& cluster_ctx,
-                                                         const DeviceContext& device_ctx,
-                                                         const bool& verbose);
+                                                          const DeviceContext& device_ctx,
+                                                          const bool& verbose);
 
 #endif

--- a/vpr/src/route/build_switchblocks.cpp
+++ b/vpr/src/route/build_switchblocks.cpp
@@ -431,8 +431,8 @@ t_sb_connection_map* alloc_and_load_switchblock_permutations(const t_chan_detail
 
     /******** slow switch block computation method; computes switchblocks at each coordinate ********/
     /* iterate over all the switchblocks specified in the architecture */
-    for (auto sb: switchblocks) {
-        
+    for (auto sb : switchblocks) {
+
         /* verify that switchblock type matches specified directionality -- currently we have to stay consistent */
         if (directionality != sb.directionality) {
             VPR_FATAL_ERROR(VPR_ERROR_ARCH, "alloc_and_load_switchblock_connections: Switchblock %s does not match directionality of architecture\n", sb.name.c_str());
@@ -505,10 +505,10 @@ static bool sb_not_here(const DeviceGrid& grid, const std::vector<bool>& inter_c
             }
             break;
         case e_sb_location::E_XY_SPECIFIED:
-            if(match_sb_xy(grid, inter_cluster_rr, x, y, layer, sb)) {
+            if (match_sb_xy(grid, inter_cluster_rr, x, y, layer, sb)) {
                 sb_not_here = false;
             }
-            
+
             break;
         default:
             VPR_FATAL_ERROR(VPR_ERROR_ARCH, "sb_not_here: unrecognized location enum: %d\n", sb.location);
@@ -564,18 +564,18 @@ static bool match_sb_xy(const DeviceGrid& grid, const std::vector<bool>& inter_c
     if (!is_prog_routing_avail(grid, inter_cluster_rr, layer)) {
         return false;
     }
-    //if one of sb_x and sb_y is defined, we either know the exact location (x,y) or the exact x location (will apply it to all rows) 
-    //or the exact y location (will apply it to all columns)   
-    if(sb.x != -1 || sb.y != -1){
-        if(x == sb.x && y == sb.y){
-            return true;
-        } 
-
-        if(x == sb.x && sb.y == -1){
+    //if one of sb_x and sb_y is defined, we either know the exact location (x,y) or the exact x location (will apply it to all rows)
+    //or the exact y location (will apply it to all columns)
+    if (sb.x != -1 || sb.y != -1) {
+        if (x == sb.x && y == sb.y) {
             return true;
         }
-        
-        if(sb.x == -1 && y == sb.y){
+
+        if (x == sb.x && sb.y == -1) {
+            return true;
+        }
+
+        if (sb.x == -1 && y == sb.y) {
             return true;
         }
     }
@@ -585,12 +585,12 @@ static bool match_sb_xy(const DeviceGrid& grid, const std::vector<bool>& inter_c
     //calculate the appropriate region based on the repeatx/repeaty and current location.
     //This is to determine whether the given location is part of the current SB specified region with regular expression or not
     //After region calculation, the current SB will apply to this location if:
-    // 1) the given (x,y) location falls into the calculated region 
+    // 1) the given (x,y) location falls into the calculated region
     // *AND*
     // 2) incrx/incry are respected within the region, this means all locations within the calculated region do
-    //    not necessarily crosspond to the current SB. If incrx/incry is equal to 1, then all locations within the 
-    //    calculated region are valid. 
-    
+    //    not necessarily crosspond to the current SB. If incrx/incry is equal to 1, then all locations within the
+    //    calculated region are valid.
+
     //calculate the region
     int x_reg_step = (sb.reg_x.repeat != 0) ? (x - sb.reg_x.start) / sb.reg_x.repeat : sb.reg_x.start;
     int y_reg_step = (sb.reg_y.repeat != 0) ? (y - sb.reg_y.start) / sb.reg_y.repeat : sb.reg_y.start;
@@ -608,23 +608,23 @@ static bool match_sb_xy(const DeviceGrid& grid, const std::vector<bool>& inter_c
     reg_endy = std::min(reg_endy, int(grid.height() - 1));
 
     //check x coordinate
-    if (x >= reg_startx && x <= reg_endx){ //should fall into the region
+    if (x >= reg_startx && x <= reg_endx) { //should fall into the region
         //we also should respect the incrx
         //if incrx is not equal to 1, all locations within this region are *NOT* valid
-        if((x + reg_startx) % sb.reg_x.incr == 0){
+        if ((x + reg_startx) % sb.reg_x.incr == 0) {
             //valid x coordinate, check for y value
-            if(y >= reg_starty && y <= reg_endy){
+            if (y >= reg_starty && y <= reg_endy) {
                 //check for incry, similar as incrx
-                if((y + reg_starty) % sb.reg_y.incr == 0){
+                if ((y + reg_starty) % sb.reg_y.incr == 0) {
                     //both x and y are valid
                     return true;
                 }
             }
-        } 
+        }
     }
 
     //if reach here, we don't have sb in this location
-    return false;  
+    return false;
 }
 
 /* Counts the number of wires in each wire type in the specified channel */

--- a/vpr/src/route/cb_metrics.cpp
+++ b/vpr/src/route/cb_metrics.cpp
@@ -164,7 +164,6 @@ void adjust_cb_metric(const e_metric metric, const float target, const float tar
     get_conn_block_metrics(block_type, pin_to_track_connections, num_segments, segment_inf, pin_type,
                            Fc_array, chan_width_inf, &cb_metrics);
 
-
     vtr::RngContainer rng(0);
     /* now run the annealer to adjust the desired metric towards the target value */
     bool success = annealer(metric, nodes_per_chan, block_type, pin_type, Fc, num_pin_type_pins, target,
@@ -620,7 +619,7 @@ static void get_pin_locations(const t_physical_tile_type_ptr block_type, const e
                 }
             }
             /* sort the vector at the current side in increasing order, for good measure */
-	    std::stable_sort(pin_locations->at(iside).begin(), pin_locations->at(iside).end());
+            std::stable_sort(pin_locations->at(iside).begin(), pin_locations->at(iside).end());
         }
     }
     /* now we have a vector of vectors [0..3][0..num_pins_on_this_side] specifying which pins are on which side */

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -662,7 +662,7 @@ static bool check_non_configurable_edges(const Netlist<>& net_list,
         t_node_edge edge = {rt_node.parent()->inode, rt_node.inode};
         routing_edges.insert(edge);
 
-        if (rrnode_set_id[rt_node.inode] >= 0) {    // The node belongs to a non-configurable RR set
+        if (rrnode_set_id[rt_node.inode] >= 0) { // The node belongs to a non-configurable RR set
             routing_non_configurable_rr_set_ids.insert(rrnode_set_id[rt_node.inode]);
         }
     }

--- a/vpr/src/route/d_ary_heap.h
+++ b/vpr/src/route/d_ary_heap.h
@@ -17,7 +17,7 @@
  * to BinaryHeap. This is likely because FourAryHeap has lower tree height, and as we can fit 8
  * heap node (each is 8 bytes) on a cache line (commonly 64 bytes on modern architectures), each
  * heap operation (the comparison among sibling nodes) tends to benefit from the caches.
-*/
+ */
 template<unsigned D>
 class DAryHeap : public HeapInterface {
   public:

--- a/vpr/src/route/d_ary_heap.tpp
+++ b/vpr/src/route/d_ary_heap.tpp
@@ -58,7 +58,7 @@ class customized_d_ary_priority_queue {
 
     inline size_t largest_child_index_partial(const size_t first_child, const size_t num_children /*must < `D`*/) {
         if constexpr (D == 2) {
-            (void) num_children;
+            (void)num_children;
             return first_child;
         } else {
             switch (num_children) {
@@ -125,7 +125,7 @@ class customized_d_ary_priority_queue {
 
   public:
     explicit customized_d_ary_priority_queue(const Compare& compare = Compare(),
-                                                const Container& cont = Container())
+                                             const Container& cont = Container())
         : comp_(compare)
         , heap_(cont) {
         heap_.resize(1); // FIXME: currently do not support `make_heap` from cont (heap_)

--- a/vpr/src/route/sink_sampling.h
+++ b/vpr/src/route/sink_sampling.h
@@ -159,7 +159,7 @@ inline void convex_hull_downsample(ParentNetId net_id, const t_bb& net_bb, vtr::
     for (auto& point : hull) {
         if (point.isink == 0) /* source */
             continue;
-        if(is_isink_reached.get(point.isink))
+        if (is_isink_reached.get(point.isink))
             continue;
         out.set(point.isink, true);
     }

--- a/vpr/src/server/commcmd.h
+++ b/vpr/src/server/commcmd.h
@@ -6,9 +6,9 @@
 namespace comm {
 
 enum class CMD : int {
-    NONE=-1,
-    GET_PATH_LIST_ID=0,
-    DRAW_PATH_ID=1
+    NONE = -1,
+    GET_PATH_LIST_ID = 0,
+    DRAW_PATH_ID = 1
 };
 
 } // namespace comm

--- a/vpr/src/server/convertutils.cpp
+++ b/vpr/src/server/convertutils.cpp
@@ -18,7 +18,7 @@ std::optional<int> try_convert_to_int(const std::string& str) {
 
 static std::string get_pretty_str_from_double(double value) {
     std::ostringstream ss;
-    ss << std::fixed << std::setprecision(2) << value;  // Set precision to 2 digit after the decimal point
+    ss << std::fixed << std::setprecision(2) << value; // Set precision to 2 digit after the decimal point
     return ss.str();
 }
 
@@ -35,10 +35,10 @@ std::string get_pretty_duration_str_from_ms(int64_t duration_ms) {
 
 std::string get_pretty_size_str_from_bytes_num(int64_t bytes_num) {
     std::string result;
-    if (bytes_num >= 1024*1024*1024) {
-        result = get_pretty_str_from_double(bytes_num / double(1024*1024*1024)) + "Gb";
-    } else if (bytes_num >= 1024*1024) {
-        result = get_pretty_str_from_double(bytes_num / double(1024*1024)) + "Mb";
+    if (bytes_num >= 1024 * 1024 * 1024) {
+        result = get_pretty_str_from_double(bytes_num / double(1024 * 1024 * 1024)) + "Gb";
+    } else if (bytes_num >= 1024 * 1024) {
+        result = get_pretty_str_from_double(bytes_num / double(1024 * 1024)) + "Mb";
     } else if (bytes_num >= 1024) {
         result = get_pretty_str_from_double(bytes_num / double(1024)) + "Kb";
     } else {

--- a/vpr/src/server/serverupdate.cpp
+++ b/vpr/src/server/serverupdate.cpp
@@ -19,7 +19,7 @@ gboolean update(gpointer data) {
         std::vector<TaskPtr> tasks_buff;
 
         gate_io.take_received_tasks(tasks_buff);
-        for (TaskPtr& task: tasks_buff) {
+        for (TaskPtr& task : tasks_buff) {
             task_resolver.own_task(std::move(task));
         }
         tasks_buff.clear();
@@ -39,7 +39,7 @@ gboolean update(gpointer data) {
         }
         gate_io.print_logs();
     }
-    
+
     // Return TRUE to keep the timer running, or FALSE to stop it
     return is_running;
 }

--- a/vpr/src/server/serverupdate.h
+++ b/vpr/src/server/serverupdate.h
@@ -21,4 +21,3 @@ gboolean update(gpointer);
 #endif /* NO_SERVER */
 
 #endif /* SERVERUPDATE_H */
-

--- a/vpr/src/server/task.cpp
+++ b/vpr/src/server/task.cpp
@@ -11,7 +11,9 @@
 namespace server {
 
 Task::Task(int jobId, comm::CMD cmd, const std::string& options)
-: m_job_id(jobId), m_cmd(cmd), m_options(options) {
+    : m_job_id(jobId)
+    , m_cmd(cmd)
+    , m_options(options) {
     m_creation_time = std::chrono::high_resolution_clock::now();
 }
 
@@ -54,7 +56,7 @@ void Task::set_success(std::string&& result) {
 std::string Task::info(bool skip_duration) const {
     std::stringstream ss;
     ss << "task["
-       << "id="   << std::to_string(m_job_id)
+       << "id=" << std::to_string(m_job_id)
        << ",cmd=" << std::to_string(static_cast<int>(m_cmd));
     if (!skip_duration) {
         ss << ",exists=" << get_pretty_duration_str_from_ms(time_ms_elapsed());

--- a/vpr/src/server/task.h
+++ b/vpr/src/server/task.h
@@ -19,7 +19,7 @@ namespace server {
  * It generates a JSON data structure to be sent back to the client as a response.
  */
 class Task {
-public:
+  public:
     /**
      * @brief Constructs a new Task object.
      * 
@@ -178,7 +178,7 @@ public:
      */
     const std::string& options() const { return m_options; }
 
-private:
+  private:
     int m_job_id = -1;
     comm::CMD m_cmd = comm::CMD::NONE;
     std::string m_options;

--- a/vpr/src/server/taskresolver.cpp
+++ b/vpr/src/server/taskresolver.cpp
@@ -14,7 +14,7 @@ namespace server {
 
 void TaskResolver::own_task(TaskPtr&& new_task) {
     // pre-process task before adding, where we could quickly detect failure scenarios
-    for (const auto& task: m_tasks) {
+    for (const auto& task : m_tasks) {
         if (task->cmd() == new_task->cmd()) {
             if (task->options_match(new_task)) {
                 std::string msg = "similar task is already in execution, reject new " + new_task->info() + " and waiting for old " + task->info() + " execution";
@@ -34,7 +34,7 @@ void TaskResolver::own_task(TaskPtr&& new_task) {
 }
 
 void TaskResolver::take_finished_tasks(std::vector<TaskPtr>& result) {
-    for (auto it=m_tasks.begin(); it != m_tasks.end();) {
+    for (auto it = m_tasks.begin(); it != m_tasks.end();) {
         TaskPtr& task = *it;
         if (task->is_finished()) {
             result.push_back(std::move(task));
@@ -61,21 +61,22 @@ std::optional<e_timing_report_detail> TaskResolver::try_get_details_level_enum(c
 
 bool TaskResolver::update(ezgl::application* app) {
     bool has_processed_task = false;
-    for (auto& task: m_tasks) {
+    for (auto& task : m_tasks) {
         if (!task->is_finished()) {
-            switch(task->cmd()) {
+            switch (task->cmd()) {
                 case comm::CMD::GET_PATH_LIST_ID: {
                     process_get_path_list_task(app, task);
                     has_processed_task = true;
                     break;
-                } 
+                }
                 case comm::CMD::DRAW_PATH_ID: {
                     process_draw_critical_path_task(app, task);
                     has_processed_task = true;
                     break;
                 }
-                default: break;
-            }           
+                default:
+                    break;
+            }
         }
     }
 

--- a/vpr/src/server/taskresolver.h
+++ b/vpr/src/server/taskresolver.h
@@ -10,7 +10,7 @@
 #include <optional>
 
 namespace ezgl {
-    class application;
+class application;
 }
 
 namespace server {
@@ -19,51 +19,51 @@ namespace server {
  * @brief Resolve server task.
  * 
  * Process and resolve server task, store result and status for processed task.
-*/
+ */
 class TaskResolver {
-public:
+  public:
     /**
      * @brief Default constructor for TaskResolver.
      */
-    TaskResolver()=default;
+    TaskResolver() = default;
 
-    ~TaskResolver()=default;
+    ~TaskResolver() = default;
 
     int tasks_num() const { return m_tasks.size(); }
 
     /**
-    * @brief Takes ownership of a task.
-    *
-    * This method takes ownership of a task by moving it into the TaskResolver's internal task queue.
-    * After calling this method, the task will be owned and managed by the TaskResolver.
-    *
-    * @param task The task to take ownership of. After calling this method, the task object will be in a valid but unspecified state.
-    *
-    * @note After calling this method, the caller should avoid accessing or modifying the task object.
-    */ 
+     * @brief Takes ownership of a task.
+     *
+     * This method takes ownership of a task by moving it into the TaskResolver's internal task queue.
+     * After calling this method, the task will be owned and managed by the TaskResolver.
+     *
+     * @param task The task to take ownership of. After calling this method, the task object will be in a valid but unspecified state.
+     *
+     * @note After calling this method, the caller should avoid accessing or modifying the task object.
+     */
     void own_task(TaskPtr&& task);
 
     /**
-    * @brief Resolve queued tasks.
-    *
-    * @param app A pointer to the ezgl::application object representing the application instance.
-    */
+     * @brief Resolve queued tasks.
+     *
+     * @param app A pointer to the ezgl::application object representing the application instance.
+     */
     bool update(ezgl::application* app);
 
     /**
-    * @brief Extracts finished tasks from the internal task queue.
-    *
-    * This function removes finished tasks from the internal task queue and appends them to the provided vector.
-    * After this operation, the internal task queue will no longer hold the extracted tasks.
-    *
-    * @param tasks A reference to a vector where the finished tasks will be appended.
-    */
+     * @brief Extracts finished tasks from the internal task queue.
+     *
+     * This function removes finished tasks from the internal task queue and appends them to the provided vector.
+     * After this operation, the internal task queue will no longer hold the extracted tasks.
+     *
+     * @param tasks A reference to a vector where the finished tasks will be appended.
+     */
     void take_finished_tasks(std::vector<TaskPtr>& tasks);
 
     // helper method used in tests
     const std::vector<TaskPtr>& tasks() const { return m_tasks; }
 
-private:
+  private:
     std::vector<TaskPtr> m_tasks;
 
     void process_get_path_list_task(ezgl::application*, const TaskPtr&);
@@ -77,4 +77,3 @@ private:
 #endif /* NO_SERVER */
 
 #endif /* TASKRESOLVER_H */
-

--- a/vpr/src/server/telegrambuffer.cpp
+++ b/vpr/src/server/telegrambuffer.cpp
@@ -55,7 +55,7 @@ void TelegramBuffer::take_telegram_frames(std::vector<comm::TelegramFramePtr>& r
 
                     result.push_back(telegram_frame_ptr);
                 } else {
-                    m_errors.push_back("wrong checkSums " + std::to_string(actual_check_sum) +" for " + header.info() + " , drop this chunk");
+                    m_errors.push_back("wrong checkSums " + std::to_string(actual_check_sum) + " for " + header.info() + " , drop this chunk");
                 }
                 m_raw_buffer.erase(m_raw_buffer.begin(), m_raw_buffer.begin() + expected_telegram_size);
                 m_header_opt.reset();

--- a/vpr/src/server/telegrambuffer.h
+++ b/vpr/src/server/telegrambuffer.h
@@ -17,20 +17,20 @@ namespace comm {
  * @brief Implements Telegram Buffer as a wrapper over BytesArray
  * 
  * It aggregates received bytes and assists in extracting telegram frames ( @ref TelegramFrame ) from the raw byte buffer.
-*/
-class TelegramBuffer
-{
+ */
+class TelegramBuffer {
     inline static const std::size_t DEFAULT_SIZE_HINT = 1024;
 
-public:
+  public:
     /**
      * @brief Constructs a TelegramBuffer object with a specified size hint.
      *
      * This constructor initializes a TelegramBuffer object with a specified size hint for the raw buffer.
      */
-    explicit TelegramBuffer(std::size_t size_hint = DEFAULT_SIZE_HINT): m_raw_buffer(size_hint) {}
+    explicit TelegramBuffer(std::size_t size_hint = DEFAULT_SIZE_HINT)
+        : m_raw_buffer(size_hint) {}
 
-    ~TelegramBuffer()=default;
+    ~TelegramBuffer() = default;
 
     /**
      * @brief Check if internal byte buffer is empty.
@@ -77,7 +77,7 @@ public:
      */
     const ByteArray& data() const { return m_raw_buffer; }
 
-private:
+  private:
     ByteArray m_raw_buffer;
     std::vector<std::string> m_errors;
     std::optional<TelegramHeader> m_header_opt;

--- a/vpr/src/server/telegramframe.h
+++ b/vpr/src/server/telegramframe.h
@@ -11,19 +11,19 @@
 namespace comm {
 
 /**
-* @brief Structure representing a TelegramFrame.
-*
-* A TelegramFrame consists of a TelegramHeader followed by data.
-*/
+ * @brief Structure representing a TelegramFrame.
+ *
+ * A TelegramFrame consists of a TelegramHeader followed by data.
+ */
 struct TelegramFrame {
     /**
-    * @brief header The TelegramHeader containing metadata about the telegram message.
-    */
+     * @brief header The TelegramHeader containing metadata about the telegram message.
+     */
     TelegramHeader header;
 
     /**
-    * @brief body The actual data of the telegram message.
-    */
+     * @brief body The actual data of the telegram message.
+     */
     ByteArray body;
 };
 using TelegramFramePtr = std::shared_ptr<TelegramFrame>;

--- a/vpr/src/server/telegramheader.h
+++ b/vpr/src/server/telegramheader.h
@@ -25,7 +25,7 @@ namespace comm {
  * @note: The DATA_CHECKSUM field can be used to check the integrity of the telegram body on the client app side.
  */
 class TelegramHeader {
-public:
+  public:
     static constexpr const char SIGNATURE[] = "IPA";
     static constexpr size_t SIGNATURE_SIZE = sizeof(SIGNATURE);
     static constexpr size_t LENGTH_SIZE = sizeof(uint32_t);
@@ -36,7 +36,7 @@ public:
     static constexpr size_t CHECKSUM_OFFSET = LENGTH_OFFSET + LENGTH_SIZE;
     static constexpr size_t COMPRESSORID_OFFSET = CHECKSUM_OFFSET + CHECKSUM_SIZE;
 
-    TelegramHeader()=default;
+    TelegramHeader() = default;
 
     /**
      * @brief Constructs a TelegramHeader object with the specified length, checksum, and optional compressor ID.
@@ -56,7 +56,7 @@ public:
      */
     explicit TelegramHeader(const ByteArray& buffer);
 
-    ~TelegramHeader()=default;
+    ~TelegramHeader() = default;
 
     /**
      * @brief Constructs a TelegramHeader based on the provided body data.
@@ -129,7 +129,7 @@ public:
      */
     std::string info() const;
 
-private:
+  private:
     bool m_is_valid = false;
     ByteArray m_buffer;
 

--- a/vpr/src/server/telegramoptions.cpp
+++ b/vpr/src/server/telegramoptions.cpp
@@ -8,11 +8,11 @@
 #include <optional>
 
 namespace server {
-    
+
 TelegramOptions::TelegramOptions(const std::string& data, const std::vector<std::string>& expected_keys) {
     // parse data string
     std::vector<std::string> options = vtr::split(data, ";");
-    for (const std::string& option_str: options) {
+    for (const std::string& option_str : options) {
         std::vector<std::string> fragments = vtr::split(option_str, ":");
         if (fragments.size() == TOTAL_INDEXES_NUM) {
             std::string name{std::move(fragments[INDEX_NAME])};
@@ -36,14 +36,14 @@ std::map<std::size_t, std::set<std::size_t>> TelegramOptions::get_map_of_sets(co
     std::string data_str = get_string(name);
     if (!data_str.empty()) {
         std::vector<std::string> paths = vtr::split(data_str, "|");
-        for (const std::string& path: paths) {
+        for (const std::string& path : paths) {
             std::vector<std::string> path_struct = vtr::split(path, "#");
             if (path_struct.size() == 2) {
                 std::string path_index_str = path_struct[0];
                 std::string path_element_indexes_str = path_struct[1];
                 std::vector<std::string> path_element_indexes = vtr::split(path_element_indexes_str, ",");
                 std::set<std::size_t> elements;
-                for (const std::string& path_element_index_Str: path_element_indexes) {
+                for (const std::string& path_element_index_Str : path_element_indexes) {
                     if (std::optional<int> opt_value = try_convert_to_int(path_element_index_Str)) {
                         elements.insert(opt_value.value());
                     } else {
@@ -91,10 +91,10 @@ bool TelegramOptions::get_bool(const std::string& name, bool fail_value) {
 
 std::string TelegramOptions::errors_str() const {
     std::string result;
-    for (const std::string& error: m_errors) {
+    for (const std::string& error : m_errors) {
         result += error + ';';
     }
-    return result; 
+    return result;
 }
 
 bool TelegramOptions::is_data_type_supported(const std::string& type) const {
@@ -104,7 +104,7 @@ bool TelegramOptions::is_data_type_supported(const std::string& type) const {
 
 bool TelegramOptions::check_keys_presence(const std::vector<std::string>& keys) {
     bool result = true;
-    for (const std::string& key: keys) {
+    for (const std::string& key : keys) {
         if (m_options.find(key) == m_options.end()) {
             m_errors.emplace_back("cannot find required option " + std::string(key));
             result = false;

--- a/vpr/src/server/telegramoptions.h
+++ b/vpr/src/server/telegramoptions.h
@@ -10,19 +10,19 @@
 #include <string>
 
 namespace server {
-    
+
 /** 
  * @brief Option class Parser
  *
  * Parse the string of options in the format "TYPE:KEY1:VALUE1;TYPE:KEY2:VALUE2", 
  * for example "int:path_num:11;string:path_type:debug;int:details_level:3;bool:is_flat_routing:0".
  * It provides a simple interface to check value presence and access them.
-*/
+ */
 
 class TelegramOptions {
-private:
+  private:
     enum {
-        INDEX_TYPE=0,
+        INDEX_TYPE = 0,
         INDEX_NAME,
         INDEX_VALUE,
         TOTAL_INDEXES_NUM
@@ -33,7 +33,7 @@ private:
         std::string value;
     };
 
-public:
+  public:
     /**
      * @brief Constructs a TelegramOptions object with the provided data and expected keys.
      *
@@ -45,7 +45,7 @@ public:
      * @param expected_keys A vector of strings representing the expected keys in the options.
      */
     TelegramOptions(const std::string& data, const std::vector<std::string>& expected_keys);
-    ~TelegramOptions()=default;
+    ~TelegramOptions() = default;
 
     /**
      * @brief Checks if there are any errors present.
@@ -115,7 +115,7 @@ public:
      */
     std::string errors_str() const;
 
-private:
+  private:
     std::unordered_map<std::string, Option> m_options;
     std::vector<std::string> m_errors;
 

--- a/vpr/src/server/telegramparser.h
+++ b/vpr/src/server/telegramparser.h
@@ -15,7 +15,7 @@ namespace comm {
  * from a JSON schema structured as follows: {JOB_ID:num, CMD:enum, OPTIONS:string, DATA:string, STATUS:num}.
  */
 class TelegramParser {
-public:
+  public:
     /**
      * @brief Attempts to extract the JOB_ID field from a given message.
      *
@@ -76,7 +76,7 @@ public:
      */
     static std::optional<int> try_extract_field_status(const std::string& message);
 
-private:
+  private:
     static std::optional<std::string> try_extract_json_value_str(const std::string& json_string, const std::string& key);
 };
 

--- a/vpr/src/server/zlibutils.h
+++ b/vpr/src/server/zlibutils.h
@@ -9,31 +9,31 @@
 constexpr const int BYTES_NUM_IN_32KB = 32768;
 
 /**
-* @brief Compresses the input sequence using zlib.
-*
-* This function takes a string representing the decompressed data as input
-* and compresses it using zlib. If compression is successful, the compressed
-* data is returned as an optional string. If compression fails, an empty optional
-* is returned.
-*
-* @param decompressed The input string representing the decompressed data.
-* @return An optional string containing the compressed data if compression is successful,
-*         or an empty optional if compression fails.
-*/
+ * @brief Compresses the input sequence using zlib.
+ *
+ * This function takes a string representing the decompressed data as input
+ * and compresses it using zlib. If compression is successful, the compressed
+ * data is returned as an optional string. If compression fails, an empty optional
+ * is returned.
+ *
+ * @param decompressed The input string representing the decompressed data.
+ * @return An optional string containing the compressed data if compression is successful,
+ *         or an empty optional if compression fails.
+ */
 std::optional<std::string> try_compress(const std::string& decompressed);
 
 /**
-* @brief Decompresses the compressed sequence using zlib.
-*
-* This function takes a string representing the compressed data as input
-* and decompresses it using zlib. If decompression is successful, the decompressed
-* data is returned as an optional string. If decompression fails, an empty optional
-* is returned.
-*
-* @param compressed The input string representing the compressed data.
-* @return An optional string containing the decompressed data if decompression is successful,
-*         or an empty optional if decompression fails.
-*/
+ * @brief Decompresses the compressed sequence using zlib.
+ *
+ * This function takes a string representing the compressed data as input
+ * and decompresses it using zlib. If decompression is successful, the decompressed
+ * data is returned as an optional string. If decompression fails, an empty optional
+ * is returned.
+ *
+ * @param compressed The input string representing the compressed data.
+ * @return An optional string containing the decompressed data if decompression is successful,
+ *         or an empty optional if decompression fails.
+ */
 std::optional<std::string> try_decompress(const std::string& compressed);
 
 #endif /* NO_SERVER */

--- a/vpr/src/timing/slack_evaluation.cpp
+++ b/vpr/src/timing/slack_evaluation.cpp
@@ -8,9 +8,9 @@
 #include "vtr_time.h"
 
 #if defined(VPR_USE_TBB)
-#    include <tbb/task_group.h>
-#    include <tbb/parallel_for_each.h>
-#    include <tbb/combinable.h>
+#include <tbb/task_group.h>
+#include <tbb/parallel_for_each.h>
+#include <tbb/combinable.h>
 #endif
 
 template<typename T>

--- a/vpr/test/test_ap_netlist.cpp
+++ b/vpr/test/test_ap_netlist.cpp
@@ -74,4 +74,3 @@ TEST_CASE("test_ap_netlist_data_storage", "[vpr_ap_netlist]") {
 }
 
 } // namespace
-

--- a/vpr/test/test_ap_partial_placement.cpp
+++ b/vpr/test/test_ap_partial_placement.cpp
@@ -131,4 +131,3 @@ TEST_CASE("test_ap_partial_placement_verify", "[vpr_ap]") {
 }
 
 } // namespace
-

--- a/vpr/test/test_ap_primitive_vector.cpp
+++ b/vpr/test/test_ap_primitive_vector.cpp
@@ -313,4 +313,3 @@ TEST_CASE("test_ap_primitive_vector_verify", "[vpr_ap]") {
 }
 
 } // namespace
-

--- a/vpr/test/test_interchange_device.cpp
+++ b/vpr/test/test_interchange_device.cpp
@@ -96,7 +96,7 @@ TEST_CASE("read_interchange_luts", "[vpr]") {
             for (auto lut_bel : lut_element.lut_bels) {
                 CHECK(lut_bels.find(lut_bel.name) != lut_bels.end());
                 REQUIRE(lut_bel.output_pin == std::string("O"));
-                for (const std::string &lut_pin : lut_bel.input_pins)
+                for (const std::string& lut_pin : lut_bel.input_pins)
                     CHECK(lut_bel_pins.find(lut_pin) != lut_bel_pins.end());
             }
         }

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -172,7 +172,7 @@ TEST_CASE("test_initial_noc_placement", "[noc_place_utils]") {
         // route it
         routing_algorithm->route_flow((NocRouterId)source_hard_router_id,
                                       (NocRouterId)sink_hard_routed_id,
-                                      (NocTrafficFlowId) traffic_flow_number,
+                                      (NocTrafficFlowId)traffic_flow_number,
                                       traffic_flow_route,
                                       noc_ctx.noc_model);
     }

--- a/vpr/test/test_odd_even_routing.cpp
+++ b/vpr/test/test_odd_even_routing.cpp
@@ -38,7 +38,6 @@ void compare_routes(const std::vector<NocLink>& golden_path,
     }
 }
 
-
 void check_turn_legality(const vtr::vector<NocTrafficFlowId, std::vector<NocLinkId>>& traffic_flow_routes,
                          const NocStorage& noc_model,
                          const TurnModelRouting& routing_algorithm) {
@@ -229,7 +228,7 @@ TEST_CASE("test_route_flow", "[vpr_noc_odd_even_routing]") {
     SECTION("Test case where multiple traffic flows are routed, and routes are checked for turn legality and deadlock freedom.") {
         std::random_device device;
         std::mt19937 rand_num_gen(device());
-        std::uniform_int_distribution<std::mt19937::result_type> dist(0,  99);
+        std::uniform_int_distribution<std::mt19937::result_type> dist(0, 99);
 
         NocTrafficFlows traffic_flow_storage;
 
@@ -264,4 +263,4 @@ TEST_CASE("test_route_flow", "[vpr_noc_odd_even_routing]") {
     }
 }
 
-}
+} // namespace

--- a/vpr/test/test_server_convertutils.cpp
+++ b/vpr/test/test_server_convertutils.cpp
@@ -5,8 +5,7 @@
 
 #include "convertutils.h"
 
-TEST_CASE("test_server_convert_utils_to_int", "[vpr]")
-{
+TEST_CASE("test_server_convert_utils_to_int", "[vpr]") {
     REQUIRE(std::optional<int>{-2} == try_convert_to_int("-2"));
     REQUIRE(std::optional<int>{0} == try_convert_to_int("0"));
     REQUIRE(std::optional<int>{2} == try_convert_to_int("2"));
@@ -18,4 +17,3 @@ TEST_CASE("test_server_convert_utils_to_int", "[vpr]")
 }
 
 #endif /* NO_SERVER */
-

--- a/vpr/test/test_server_taskresolver.cpp
+++ b/vpr/test/test_server_taskresolver.cpp
@@ -29,7 +29,7 @@ TEST_CASE("test_server_taskresolver_cmdSpamFilter", "[vpr]") {
 
     REQUIRE(finished.size() == 4);
 
-    for (const auto& task: finished) {
+    for (const auto& task : finished) {
         REQUIRE(task->is_finished());
         REQUIRE(task->has_error());
         REQUIRE(task->job_id() != 1);
@@ -60,7 +60,7 @@ TEST_CASE("test_server_taskresolver_cmdOverrideFilter", "[vpr]") {
 
     REQUIRE(finished.size() == 2);
 
-    for (const server::TaskPtr& task: finished) {
+    for (const server::TaskPtr& task : finished) {
         REQUIRE(task->is_finished());
         REQUIRE(task->has_error());
         REQUIRE(task->job_id() != 3);

--- a/vpr/test/test_server_telegrambuffer.cpp
+++ b/vpr/test/test_server_telegrambuffer.cpp
@@ -47,8 +47,7 @@ TEST_CASE("test_server_telegrambuffer_oneOpened", "[vpr]") {
     REQUIRE(std::string_view{buff.data()} == "111222");
 }
 
-TEST_CASE("test_server_telegrambuffer_notFilledTelegramButWithPrependedRubish", "[vpr]")
-{
+TEST_CASE("test_server_telegrambuffer_notFilledTelegramButWithPrependedRubish", "[vpr]") {
     comm::TelegramBuffer tBuff;
 
     const comm::ByteArray rubbish{"#@!"};
@@ -65,8 +64,7 @@ TEST_CASE("test_server_telegrambuffer_notFilledTelegramButWithPrependedRubish", 
     REQUIRE(msgHeader.buffer() == tBuff.data()); // the rubbish prefix fragment will be absent here
 }
 
-TEST_CASE("test_server_telegrambuffer__oneFinishedOneOpened", "[vpr]")
-{
+TEST_CASE("test_server_telegrambuffer__oneFinishedOneOpened", "[vpr]") {
     comm::TelegramBuffer tBuff;
 
     const comm::ByteArray msgBody1{"message1"};
@@ -80,7 +78,7 @@ TEST_CASE("test_server_telegrambuffer__oneFinishedOneOpened", "[vpr]")
 
     comm::ByteArray t2(msgHeader2.buffer());
     t2.append(msgBody2);
-    t2.resize(t2.size()-2); // drop 2 last elements
+    t2.resize(t2.size() - 2); // drop 2 last elements
 
     tBuff.append(t1);
     tBuff.append(t2);
@@ -94,8 +92,7 @@ TEST_CASE("test_server_telegrambuffer__oneFinishedOneOpened", "[vpr]")
     REQUIRE(t2 == tBuff.data());
 }
 
-TEST_CASE("test_server_telegrambuffer_twoFinished", "[vpr]")
-{
+TEST_CASE("test_server_telegrambuffer_twoFinished", "[vpr]") {
     comm::TelegramBuffer tBuff;
 
     const comm::ByteArray msgBody1{"message1"};
@@ -123,8 +120,7 @@ TEST_CASE("test_server_telegrambuffer_twoFinished", "[vpr]")
     REQUIRE(comm::ByteArray{} == tBuff.data());
 }
 
-TEST_CASE("test_server_telegrambuffer_clear", "[vpr]")
-{
+TEST_CASE("test_server_telegrambuffer_clear", "[vpr]") {
     comm::TelegramBuffer tBuff;
 
     const comm::ByteArray msgBody1{"message1"};

--- a/vpr/test/test_server_telegramparser.cpp
+++ b/vpr/test/test_server_telegramparser.cpp
@@ -5,8 +5,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_all.hpp"
 
-TEST_CASE("test_server_telegram_parser_base", "[vpr]")
-{
+TEST_CASE("test_server_telegram_parser_base", "[vpr]") {
     const std::string tdata{R"({"JOB_ID":"7","CMD":"2","OPTIONS":"type1:name1:value1;type2:name2:v a l u e 2;t3:n3:v3","DATA":"some_data...","STATUS":"1"})"};
 
     REQUIRE(std::optional<int>{7} == comm::TelegramParser::try_extract_field_job_id(tdata));
@@ -16,10 +15,9 @@ TEST_CASE("test_server_telegram_parser_base", "[vpr]")
     REQUIRE(std::optional<int>{1} == comm::TelegramParser::try_extract_field_status(tdata));
 }
 
-TEST_CASE("test_server_telegram_parser_invalid_keys", "[vpr]")
-{
+TEST_CASE("test_server_telegram_parser_invalid_keys", "[vpr]") {
     const std::string tBadData{R"({"_JOB_ID":"7","_CMD":"2","_OPTIONS":"type1:name1:value1;type2:name2:v a l u e 2;t3:n3:v3","_DATA":"some_data...","_STATUS":"1"})"};
-    
+
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_job_id(tBadData));
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_cmd(tBadData));
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_options(tBadData));
@@ -27,10 +25,9 @@ TEST_CASE("test_server_telegram_parser_invalid_keys", "[vpr]")
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_status(tBadData));
 }
 
-TEST_CASE("test_server_telegram_parser_invalid_types", "[vpr]")
-{
+TEST_CASE("test_server_telegram_parser_invalid_types", "[vpr]") {
     const std::string tBadData{R"({"JOB_ID":"x","CMD":"y","STATUS":"z"})"};
-    
+
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_job_id(tBadData));
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_cmd(tBadData));
     REQUIRE(std::nullopt == comm::TelegramParser::try_extract_field_status(tBadData));

--- a/vpr/test/test_server_zlibutils.cpp
+++ b/vpr/test/test_server_zlibutils.cpp
@@ -5,8 +5,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_all.hpp"
 
-TEST_CASE("test_server_zlib_utils", "[vpr]")
-{
+TEST_CASE("test_server_zlib_utils", "[vpr]") {
     const std::string orig{"This string is going to be compressed now"};
 
     std::optional<std::string> compressedOpt = try_compress(orig);
@@ -20,8 +19,3 @@ TEST_CASE("test_server_zlib_utils", "[vpr]")
 }
 
 #endif /* NO_SERVER */
-
-
-
-
-


### PR DESCRIPTION
This PR patially updates the code base according to the `.clagn-format` file.

The current formatting rules remove empty lines at the end of file. I'll update `.clagn-format` after the format check CI test is brought back to fix this.