### PR TITLE
[AP][Solver] Enabled Parallel Eigen

### DIFF
--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -12,6 +12,8 @@ set_property(CACHE VPR_PGO_CONFIG PROPERTY STRINGS prof_gen prof_use none)
 
 set(VPR_PGO_DATA_DIR "." CACHE PATH "Where to store and retrieve PGO data")
 
+set(VPR_ENABLE_OPEN_MP "on" CACHE STRING "Enable OpenMP when compiling VPR")
+
 #Handle graphics setup
 set(GRAPHICS_DEFINES "")
 
@@ -293,6 +295,21 @@ elseif(VPR_USE_EXECUTION_ENGINE STREQUAL "serial")
     message(STATUS "VPR: will only support serial execution")
 else()
     message(FATAL_ERROR "VPR: Unrecognized execution engine '${VPR_USE_EXECUTION_ENGINE}'")
+endif()
+
+#
+# OpenMP configuration
+#
+if (VPR_ENABLE_OPEN_MP STREQUAL "on")
+    find_package(OpenMP)
+    if (OpenMP_CXX_FOUND)
+        target_link_libraries(libvpr OpenMP::OpenMP_CXX)
+        message(STATUS "OpenMP: Enabled")
+    else()
+        message(STATUS "OpenMP: Disabled (requested but not found)")
+    endif()
+else()
+    message(STATUS "OpenMP: Disabled")
 endif()
 
 #

--- a/vpr/src/analytical_place/analytical_placement_flow.cpp
+++ b/vpr/src/analytical_place/analytical_placement_flow.cpp
@@ -144,6 +144,7 @@ static PartialPlacement run_global_placer(const t_ap_opts& ap_opts,
                                                                          device_ctx.physical_tile_types,
                                                                          pre_cluster_timing_manager,
                                                                          ap_opts.ap_timing_tradeoff,
+                                                                         ap_opts.num_threads,
                                                                          ap_opts.log_verbosity);
         return global_placer->place();
     }

--- a/vpr/src/analytical_place/analytical_solver.cpp
+++ b/vpr/src/analytical_place/analytical_solver.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <limits>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 #include "PreClusterTimingManager.h"
@@ -32,6 +33,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference"
 
+#include <Eigen/src/Core/products/Parallelizer.h>
 #include <Eigen/src/SparseCore/SparseMatrix.h>
 #include <Eigen/SVD>
 #include <Eigen/Sparse>
@@ -48,7 +50,22 @@ std::unique_ptr<AnalyticalSolver> make_analytical_solver(e_ap_analytical_solver 
                                                          const AtomNetlist& atom_netlist,
                                                          const PreClusterTimingManager& pre_cluster_timing_manager,
                                                          float ap_timing_tradeoff,
+                                                         unsigned num_threads,
                                                          int log_verbosity) {
+#ifdef EIGEN_INSTALLED
+    // Set the number of threads that Eigen can use.
+    unsigned eigen_num_threads = num_threads;
+    if (num_threads == 0) {
+        eigen_num_threads = std::thread::hardware_concurrency();
+    }
+    // Set the number of threads globally used by Eigen (if OpenMP is enabled).
+    // NOTE: Since this is a global update, all solvers will have this number
+    //       of threads.
+    Eigen::setNbThreads(eigen_num_threads);
+#else
+    (void)num_threads;
+#endif // EIGEN_INSTALLED
+
     // Based on the solver type passed in, build the solver.
     switch (solver_type) {
         case e_ap_analytical_solver::QP_Hybrid:

--- a/vpr/src/analytical_place/analytical_solver.h
+++ b/vpr/src/analytical_place/analytical_solver.h
@@ -138,6 +138,7 @@ std::unique_ptr<AnalyticalSolver> make_analytical_solver(e_ap_analytical_solver 
                                                          const AtomNetlist& atom_netlist,
                                                          const PreClusterTimingManager& pre_cluster_timing_manager,
                                                          float ap_timing_tradeoff,
+                                                         unsigned num_threads,
                                                          int log_verbosity);
 
 // The Eigen library is used to solve matrix equations in the following solvers.

--- a/vpr/src/analytical_place/global_placer.cpp
+++ b/vpr/src/analytical_place/global_placer.cpp
@@ -37,6 +37,7 @@ std::unique_ptr<GlobalPlacer> make_global_placer(e_ap_analytical_solver analytic
                                                  const std::vector<t_physical_tile_type>& physical_tile_types,
                                                  const PreClusterTimingManager& pre_cluster_timing_manager,
                                                  float ap_timing_tradeoff,
+                                                 unsigned num_threads,
                                                  int log_verbosity) {
     return std::make_unique<SimPLGlobalPlacer>(analytical_solver_type,
                                                partial_legalizer_type,
@@ -48,6 +49,7 @@ std::unique_ptr<GlobalPlacer> make_global_placer(e_ap_analytical_solver analytic
                                                physical_tile_types,
                                                pre_cluster_timing_manager,
                                                ap_timing_tradeoff,
+                                               num_threads,
                                                log_verbosity);
 }
 
@@ -61,6 +63,7 @@ SimPLGlobalPlacer::SimPLGlobalPlacer(e_ap_analytical_solver analytical_solver_ty
                                      const std::vector<t_physical_tile_type>& physical_tile_types,
                                      const PreClusterTimingManager& pre_cluster_timing_manager,
                                      float ap_timing_tradeoff,
+                                     unsigned num_threads,
                                      int log_verbosity)
     : GlobalPlacer(ap_netlist, log_verbosity) {
     // This can be a long method. Good to time this to see how long it takes to
@@ -75,6 +78,7 @@ SimPLGlobalPlacer::SimPLGlobalPlacer(e_ap_analytical_solver analytical_solver_ty
                                      atom_netlist,
                                      pre_cluster_timing_manager,
                                      ap_timing_tradeoff,
+                                     num_threads,
                                      log_verbosity_);
 
     // Build the density manager used by the partial legalizer.

--- a/vpr/src/analytical_place/global_placer.h
+++ b/vpr/src/analytical_place/global_placer.h
@@ -83,6 +83,7 @@ std::unique_ptr<GlobalPlacer> make_global_placer(e_ap_analytical_solver analytic
                                                  const std::vector<t_physical_tile_type>& physical_tile_types,
                                                  const PreClusterTimingManager& pre_cluster_timing_manager,
                                                  float ap_timing_tradeoff,
+                                                 unsigned num_threads,
                                                  int log_verbosity);
 
 /**
@@ -148,6 +149,7 @@ class SimPLGlobalPlacer : public GlobalPlacer {
                       const std::vector<t_physical_tile_type>& physical_tile_types,
                       const PreClusterTimingManager& pre_cluster_timing_manager,
                       float ap_timing_tradeoff,
+                      unsigned num_threads,
                       int log_verbosity);
 
     /**

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -559,6 +559,7 @@ void SetupAPOpts(const t_options& options,
     apOpts.detailed_placer_type = options.ap_detailed_placer.value();
     apOpts.ap_timing_tradeoff = options.ap_timing_tradeoff.value();
     apOpts.appack_max_dist_th = options.appack_max_dist_th.value();
+    apOpts.num_threads = options.num_workers.value();
     apOpts.log_verbosity = options.ap_verbosity.value();
 }
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1116,6 +1116,8 @@ struct t_placer_opts {
  *   @param appack_max_dist_th
  *              Array of string passed by the user to configure the max candidate
  *              distance thresholds.
+ *   @param num_threads
+ *              The number of threads the AP flow can use.
  *   @param log_verbosity
  *              The verbosity level of log messages in the AP flow, with higher
  *              values leading to more verbose messages.
@@ -1134,6 +1136,8 @@ struct t_ap_opts {
     float ap_timing_tradeoff;
 
     std::vector<std::string> appack_max_dist_th;
+
+    unsigned num_threads;
 
     int log_verbosity;
 };


### PR DESCRIPTION
The Eigen solver has the ability to use OpenMP to run the solver computations in parallel. Made the AP flow use the num_workers option to set the number of threads that Eigen can use.

VPR did not have the ability to build with OpenMP in its CMAKE. Added an option to the CMAKE to allow the user to enable OpenMP.

Resolves #3030 

Currently running the VTR circuits using 4 threads, will show the results. As a preview, MCML's Global Placement went from 141 seconds to 92 seconds on 4 threads.

I made OpenMP disabled by default for now since only the AP flow uses OpenMP. Perhaps we can enable this by default only when AP is enabled or just always enable it.