### PR TITLE
Clean up confusing rr-node lookup convention for x/y location of CHANX nodes

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_builder.cpp
+++ b/libs/librrgraph/src/base/rr_graph_builder.cpp
@@ -31,31 +31,29 @@ void RRGraphBuilder::add_node_to_all_locs(RRNodeId node) {
     short node_layer = node_storage_.node_layer(node);
     short node_twist = node_storage_.node_ptc_twist(node);
     int node_offset = 0;
+
     for (int ix = node_storage_.node_xlow(node); ix <= node_storage_.node_xhigh(node); ix++) {
         for (int iy = node_storage_.node_ylow(node); iy <= node_storage_.node_yhigh(node); iy++) {
             node_ptc_num += node_twist * node_offset;
             node_offset++;
+
             switch (node_type) {
                 case e_rr_type::SOURCE:
                 case e_rr_type::SINK:
                 case e_rr_type::CHANY:
+                case e_rr_type::CHANX:
                     node_lookup_.add_node(node, node_layer, ix, iy, node_type, node_ptc_num, TOTAL_2D_SIDES[0]);
                     break;
-                case e_rr_type::CHANX:
-                    /* Currently need to swap x and y for CHANX because of chan, seg convention 
-                     * TODO: Once the builders is reworked for use consistent (x, y) convention,
-                     * the following swapping can be removed
-                     */
-                    node_lookup_.add_node(node, node_layer, iy, ix, node_type, node_ptc_num, TOTAL_2D_SIDES[0]);
-                    break;
+
                 case e_rr_type::OPIN:
                 case e_rr_type::IPIN:
-                    for (const e_side& side : TOTAL_2D_SIDES) {
+                    for (const e_side side : TOTAL_2D_SIDES) {
                         if (node_storage_.is_node_on_specific_side(node, side)) {
                             node_lookup_.add_node(node,node_layer, ix, iy, node_type, node_ptc_num, side);
                         }
                     }
                     break;
+
                 default:
                     VTR_LOG_ERROR("Invalid node type for node '%lu' in the routing resource graph file", size_t(node));
                     break;

--- a/libs/librrgraph/src/base/rr_graph_view.h
+++ b/libs/librrgraph/src/base/rr_graph_view.h
@@ -351,7 +351,7 @@ class RRGraphView {
 
                 start_x = " (" + std::to_string(node_xhigh(node)) + ","; //start coordinates have large value
                 start_y = std::to_string(node_yhigh(node)) + ",";
-                start_layer_str = std::to_string(node_layer_num);
+                start_layer_str = std::to_string(node_layer_num) + ")";
                 end_x = " (" + std::to_string(node_xlow(node)) + ","; //end coordinates have smaller value
                 end_y = std::to_string(node_ylow(node)) + ",";
                 end_layer_str = std::to_string(node_layer_num) + ")";
@@ -360,7 +360,7 @@ class RRGraphView {
             else {                                                      // signal travels in increasing direction, stays at same point, or can travel both directions
                 start_x = " (" + std::to_string(node_xlow(node)) + ","; //start coordinates have smaller value
                 start_y = std::to_string(node_ylow(node)) + ",";
-                start_layer_str = std::to_string(node_layer_num);
+                start_layer_str = std::to_string(node_layer_num) + ")";
                 end_x = " (" + std::to_string(node_xhigh(node)) + ","; //end coordinates have larger value
                 end_y = std::to_string(node_yhigh(node)) + ",";
                 end_layer_str = std::to_string(node_layer_num) + ")"; //layer number

--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -47,11 +47,11 @@ RRNodeId RRSpatialLookup::find_node(int layer,
         return RRNodeId::INVALID();
     }
 
-    if (x >= rr_node_indices_[type].dim_size(1)) {
+    if (size_t(x) >= rr_node_indices_[type].dim_size(1)) {
         return RRNodeId::INVALID();
     }
 
-    if(y >= rr_node_indices_[type].dim_size(2)){
+    if (size_t(y) >= rr_node_indices_[type].dim_size(2)){
         return RRNodeId::INVALID();
     }
 

--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -116,11 +116,11 @@ std::vector<RRNodeId> RRSpatialLookup::find_nodes(int layer,
         return nodes;
     }
 
-    if (x >= rr_node_indices_[type].dim_size(1)) {
+    if (size_t(x) >= rr_node_indices_[type].dim_size(1)) {
         return nodes;
     }
 
-    if(y >= rr_node_indices_[type].dim_size(2)){
+    if (size_t(y) >= rr_node_indices_[type].dim_size(2)){
         return nodes;
     }
 

--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -33,18 +33,6 @@ RRNodeId RRSpatialLookup::find_node(int layer,
         return RRNodeId::INVALID();
     }
 
-    /* Currently need to swap x and y for CHANX because of chan, seg convention 
-     * This is due to that the fast look-up builders uses (y, x) coordinate when
-     * registering a CHANX node in the look-up
-     * TODO: Once the builders is reworked for use consistent (x, y) convention,
-     * the following swapping can be removed
-     */
-    size_t node_x = x;
-    size_t node_y = y;
-    if (type == e_rr_type::CHANX) {
-        std::swap(node_x, node_y);
-    }
-
     VTR_ASSERT_SAFE(4 == rr_node_indices_[type].ndims());
 
     /* Sanity check to ensure the layer, x, y, side and ptc are in range
@@ -59,11 +47,11 @@ RRNodeId RRSpatialLookup::find_node(int layer,
         return RRNodeId::INVALID();
     }
 
-    if (node_x >= rr_node_indices_[type].dim_size(1)) {
+    if (x >= rr_node_indices_[type].dim_size(1)) {
         return RRNodeId::INVALID();
     }
 
-    if(node_y >= rr_node_indices_[type].dim_size(2)){
+    if(y >= rr_node_indices_[type].dim_size(2)){
         return RRNodeId::INVALID();
     }
 
@@ -71,11 +59,11 @@ RRNodeId RRSpatialLookup::find_node(int layer,
         return RRNodeId::INVALID();
     }
 
-    if (size_t(ptc) >= rr_node_indices_[type][layer][node_x][node_y][node_side].size()) {
+    if (size_t(ptc) >= rr_node_indices_[type][layer][x][y][node_side].size()) {
         return RRNodeId::INVALID();
     }
 
-    return rr_node_indices_[type][layer][node_x][node_y][node_side][ptc];
+    return rr_node_indices_[type][layer][x][y][node_side][ptc];
 }
 
 std::vector<RRNodeId> RRSpatialLookup::find_nodes_in_range(int layer,
@@ -114,18 +102,6 @@ std::vector<RRNodeId> RRSpatialLookup::find_nodes(int layer,
         return nodes;
     }
 
-    /* Currently need to swap x and y for CHANX because of chan, seg convention 
-     * This is due to that the fast look-up builders uses (y, x) coordinate when
-     * registering a CHANX node in the look-up
-     * TODO: Once the builders is reworked for use consistent (x, y) convention,
-     * the following swapping can be removed
-     */
-    size_t node_x = x;
-    size_t node_y = y;
-    if (type == e_rr_type::CHANX) {
-        std::swap(node_x, node_y);
-    }
-
     VTR_ASSERT_SAFE(4 == rr_node_indices_[type].ndims());
 
     /* Sanity check to ensure the x, y, side are in range 
@@ -140,11 +116,11 @@ std::vector<RRNodeId> RRSpatialLookup::find_nodes(int layer,
         return nodes;
     }
 
-    if (node_x >= rr_node_indices_[type].dim_size(1)) {
+    if (x >= rr_node_indices_[type].dim_size(1)) {
         return nodes;
     }
 
-    if(node_y >= rr_node_indices_[type].dim_size(2)){
+    if(y >= rr_node_indices_[type].dim_size(2)){
         return nodes;
     }
 
@@ -154,14 +130,14 @@ std::vector<RRNodeId> RRSpatialLookup::find_nodes(int layer,
 
     /* Reserve space to avoid memory fragmentation */
     size_t num_nodes = 0;
-    for (const auto& node : rr_node_indices_[type][layer][node_x][node_y][side]) {
+    for (const auto& node : rr_node_indices_[type][layer][x][y][side]) {
         if (node.is_valid()) {
             num_nodes++;
         }
     }
 
     nodes.reserve(num_nodes);
-    for (const auto& node : rr_node_indices_[type][layer][node_x][node_y][side]) {
+    for (const auto& node : rr_node_indices_[type][layer][x][y][side]) {
         if (node.is_valid()) {
             nodes.emplace_back(node);
         }

--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -338,7 +338,7 @@ void RRSpatialLookup::resize_nodes(int layer,
         || (x >= int(rr_node_indices_[type].dim_size(1)))
         || (y >= int(rr_node_indices_[type].dim_size(2)))
         || (size_t(side) >= rr_node_indices_[type].dim_size(3))) {
-        rr_node_indices_[type].resize({std::max(rr_node_indices_[type].dim_size(0),size_t(layer)+1),
+        rr_node_indices_[type].resize({std::max(rr_node_indices_[type].dim_size(0), size_t(layer)+1),
                                        std::max(rr_node_indices_[type].dim_size(1), size_t(x) + 1),
                                        std::max(rr_node_indices_[type].dim_size(2), size_t(y) + 1),
                                        std::max(rr_node_indices_[type].dim_size(3), size_t(side) + 1)});

--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -1,9 +1,6 @@
 #include "vtr_assert.h"
 #include "rr_spatial_lookup.h"
 
-RRSpatialLookup::RRSpatialLookup() {
-}
-
 RRNodeId RRSpatialLookup::find_node(int layer,
                                     int x,
                                     int y,
@@ -130,14 +127,14 @@ std::vector<RRNodeId> RRSpatialLookup::find_nodes(int layer,
 
     /* Reserve space to avoid memory fragmentation */
     size_t num_nodes = 0;
-    for (const auto& node : rr_node_indices_[type][layer][x][y][side]) {
+    for (RRNodeId node : rr_node_indices_[type][layer][x][y][side]) {
         if (node.is_valid()) {
             num_nodes++;
         }
     }
 
     nodes.reserve(num_nodes);
-    for (const auto& node : rr_node_indices_[type][layer][x][y][side]) {
+    for (RRNodeId node : rr_node_indices_[type][layer][x][y][side]) {
         if (node.is_valid()) {
             nodes.emplace_back(node);
         }
@@ -328,7 +325,7 @@ void RRSpatialLookup::reorder(const vtr::vector<RRNodeId, RRNodeId>& dest_order)
             for (size_t x = 0; x < grid.dim_size(1); x++) {
                 for (size_t y = 0; y < grid.dim_size(2); y++) {
                     for (size_t s = 0; s < grid.dim_size(3); s++) {
-                        for (auto &node: grid[l][x][y][s]) {
+                        for (RRNodeId &node: grid[l][x][y][s]) {
                             if (node.is_valid()) {
                                 node = dest_order[node];
                             }

--- a/libs/librrgraph/src/base/rr_spatial_lookup.h
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.h
@@ -1,5 +1,4 @@
-#ifndef RR_SPATIAL_LOOKUP_H
-#define RR_SPATIAL_LOOKUP_H
+#pragma once
 
 /** 
  * @file
@@ -25,7 +24,7 @@ class RRSpatialLookup {
     /* -- Constructors -- */
   public:
     /* Explicitly define the only way to create an object */
-    explicit RRSpatialLookup();
+    explicit RRSpatialLookup() = default;
 
     /* Disable copy constructors and copy assignment operator
      * This is to avoid accidental copy because it could be an expensive operation considering that the 
@@ -293,5 +292,3 @@ class RRSpatialLookup {
     /* Fast look-up: TODO: Should rework the data type. Currently it is based on a 3-dimensional array mater where some dimensions must always be accessed with a specific index. Such limitation should be overcome */
     t_rr_node_indices rr_node_indices_;
 };
-
-#endif

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1848,16 +1848,11 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
         /* Alloc the lookup table */
         for (e_rr_type rr_type : RR_TYPES) {
-            if (rr_type == e_rr_type::CHANX) {
-                rr_graph_builder.node_lookup().resize_nodes(grid_.get_num_layers(), grid_.height(), grid_.width(), rr_type, NUM_2D_SIDES);
-            } else {
-                rr_graph_builder.node_lookup().resize_nodes(grid_.get_num_layers(), grid_.width(), grid_.height(), rr_type, NUM_2D_SIDES);
-            }
+            rr_graph_builder.node_lookup().resize_nodes(grid_.get_num_layers(), grid_.width(), grid_.height(), rr_type, NUM_2D_SIDES);
         }
 
         /* Add the correct node into the vector */
-        for (size_t inode = 0; inode < rr_nodes_->size(); inode++) {
-            auto node = (*rr_nodes_)[inode];
+        for (const t_rr_node& node : *rr_nodes_) {
             rr_graph_builder.add_node_to_all_locs(node.id());
         }
     }

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -372,8 +372,7 @@ int ClockRib::create_chanx_wire(int layer,
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
-            //TODO: CHANX uses odd swapped x/y indices here. Will rework once rr_node_indices is shadowed
-            rr_graph_builder.node_lookup().add_node(chanx_node, layer, iy, ix, rr_graph.node_type(chanx_node), rr_graph.node_track_num(chanx_node));
+            rr_graph_builder.node_lookup().add_node(chanx_node, layer, ix, iy, rr_graph.node_type(chanx_node), rr_graph.node_track_num(chanx_node));
         }
     }
 

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1254,8 +1254,7 @@ static void build_rr_graph(e_graph_type graph_type,
                                    grid,
                                    &num_rr_nodes,
                                    chan_details_x,
-                                   chan_details_y,
-                                   is_flat);
+                                   chan_details_y);
 
     size_t expected_node_count = num_rr_nodes;
     if (clock_modeling == DEDICATED_NETWORK) {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1250,7 +1250,7 @@ static void build_rr_graph(e_graph_type graph_type,
 
     // Add routing resources to rr_graph lookup table
     alloc_and_load_rr_node_indices(device_ctx.rr_graph_builder,
-                                   &nodes_per_chan,
+                                   nodes_per_chan,
                                    grid,
                                    &num_rr_nodes,
                                    chan_details_x,

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1336,11 +1336,10 @@ static void build_rr_graph(e_graph_type graph_type,
      */
     if (grid.get_num_layers() > 1 && sb_type == CUSTOM) {
         //keep how many nodes each switchblock requires for each x,y location
-        auto extra_nodes_per_switchblock = get_number_track_to_track_inter_die_conn(sb_conn_map, custom_3d_sb_fanin_fanout, device_ctx.rr_graph_builder);
+        vtr::NdMatrix<int, 2> extra_nodes_per_switchblock = get_number_track_to_track_inter_die_conn(sb_conn_map, custom_3d_sb_fanin_fanout, device_ctx.rr_graph_builder);
         //allocate new nodes in each switchblocks
-        alloc_and_load_inter_die_rr_node_indices(device_ctx.rr_graph_builder, &nodes_per_chan, grid, extra_nodes_per_switchblock, &num_rr_nodes);
+        alloc_and_load_inter_die_rr_node_indices(device_ctx.rr_graph_builder, nodes_per_chan, grid, extra_nodes_per_switchblock, &num_rr_nodes);
         device_ctx.rr_graph_builder.resize_nodes(num_rr_nodes);
-        extra_nodes_per_switchblock.clear();
     }
 
     /* START IPIN MAP */

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -49,7 +49,6 @@ static void load_block_rr_indices(RRGraphBuilder& rr_graph_builder,
                                   const DeviceGrid& grid,
                                   int* index);
 
-
 static void add_pins_spatial_lookup(RRGraphBuilder& rr_graph_builder,
                                     t_physical_tile_type_ptr physical_type_ptr,
                                     const std::vector<int>& pin_num_vec,

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1547,6 +1547,7 @@ bool verify_rr_node_indices(const DeviceGrid& grid,
                     } else {
                         nodes_from_lookup = rr_graph.node_lookup().find_grid_nodes_at_all_sides(l, x, y, rr_type);
                     }
+
                     for (RRNodeId inode : nodes_from_lookup) {
                         rr_node_counts[inode]++;
 

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1439,7 +1439,6 @@ static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
     }
 }
 
-/* As the rr_indices builders modify a local copy of indices, use the local copy in the builder */
 void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const t_chan_width& nodes_per_chan,
                                     const DeviceGrid& grid,
@@ -1447,9 +1446,6 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const t_chan_details& chan_details_x,
                                     const t_chan_details& chan_details_y,
                                     bool is_flat) {
-    /* Allocates and loads all the structures needed for fast lookups of the
-     * index of an rr_node. rr_node_indices is a matrix containing the index
-     * of the *first* rr_node at a given (i,j) location. */
 
     /* Alloc the lookup table */
     for (e_rr_type rr_type : RR_TYPES) {

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -33,6 +33,18 @@ static void load_chan_rr_indices(const int max_chan_width,
                                  RRGraphBuilder& rr_graph_builder,
                                  int* index);
 
+/**
+ * @brief Assigns and loads rr_node indices for block-level routing resources (SOURCE, SINK, IPIN, OPIN).
+ *
+ * This function walks through the device grid and assigns unique rr_node indices to the routing resources
+ * associated with each block (tiles).
+ *
+ * For SINKs and SOURCEs, it uses side 0 by convention (since they have no geometric side). For IPINs and OPINs,
+ * it determines the correct sides based on the tile's position in the grid, following special rules for
+ * edge and corner tiles.
+ *
+ * The index counter is passed and updated as rr_nodes are added.
+ */
 static void load_block_rr_indices(RRGraphBuilder& rr_graph_builder,
                                   const DeviceGrid& grid,
                                   int* index,
@@ -1347,6 +1359,7 @@ static void load_block_rr_indices(RRGraphBuilder& rr_graph_builder,
         }
     }
 }
+
 static void add_pins_spatial_lookup(RRGraphBuilder& rr_graph_builder,
                                     t_physical_tile_type_ptr physical_type_ptr,
                                     const std::vector<int>& pin_num_vec,

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1441,7 +1441,7 @@ static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
 
 /* As the rr_indices builders modify a local copy of indices, use the local copy in the builder */
 void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
-                                    const t_chan_width* nodes_per_chan,
+                                    const t_chan_width& nodes_per_chan,
                                     const DeviceGrid& grid,
                                     int* index,
                                     const t_chan_details& chan_details_x,
@@ -1464,9 +1464,9 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
     load_block_rr_indices(rr_graph_builder, grid, index, is_flat);
 
     /* Load the data for x and y channels */
-    load_chan_rr_indices(nodes_per_chan->x_max, grid, grid.width(), grid.height(),
+    load_chan_rr_indices(nodes_per_chan.x_max, grid, grid.width(), grid.height(),
                          e_rr_type::CHANX, chan_details_x, rr_graph_builder, index);
-    load_chan_rr_indices(nodes_per_chan->y_max, grid, grid.height(), grid.width(),
+    load_chan_rr_indices(nodes_per_chan.y_max, grid, grid.height(), grid.width(),
                          e_rr_type::CHANY, chan_details_y, rr_graph_builder, index);
 }
 

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1115,7 +1115,7 @@ static void load_chan_rr_indices(const int max_chan_width,
                 const t_chan_seg_details* seg_details = chan_details[x][y].data();
 
                 // Reserve nodes in lookup to save memory
-                rr_graph_builder.node_lookup().reserve_nodes(layer, chan, seg, type, max_chan_width);
+                rr_graph_builder.node_lookup().reserve_nodes(layer, x, y, type, max_chan_width);
 
                 for (int track = 0; track < max_chan_width; ++track) {
                     /* TODO: May let the length() == 0 case go through, to model muxes */

--- a/vpr/src/route/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph2.cpp
@@ -1131,7 +1131,7 @@ static void load_chan_rr_indices(const int max_chan_width,
                     if (!inode) {
                         inode = RRNodeId(*index);
                         ++(*index);
-                        rr_graph_builder.node_lookup().add_node(inode, layer, chan, start, type, track);
+                        rr_graph_builder.node_lookup().add_node(inode, layer, node_start_x, node_start_y, type, track);
                     }
 
                     // Assign RRNodeId of start of wire to current position
@@ -1516,15 +1516,6 @@ void alloc_and_load_intra_cluster_rr_node_indices(RRGraphBuilder& rr_graph_build
     }
 }
 
-/**
- * Validate the node look-up matches all the node-level information 
- * in the storage of a routing resource graph
- * This function will check the following aspects:
- * - The type of each node matches its type that is indexed in the node look-up
- * - For bounding box (xlow, ylow, xhigh, yhigh) of each node is indexable in the node look-up
- * - The number of unique indexable nodes in the node look up matches the number of nodes in the storage
- *   This ensures that every node in the storage is indexable and there are no hidden nodes in the look-up
- */
 bool verify_rr_node_indices(const DeviceGrid& grid,
                             const RRGraphView& rr_graph,
                             const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -27,7 +27,6 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const t_chan_details& chan_details_x,
                                     const t_chan_details& chan_details_y);
 
-
 /**
  * @brief Allocates extra nodes within the RR graph to support 3D custom switch blocks for multi-die FPGAs
  *

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -29,7 +29,7 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
 
 
 /**
- * @brief allocates extra nodes within the RR graph to support 3D custom switch blocks for multi-die FPGAs
+ * @brief Allocates extra nodes within the RR graph to support 3D custom switch blocks for multi-die FPGAs
  *
  *  @param rr_graph_builder RRGraphBuilder data structure which allows data modification on a routing resource graph
  *  @param nodes_per_chan number of tracks per channel (x, y)
@@ -39,7 +39,7 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
  *  @param index RRNodeId that should be assigned to add a new RR node to the RR graph
  */
 void alloc_and_load_inter_die_rr_node_indices(RRGraphBuilder& rr_graph_builder,
-                                              const t_chan_width* nodes_per_chan,
+                                              const t_chan_width& nodes_per_chan,
                                               const DeviceGrid& grid,
                                               const vtr::NdMatrix<int, 2>& extra_nodes_per_switchblock,
                                               int* index);

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -14,6 +14,12 @@
 
 /******************* Subroutines exported by rr_graph2.c *********************/
 
+/**
+ * @brief Allocates and populates data structures for efficient rr_node index lookups.
+ *
+ * This function sets up the `rr_node_indices` structure, which maps a physical location
+ * and type to the index of the first corresponding rr_node.
+ */
 void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const t_chan_width& nodes_per_chan,
                                     const DeviceGrid& grid,
@@ -21,6 +27,7 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const t_chan_details& chan_details_x,
                                     const t_chan_details& chan_details_y,
                                     bool is_flat);
+
 
 /**
  * @brief allocates extra nodes within the RR graph to support 3D custom switch blocks for multi-die FPGAs

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -56,6 +56,15 @@ void alloc_and_load_intra_cluster_rr_node_indices(RRGraphBuilder& rr_graph_build
                                                   const vtr::vector<ClusterBlockId, std::unordered_set<int>>& pin_chains_num,
                                                   int* index);
 
+/**
+ * Validate the node look-up matches all the node-level information
+ * in the storage of a routing resource graph
+ * This function will check the following aspects:
+ * - The type of each node matches its type that is indexed in the node look-up
+ * - For bounding box (xlow, ylow, xhigh, yhigh) of each node is indexable in the node look-up
+ * - The number of unique indexable nodes in the node look up matches the number of nodes in the storage
+ *   This ensures that every node in the storage is indexable and there are no hidden nodes in the look-up
+ */
 bool verify_rr_node_indices(const DeviceGrid& grid,
                             const RRGraphView& rr_graph,
                             const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -1,5 +1,5 @@
-#ifndef RR_GRAPH2_H
-#define RR_GRAPH2_H
+#pragma once
+
 #include <vector>
 
 #include "build_switchblocks.h"
@@ -15,7 +15,7 @@
 /******************* Subroutines exported by rr_graph2.c *********************/
 
 void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
-                                    const t_chan_width* nodes_per_chan,
+                                    const t_chan_width& nodes_per_chan,
                                     const DeviceGrid& grid,
                                     int* index,
                                     const t_chan_details& chan_details_x,
@@ -252,4 +252,3 @@ void dump_track_to_pin_map(t_track_to_pin_lookup& track_to_pin_map,
                            FILE* fp);
 
 inline int get_chan_width(enum e_side side, const t_chan_width& nodes_per_channel);
-#endif

--- a/vpr/src/route/rr_graph2.h
+++ b/vpr/src/route/rr_graph2.h
@@ -25,8 +25,7 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const DeviceGrid& grid,
                                     int* index,
                                     const t_chan_details& chan_details_x,
-                                    const t_chan_details& chan_details_y,
-                                    bool is_flat);
+                                    const t_chan_details& chan_details_y);
 
 
 /**


### PR DESCRIPTION
`RRSpatialLookup` swaps the x and y coordinates of CHANX wires when putting them in the `rr_node_lookup` data structure, and `find_node()` function swaps them as well. This PR gets rid of these swaps.

Addresses #355 and #2978