### PR TITLE
[AP][MassLegalizer] Revistited Mass Legalizer

### DIFF
--- a/vpr/src/analytical_place/partial_legalizer.h
+++ b/vpr/src/analytical_place/partial_legalizer.h
@@ -483,7 +483,7 @@ class BiPartitioningPartialLegalizer : public PartialLegalizer {
      * the direction of the partition (vertical / horizontal) and the position
      * of the cut.
      */
-    PartitionedWindow partition_window(SpreadingWindow& window);
+    PartitionedWindow partition_window(SpreadingWindow& window, ModelGroupId group_id);
 
     /**
      * @brief Partition the blocks in the given window into the partitioned

--- a/vpr/src/analytical_place/primitive_vector.h
+++ b/vpr/src/analytical_place/primitive_vector.h
@@ -267,6 +267,20 @@ class PrimitiveVector {
     }
 
     /**
+     * @brief Computes the sum across all dimensions of the vector.
+     *
+     * This is similar to manhattan_norm, however this does not take the
+     * absolute value of each dimension.
+     */
+    inline float sum() const {
+        float sum = 0.f;
+        for (const auto& p : data_) {
+            sum += p.second;
+        }
+        return sum;
+    }
+
+    /**
      * @brief Project this vector onto the given vector.
      *
      * This basically just means zero-ing all dimension which are zero in the

--- a/vpr/test/test_ap_primitive_vector.cpp
+++ b/vpr/test/test_ap_primitive_vector.cpp
@@ -241,6 +241,24 @@ TEST_CASE("test_ap_primitive_vector_verify", "[vpr_ap]") {
         vec2 *= -1.f;
         REQUIRE(vec2.manhattan_norm() == vec1.manhattan_norm());
 
+        // sum:
+        vec1.clear();
+        // Sum of the zero vector is zero.
+        REQUIRE(vec1.sum() == 0.f);
+        // Sum of a non-negative vector is the sum of its dims.
+        vec1.set_dim_val(0, 1.f);
+        REQUIRE(vec1.sum() == 1.f);
+        vec1.set_dim_val(1, 2.f);
+        vec1.set_dim_val(2, 3.f);
+        vec1.set_dim_val(3, 4.f);
+        vec1.set_dim_val(4, 5.f);
+        REQUIRE(vec1.sum() == 15.f);
+        // Sum of a negative vector is the opposite of the sum of the absolute
+        // value of its dims.
+        vec2 = vec1;
+        vec2 *= -1.f;
+        REQUIRE(vec2.sum() == -1.f * vec1.sum());
+
         // Projection:
         // Basic example:
         vec1.clear();


### PR DESCRIPTION
Found that the mass legalizer was not spreading out the blocks well enough according to the mass.

Revistied the spatial partitioning in the mass legalizer. Before, we just cut the window in half in the larger dimension. This was fine, however it may create an inbalanced cut which can cause things to not spread well. Instead, we now search for the best partition by trying different partition lines and computing how balanced the partition is. Although this is more expensive than before, by creating more balanced partitions, it should allow the mass legalizer to converge faster. Time in the mass legalizer is also dominated by partitioning the blocks, so increasing the time to choose the partition line should not have that large of an effect anyways.

Found an oversight with how blocks were partitioned when one of the partitions become overfilled. Fixed this issue.