### PR TITLE
[CI] Added Serial Execution Engine Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,12 @@ jobs:
             extra_pkgs: ""
           },
           {
+            name: 'Basic with serial VPR_EXECUTION_ENGINE',
+            params: '-DCMAKE_COMPILE_WARNING_AS_ERROR=on -DVTR_IPO_BUILD=off -DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DVPR_EXECUTION_ENGINE=serial -DTATUM_EXECUTION_ENGINE=serial',
+            suite: 'vtr_reg_basic',
+            extra_pkgs: ""
+          },
+          {
             name: 'Basic with VTR_ENABLE_DEBUG_LOGGING',
             params: '-DCMAKE_COMPILE_WARNING_AS_ERROR=on -DVTR_IPO_BUILD=off -DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DVTR_ENABLE_DEBUG_LOGGING=on',
             suite: 'vtr_reg_basic',


### PR DESCRIPTION
Since the CI always installs oneTBB and the execution engine is set to auto, I found that the CI always tested with the tbb execution engine. Some users may not have oneTBB installed for one reason or another and we need to ensure that VTR always builds.

Added a CI test which sets the parallel execution engine to serial for Tatum and VPR.