### PR TITLE
add docs for `vtr::thread_pool`

### DIFF
--- a/doc/src/api/vtrutil/index.rst
+++ b/doc/src/api/vtrutil/index.rst
@@ -11,4 +11,5 @@ VTRUTIL API
    container_utils
    logging
    geometry
+   parallel
    other

--- a/doc/src/api/vtrutil/parallel.rst
+++ b/doc/src/api/vtrutil/parallel.rst
@@ -1,0 +1,13 @@
+=====
+Parallel
+=====
+
+vtr_thread_pool
+-------------
+.. doxygenfile:: vtr_thread_pool.h
+   :project: vtr
+   :sections: briefdescription detaileddescription func innernamespace enum
+
+.. doxygenclass:: vtr::thread_pool
+   :project: vtr
+   :members:


### PR DESCRIPTION
Adds some doxygen docs for `vtr::thread_pool` and sets up to show them on the RTD page.
