### PR TITLE
Increase the daily stale issue action API call limit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,11 @@ jobs:
           # Start from the oldest issues
           ascending: true
           
+          # Upper limit for number of API calls per day
+          # This worklfow does 2-3 API calls per issue
+          # including issues that have been marked stale
+          operations-per-run: 300
+
           # The configuration below can be used to allow the same behaviour with PRs.
           # Since we currently don't want to close old PRs, it is commented out but 
           # left here in case we change our mind.


### PR DESCRIPTION
The default 30 API call per day limit for the stale issue github action was too low. This workflow consumes 2 API calls to check if a stale issue should be closed, which means that when we mark 15 issues as stale the workflow gets stuck checking these for 15 days until they get closed. This changes the limit to 300 which should hopefully make things go a little bit faster, but not too fast.