### PR TITLE
Fix the regex pattern for initial placement WL

### DIFF
--- a/vtr_flow/parse/parse_config/common/vpr.place.txt
+++ b/vtr_flow/parse/parse_config/common/vpr.place.txt
@@ -1,5 +1,5 @@
 #VPR Place Metrics
-initial_placed_wirelength_est;vpr.out;Initial placement BB estimate of wirelength:\s*(\d+)
+initial_placed_wirelength_est;vpr.out;Initial placement BB estimate of wirelength:\s*(.*)
 placed_wirelength_est;vpr.out;BB estimate of min-dist \(placement\) wire length: (\d+)
 
 #VPR Number of heap operations


### PR DESCRIPTION
The wirelength from the initial placement is printed in scientific notation (e.g., `Initial placement BB estimate of wirelength: 2.5437e+07`), but the pattern was expecting an integer. I updated the pattern to accept any numeric format.
