### PR TITLE
[RR Graph] RR Node Indices Value Type

### DIFF
--- a/libs/librrgraph/src/base/rr_node_types.h
+++ b/libs/librrgraph/src/base/rr_node_types.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include "vtr_range.h"
 #include "vtr_ndmatrix.h"
+#include "rr_graph_fwd.h"
 
 /**
  * @brief Type of a routing resource node.
@@ -123,6 +124,6 @@ struct t_rr_rc_data {
 
 // This is the data type of fast lookups of an rr-node given an (rr_type, layer, x, y, and the side)
 //[0..num_rr_types-1][0..num_layer-1][0..grid_width-1][0..grid_height-1][0..NUM_2D_SIDES-1][0..max_ptc-1]
-typedef std::array<vtr::NdMatrix<std::vector<int>, 4>, NUM_RR_TYPES> t_rr_node_indices;
+typedef std::array<vtr::NdMatrix<std::vector<RRNodeId>, 4>, NUM_RR_TYPES> t_rr_node_indices;
 
 #endif

--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -75,7 +75,7 @@ RRNodeId RRSpatialLookup::find_node(int layer,
         return RRNodeId::INVALID();
     }
 
-    return RRNodeId(rr_node_indices_[type][layer][node_x][node_y][node_side][ptc]);
+    return rr_node_indices_[type][layer][node_x][node_y][node_side][ptc];
 }
 
 std::vector<RRNodeId> RRSpatialLookup::find_nodes_in_range(int layer,
@@ -155,14 +155,14 @@ std::vector<RRNodeId> RRSpatialLookup::find_nodes(int layer,
     /* Reserve space to avoid memory fragmentation */
     size_t num_nodes = 0;
     for (const auto& node : rr_node_indices_[type][layer][node_x][node_y][side]) {
-        if (RRNodeId(node)) {
+        if (node.is_valid()) {
             num_nodes++;
         }
     }
 
     nodes.reserve(num_nodes);
     for (const auto& node : rr_node_indices_[type][layer][node_x][node_y][side]) {
-        if (RRNodeId(node)) {
+        if (node.is_valid()) {
             nodes.emplace_back(node);
         }
     }
@@ -272,11 +272,11 @@ void RRSpatialLookup::add_node(RRNodeId node,
 
     if (size_t(ptc) >= rr_node_indices_[type][layer][x][y][side].size()) {
         /* Deposit invalid ids to newly allocated elements while original elements are untouched */
-        rr_node_indices_[type][layer][x][y][side].resize(ptc + 1, int(RRNodeId::INVALID()));
+        rr_node_indices_[type][layer][x][y][side].resize(ptc + 1, RRNodeId::INVALID());
     }
 
     /* Resize on demand finished; Register the node */
-    rr_node_indices_[type][layer][x][y][side][ptc] = int(node);
+    rr_node_indices_[type][layer][x][y][side][ptc] = node;
 }
 
 bool RRSpatialLookup::remove_node(RRNodeId node,
@@ -302,11 +302,11 @@ bool RRSpatialLookup::remove_node(RRNodeId node,
     if ((size_t)y >= rr_node_indices_[type].dim_size(2)) return false;
     if (side >= rr_node_indices_[type].dim_size(3)) return false;
     if ((size_t)ptc >= rr_node_indices_[type][layer][x][y][side].size()) return false;
-    if (rr_node_indices_[type][layer][x][y][side][ptc] != int(node)) return false;
+    if (rr_node_indices_[type][layer][x][y][side][ptc] != node) return false;
 
     // The node was in the spatial lookup; remove it. -1 corresponds to an invalid node id,
     // and so is treated as absent in the spatial lookup
-    rr_node_indices_[type][layer][x][y][side][ptc] = -1;
+    rr_node_indices_[type][layer][x][y][side][ptc] = RRNodeId::INVALID();
     return true;
 }
 
@@ -353,8 +353,8 @@ void RRSpatialLookup::reorder(const vtr::vector<RRNodeId, RRNodeId> dest_order) 
                 for (size_t y = 0; y < grid.dim_size(2); y++) {
                     for (size_t s = 0; s < grid.dim_size(3); s++) {
                         for (auto &node: grid[l][x][y][s]) {
-                            if (node != OPEN) {
-                                node = size_t(dest_order[RRNodeId(node)]);
+                            if (node.is_valid()) {
+                                node = dest_order[node];
                             }
                         }
                     }

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1870,7 +1870,6 @@ int get_track_to_pins(RRGraphBuilder& rr_graph_builder,
                         }
 
                         /* Check there is a connection and Fc map isn't wrong */
-                        /*int to_node = get_rr_node_index(L_rr_node_indices, x + width_offset, y + height_offset, IPIN, ipin, side);*/
                         RRNodeId to_node = rr_graph_builder.node_lookup().find_node(layer_index, x, y, IPIN, ipin, side);
                         int switch_type = (layer_index == layer) ? wire_to_ipin_switch : wire_to_pin_between_dice_switch;
                         if (to_node) {

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -63,21 +63,6 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                             const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
                             const t_rr_graph_storage& rr_nodes,
                             bool is_flat);
-
-//Returns all x-channel or y-channel wires at the specified location
-std::vector<int> get_rr_node_chan_wires_at_location(const t_rr_node_indices& L_rr_node_indices,
-                                                    t_rr_type rr_type,
-                                                    int x,
-                                                    int y);
-
-//Return the first rr node of the specified type and coordinates
-// For non-IPIN/OPIN types 'side' is ignored
-int get_rr_node_index(const t_rr_node_indices& L_rr_node_indices,
-                      int x,
-                      int y,
-                      t_rr_type rr_type,
-                      int ptc,
-                      e_side side = NUM_2D_SIDES);
 /**
  * @brief goes through 3D custom switch blocks and counts how many connections are crossing dice for each switch block.
  *

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -75,12 +75,6 @@ vtr::NdMatrix<int, 2> get_number_track_to_track_inter_die_conn(t_sb_connection_m
                                                                const int custom_3d_sb_fanin_fanout,
                                                                RRGraphBuilder& rr_graph_builder);
 
-int find_average_rr_node_index(int device_width,
-                               int device_height,
-                               t_rr_type rr_type,
-                               int ptc,
-                               const t_rr_node_indices& L_rr_node_indices);
-
 t_seg_details* alloc_and_load_seg_details(int* max_chan_width,
                                           const int max_len,
                                           const std::vector<t_segment_inf>& segment_inf,
@@ -254,8 +248,6 @@ void dump_track_to_pin_map(t_track_to_pin_lookup& track_to_pin_map,
                            const std::vector<t_physical_tile_type>& types,
                            int max_chan_width,
                            FILE* fp);
-
-void add_to_rr_node_indices(t_rr_node_indices& rr_node_indices, const t_rr_graph_storage& rr_nodes, int inode);
 
 void insert_at_ptc_index(std::vector<int>& rr_indices, int ptc, int inode);
 


### PR DESCRIPTION
This PR updates rr_node_indices_ to store RRNodeId instead of int. This change addresses issues that arise when the RR graph contains more than 2 million nodes. Additionally, it simplifies handling of invalid RRNodeId values and eliminates the need to cast unsigned int to int. This issue was flagged by @heshpdx.