### PR TITLE
Change some internal packer APIs to not use C-style arrays

### DIFF
--- a/libs/libarchfpga/src/cad_types.h
+++ b/libs/libarchfpga/src/cad_types.h
@@ -126,7 +126,7 @@ struct t_cluster_placement_primitive {
     t_pb_graph_node* pb_graph_node;
     bool valid;
     float base_cost;        /* cost independent of current status of packing */
-    float incremental_cost; /* cost dependant on current status of packing */
+    float incremental_cost; /* cost dependent on current status of packing */
 };
 
 #endif

--- a/vpr/src/pack/cluster_legalizer.cpp
+++ b/vpr/src/pack/cluster_legalizer.cpp
@@ -1205,7 +1205,7 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
     while (block_pack_status != e_block_pack_status::BLK_PASSED) {
         if (!get_next_primitive_list(cluster.placement_stats,
                                      molecule_id,
-                                     primitives_list.data(),
+                                     primitives_list,
                                      prepacker_)) {
             VTR_LOGV(log_verbosity_ > 3, "\t\tFAILED No candidate primitives available\n");
             block_pack_status = e_block_pack_status::BLK_FAILED_FEASIBLE;

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -46,13 +46,13 @@ static void update_primitive_cost_or_status(t_intra_cluster_placement_stats* clu
 static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placement_stats,
                                 PackMoleculeId molecule_id,
                                 t_pb_graph_node* root,
-                                t_pb_graph_node** primitives_list,
+                                std::vector<t_pb_graph_node*>& primitives_list,
                                 const Prepacker& prepacker);
 
 static bool expand_forced_pack_molecule_placement(t_intra_cluster_placement_stats* cluster_placement_stats,
                                                   PackMoleculeId molecule_id,
                                                   const t_pack_pattern_block* pack_pattern_block,
-                                                  t_pb_graph_node** primitives_list,
+                                                  std::vector<t_pb_graph_node*>& primitives_list,
                                                   const Prepacker& prepacker,
                                                   float* cost);
 
@@ -177,7 +177,7 @@ void free_cluster_placement_stats(t_intra_cluster_placement_stats* cluster_place
 
 bool get_next_primitive_list(t_intra_cluster_placement_stats* cluster_placement_stats,
                              PackMoleculeId molecule_id,
-                             t_pb_graph_node** primitives_list,
+                             std::vector<t_pb_graph_node*>& primitives_list,
                              const Prepacker& prepacker,
                              int force_site) {
     std::unordered_multimap<int, t_cluster_placement_primitive*>::iterator best;
@@ -479,7 +479,7 @@ static void update_primitive_cost_or_status(t_intra_cluster_placement_stats* clu
 static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placement_stats,
                                 PackMoleculeId molecule_id,
                                 t_pb_graph_node* root,
-                                t_pb_graph_node** primitives_list,
+                                std::vector<t_pb_graph_node*>& primitives_list,
                                 const Prepacker& prepacker) {
     float cost = std::numeric_limits<float>::max();
     const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
@@ -527,7 +527,7 @@ static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placeme
 static bool expand_forced_pack_molecule_placement(t_intra_cluster_placement_stats* cluster_placement_stats,
                                                   PackMoleculeId molecule_id,
                                                   const t_pack_pattern_block* pack_pattern_block,
-                                                  t_pb_graph_node** primitives_list,
+                                                  std::vector<t_pb_graph_node*>& primitives_list,
                                                   const Prepacker& prepacker,
                                                   float* cost) {
     t_pb_graph_node* pb_graph_node = primitives_list[pack_pattern_block->block_id];

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -163,7 +163,7 @@ void free_cluster_placement_stats(t_intra_cluster_placement_stats* cluster_place
 bool get_next_primitive_list(
     t_intra_cluster_placement_stats* cluster_placement_stats,
     PackMoleculeId molecule_id,
-    t_pb_graph_node** primitives_list,
+    std::vector<t_pb_graph_node*>& primitives_list,
     const Prepacker& prepacker,
     int force_site = -1);
 

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -53,13 +53,13 @@ static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
                                                        const t_pb_graph_node* pb_graph_node);
 
 static void forward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expansion_edge,
-                                                  t_pack_patterns* list_of_packing_patterns,
+                                                  std::vector<t_pack_patterns>& list_of_packing_patterns,
                                                   const int curr_pattern_index,
                                                   int* L_num_blocks,
                                                   const bool make_root_of_chain);
 
 static void backward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expansion_edge,
-                                                   t_pack_patterns* list_of_packing_patterns,
+                                                   std::vector<t_pack_patterns>& list_of_packing_patterns,
                                                    const int curr_pattern_index,
                                                    t_pb_graph_pin* destination_pin,
                                                    t_pack_pattern_block* destination_block,
@@ -160,7 +160,7 @@ static std::vector<t_pack_patterns> alloc_and_load_pack_patterns(const std::vect
             list_of_packing_patterns[i].base_cost = 0;
             // use the found expansion edge to build the pack pattern
             backward_expand_pack_pattern_from_edge(expansion_edge,
-                                                   list_of_packing_patterns.data(), i, nullptr, nullptr, &L_num_blocks);
+                                                   list_of_packing_patterns, i, nullptr, nullptr, &L_num_blocks);
             list_of_packing_patterns[i].num_blocks = L_num_blocks;
 
             /* Default settings: A section of a netlist must match all blocks in a pack
@@ -468,7 +468,7 @@ static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
  *              future multi-fanout support easier) so this function will not update connections
  */
 static void forward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expansion_edge,
-                                                  t_pack_patterns* list_of_packing_patterns,
+                                                  std::vector<t_pack_patterns>& list_of_packing_patterns,
                                                   const int curr_pattern_index,
                                                   int* L_num_blocks,
                                                   bool make_root_of_chain) {
@@ -610,7 +610,7 @@ static void forward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expansi
  *               destination blocks
  */
 static void backward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expansion_edge,
-                                                   t_pack_patterns* list_of_packing_patterns,
+                                                   std::vector<t_pack_patterns>& list_of_packing_patterns,
                                                    const int curr_pattern_index,
                                                    t_pb_graph_pin* destination_pin,
                                                    t_pack_pattern_block* destination_block,

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -47,7 +47,7 @@ static void forward_infer_pattern(t_pb_graph_pin* pb_graph_pin);
 
 static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin);
 
-static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names);
+static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(const std::unordered_map<std::string, int>& pattern_names);
 
 static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
                                                        const t_pb_graph_node* pb_graph_node);
@@ -346,7 +346,7 @@ static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin) {
  * Allocates memory for models and loads the name of the packing pattern
  * so that it can be identified and loaded with more complete information later
  */
-static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(std::unordered_map<std::string, int> pattern_names) {
+static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(const std::unordered_map<std::string, int>& pattern_names) {
     std::vector<t_pack_patterns> nlist(pattern_names.size());
 
     for (const auto& curr_pattern : pattern_names) {


### PR DESCRIPTION
This commit changes some functions in the packer and prepacker that used C-style arrays to use std::vector instead. Previously we used the .data() method of std::vector to pass a pointer to these functions.