### PR TITLE
Add artifact upload to nightly test workflow

### DIFF
--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -104,3 +104,12 @@ jobs:
       run: |
         source .venv/bin/activate
         ./run_reg_test.py -j12 vtr_reg_nightly_test7
+
+    - name: Upload regression results
+      if: success() || failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly_test_results
+        path: |
+          vtr_flow/**/*.log
+          vtr_flow/**/parse_results*.txt


### PR DESCRIPTION
This PR uploads the .log and parse_results files of the nightly tests as artifacts. This should make it possible to see the details of a nightly test run without needing to login to the runner or re-running the tests on a machine you have access to.