### PR TITLE
[FASM] Fixed Bug With Wire Creation

### DIFF
--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -217,26 +217,62 @@ std::string FasmWriterVisitor::build_clb_prefix(const t_pb *pb, const t_pb_graph
   return clb_prefix;
 }
 
-static const t_pb_graph_pin* is_node_used(const t_pb_routes &top_pb_route, const t_pb_graph_node* pb_graph_node) {
-    // Is the node used at all?
-    const t_pb_graph_pin* pin = nullptr;
-    for(int port_index = 0; port_index < pb_graph_node->num_output_ports; ++port_index) {
-        for(int pin_index = 0; pin_index < pb_graph_node->num_output_pins[port_index]; ++pin_index) {
-            pin = &pb_graph_node->output_pins[port_index][pin_index];
-            if (top_pb_route.count(pin->pin_count_in_cluster) > 0 && top_pb_route[pin->pin_count_in_cluster].atom_net_id != AtomNetId::INVALID()) {
-                return pin;
-            }
-        }
-    }
+/**
+ * @brief Returns true if the given pin is used (i.e. is not "open").
+ */
+static bool is_pin_used(const t_pb_graph_pin* pin, const t_pb_routes &top_pb_route) {
+    // A pin is used if it has a pb_route that is connected to an atom net.
+    if (top_pb_route.count(pin->pin_count_in_cluster) == 0)
+        return false;
+    if (!top_pb_route[pin->pin_count_in_cluster].atom_net_id.is_valid())
+        return false;
+    return true;
+}
+
+/**
+ * @brief Returns the input pin for the given wire.
+ *
+ * Wires in VPR are a special primitive which is a LUT which acts like a wire
+ * pass-through. Only one input of this LUT should be used.
+ */
+static const t_pb_graph_pin* get_wire_input_pin(const t_pb_routes &top_pb_route, const t_pb_graph_node* pb_graph_node) {
+    const t_pb_graph_pin* wire_input_pin = nullptr;
     for(int port_index = 0; port_index < pb_graph_node->num_input_ports; ++port_index) {
         for(int pin_index = 0; pin_index < pb_graph_node->num_input_pins[port_index]; ++pin_index) {
-            pin = &pb_graph_node->input_pins[port_index][pin_index];
-            if (top_pb_route.count(pin->pin_count_in_cluster) > 0 && top_pb_route[pin->pin_count_in_cluster].atom_net_id != AtomNetId::INVALID()) {
-                return pin;
+            const t_pb_graph_pin* pin = &pb_graph_node->input_pins[port_index][pin_index];
+            if (is_pin_used(pin, top_pb_route)) {
+                VTR_ASSERT_MSG(wire_input_pin == nullptr,
+                               "Wire found with more than 1 used input");
+                wire_input_pin = pin;
             }
         }
     }
-    return nullptr;
+    return wire_input_pin;
+}
+
+/**
+ * @brief Returns true if the given wire is used.
+ *
+ * A wire is used if it has a used output pin.
+ */
+static bool is_wire_used(const t_pb_routes &top_pb_route, const t_pb_graph_node* pb_graph_node) {
+    // A wire is used if it has a used output pin.
+    const t_pb_graph_pin* wire_output_pin = nullptr;
+    for(int port_index = 0; port_index < pb_graph_node->num_output_ports; ++port_index) {
+        for(int pin_index = 0; pin_index < pb_graph_node->num_output_pins[port_index]; ++pin_index) {
+            const t_pb_graph_pin* pin = &pb_graph_node->output_pins[port_index][pin_index];
+            if (is_pin_used(pin, top_pb_route)) {
+                VTR_ASSERT_MSG(wire_output_pin == nullptr,
+                               "Wire found with more than 1 used output");
+                wire_output_pin = pin;
+            }
+        }
+    }
+
+    if (wire_output_pin != nullptr)
+        return true;
+
+    return false;
 }
 
 void FasmWriterVisitor::check_features(const t_metadata_dict *meta) const {
@@ -278,14 +314,19 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
   }
 
   if(mode != nullptr && std::string(mode->name) == "wire") {
-    auto io_pin = is_node_used(pb_routes, pb_graph_node);
-    if(io_pin != nullptr) {
-      const auto& route = pb_routes.at(io_pin->pin_count_in_cluster);
+    if (is_wire_used(pb_routes, pb_graph_node)) {
+      const t_pb_graph_pin* wire_input_pin = get_wire_input_pin(pb_routes, pb_graph_node);
+      VTR_ASSERT_MSG(wire_input_pin != nullptr,
+                     "Wire found with no used input pins");
+      const auto& route = pb_routes.at(wire_input_pin->pin_count_in_cluster);
       const int num_inputs = *route.pb_graph_pin->parent_node->num_input_pins;
       const auto *lut_definition = find_lut(route.pb_graph_pin->parent_node);
       VTR_ASSERT(lut_definition->num_inputs == num_inputs);
 
       output_fasm_features(lut_definition->CreateWire(route.pb_graph_pin->pin_number));
+    } else {
+      VTR_ASSERT_MSG(get_wire_input_pin(pb_routes, pb_graph_node) == nullptr,
+                     "Wire found with a used input pin, but no used output pin");
     }
   }
 

--- a/vpr/src/base/read_netlist.cpp
+++ b/vpr/src/base/read_netlist.cpp
@@ -755,6 +755,7 @@ static void processPorts(pugi::xml_node Parent, t_pb* pb, t_pb_routes& pb_route,
                     pb_route.insert(std::make_pair(rr_node_index, t_pb_route()));
                     pb_route[rr_node_index].driver_pb_pin_id = pin_node[0][0]->pin_count_in_cluster;
                     pb_route[rr_node_index].pb_graph_pin = pb_gpin;
+                    VTR_ASSERT(pb_route[rr_node_index].pb_graph_pin->pin_number == i);
 
                     found = false;
                     for (j = 0; j < pin_node[0][0]->num_output_edges; j++) {

--- a/vpr/src/route/route_utils.cpp
+++ b/vpr/src/route/route_utils.cpp
@@ -19,10 +19,7 @@
 #include "route_tree.h"
 #include "rr_graph.h"
 #include "tatum/TimingReporter.hpp"
-
-#ifdef VPR_USE_TBB
 #include "stats.h"
-#endif // VPR_USE_TBB
 
 bool check_net_delays(const Netlist<>& net_list, NetPinsMatrix<float>& net_delay) {
     constexpr float ERROR_TOL = 0.0001;


### PR DESCRIPTION
Found a bug within FASM's wire generation where it uses the index of the output pin to create the wire instead of the index of the input pin.

This stemmed from some confusing code which both verified that the wire was being used and returning the first valid pin. It just so happens that it checked the outputs first and returned the output pin instead.

Cleaned up the code and added more error checking to prevent issues like this in the future.