### PR TITLE
[LibArchFPGA] Added Library Model IDs as constexpr

### DIFF
--- a/libs/libarchfpga/src/logic_types.cpp
+++ b/libs/libarchfpga/src/logic_types.cpp
@@ -28,6 +28,7 @@ LogicalModels::LogicalModels() {
     //INPAD
     {
         LogicalModelId inpad_model_id = create_logical_model(MODEL_INPUT);
+        VTR_ASSERT_OPT(inpad_model_id == MODEL_INPUT_ID);
         t_model& inpad_model = get_model(inpad_model_id);
 
         inpad_model.inputs = nullptr;
@@ -47,6 +48,7 @@ LogicalModels::LogicalModels() {
     //OUTPAD
     {
         LogicalModelId outpad_model_id = create_logical_model(MODEL_OUTPUT);
+        VTR_ASSERT_OPT(outpad_model_id == MODEL_OUTPUT_ID);
         t_model& outpad_model = get_model(outpad_model_id);
 
         outpad_model.inputs = new t_model_ports;
@@ -66,6 +68,7 @@ LogicalModels::LogicalModels() {
     //LATCH
     {
         LogicalModelId latch_model_id = create_logical_model(MODEL_LATCH);
+        VTR_ASSERT_OPT(latch_model_id == MODEL_LATCH_ID);
         t_model& latch_model = get_model(latch_model_id);
         t_model_ports* latch_model_input_port_1 = new t_model_ports;
         t_model_ports* latch_model_input_port_2 = new t_model_ports;
@@ -104,6 +107,7 @@ LogicalModels::LogicalModels() {
     //NAMES
     {
         LogicalModelId names_model_id = create_logical_model(MODEL_NAMES);
+        VTR_ASSERT_OPT(names_model_id == MODEL_NAMES_ID);
         t_model& names_model = get_model(names_model_id);
 
         names_model.inputs = new t_model_ports;

--- a/libs/libarchfpga/src/logic_types.h
+++ b/libs/libarchfpga/src/logic_types.h
@@ -97,6 +97,13 @@ class LogicalModels {
     static constexpr const char* MODEL_INPUT = ".input";
     static constexpr const char* MODEL_OUTPUT = ".output";
 
+    // The IDs of each of the library models. These are known ahead of time,
+    // and making these constexpr can save having to look them up in this class.
+    static constexpr LogicalModelId MODEL_INPUT_ID = LogicalModelId(0);
+    static constexpr LogicalModelId MODEL_OUTPUT_ID = LogicalModelId(1);
+    static constexpr LogicalModelId MODEL_LATCH_ID = LogicalModelId(2);
+    static constexpr LogicalModelId MODEL_NAMES_ID = LogicalModelId(3);
+
     // Iterator for the logical model IDs array.
     typedef typename vtr::vector_map<LogicalModelId, LogicalModelId>::const_iterator model_iterator;
 

--- a/libs/libarchfpga/src/read_fpga_interchange_arch.cpp
+++ b/libs/libarchfpga/src/read_fpga_interchange_arch.cpp
@@ -1290,7 +1290,7 @@ struct ArchReader {
         lut->parent_mode = mode;
 
         lut->blif_model = vtr::strdup(LogicalModels::MODEL_NAMES);
-        lut->model_id = get_model(arch_, LogicalModels::MODEL_NAMES);
+        lut->model_id = LogicalModels::MODEL_NAMES_ID;
 
         lut->num_ports = 2;
         lut->ports = (t_port*)vtr::calloc(lut->num_ports, sizeof(t_port));
@@ -1397,7 +1397,7 @@ struct ArchReader {
         opad->num_ports = num_ports;
         opad->ports = (t_port*)vtr::calloc(num_ports, sizeof(t_port));
         opad->blif_model = vtr::strdup(LogicalModels::MODEL_OUTPUT);
-        opad->model_id = get_model(arch_, LogicalModels::MODEL_OUTPUT);
+        opad->model_id = LogicalModels::MODEL_OUTPUT_ID;
 
         opad->ports[0] = get_generic_port(arch_, opad, IN_PORT, "outpad", LogicalModels::MODEL_OUTPUT);
         omode->pb_type_children[0] = *opad;
@@ -1419,7 +1419,7 @@ struct ArchReader {
         ipad->num_ports = num_ports;
         ipad->ports = (t_port*)vtr::calloc(num_ports, sizeof(t_port));
         ipad->blif_model = vtr::strdup(LogicalModels::MODEL_INPUT);
-        ipad->model_id = get_model(arch_, LogicalModels::MODEL_INPUT);
+        ipad->model_id = LogicalModels::MODEL_INPUT_ID;
 
         ipad->ports[0] = get_generic_port(arch_, ipad, OUT_PORT, "inpad", LogicalModels::MODEL_INPUT);
         imode->pb_type_children[0] = *ipad;

--- a/vpr/src/base/atom_netlist.cpp
+++ b/vpr/src/base/atom_netlist.cpp
@@ -13,33 +13,20 @@
  *
  */
 AtomNetlist::AtomNetlist(std::string name, std::string id)
-    : Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId>(name, id)
-    , inpad_model_(LogicalModelId::INVALID())
-    , outpad_model_(LogicalModelId::INVALID()) {}
+    : Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId>(name, id) {}
 
 /*
  *
  * Blocks
  *
  */
-void AtomNetlist::set_block_types(LogicalModelId inpad, LogicalModelId outpad) {
-    VTR_ASSERT(inpad.is_valid());
-    VTR_ASSERT(outpad.is_valid());
-
-    inpad_model_ = inpad;
-    outpad_model_ = outpad;
-}
-
 AtomBlockType AtomNetlist::block_type(const AtomBlockId id) const {
-    VTR_ASSERT(inpad_model_.is_valid());
-    VTR_ASSERT(outpad_model_.is_valid());
-
     LogicalModelId blk_model = block_model(id);
 
     AtomBlockType type = AtomBlockType::BLOCK;
-    if (blk_model == inpad_model_) {
+    if (blk_model == LogicalModels::MODEL_INPUT_ID) {
         type = AtomBlockType::INPAD;
-    } else if (blk_model == outpad_model_) {
+    } else if (blk_model == LogicalModels::MODEL_OUTPUT_ID) {
         type = AtomBlockType::OUTPAD;
     } else {
         type = AtomBlockType::BLOCK;

--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -94,11 +94,6 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     typedef std::vector<std::vector<vtr::LogicValue>> TruthTable;
 
   public: //Public Accessors
-    /*
-     * Blocks
-     */
-    void set_block_types(LogicalModelId inpad, LogicalModelId outpad);
-
     ///@brief Returns the type of the specified block
     AtomBlockType block_type(const AtomBlockId id) const;
 
@@ -264,14 +259,6 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
     //Block data
     vtr::vector_map<AtomBlockId, LogicalModelId> block_models_;   //Architecture model of each block
     vtr::vector_map<AtomBlockId, TruthTable> block_truth_tables_; //Truth tables of each block
-
-    // Input IOs and output IOs always exist and have their own architecture
-    // models. While their models are already included in block_models_, we
-    // also store direct pointers to them to make checks of whether a block is
-    // an INPAD or OUTPAD fast, as such checks are common in some netlist
-    // operations (e.g. clean-up of an input netlist).
-    LogicalModelId inpad_model_;
-    LogicalModelId outpad_model_;
 
     //Port data
     vtr::vector_map<AtomPortId, const t_model_ports*> port_models_; //Architecture port models of each port

--- a/vpr/src/base/atom_netlist_utils.cpp
+++ b/vpr/src/base/atom_netlist_utils.cpp
@@ -34,7 +34,7 @@ std::vector<AtomPortId> find_combinationally_connected_input_ports(const AtomNet
 ///@brief Returns the set of clock ports which are combinationally connected to output_port
 std::vector<AtomPortId> find_combinationally_connected_clock_ports(const AtomNetlist& netlist, AtomPortId output_port);
 
-bool is_buffer_lut(const AtomNetlist& netlist, const AtomBlockId blk, const LogicalModels& models);
+bool is_buffer_lut(const AtomNetlist& netlist, const AtomBlockId blk);
 bool is_removable_block(const AtomNetlist& netlist, const AtomBlockId blk, const LogicalModels& models, std::string* reason = nullptr);
 bool is_removable_input(const AtomNetlist& netlist, const AtomBlockId blk, const LogicalModels& models, std::string* reason = nullptr);
 bool is_removable_output(const AtomNetlist& netlist, const AtomBlockId blk, std::string* reason = nullptr);
@@ -137,7 +137,7 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist, const LogicalMod
     }
 
     //Latch
-    LogicalModelId latch_model = models.get_model_by_name(LogicalModels::MODEL_LATCH);
+    LogicalModelId latch_model = LogicalModels::MODEL_LATCH_ID;
     for (auto blk_id : netlist.blocks()) {
         if (netlist.block_type(blk_id) == AtomBlockType::BLOCK) {
             LogicalModelId blk_model = netlist.block_model(blk_id);
@@ -225,7 +225,7 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist, const LogicalMod
     }
 
     //Names
-    LogicalModelId names_model = models.get_model_by_name(LogicalModels::MODEL_NAMES);
+    LogicalModelId names_model = LogicalModels::MODEL_NAMES_ID;
     for (auto blk_id : netlist.blocks()) {
         if (netlist.block_type(blk_id) == AtomBlockType::BLOCK) {
             LogicalModelId blk_model = netlist.block_model(blk_id);
@@ -292,8 +292,8 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist, const LogicalMod
     }
 
     //Subckt
-    LogicalModelId input_model = models.get_model_by_name(LogicalModels::MODEL_INPUT);
-    LogicalModelId output_model = models.get_model_by_name(LogicalModels::MODEL_OUTPUT);
+    LogicalModelId input_model = LogicalModels::MODEL_INPUT_ID;
+    LogicalModelId output_model = LogicalModels::MODEL_OUTPUT_ID;
     std::set<LogicalModelId> subckt_models;
     for (auto blk_id : netlist.blocks()) {
         LogicalModelId blk_model = netlist.block_model(blk_id);
@@ -690,7 +690,7 @@ void absorb_buffer_luts(AtomNetlist& netlist, const LogicalModels& models, int v
 
     //Remove the buffer luts
     for (auto blk : netlist.blocks()) {
-        if (is_buffer_lut(netlist, blk, models)) {
+        if (is_buffer_lut(netlist, blk)) {
             if (remove_buffer_lut(netlist, blk, models, verbosity)) {
                 ++removed_buffer_count;
             }
@@ -701,9 +701,9 @@ void absorb_buffer_luts(AtomNetlist& netlist, const LogicalModels& models, int v
     //TODO: absorb inverter LUTs?
 }
 
-bool is_buffer_lut(const AtomNetlist& netlist, const AtomBlockId blk, const LogicalModels& models) {
+bool is_buffer_lut(const AtomNetlist& netlist, const AtomBlockId blk) {
     if (netlist.block_type(blk) == AtomBlockType::BLOCK) {
-        const LogicalModelId names_model = models.get_model_by_name(LogicalModels::MODEL_NAMES);
+        const LogicalModelId names_model = LogicalModels::MODEL_NAMES_ID;
         if (netlist.block_model(blk) != names_model) return false;
 
         auto input_ports = netlist.block_input_ports(blk);
@@ -1412,7 +1412,7 @@ std::set<AtomPinId> find_netlist_logical_clock_drivers(const AtomNetlist& netlis
     //to find the true source
     size_t assumed_buffer_count = 0;
     std::set<AtomNetId> prev_clock_nets;
-    LogicalModelId names_model_id = models.get_model_by_name(LogicalModels::MODEL_NAMES);
+    LogicalModelId names_model_id = LogicalModels::MODEL_NAMES_ID;
     while (prev_clock_nets != clock_nets) { //Still tracing back
         prev_clock_nets = clock_nets;
         clock_nets.clear();

--- a/vpr/src/base/check_netlist.cpp
+++ b/vpr/src/base/check_netlist.cpp
@@ -129,7 +129,6 @@ static int check_connections_to_global_clb_pins(ClusterNetId net_id, int verbosi
 static int check_clb_conn(ClusterBlockId iblk, int num_conn) {
     auto& cluster_ctx = g_vpr_ctx.clustering();
     auto& clb_nlist = cluster_ctx.clb_nlist;
-    const LogicalModels& models = g_vpr_ctx.device().arch->models;
 
     int error = 0;
     t_logical_block_type_ptr type = clb_nlist.block_type(iblk);
@@ -138,7 +137,7 @@ static int check_clb_conn(ClusterBlockId iblk, int num_conn) {
         for (auto pin_id : clb_nlist.block_pins(iblk)) {
             auto pin_type = clb_nlist.pin_type(pin_id);
 
-            if (pin_type == PinType::SINK && !clb_nlist.block_contains_primary_output(iblk, models)) {
+            if (pin_type == PinType::SINK && !clb_nlist.block_contains_primary_output(iblk)) {
                 //Input only and not a Primary-Output block
                 VTR_LOG_WARN(
                     "Logic block #%d (%s) has only 1 input pin '%s'"
@@ -146,7 +145,7 @@ static int check_clb_conn(ClusterBlockId iblk, int num_conn) {
                     iblk, clb_nlist.block_name(iblk).c_str(),
                     clb_nlist.pin_name(pin_id).c_str());
             }
-            if (pin_type == PinType::DRIVER && !clb_nlist.block_contains_primary_input(iblk, models)) {
+            if (pin_type == PinType::DRIVER && !clb_nlist.block_contains_primary_input(iblk)) {
                 //Output only and not a Primary-Input block
                 VTR_LOG_WARN(
                     "Logic block #%d (%s) has only 1 output pin '%s'."

--- a/vpr/src/base/clustered_netlist.cpp
+++ b/vpr/src/base/clustered_netlist.cpp
@@ -58,17 +58,17 @@ ClusterPinId ClusteredNetlist::block_pin(const ClusterBlockId blk, const int log
     return block_logical_pins_[blk][logical_pin_index];
 }
 
-bool ClusteredNetlist::block_contains_primary_input(const ClusterBlockId blk, const LogicalModels& models) const {
+bool ClusteredNetlist::block_contains_primary_input(const ClusterBlockId blk) const {
     const t_pb* pb = block_pb(blk);
-    LogicalModelId input_model_id = models.get_model_by_name(LogicalModels::MODEL_INPUT);
+    LogicalModelId input_model_id = LogicalModels::MODEL_INPUT_ID;
     const t_pb* primary_input_pb = pb->find_pb_for_model(input_model_id);
     return primary_input_pb != nullptr;
 }
 
 ///@brief Returns true if the specified block contains a primary output (e.g. BLIF .output primitive)
-bool ClusteredNetlist::block_contains_primary_output(const ClusterBlockId blk, const LogicalModels& models) const {
+bool ClusteredNetlist::block_contains_primary_output(const ClusterBlockId blk) const {
     const t_pb* pb = block_pb(blk);
-    LogicalModelId output_model_id = models.get_model_by_name(LogicalModels::MODEL_OUTPUT);
+    LogicalModelId output_model_id = LogicalModels::MODEL_OUTPUT_ID;
     const t_pb* primary_output_pb = pb->find_pb_for_model(output_model_id);
     return primary_output_pb != nullptr;
 }

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -144,10 +144,10 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
     ClusterPinId block_pin(const ClusterBlockId blk, const int logical_pin_index) const;
 
     ////@brief Returns true if the specified block contains a primary input (e.g. BLIF .input primitive)
-    bool block_contains_primary_input(const ClusterBlockId blk, const LogicalModels& models) const;
+    bool block_contains_primary_input(const ClusterBlockId blk) const;
 
     ///@brief Returns true if the specified block contains a primary output (e.g. BLIF .output primitive)
-    bool block_contains_primary_output(const ClusterBlockId blk, const LogicalModels& models) const;
+    bool block_contains_primary_output(const ClusterBlockId blk) const;
 
     /*
      * Pins

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -45,10 +45,6 @@ struct BlifAllocCallback : public blifparse::Callback {
         , blif_format_(blif_format) {
         VTR_ASSERT(blif_format_ == e_circuit_format::BLIF
                    || blif_format_ == e_circuit_format::EBLIF);
-        inpad_model_ = models.get_model_by_name(LogicalModels::MODEL_INPUT);
-        outpad_model_ = models.get_model_by_name(LogicalModels::MODEL_OUTPUT);
-
-        main_netlist_.set_block_types(inpad_model_, outpad_model_);
     }
 
     static constexpr const char* OUTPAD_NAME_PREFIX = "out:";
@@ -68,14 +64,13 @@ struct BlifAllocCallback : public blifparse::Callback {
         //Create a new model, and set it's name
 
         blif_models_.emplace_back(model_name, netlist_id_);
-        blif_models_.back().set_block_types(inpad_model_, outpad_model_);
         blif_models_black_box_.emplace_back(false);
         ended_ = false;
         set_curr_block(AtomBlockId::INVALID()); //This statement doesn't define a block, so mark invalid
     }
 
     void inputs(std::vector<std::string> input_names) override {
-        LogicalModelId blk_model_id = models_.get_model_by_name(LogicalModels::MODEL_INPUT);
+        LogicalModelId blk_model_id = LogicalModels::MODEL_INPUT_ID;
         const t_model& blk_model = models_.get_model(blk_model_id);
 
         VTR_ASSERT_MSG(!blk_model.inputs, "Inpad model has an input port");
@@ -94,7 +89,7 @@ struct BlifAllocCallback : public blifparse::Callback {
     }
 
     void outputs(std::vector<std::string> output_names) override {
-        LogicalModelId blk_model_id = models_.get_model_by_name(LogicalModels::MODEL_OUTPUT);
+        LogicalModelId blk_model_id = LogicalModels::MODEL_OUTPUT_ID;
         const t_model& blk_model = models_.get_model(blk_model_id);
 
         VTR_ASSERT_MSG(!blk_model.outputs, "Outpad model has an output port");
@@ -115,7 +110,7 @@ struct BlifAllocCallback : public blifparse::Callback {
     }
 
     void names(std::vector<std::string> nets, std::vector<std::vector<blifparse::LogicValue>> so_cover) override {
-        LogicalModelId blk_model_id = models_.get_model_by_name(LogicalModels::MODEL_NAMES);
+        LogicalModelId blk_model_id = LogicalModels::MODEL_NAMES_ID;
         const t_model& blk_model = models_.get_model(blk_model_id);
 
         VTR_ASSERT_MSG(nets.size() > 0, "BLIF .names has no connections");
@@ -199,7 +194,7 @@ struct BlifAllocCallback : public blifparse::Callback {
             vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_, "Latch must have a clock\n");
         }
 
-        LogicalModelId blk_model_id = models_.get_model_by_name(LogicalModels::MODEL_LATCH);
+        LogicalModelId blk_model_id = LogicalModels::MODEL_LATCH_ID;
         const t_model& blk_model = models_.get_model(blk_model_id);
 
         VTR_ASSERT_MSG(blk_model.inputs, "Has one input port");
@@ -617,8 +612,6 @@ struct BlifAllocCallback : public blifparse::Callback {
     AtomNetlist& main_netlist_;    ///<User object we fill
     const std::string netlist_id_; ///<Unique identifier based on the contents of the blif file
     const LogicalModels& models_;
-    LogicalModelId inpad_model_;
-    LogicalModelId outpad_model_;
 
     size_t unique_subckt_name_counter_ = 0;
 

--- a/vpr/src/base/read_circuit.cpp
+++ b/vpr/src/base/read_circuit.cpp
@@ -149,7 +149,7 @@ static void show_circuit_stats(const AtomNetlist& netlist, const LogicalModels& 
     // Count the block statistics
     std::map<std::string, size_t> block_type_counts;
     std::map<std::string, size_t> lut_size_counts;
-    LogicalModelId names_model_id = models.get_model_by_name(LogicalModels::MODEL_NAMES);
+    LogicalModelId names_model_id = LogicalModels::MODEL_NAMES_ID;
     for (auto blk_id : netlist.blocks()) {
         // For each model, count the number of occurrences in the netlist.
         LogicalModelId blk_model_id = netlist.block_model(blk_id);

--- a/vpr/src/base/read_interchange_netlist.cpp
+++ b/vpr/src/base/read_interchange_netlist.cpp
@@ -54,10 +54,6 @@ struct NetlistReader {
         auto str_list = nr_.getStrList();
         main_netlist_ = AtomNetlist(str_list[top_cell_instance_.getName()], netlist_id);
 
-        inpad_model_ = models_.get_model_by_name(LogicalModels::MODEL_INPUT);
-        outpad_model_ = models_.get_model_by_name(LogicalModels::MODEL_OUTPUT);
-        main_netlist_.set_block_types(inpad_model_, outpad_model_);
-
         prepare_port_net_maps();
 
         VTR_LOG("Reading IOs...\n");
@@ -75,8 +71,6 @@ struct NetlistReader {
 
     const char* netlist_file_;
 
-    LogicalModelId inpad_model_;
-    LogicalModelId outpad_model_;
     const LogicalModels& models_;
     const t_arch& arch_;
 
@@ -137,9 +131,9 @@ struct NetlistReader {
     }
 
     void read_ios() {
-        LogicalModelId input_model_id = models_.get_model_by_name(LogicalModels::MODEL_INPUT);
+        LogicalModelId input_model_id = LogicalModels::MODEL_INPUT_ID;
         const t_model& input_model = models_.get_model(input_model_id);
-        LogicalModelId output_model_id = models_.get_model_by_name(LogicalModels::MODEL_OUTPUT);
+        LogicalModelId output_model_id = LogicalModels::MODEL_OUTPUT_ID;
         const t_model& output_model = models_.get_model(output_model_id);
 
         auto str_list = nr_.getStrList();
@@ -187,7 +181,7 @@ struct NetlistReader {
     }
 
     void read_names() {
-        LogicalModelId blk_model_id = models_.get_model_by_name(LogicalModels::MODEL_NAMES);
+        LogicalModelId blk_model_id = LogicalModels::MODEL_NAMES_ID;
         const t_model& blk_model = models_.get_model(blk_model_id);
 
         // Set the max size of the LUT

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -274,11 +274,8 @@ void print_pb_type_count(const ClusteredNetlist& clb_nlist) {
     VTR_LOG("\n");
 }
 
-t_logical_block_type_ptr identify_logic_block_type(const vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types,
-                                                   const LogicalModels& models) {
-    LogicalModelId lut_model_id = models.get_model_by_name(LogicalModels::MODEL_NAMES);
-
-    VTR_ASSERT(lut_model_id.is_valid());
+t_logical_block_type_ptr identify_logic_block_type(const vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types) {
+    LogicalModelId lut_model_id = LogicalModels::MODEL_NAMES_ID;
     if (primitive_candidate_block_types[lut_model_id].size() == 0)
         return nullptr;
 

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -91,8 +91,7 @@ void print_pb_type_count(const ClusteredNetlist& clb_nlist);
  * @brief This function identifies the logic block type which is defined by the
  *        block type which has a lut primitive.
  */
-t_logical_block_type_ptr identify_logic_block_type(const vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types,
-                                                   const LogicalModels& models);
+t_logical_block_type_ptr identify_logic_block_type(const vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types);
 
 /*
  * @brief This function returns the pb_type that is similar to Logic Element (LE)

--- a/vpr/src/pack/greedy_clusterer.cpp
+++ b/vpr/src/pack/greedy_clusterer.cpp
@@ -526,7 +526,7 @@ bool GreedyClusterer::try_add_candidate_mol_to_cluster(PackMoleculeId candidate_
 
 void GreedyClusterer::report_le_physical_block_usage(const ClusterLegalizer& cluster_legalizer) {
     // find the cluster type that has lut primitives
-    auto logic_block_type = identify_logic_block_type(primitive_candidate_block_types_, arch_.models);
+    auto logic_block_type = identify_logic_block_type(primitive_candidate_block_types_);
     // find a LE pb_type within the found logic_block_type
     auto le_pb_type = identify_le_block_type(logic_block_type);
 

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -71,8 +71,7 @@ static void free_pack_pattern_block(t_pack_pattern_block* pattern_block, t_pack_
 static bool try_expand_molecule(t_pack_molecule& molecule,
                                 const AtomBlockId blk_id,
                                 const std::multimap<AtomBlockId, PackMoleculeId>& atom_molecules,
-                                const AtomNetlist& atom_nlist,
-                                const LogicalModels& models);
+                                const AtomNetlist& atom_nlist);
 
 static void print_pack_molecules(const char* fname,
                                  const std::vector<t_pack_patterns>& list_of_pack_patterns,
@@ -110,8 +109,7 @@ static void init_molecule_chain_info(const AtomBlockId blk_id,
 
 static AtomBlockId get_sink_block(const AtomBlockId block_id,
                                   const t_pack_pattern_connections& connections,
-                                  const AtomNetlist& atom_nlist,
-                                  const LogicalModels& models);
+                                  const AtomNetlist& atom_nlist);
 
 static AtomBlockId get_driving_block(const AtomBlockId block_id,
                                      const t_pack_pattern_connections& connections,
@@ -815,8 +813,7 @@ void Prepacker::alloc_and_load_pack_molecules(std::multimap<AtomBlockId, PackMol
             PackMoleculeId cur_molecule_id = try_create_molecule(best_pattern,
                                                                  blk_id,
                                                                  atom_molecules_multimap,
-                                                                 atom_nlist,
-                                                                 models);
+                                                                 atom_nlist);
 
             // If the molecule could not be created, move to the next block.
             if (!cur_molecule_id.is_valid())
@@ -925,8 +922,7 @@ static void free_pack_pattern_block(t_pack_pattern_block* pattern_block, t_pack_
 PackMoleculeId Prepacker::try_create_molecule(const int pack_pattern_index,
                                               AtomBlockId blk_id,
                                               std::multimap<AtomBlockId, PackMoleculeId>& atom_molecules_multimap,
-                                              const AtomNetlist& atom_nlist,
-                                              const LogicalModels& models) {
+                                              const AtomNetlist& atom_nlist) {
     auto pack_pattern = &list_of_pack_patterns[pack_pattern_index];
 
     // Check pack pattern validity
@@ -950,7 +946,7 @@ PackMoleculeId Prepacker::try_create_molecule(const int pack_pattern_index,
     molecule.root = pack_pattern->root_block->block_id;
     molecule.chain_id = MoleculeChainId::INVALID();
 
-    if (!try_expand_molecule(molecule, blk_id, atom_molecules_multimap, atom_nlist, models)) {
+    if (!try_expand_molecule(molecule, blk_id, atom_molecules_multimap, atom_nlist)) {
         // Failed to create molecule
         return PackMoleculeId::INVALID();
     }
@@ -994,8 +990,7 @@ PackMoleculeId Prepacker::try_create_molecule(const int pack_pattern_index,
 static bool try_expand_molecule(t_pack_molecule& molecule,
                                 const AtomBlockId blk_id,
                                 const std::multimap<AtomBlockId, PackMoleculeId>& atom_molecules,
-                                const AtomNetlist& atom_nlist,
-                                const LogicalModels& models) {
+                                const AtomNetlist& atom_nlist) {
     // root block of the pack pattern, which is the starting point of this pattern
     const auto pattern_root_block = molecule.pack_pattern->root_block;
     // bool array indicating whether a position in a pack pattern is optional or should
@@ -1052,7 +1047,7 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
             // this block is the driver of this connection
             if (block_connection->from_block == pattern_block) {
                 // find the block this connection is driving and add it to the queue
-                auto sink_blk_id = get_sink_block(block_id, *block_connection, atom_nlist, models);
+                auto sink_blk_id = get_sink_block(block_id, *block_connection, atom_nlist);
                 // add this sink block id with its corresponding pattern block to the queue
                 pattern_block_queue.push(std::make_pair(block_connection->to_block, sink_blk_id));
                 // this block is being driven by this connection
@@ -1084,8 +1079,7 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
  */
 static AtomBlockId get_sink_block(const AtomBlockId block_id,
                                   const t_pack_pattern_connections& connections,
-                                  const AtomNetlist& atom_nlist,
-                                  const LogicalModels& models) {
+                                  const AtomNetlist& atom_nlist) {
     const t_model_ports* from_port_model = connections.from_pin->port->model_port;
     const int from_pin_number = connections.from_pin->pin_number;
     auto from_port_id = atom_nlist.find_atom_port(block_id, from_port_model);
@@ -1107,7 +1101,7 @@ static AtomBlockId get_sink_block(const AtomBlockId block_id,
     // Iterate through all sink blocks and check whether any of them
     // is compatible with the block specified in the pack pattern.
     bool connected_to_latch = false;
-    LogicalModelId latch_model_id = models.get_model_by_name(LogicalModels::MODEL_LATCH);
+    LogicalModelId latch_model_id = LogicalModels::MODEL_LATCH_ID;
     AtomBlockId pattern_sink_block_id = AtomBlockId::INVALID();
     for (const auto& sink_pin_id : net_sinks) {
         auto sink_block_id = atom_nlist.pin_block(sink_pin_id);

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -327,8 +327,7 @@ class Prepacker {
     PackMoleculeId try_create_molecule(const int pack_pattern_index,
                                        AtomBlockId blk_id,
                                        std::multimap<AtomBlockId, PackMoleculeId>& atom_molecules_multimap,
-                                       const AtomNetlist& atom_nlist,
-                                       const LogicalModels& models);
+                                       const AtomNetlist& atom_nlist);
 
   private:
     /**


### PR DESCRIPTION
Created static constexpr references to the library model IDs (such as input, output, names, and latch). It is very common to reference these models during execution of VPR. Often we would search for these models in the LogicalModels structure; however, these model IDs will always be the same.

By storing static references to these IDs, the compiler can easily optimize parts of the code which need to check if a model ID is an input/output for example.