### PR TITLE
Fix clang format version

### DIFF
--- a/cmake/modules/AutoClangFormat.cmake
+++ b/cmake/modules/AutoClangFormat.cmake
@@ -21,11 +21,11 @@ add_custom_target(format-cpp-files
     COMMAND find ${DIRS_TO_FORMAT_CPP} ${FIND_TO_FORMAT_CPP})
 
 #
-# Use clang-format-14 for code format
+# Use clang-format for code format
 #
 add_custom_target(format-cpp
     COMMAND find ${DIRS_TO_FORMAT_CPP} ${FIND_TO_FORMAT_CPP} |
-    xargs -P ${CPU_COUNT} clang-format-14 -style=file -i)
+    xargs -P ${CPU_COUNT} clang-format -style=file -i)
 
 #
 # Use simple python script for fixing C like boxed comments


### PR DESCRIPTION
Running 'make format' when clang-format version is not 14 resulted in a crash since the build scripts specifically asks for clang-format version 14. This commit fixes that and makes it possible to use the default clang-format installed on the user's system.

Fixes #2940 

This should not affect CI in any way since the dependency install scripts install clang-format version 14.