### PR TITLE
[VTR Script] Add Run Number to Parse Script

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/__init__.py
+++ b/vtr_flow/scripts/python_libs/vtr/__init__.py
@@ -21,6 +21,7 @@ from .util import (
     verify_file,
     pretty_print_table,
     find_task_dir,
+    set_global_run_dir_number
 )
 from .log_parse import (
     determine_lut_size,

--- a/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
+++ b/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
@@ -32,6 +32,7 @@ from vtr import (
     VtrError,
     create_jobs,
     paths,
+    set_global_run_dir_number,
 )
 
 # pylint: enable=wrong-import-position
@@ -130,7 +131,7 @@ def vtr_command_argparser(prog=None):
         help="QoR geomeans are not computed by default",
     )
 
-    parser.add_argument("-run", default=None, type=str, help="")
+    parser.add_argument("-run", default=None, type=int, help="Run number to parse. If not provided, the latest run will be parsed.")
 
     parser.add_argument("-revision", default="", help="Revision number")
 
@@ -144,6 +145,8 @@ def vtr_command_main(arg_list, prog=None):
     """
     # Load the arguments
     args = vtr_command_argparser(prog).parse_args(arg_list)
+    if args.run is not None:
+        set_global_run_dir_number(args.run)
     try:
         task_names = args.task
 


### PR DESCRIPTION
This PR introduces a run option to the parse script, allowing users to specify a specific run directory instead of always parsing the latest. If a run directory is provided, it will be parsed; otherwise, the script defaults to the latest run directory.