### PR TITLE
[Hotfix][CI] Remove PR staling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          # Set default number of days before being marked stale to 100 years
+          # This will be overriden by "days-before-issue-stale" and "days-before-pr-stale"
+          # This is done to avoid marking PRs as stale, as it is not something
+          # we want to do.
+          days-before-stale: 36500
           # The message to be shown for stale issues
           stale-issue-message: 'This issue has been inactive for a year and has been marked as stale. It will be closed in 15 days if it continues to be stale. If you believe this is still an issue, please add a comment.'
           close-issue-message: 'This issue has been marked stale for 15 days and has been automatically closed.'


### PR DESCRIPTION
This commit sets the number of days before marking issues or PRs as stale to 100 years. This number is overridden for issues to be 1 years but stays 100 years for PRs. This means that PRs effectively do not get marked as stale.