### PR TITLE
[Infra] Updated Install Packages Script For Backwards Compatibility

### DIFF
--- a/.github/scripts/install_dependencies.sh
+++ b/.github/scripts/install_dependencies.sh
@@ -2,40 +2,32 @@
 
 sudo apt update
 
+# Required packages specifically for the CI and not VTR in general.
 sudo apt install -y \
   autoconf \
   automake \
   bash \
-  bison \
   binutils \
   binutils-gold \
-  build-essential \
   capnproto \
   exuberant-ctags \
   curl \
   doxygen \
-  flex \
   fontconfig \
   gdb \
-  git \
   gperf \
   libcairo2-dev \
   libcapnp-dev \
-  libgtk-3-dev \
   libevent-dev \
   libfontconfig1-dev \
   liblist-moreutils-perl \
   libncurses5-dev \
-  libx11-dev \
   libxft-dev \
   libxml2-utils \
   libxml++2.6-dev \
-  libreadline-dev \
   tcllib \
   tcl8.6-dev \
-  libffi-dev \
   perl \
-  pkg-config \
   texinfo \
   time \
   valgrind \
@@ -54,9 +46,10 @@ sudo apt install -y \
   clang-15 \
   clang-16 \
   clang-17 \
-  clang-18 \
-  clang-format-18 \
-  libtbb-dev
+  clang-18
+
+# Standard packages install script.
+./install_apt_packages.sh
 
 pip install -r requirements.txt
 

--- a/.github/scripts/install_jammy_dependencies.sh
+++ b/.github/scripts/install_jammy_dependencies.sh
@@ -2,40 +2,32 @@
 
 sudo apt update
 
+# Required packages specifically for the CI and not VTR in general.
 sudo apt install -y \
   autoconf \
   automake \
   bash \
-  bison \
   binutils \
   binutils-gold \
-  build-essential \
   capnproto \
   exuberant-ctags \
   curl \
   doxygen \
-  flex \
   fontconfig \
   gdb \
-  git \
   gperf \
   libcairo2-dev \
   libcapnp-dev \
-  libgtk-3-dev \
   libevent-dev \
   libfontconfig1-dev \
   liblist-moreutils-perl \
   libncurses5-dev \
-  libx11-dev \
   libxft-dev \
   libxml2-utils \
   libxml++2.6-dev \
-  libreadline-dev \
   tcllib \
   tcl8.6-dev \
-  libffi-dev \
   perl \
-  pkg-config \
   texinfo \
   time \
   valgrind \
@@ -50,9 +42,10 @@ sudo apt install -y \
   g++-11 \
   gcc-11 \
   g++-12 \
-  gcc-12 \
-  clang-format-14 \
-  libtbb-dev
+  gcc-12
+
+# Standard packages install script.
+./install_apt_packages.sh
 
 pip install -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,15 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # Install and cleanup is done in one command to minimize the build cache size
 RUN apt-get update -qq \
 # Extract package names from install_apt_packages.sh
-    && sed '/sudo/d' install_apt_packages.sh | sed '/#/d' | sed 's/ \\//g' | sed '/^$/d' | sed '/^[[:space:]]*$/d' \
+    && sed '/sudo/d' install_apt_packages.sh | sed '/#/d' | sed '/if\s.*then$/d' | sed '/else$/d' | sed '/fi$/d' | sed '/echo\s/d' | sed 's/ \\//g' | sed '/^$/d' | sed '/^[[:space:]]*$/d' | sed 's/\s//g' \
 # Install packages
     | xargs apt-get -y install --no-install-recommends \
 # Additional packages not listed in install_apt_packages.sh
     && apt-get -y install --no-install-recommends \
     wget \
     ninja-build \
-    default-jre \
     libeigen3-dev \
-    libtbb-dev \
     python3-pip \
-    git \
     time \
 # Install python packages
     && pip install -r requirements.txt \

--- a/install_apt_packages.sh
+++ b/install_apt_packages.sh
@@ -10,7 +10,11 @@ sudo apt-get install -y \
     flex \
     python3-dev \
     python3-venv
-    
+
+# Packages for more complex features of VTR that most people will use.
+sudo apt-get install -y \
+    libtbb-dev
+
 # Required for graphics
 sudo apt-get install -y \
     libgtk-3-dev \
@@ -42,6 +46,11 @@ sudo apt-get install -y \
     sphinx-common
 
 # Required for code formatting
-sudo apt-get install -y \
-    clang-format-18
-
+# NOTE: clang-format-18 may only be found on specific distributions. Only
+#       install it if the distribution has this version of clang format.
+if apt-cache search '^clang-format-18$' | grep -q 'clang-format-18'; then
+    sudo apt-get install -y \
+        clang-format-18
+else
+    echo "clang-format-18 not found in apt-cache. Skipping installation."
+fi


### PR DESCRIPTION
The install_apt_packages.sh script is no longer backward compatible with older versions of Ubuntu due to the dependency on clang-format-18.

Added an if statement to check if the distribution can support clang-format-18 and only installing it if it can.

Added this script to the CI build process so it can always be tested within the CI to prevent future regression.