### PR TITLE
[STA] Enabled Dedicated Routing SDC Generation

### DIFF
--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -2689,22 +2689,8 @@ void add_original_sdc_to_post_implemented_sdc_file(std::ofstream& sdc_os,
  *
  *  @param sdc_os
  *      The file stream to add the propagated clock commands to.
- *  @param clock_modeling
- *      The type of clock modeling used by VPR during the CAD flow.
  */
-void add_propagated_clocks_to_sdc_file(std::ofstream& sdc_os,
-                                       e_clock_modeling clock_modeling) {
-
-    // Ideal and routed clocks are handled by the code below. Other clock models
-    // like dedicated routing are not supported yet.
-    // TODO: Supporting dedicated routing should be simple; however it should
-    //       be investigated. Tried quickly but found that the delays produced
-    //       were off by 0.003 ns. Need to investigate why.
-    if (clock_modeling != e_clock_modeling::ROUTED_CLOCK && clock_modeling != e_clock_modeling::IDEAL_CLOCK) {
-        VPR_FATAL_ERROR(VPR_ERROR_IMPL_NETLIST_WRITER,
-                        "Only ideal and routed clock modeling are currentlt "
-                        "supported for post-implementation SDC file generation");
-    }
+void add_propagated_clocks_to_sdc_file(std::ofstream& sdc_os) {
 
     // The timing constraints contain information on all the clocks in the circuit
     // (provided by the user-provided SDC file).
@@ -2751,18 +2737,15 @@ void add_propagated_clocks_to_sdc_file(std::ofstream& sdc_os,
 
 /**
  * @brief Generates a post-implementation SDC file with the given file name
- *        based on the timing info and clock modeling set for VPR.
+ *        based on the timing info used for VPR.
  *
  *  @param sdc_filename
  *      The file name of the SDC file to generate.
  *  @param timing_info
  *      Information on the timing used in the VPR flow.
- *  @param clock_modeling
- *      The type of clock modeling used by VPR during its flow.
  */
 void generate_post_implementation_sdc(const std::string& sdc_filename,
-                                      const t_timing_inf& timing_info,
-                                      e_clock_modeling clock_modeling) {
+                                      const t_timing_inf& timing_info) {
     if (!timing_info.timing_analysis_enabled) {
         VTR_LOG_WARN("Timing analysis is disabled. Post-implementation SDC file "
                      "will not be generated.\n");
@@ -2783,7 +2766,7 @@ void generate_post_implementation_sdc(const std::string& sdc_filename,
     add_original_sdc_to_post_implemented_sdc_file(sdc_os, timing_info);
 
     // Add propagated clocks to SDC file if needed.
-    add_propagated_clocks_to_sdc_file(sdc_os, clock_modeling);
+    add_propagated_clocks_to_sdc_file(sdc_os);
 }
 
 } // namespace
@@ -2797,7 +2780,6 @@ void netlist_writer(const std::string basename,
                     std::shared_ptr<const AnalysisDelayCalculator> delay_calc,
                     const LogicalModels& models,
                     const t_timing_inf& timing_info,
-                    e_clock_modeling clock_modeling,
                     t_analysis_opts opts) {
     std::string verilog_filename = basename + "_post_synthesis.v";
     std::string blif_filename = basename + "_post_synthesis.blif";
@@ -2822,8 +2804,7 @@ void netlist_writer(const std::string basename,
         VTR_LOG("Writing Implementation SDC    : %s\n", sdc_filename.c_str());
 
         generate_post_implementation_sdc(sdc_filename,
-                                         timing_info,
-                                         clock_modeling);
+                                         timing_info);
     }
 }
 

--- a/vpr/src/base/netlist_writer.h
+++ b/vpr/src/base/netlist_writer.h
@@ -24,8 +24,6 @@ class LogicalModels;
  *      The logical models in the architecture.
  *  @param timing_info
  *      Information on the timing used in the VPR flow.
- *  @param clock_modeling
- *      The type of clock modeling used in the VPR flow.
  *  @param opts
  *      The analysis options.
  */
@@ -33,7 +31,6 @@ void netlist_writer(const std::string basename,
                     std::shared_ptr<const AnalysisDelayCalculator> delay_calc,
                     const LogicalModels& models,
                     const t_timing_inf& timing_info,
-                    e_clock_modeling clock_modeling,
                     t_analysis_opts opts);
 
 /**

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1466,8 +1466,11 @@ void vpr_analysis(const Netlist<>& net_list,
 
         //Write the post-synthesis netlist
         if (vpr_setup.AnalysisOpts.gen_post_synthesis_netlist) {
-            netlist_writer(atom_ctx.netlist().netlist_name(), analysis_delay_calc,
-                           Arch.models, vpr_setup.Timing, vpr_setup.clock_modeling, vpr_setup.AnalysisOpts);
+            netlist_writer(atom_ctx.netlist().netlist_name(),
+                           analysis_delay_calc,
+                           Arch.models,
+                           vpr_setup.Timing,
+                           vpr_setup.AnalysisOpts);
         }
 
         //Write the post-implementation merged netlist


### PR DESCRIPTION
Through experimentation, found that dedicated clock routing worked with the external STA path. Removed the error check for this.

See #3027 

This does not resolve the issue above quite yet, since I found that issue to be unrelated to dedicated clock routing.
