### PR TITLE
[STA] Added Option to Remove Parameters from Post-Implementation Netlist

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1730,6 +1730,16 @@ Analysis Options
 
     **Default:** ``unconnected``
 
+.. option:: --post_synth_netlist_module_parameters { on | off }
+
+    Controls whether the post-synthesis netlist output by VTR can use Verilog parameters
+    or not. When using the post-synthesis netlist for external timing analysis,
+    some tools cannot accept the netlist if it contains parameters. By setting
+    this option to ``off``, VPR will try to represent the netlist using non-parameterized
+    modules.
+
+    **Default:** ``on``
+
 .. option:: --timing_report_npaths <int>
 
     Controls how many timing paths are reported.

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -714,6 +714,7 @@ static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysi
 
     analysis_opts.post_synth_netlist_unconn_input_handling = Options.post_synth_netlist_unconn_input_handling;
     analysis_opts.post_synth_netlist_unconn_output_handling = Options.post_synth_netlist_unconn_output_handling;
+    analysis_opts.post_synth_netlist_module_parameters = Options.post_synth_netlist_module_parameters.value();
 
     analysis_opts.timing_update_type = Options.timing_update_type;
     analysis_opts.write_timing_summary = Options.write_timing_summary;

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -717,6 +717,7 @@ static void ShowAnalysisOpts(const t_analysis_opts& AnalysisOpts) {
                 VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown post_synth_netlist_unconn_handling\n");
         }
     }
+    VTR_LOG("AnalysisOpts.post_synth_netlist_module_parameters: %s\n", AnalysisOpts.post_synth_netlist_module_parameters ? "on" : "off");
     VTR_LOG("\n");
 }
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2997,6 +2997,16 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("unconnected")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    analysis_grp.add_argument<bool, ParseOnOff>(args.post_synth_netlist_module_parameters, "--post_synth_netlist_module_parameters")
+        .help(
+            "Controls whether the post-synthesis netlist output by VTR can use Verilog parameters "
+            "or not. When using the post-synthesis netlist for external timing analysis, "
+            "some tools cannot accept the netlist if it contains parameters. By setting "
+            "this option to off, VPR will try to represent the netlist using non-parameterized "
+            "modules\n")
+        .default_value("on")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     analysis_grp.add_argument(args.write_timing_summary, "--write_timing_summary")
         .help("Writes implemented design final timing summary to the specified JSON, XML or TXT file.")
         .show_in(argparse::ShowIn::HELP_ONLY);

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -265,6 +265,7 @@ struct t_options {
     argparse::ArgValue<std::string> echo_dot_timing_graph_node;
     argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_input_handling;
     argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_output_handling;
+    argparse::ArgValue<bool> post_synth_netlist_module_parameters;
     argparse::ArgValue<std::string> write_timing_summary;
 };
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1278,6 +1278,7 @@ struct t_analysis_opts {
     bool gen_post_implementation_merged_netlist;
     e_post_synth_netlist_unconn_handling post_synth_netlist_unconn_input_handling;
     e_post_synth_netlist_unconn_handling post_synth_netlist_unconn_output_handling;
+    bool post_synth_netlist_module_parameters;
 
     int timing_report_npaths;
     e_timing_report_detail timing_report_detail;

--- a/vpr/test/test_post_verilog_i_gnd_o_unconnected.golden.v
+++ b/vpr/test/test_post_verilog_i_gnd_o_unconnected.golden.v
@@ -199,8 +199,7 @@ module unconnected (
     wire \__vpr__unconn7 ;
 
     //Cell instances
-    dsp #(
-    ) \dsp_inst  (
+    dsp \dsp_inst  (
         .a({
             1'b0,
             1'b0,

--- a/vpr/test/test_post_verilog_i_nets_o_unconnected.golden.v
+++ b/vpr/test/test_post_verilog_i_nets_o_unconnected.golden.v
@@ -204,8 +204,7 @@ module unconnected (
     wire \__vpr__unconn12 ;
 
     //Cell instances
-    dsp #(
-    ) \dsp_inst  (
+    dsp \dsp_inst  (
         .a({
             __vpr__unconn0,
             __vpr__unconn1,

--- a/vpr/test/test_post_verilog_i_unconnected_o_nets.golden.v
+++ b/vpr/test/test_post_verilog_i_unconnected_o_nets.golden.v
@@ -200,8 +200,7 @@ module unconnected (
     wire \__vpr__unconn8 ;
 
     //Cell instances
-    dsp #(
-    ) \dsp_inst  (
+    dsp \dsp_inst  (
         .a({
             1'bX,
             1'bX,

--- a/vpr/test/test_post_verilog_i_unconnected_o_unconnected.golden.v
+++ b/vpr/test/test_post_verilog_i_unconnected_o_unconnected.golden.v
@@ -199,8 +199,7 @@ module unconnected (
     wire \__vpr__unconn7 ;
 
     //Cell instances
-    dsp #(
-    ) \dsp_inst  (
+    dsp \dsp_inst  (
         .a({
             1'bX,
             1'bX,

--- a/vpr/test/test_post_verilog_i_vcc_o_unconnected.golden.v
+++ b/vpr/test/test_post_verilog_i_vcc_o_unconnected.golden.v
@@ -199,8 +199,7 @@ module unconnected (
     wire \__vpr__unconn7 ;
 
     //Cell instances
-    dsp #(
-    ) \dsp_inst  (
+    dsp \dsp_inst  (
         .a({
             1'b1,
             1'b1,


### PR DESCRIPTION
When performing post-implementation timing analysis using OpenSTA, the generated netlist cannot use parameters since each module needs to correspond with a cell in a liberty file.

Added a command-line option which tells the netlist writer to not use parameters when generating the netlist. If a primitive cannot be generated without using parameters, it will error out.