### PR TITLE
Remove atom_net global context mutation from packer

### DIFF
--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -250,12 +250,8 @@ bool try_pack(const t_packer_opts& packer_opts,
             VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Failed to find device which satisfies resource requirements required: %s (available %s)", resource_reqs.c_str(), resource_avail.c_str());
         }
 
-        //Reset clustering for re-packing
-        for (auto net : g_vpr_ctx.atom().netlist().nets()) {
-            g_vpr_ctx.mutable_atom().mutable_lookup().remove_atom_net(net);
-        }
+        //Reset floorplanning constraints for re-packing
         g_vpr_ctx.mutable_floorplanning().cluster_constraints.clear();
-        //attraction_groups.reset_attraction_groups();
 
         // Reset the cluster legalizer for re-clustering.
         cluster_legalizer.reset();


### PR DESCRIPTION
While making the packer parallel, we removed these writes to the global context and nothing went wrong. This WIP PR does the same to VTR master. If these mutations are not needed, removing them will make the code cleaner (less "why is it doing this?") and could potentially make packing a bit faster.

The reason I think things should be mostly fine (other than passing the strong tests) is that atom_net lookup data is only ever changed after packing (add_atom_clb_net is only called after packing is done) and atom_clb is the same (set_atom_clb is only called after packing).