### PR TITLE
[Tatum][Parse] Fixed Extraneous Warning With get_clocks

### DIFF
--- a/vpr/src/timing/read_sdc.cpp
+++ b/vpr/src/timing/read_sdc.cpp
@@ -946,12 +946,11 @@ class SdcParseCallback : public sdcparse::Callback {
                         }
                     }
                 }
-
-                if (!found) {
-                    VTR_LOGF_WARN(fname_.c_str(), lineno_,
-                                  "get_clocks target name or pattern '%s' matched no clocks\n",
-                                  clock_glob_pattern.c_str());
-                }
+            }
+            if (!found) {
+                VTR_LOGF_WARN(fname_.c_str(), lineno_,
+                              "get_clocks target name or pattern '%s' matched no clocks\n",
+                              clock_glob_pattern.c_str());
             }
         }
 


### PR DESCRIPTION
The get_clocks command is used in an SDC file to reference a set of clocks by name using a regex string. The code to do this tries to produce a warning if get_clocks is used on a regex string and no clocks could be found. The issue is that the code to do this was mistakenly producing this warning for each clock in the circuit. For example, if we had {clk1, clk2, clk3} and we wanted to do "get_clocks {clk3}", we will get two warnings since clk1 and clk2 did not match.

Fixed this by moving the warning out of one loop nest.

I noticed this when I was looking at the output of the directrf circuit and saw weird warnings:
![Screenshot from 2025-04-29 17-15-54](https://github.com/user-attachments/assets/5409b18b-f721-4409-82cc-5c067904d60d)

This was strange since we clearly create the clocks with those names:
![Screenshot from 2025-04-29 17-16-10](https://github.com/user-attachments/assets/65ef3ed6-ed01-4cf8-86c1-2b29d04e97e5)

I think this was just a mistake and, since it was a warning, no one noticed.
