### PR TITLE
Add Github action to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: 'Close Stale Issues'
+on:
+  schedule:
+    # Run everyday at 1 PM UTC
+    - cron: '0 13 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # The message to be shown for stale issues
+          stale-issue-message: 'This issue has been inactive for a year and has been marked as stale. It will be closed in 15 days if it continues to be stale. If you believe this is still an issue, please add a comment.'
+          close-issue-message: 'This issue has been marked stale for 15 days and has been automatically closed.'
+          # If you want to exempt an issue from being marked stale/deleted, label it as 'no-stale'
+          exempt-issue-labels: 'no-stale'
+          days-before-issue-stale: 365
+          days-before-issue-close: 15
+          # Start from the oldest issues
+          ascending: true
+          
+          # The configuration below can be used to allow the same behaviour with PRs.
+          # Since we currently don't want to close old PRs, it is commented out but 
+          # left here in case we change our mind.
+
+          # stale-pr-message: 'This PR has been inactive for a year and has been marked as stale. It will be closed in 15 days if it continues to be stale. If you are still working on this PR, please add a comment.'
+          # close-pr-message: 'This PR has been marked stale for 15 days and has been automatically closed.'
+          # exempt-pr-labels: 'no-stale'
+          # days-before-pr-stale: 365
+          # days-before-pr-close: 15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ This information helps us to quickly reproduce (and hopefully fix) the issue:
 
     Tell us what version of VTR you are using (e.g. the output of `vpr --version`), which Operating System and compiler you are using, or any other relevant information about where or how you are building/running VTR.
 
-Once you've gathered all the information [open an Issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/new?template=bug_report.md) on our issue tracker.
+Once you've gathered all the information [open an Issue](https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/new?template=bug_report.md) on our issue tracker. Issues that do not have any activity for a year will be automatically marked as stale and will be closed after 15 days of being marked as stale.
 
 If you know how to fix the issue, or already have it coded-up, please also consider [submitting the fix](#submitting-code-to-vtr).
 This is likely the fastest way to get bugs fixed!


### PR DESCRIPTION
We currently have too many old and abandoned issues, which makes the issues tab not very important for maintainers. 

The added workflow will close up to 30 old issues every day, starting from the oldest ones. Issues that have been inactive for more than a year will be first marked as stale, and if they remain stale after 15 days they will be automatically closed. If for any reason you want an issue to be exempt from being close by this workflow, you can mark it as 'no-stale'. The workflow runs every day at 1PM UTC or 9AM Toronto time.

I have commented out some code that does the same thing for PRs but I think it might be too much currently and we only agreed to automatically close old issues, not PRs. I left it in there in case the situation is different in the future.

Since there's a limit of 30 issues per day because of the GitHub API restrictions, this should take many weeks to go through all of the issues and would dampen the change by a good amount, which is a good thing in my opinion.