### PR TITLE
[Place] Add CLI Option to Skip Annealing Phase in VPR

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -926,6 +926,13 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
 
     **Default:** ``move_block_type``
 
+.. option:: --place_quench_only {on | off}
+    
+    If this option is set to ``on``, the placement will skip the annealing phase and only perform the placement quench.
+    This option is useful when the the quality of initial placement is good enough and there is no need to perform the 
+    annealing phase.
+
+    **Default:** ``off``
 
 
 .. option:: --placer_debug_block <int>

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -692,7 +692,7 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
     PlacerOpts->place_constraint_subtile = Options.place_constraint_subtile;
     PlacerOpts->floorplan_num_horizontal_partitions = Options.floorplan_num_horizontal_partitions;
     PlacerOpts->floorplan_num_vertical_partitions = Options.floorplan_num_vertical_partitions;
-    PlacerOpts->place_skip_anneal = Options.place_skip_anneal;
+    PlacerOpts->place_quench_only = Options.place_quench_only;
 
     PlacerOpts->seed = Options.Seed;
 

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -692,6 +692,7 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
     PlacerOpts->place_constraint_subtile = Options.place_constraint_subtile;
     PlacerOpts->floorplan_num_horizontal_partitions = Options.floorplan_num_horizontal_partitions;
     PlacerOpts->floorplan_num_vertical_partitions = Options.floorplan_num_vertical_partitions;
+    PlacerOpts->place_skip_anneal = Options.place_skip_anneal;
 
     PlacerOpts->seed = Options.Seed;
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2309,6 +2309,12 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    place_grp.add_argument<bool, ParseOnOff>(args.place_skip_anneal, "--place_skip_anneal")
+        .help(
+            "Skip the placement annealing phase and go straight to the placement quench.")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     place_grp.add_argument<e_agent_algorithm, ParsePlaceAgentAlgorithm>(args.place_agent_algorithm, "--place_agent_algorithm")
         .help("Controls which placement RL agent is used")
         .default_value("softmax")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2315,7 +2315,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    place_grp.add_argument<bool, ParseOnOff>(args.place_skip_anneal, "--place_skip_anneal")
+    place_grp.add_argument<bool, ParseOnOff>(args.place_quench_only, "--place_quench_only")
         .help(
             "Skip the placement annealing phase and go straight to the placement quench.")
         .default_value("off")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -156,7 +156,7 @@ struct t_options {
     argparse::ArgValue<bool> place_constraint_subtile;
     argparse::ArgValue<int> floorplan_num_horizontal_partitions;
     argparse::ArgValue<int> floorplan_num_vertical_partitions;
-    argparse::ArgValue<bool> place_skip_anneal;
+    argparse::ArgValue<bool> place_quench_only;
 
     argparse::ArgValue<int> placer_debug_block;
     argparse::ArgValue<int> placer_debug_net;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -156,6 +156,7 @@ struct t_options {
     argparse::ArgValue<bool> place_constraint_subtile;
     argparse::ArgValue<int> floorplan_num_horizontal_partitions;
     argparse::ArgValue<int> floorplan_num_vertical_partitions;
+    argparse::ArgValue<bool> place_skip_anneal;
 
     argparse::ArgValue<int> placer_debug_block;
     argparse::ArgValue<int> placer_debug_net;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1014,7 +1014,7 @@ struct t_placer_opts {
     bool place_constraint_subtile;
     int floorplan_num_horizontal_partitions;
     int floorplan_num_vertical_partitions;
-    bool place_skip_anneal;
+    bool place_quench_only;
 
     int placer_debug_block;
     int placer_debug_net;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1014,6 +1014,7 @@ struct t_placer_opts {
     bool place_constraint_subtile;
     int floorplan_num_horizontal_partitions;
     int floorplan_num_vertical_partitions;
+    bool place_skip_anneal;
 
     int placer_debug_block;
     int placer_debug_net;

--- a/vpr/src/place/placer.cpp
+++ b/vpr/src/place/placer.cpp
@@ -45,6 +45,7 @@ Placer::Placer(const Netlist<>& net_list,
     , net_cost_handler_(placer_opts, placer_state_, cube_bb)
     , place_delay_model_(std::move(place_delay_model))
     , log_printer_(*this, quiet)
+    , skip_anneal_(placer_opts.place_skip_anneal)
     , is_flat_(is_flat) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
 
@@ -285,15 +286,14 @@ void Placer::place() {
     const auto& timing_ctx = g_vpr_ctx.timing();
     const auto& cluster_ctx = g_vpr_ctx.clustering();
 
-    bool skip_anneal = false;
 #ifdef ENABLE_ANALYTIC_PLACE
     // Cluster-level analytic placer: when enabled, skip most of the annealing and go straight to quench
     if (placer_opts_.enable_analytic_placer) {
-        skip_anneal = true;
+        skip_anneal_ = true;
     }
 #endif
 
-    if (!skip_anneal) {
+    if (!skip_anneal_) {
         // Table header
         log_printer_.print_place_status_header();
 

--- a/vpr/src/place/placer.cpp
+++ b/vpr/src/place/placer.cpp
@@ -285,15 +285,15 @@ int Placer::check_placement_costs_() {
 void Placer::place() {
     const auto& timing_ctx = g_vpr_ctx.timing();
     const auto& cluster_ctx = g_vpr_ctx.clustering();
-
+    bool analytic_place_enabled = false;
 #ifdef ENABLE_ANALYTIC_PLACE
     // Cluster-level analytic placer: when enabled, skip most of the annealing and go straight to quench
     if (placer_opts_.enable_analytic_placer) {
-        skip_anneal_ = true;
+        analytic_place_enabled = true;
     }
 #endif
 
-    if (!skip_anneal_) {
+    if (!analytic_place_enabled && !skip_anneal_) {
         // Table header
         log_printer_.print_place_status_header();
 

--- a/vpr/src/place/placer.cpp
+++ b/vpr/src/place/placer.cpp
@@ -45,7 +45,7 @@ Placer::Placer(const Netlist<>& net_list,
     , net_cost_handler_(placer_opts, placer_state_, cube_bb)
     , place_delay_model_(std::move(place_delay_model))
     , log_printer_(*this, quiet)
-    , skip_anneal_(placer_opts.place_skip_anneal)
+    , quench_only_(placer_opts.place_quench_only)
     , is_flat_(is_flat) {
     const auto& cluster_ctx = g_vpr_ctx.clustering();
 
@@ -293,7 +293,7 @@ void Placer::place() {
     }
 #endif
 
-    if (!analytic_place_enabled && !skip_anneal_) {
+    if (!analytic_place_enabled && !quench_only_) {
         // Table header
         log_printer_.print_place_status_header();
 

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -97,8 +97,8 @@ class Placer {
     std::shared_ptr<PlaceDelayModel> place_delay_model_;
     /// Prints logs during placement
     const PlacementLogPrinter log_printer_;
-    /// Indicates if the placement annealing phase should be skipped.
-    const bool skip_anneal_;
+    /// Indicates if the placement quench phase should be skipped.
+    const bool quench_only_;
     /// Indicates if flat routing resource graph and delay model is used. It should be false.
     const bool is_flat_;
 

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -97,6 +97,8 @@ class Placer {
     std::shared_ptr<PlaceDelayModel> place_delay_model_;
     /// Prints logs during placement
     const PlacementLogPrinter log_printer_;
+    /// Indicates if the placement annealing phase should be skipped.
+    const bool skip_anneal_;
     /// Indicates if flat routing resource graph and delay model is used. It should be false.
     const bool is_flat_;
 


### PR DESCRIPTION
This PR adds a CLI parameter to VPR that allows users to skip the annealing phase and run only the quench phase. By default, this parameter is disabled, meaning the annealing phase is performed as usual.