### PR TITLE
[Place] Fix y_range Calculation for Placement

### DIFF
--- a/vpr/src/place/move_utils.cpp
+++ b/vpr/src/place/move_utils.cpp
@@ -1033,7 +1033,7 @@ bool find_compatible_compressed_loc_in_range(t_logical_block_type_ptr type,
         std::unordered_set<int> tried_dy;
         while (!legal && (int)tried_dy.size() < y_range) { //Until legal or all possibilities exhausted
             //Randomly pick a y location
-            int dy = rng.irand(y_range - 1);
+            int dy = rng.irand(y_range);
 
             //Record this y location as tried
             auto res2 = tried_dy.insert(dy);


### PR DESCRIPTION
y_range determines the range on the y-axis (in the compressed grid) to search for a compatible location. Within this search range, a compatible location is chosen randomly by generating a random number (dy) and adding it to search_range.ymin. rng.irand is used to generate this number, and its documentation [(Link)](https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/master/libs/libvtrutil/src/vtr_random.cpp#L20-L41) indicates that the range is inclusive. Therefore, I believe we should pass y_range to this function, not y_range - 1. This is particularly problematic for IO blocks when the chosen x is located in the middle of the device, where y_range would be 1, resulting in dy always being zero and preventing the changing of IO block rows.