### PR TITLE
[Prepacker] Moved the Prepacker Out of Try Pack

### DIFF
--- a/vpr/src/analytical_place/full_legalizer.cpp
+++ b/vpr/src/analytical_place/full_legalizer.cpp
@@ -518,6 +518,7 @@ void APPack::legalize(const PartialPlacement& p_placement) {
              arch_,
              vpr_setup_.RoutingArch,
              vpr_setup_.PackerRRGraph,
+             prepacker_,
              flat_placement_info);
 
     // The Packer stores the clusters into a .net file. Load the packing file.

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -614,9 +614,17 @@ bool vpr_pack(t_vpr_setup& vpr_setup, const t_arch& arch) {
                                                                                      g_vpr_ctx.atom().netlist());
     }
 
+    // Run the prepacker, packing the atoms into molecules.
+    // The Prepacker object performs prepacking and stores the pack molecules.
+    // As long as the molecules are used, this object must persist.
+    const Prepacker prepacker(g_vpr_ctx.atom().netlist(),
+                              g_vpr_ctx.device().logical_block_types);
+
     return try_pack(&vpr_setup.PackerOpts, &vpr_setup.AnalysisOpts,
                     arch, vpr_setup.RoutingArch,
-                    vpr_setup.PackerRRGraph, g_vpr_ctx.atom().flat_placement_info());
+                    vpr_setup.PackerRRGraph,
+                    prepacker,
+                    g_vpr_ctx.atom().flat_placement_info());
 }
 
 void vpr_load_packing(const t_vpr_setup& vpr_setup, const t_arch& arch) {

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -56,6 +56,7 @@ bool try_pack(t_packer_opts* packer_opts,
               const t_arch& arch,
               const t_det_routing_arch& routing_arch,
               std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,
+              const Prepacker& prepacker,
               const FlatPlacementInfo& flat_placement_info) {
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
     const DeviceContext& device_ctx = g_vpr_ctx.device();
@@ -85,18 +86,10 @@ bool try_pack(t_packer_opts* packer_opts,
     VTR_LOG("\ttotal blocks: %zu, total nets: %zu, total inputs: %zu, total outputs: %zu\n",
             atom_ctx.netlist().blocks().size(), atom_ctx.netlist().nets().size(), num_p_inputs, num_p_outputs);
 
-    // Run the prepacker, packing the atoms into molecules.
-    // The Prepacker object performs prepacking and stores the pack molecules.
-    // As long as the molecules are used, this object must persist.
-    VTR_LOG("Begin prepacking.\n");
-    const Prepacker prepacker(atom_ctx.netlist(), device_ctx.logical_block_types);
-
     /* We keep attraction groups off in the first iteration,  and
      * only turn on in later iterations if some floorplan regions turn out to be overfull.
      */
     AttractionInfo attraction_groups(false);
-    VTR_LOG("%d attraction groups were created during prepacking.\n", attraction_groups.num_attraction_groups());
-    VTR_LOG("Finish prepacking.\n");
 
     // We keep track of the overfilled partition regions from all pack iterations in
     // this vector. This is so that if the first iteration fails due to overfilled

--- a/vpr/src/pack/pack.h
+++ b/vpr/src/pack/pack.h
@@ -6,6 +6,7 @@
 
 class AtomNetId;
 class FlatPlacementInfo;
+class Prepacker;
 struct t_analysis_opts;
 struct t_arch;
 struct t_det_routing_arch;
@@ -35,6 +36,7 @@ bool try_pack(t_packer_opts* packer_opts,
               const t_arch& arch,
               const t_det_routing_arch& routing_arch,
               std::vector<t_lb_type_rr_node>* lb_type_rr_graphs,
+              const Prepacker& prepacker,
               const FlatPlacementInfo& flat_placement_info);
 
 std::unordered_set<AtomNetId> alloc_and_load_is_clock();

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -27,6 +27,7 @@
 #include "vpr_utils.h"
 #include "vtr_assert.h"
 #include "vtr_range.h"
+#include "vtr_time.h"
 #include "vtr_util.h"
 #include "vtr_vector.h"
 
@@ -1668,7 +1669,7 @@ static void print_chain_starting_points(t_pack_patterns* chain_pattern) {
 
 Prepacker::Prepacker(const AtomNetlist& atom_nlist,
                      const std::vector<t_logical_block_type>& logical_block_types) {
-    VTR_ASSERT_MSG(pack_molecules_.empty(), "Prepacker cannot be initialized twice.");
+    vtr::ScopedStartFinishTimer prepacker_timer("Prepacker");
 
     // Allocate the pack patterns from the logical block types.
     list_of_pack_patterns = alloc_and_load_pack_patterns(logical_block_types);


### PR DESCRIPTION
The AP flow makes its own prepacker which it uses throughout. However, a full legalizer in the AP flow (APPack) uses the try_pack method which creates its own prepacker. This creates two independent prepacker objects when only one is needed.

Move the construction of the prepacker object into vpr_api and have it get passed into the try_pack function.

Resolves #2950 