### PR TITLE
Hotfix win32 sockpp and vtr enum collisions

### DIFF
--- a/vpr/src/server/gateio.cpp
+++ b/vpr/src/server/gateio.cpp
@@ -6,7 +6,160 @@
 #include "commconstants.h"
 #include "convertutils.h"
 
+#include "sockpp/tcp6_acceptor.h"
+
 namespace server {
+
+static ActivityStatus check_client_connection(sockpp::tcp6_acceptor& tcp_server, std::optional<sockpp::tcp6_socket>& client_opt, TLogger& logger) {
+    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
+
+    sockpp::inet6_address peer;
+    sockpp::tcp6_socket client = tcp_server.accept(&peer);
+    if (client) {
+        logger.queue(LogLevel::Info, "client", client.address().to_string() , "connection accepted");
+        client.set_non_blocking(true);
+        client_opt = std::move(client);
+
+        status = ActivityStatus::CLIENT_ACTIVITY;
+    }
+
+    return status;
+}
+
+static ActivityStatus handle_sending_data(sockpp::tcp6_socket& client, std::mutex& tasks_mutex, std::vector<TaskPtr>& send_tasks, TLogger& logger) {
+    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
+    std::unique_lock<std::mutex> lock(tasks_mutex);
+
+    if (!send_tasks.empty()) {
+        const TaskPtr& task = send_tasks.at(0);
+        try {
+            std::size_t bytes_to_send = std::min(CHUNK_MAX_BYTES_NUM, task->response_buffer().size());
+            std::size_t bytes_sent = client.write_n(task->response_buffer().data(), bytes_to_send);
+            if (bytes_sent <= task->orig_reponse_bytes_num()) {
+                task->chop_num_sent_bytes_from_response_buffer(bytes_sent);
+                logger.queue(LogLevel::Detail,
+                            "sent chunk:", get_pretty_size_str_from_bytes_num(bytes_sent),
+                            "from", get_pretty_size_str_from_bytes_num(task->orig_reponse_bytes_num()),
+                            "left:", get_pretty_size_str_from_bytes_num(task->response_buffer().size()));
+                status = ActivityStatus::CLIENT_ACTIVITY;
+            }
+        } catch(...) {
+            logger.queue(LogLevel::Detail, "error while writing chunk");
+            status = ActivityStatus::COMMUNICATION_PROBLEM;
+        }
+
+        if (task->is_response_fully_sent()) {
+            logger.queue(LogLevel::Info, "sent:", task->telegram_header().info(), task->info());
+        }
+    }
+
+    // remove reported tasks
+    std::size_t tasks_num_before_removing = send_tasks.size();
+
+    auto partition_iter = std::partition(send_tasks.begin(), send_tasks.end(),
+                                        [](const TaskPtr& task) { return !task->is_response_fully_sent(); });
+    send_tasks.erase(partition_iter, send_tasks.end());
+    bool is_removing_took_place = tasks_num_before_removing != send_tasks.size();
+    if (!send_tasks.empty() && is_removing_took_place) {
+        logger.queue(LogLevel::Detail, "left tasks num to send ", send_tasks.size());
+    }
+
+    return status;
+}
+
+static ActivityStatus handle_receiving_data(sockpp::tcp6_socket& client, comm::TelegramBuffer& telegram_buff, std::string& received_message, TLogger& logger) {
+    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
+    std::size_t bytes_actually_received{0};
+    try {
+        bytes_actually_received = client.read_n(&received_message[0], CHUNK_MAX_BYTES_NUM);
+    } catch(...) {
+        logger.queue(LogLevel::Error, "fail to receiving");
+        status = ActivityStatus::COMMUNICATION_PROBLEM;
+    }
+
+    if ((bytes_actually_received > 0) && (bytes_actually_received <= CHUNK_MAX_BYTES_NUM)) {
+        logger.queue(LogLevel::Detail, "received chunk:", get_pretty_size_str_from_bytes_num(bytes_actually_received));
+        telegram_buff.append(comm::ByteArray{received_message.c_str(), bytes_actually_received});
+        status = ActivityStatus::CLIENT_ACTIVITY;
+    }
+
+    return status;
+}
+
+static ActivityStatus handle_telegrams(std::vector<comm::TelegramFramePtr>& telegram_frames, comm::TelegramBuffer& telegram_buff, std::mutex& tasks_mutex, std::vector<TaskPtr>& received_tasks, TLogger& logger) {
+    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
+    telegram_frames.clear();
+    telegram_buff.take_telegram_frames(telegram_frames);
+    for (const comm::TelegramFramePtr& telegram_frame: telegram_frames) {
+        // process received data
+        std::string message{telegram_frame->body};
+        bool is_echo_telegram = false;
+        if ((message.size() == comm::ECHO_TELEGRAM_BODY.size()) && (message == comm::ECHO_TELEGRAM_BODY)) {
+            logger.queue(LogLevel::Detail, "received", comm::ECHO_TELEGRAM_BODY);
+            is_echo_telegram = true;
+            status = ActivityStatus::CLIENT_ACTIVITY;
+        }
+
+        if (!is_echo_telegram) {
+            logger.queue(LogLevel::Detail, "received composed", get_pretty_size_str_from_bytes_num(message.size()), ":", get_truncated_middle_str(message));
+            std::optional<int> job_id_opt = comm::TelegramParser::try_extract_field_job_id(message);
+            std::optional<int> cmd_opt = comm::TelegramParser::try_extract_field_cmd(message);
+            std::optional<std::string> options_opt = comm::TelegramParser::try_extract_field_options(message);
+            if (job_id_opt && cmd_opt && options_opt) {
+                TaskPtr task = std::make_unique<Task>(job_id_opt.value(), static_cast<comm::CMD>(cmd_opt.value()), options_opt.value());
+                const comm::TelegramHeader& header = telegram_frame->header;
+                logger.queue(LogLevel::Info, "received:", header.info(), task->info(/*skipDuration*/true));
+                std::unique_lock<std::mutex> lock(tasks_mutex);
+                received_tasks.push_back(std::move(task));
+            } else {
+                logger.queue(LogLevel::Error, "broken telegram detected, fail extract options from", message);
+            }
+        }
+    }
+
+    return status;
+}
+
+static ActivityStatus handle_client_alive_tracker(sockpp::tcp6_socket& client, std::unique_ptr<ClientAliveTracker>& client_alive_tracker_ptr, TLogger& logger) {
+    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
+    if (client_alive_tracker_ptr) {
+        /// handle sending echo to client
+        if (client_alive_tracker_ptr->is_time_to_sent_echo()) {
+            comm::TelegramHeader echo_header = comm::TelegramHeader::construct_from_body(comm::ECHO_TELEGRAM_BODY);
+            std::string message{echo_header.buffer()};
+            message.append(comm::ECHO_TELEGRAM_BODY);
+            try {
+                std::size_t bytes_sent = client.write(message);
+                if (bytes_sent == message.size()) {
+                    logger.queue(LogLevel::Detail, "sent", comm::ECHO_TELEGRAM_BODY);
+                    client_alive_tracker_ptr->on_echo_sent();
+                }
+            } catch(...) {
+                logger.queue(LogLevel::Debug, "fail to sent", comm::ECHO_TELEGRAM_BODY);
+                status = ActivityStatus::COMMUNICATION_PROBLEM;
+            }
+        }
+
+        /// handle client timeout
+        if (client_alive_tracker_ptr->is_client_timeout()) {
+            logger.queue(LogLevel::Error, "client didn't respond too long");
+            status = ActivityStatus::COMMUNICATION_PROBLEM;
+        }
+    }
+
+    return status;
+}
+
+static void handle_activity_status(ActivityStatus status, std::unique_ptr<ClientAliveTracker>& client_alive_tracker_ptr, bool& is_communication_problem_detected) {
+    if (status == ActivityStatus::CLIENT_ACTIVITY) {
+        if (client_alive_tracker_ptr) {
+            client_alive_tracker_ptr->on_client_activity();
+        }
+    } else if (status == ActivityStatus::COMMUNICATION_PROBLEM) {
+        is_communication_problem_detected = true;
+    }
+}
+
 
 GateIO::GateIO() {
     m_is_running.store(false);
@@ -36,7 +189,7 @@ void GateIO::stop() {
 
 void GateIO::take_received_tasks(std::vector<TaskPtr>& tasks) {
     std::unique_lock<std::mutex> lock(m_tasks_mutex);
-    for (TaskPtr& task : m_received_tasks) {
+    for (TaskPtr& task: m_received_tasks) {
         m_logger.queue(LogLevel::Debug, "move task id=", task->job_id(), "for processing");
         tasks.push_back(std::move(task));
     }
@@ -45,166 +198,17 @@ void GateIO::take_received_tasks(std::vector<TaskPtr>& tasks) {
 
 void GateIO::move_tasks_to_send_queue(std::vector<TaskPtr>& tasks) {
     std::unique_lock<std::mutex> lock(m_tasks_mutex);
-    for (TaskPtr& task : tasks) {
+    for (TaskPtr& task: tasks) {
         m_logger.queue(LogLevel::Debug, "move task id=", task->job_id(), "finished", (task->has_error() ? "with error" : "successfully"), task->error(), "to send queue");
         m_send_tasks.push_back(std::move(task));
     }
     tasks.clear();
 }
 
-GateIO::ActivityStatus GateIO::check_client_connection(sockpp::tcp6_acceptor& tcp_server, std::optional<sockpp::tcp6_socket>& client_opt) {
-    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
-
-    sockpp::inet6_address peer;
-    sockpp::tcp6_socket client = tcp_server.accept(&peer);
-    if (client) {
-        m_logger.queue(LogLevel::Info, "client", client.address().to_string(), "connection accepted");
-        client.set_non_blocking(true);
-        client_opt = std::move(client);
-
-        status = ActivityStatus::CLIENT_ACTIVITY;
-    }
-
-    return status;
-}
-
-GateIO::ActivityStatus GateIO::handle_sending_data(sockpp::tcp6_socket& client) {
-    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
-    std::unique_lock<std::mutex> lock(m_tasks_mutex);
-
-    if (!m_send_tasks.empty()) {
-        const TaskPtr& task = m_send_tasks.at(0);
-        try {
-            std::size_t bytes_to_send = std::min(CHUNK_MAX_BYTES_NUM, task->response_buffer().size());
-            std::size_t bytes_sent = client.write_n(task->response_buffer().data(), bytes_to_send);
-            if (bytes_sent <= task->orig_reponse_bytes_num()) {
-                task->chop_num_sent_bytes_from_response_buffer(bytes_sent);
-                m_logger.queue(LogLevel::Detail,
-                               "sent chunk:", get_pretty_size_str_from_bytes_num(bytes_sent),
-                               "from", get_pretty_size_str_from_bytes_num(task->orig_reponse_bytes_num()),
-                               "left:", get_pretty_size_str_from_bytes_num(task->response_buffer().size()));
-                status = ActivityStatus::CLIENT_ACTIVITY;
-            }
-        } catch (...) {
-            m_logger.queue(LogLevel::Detail, "error while writing chunk");
-            status = ActivityStatus::COMMUNICATION_PROBLEM;
-        }
-
-        if (task->is_response_fully_sent()) {
-            m_logger.queue(LogLevel::Info, "sent:", task->telegram_header().info(), task->info());
-        }
-    }
-
-    // remove reported tasks
-    std::size_t tasks_num_before_removing = m_send_tasks.size();
-
-    auto partition_iter = std::partition(m_send_tasks.begin(), m_send_tasks.end(),
-                                         [](const TaskPtr& task) { return !task->is_response_fully_sent(); });
-    m_send_tasks.erase(partition_iter, m_send_tasks.end());
-    bool is_removing_took_place = tasks_num_before_removing != m_send_tasks.size();
-    if (!m_send_tasks.empty() && is_removing_took_place) {
-        m_logger.queue(LogLevel::Detail, "left tasks num to send ", m_send_tasks.size());
-    }
-
-    return status;
-}
-
-GateIO::ActivityStatus GateIO::handle_receiving_data(sockpp::tcp6_socket& client, comm::TelegramBuffer& telegram_buff, std::string& received_message) {
-    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
-    std::size_t bytes_actually_received{0};
-    try {
-        bytes_actually_received = client.read_n(&received_message[0], CHUNK_MAX_BYTES_NUM);
-    } catch (...) {
-        m_logger.queue(LogLevel::Error, "fail to receiving");
-        status = ActivityStatus::COMMUNICATION_PROBLEM;
-    }
-
-    if ((bytes_actually_received > 0) && (bytes_actually_received <= CHUNK_MAX_BYTES_NUM)) {
-        m_logger.queue(LogLevel::Detail, "received chunk:", get_pretty_size_str_from_bytes_num(bytes_actually_received));
-        telegram_buff.append(comm::ByteArray{received_message.c_str(), bytes_actually_received});
-        status = ActivityStatus::CLIENT_ACTIVITY;
-    }
-
-    return status;
-}
-
-GateIO::ActivityStatus GateIO::handle_telegrams(std::vector<comm::TelegramFramePtr>& telegram_frames, comm::TelegramBuffer& telegram_buff) {
-    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
-    telegram_frames.clear();
-    telegram_buff.take_telegram_frames(telegram_frames);
-    for (const comm::TelegramFramePtr& telegram_frame : telegram_frames) {
-        // process received data
-        std::string message{telegram_frame->body};
-        bool is_echo_telegram = false;
-        if ((message.size() == comm::ECHO_TELEGRAM_BODY.size()) && (message == comm::ECHO_TELEGRAM_BODY)) {
-            m_logger.queue(LogLevel::Detail, "received", comm::ECHO_TELEGRAM_BODY);
-            is_echo_telegram = true;
-            status = ActivityStatus::CLIENT_ACTIVITY;
-        }
-
-        if (!is_echo_telegram) {
-            m_logger.queue(LogLevel::Detail, "received composed", get_pretty_size_str_from_bytes_num(message.size()), ":", get_truncated_middle_str(message));
-            std::optional<int> job_id_opt = comm::TelegramParser::try_extract_field_job_id(message);
-            std::optional<int> cmd_opt = comm::TelegramParser::try_extract_field_cmd(message);
-            std::optional<std::string> options_opt = comm::TelegramParser::try_extract_field_options(message);
-            if (job_id_opt && cmd_opt && options_opt) {
-                TaskPtr task = std::make_unique<Task>(job_id_opt.value(), static_cast<comm::CMD>(cmd_opt.value()), options_opt.value());
-                const comm::TelegramHeader& header = telegram_frame->header;
-                m_logger.queue(LogLevel::Info, "received:", header.info(), task->info(/*skipDuration*/ true));
-                std::unique_lock<std::mutex> lock(m_tasks_mutex);
-                m_received_tasks.push_back(std::move(task));
-            } else {
-                m_logger.queue(LogLevel::Error, "broken telegram detected, fail extract options from", message);
-            }
-        }
-    }
-
-    return status;
-}
-
-GateIO::ActivityStatus GateIO::handle_client_alive_tracker(sockpp::tcp6_socket& client, std::unique_ptr<ClientAliveTracker>& client_alive_tracker_ptr) {
-    ActivityStatus status = ActivityStatus::WAITING_ACTIVITY;
-    if (client_alive_tracker_ptr) {
-        /// handle sending echo to client
-        if (client_alive_tracker_ptr->is_time_to_sent_echo()) {
-            comm::TelegramHeader echo_header = comm::TelegramHeader::construct_from_body(comm::ECHO_TELEGRAM_BODY);
-            std::string message{echo_header.buffer()};
-            message.append(comm::ECHO_TELEGRAM_BODY);
-            try {
-                std::size_t bytes_sent = client.write(message);
-                if (bytes_sent == message.size()) {
-                    m_logger.queue(LogLevel::Detail, "sent", comm::ECHO_TELEGRAM_BODY);
-                    client_alive_tracker_ptr->on_echo_sent();
-                }
-            } catch (...) {
-                m_logger.queue(LogLevel::Debug, "fail to sent", comm::ECHO_TELEGRAM_BODY);
-                status = ActivityStatus::COMMUNICATION_PROBLEM;
-            }
-        }
-
-        /// handle client timeout
-        if (client_alive_tracker_ptr->is_client_timeout()) {
-            m_logger.queue(LogLevel::Error, "client didn't respond too long");
-            status = ActivityStatus::COMMUNICATION_PROBLEM;
-        }
-    }
-
-    return status;
-}
-
-void GateIO::handle_activity_status(ActivityStatus status, std::unique_ptr<ClientAliveTracker>& client_alive_tracker_ptr, bool& is_communication_problem_detected) {
-    if (status == ActivityStatus::CLIENT_ACTIVITY) {
-        if (client_alive_tracker_ptr) {
-            client_alive_tracker_ptr->on_client_activity();
-        }
-    } else if (status == ActivityStatus::COMMUNICATION_PROBLEM) {
-        is_communication_problem_detected = true;
-    }
-}
-
 void GateIO::start_listening() {
 #ifdef ENABLE_CLIENT_ALIVE_TRACKER
-    std::unique_ptr<ClientAliveTracker> client_alive_tracker_ptr = std::make_unique<ClientAliveTracker>(std::chrono::milliseconds{5000}, std::chrono::milliseconds{20000});
+    std::unique_ptr<ClientAliveTracker> client_alive_tracker_ptr =
+         std::make_unique<ClientAliveTracker>(std::chrono::milliseconds{5000}, std::chrono::milliseconds{20000});
 #else
     std::unique_ptr<ClientAliveTracker> client_alive_tracker_ptr;
 #endif
@@ -228,11 +232,11 @@ void GateIO::start_listening() {
     received_message.resize(CHUNK_MAX_BYTES_NUM);
 
     /// comm event loop
-    while (m_is_running.load()) {
+    while(m_is_running.load()) {
         bool is_communication_problem_detected = false;
 
         if (!client_opt) {
-            ActivityStatus status = check_client_connection(tcp_server, client_opt);
+            ActivityStatus status = check_client_connection(tcp_server, client_opt, m_logger);
             if (status == ActivityStatus::CLIENT_ACTIVITY) {
                 if (client_alive_tracker_ptr) {
                     client_alive_tracker_ptr->reset();
@@ -244,26 +248,26 @@ void GateIO::start_listening() {
             sockpp::tcp6_socket& client = client_opt.value(); // shortcut
 
             /// handle sending
-            ActivityStatus status = handle_sending_data(client);
+            ActivityStatus status = handle_sending_data(client, m_tasks_mutex, m_send_tasks, m_logger);
             handle_activity_status(status, client_alive_tracker_ptr, is_communication_problem_detected);
 
             /// handle receiving
-            status = handle_receiving_data(client, telegram_buff, received_message);
+            status = handle_receiving_data(client, telegram_buff, received_message, m_logger);
             handle_activity_status(status, client_alive_tracker_ptr, is_communication_problem_detected);
 
             /// handle telegrams
-            status = handle_telegrams(telegram_frames, telegram_buff);
+            status = handle_telegrams(telegram_frames, telegram_buff, m_tasks_mutex, m_received_tasks, m_logger);
             handle_activity_status(status, client_alive_tracker_ptr, is_communication_problem_detected);
 
             // forward telegramBuffer errors
             std::vector<std::string> telegram_buffer_errors;
             telegram_buff.take_errors(telegram_buffer_errors);
-            for (const std::string& error : telegram_buffer_errors) {
+            for (const std::string& error: telegram_buffer_errors) {
                 m_logger.queue(LogLevel::Info, error);
             }
 
             /// handle client alive tracker
-            status = handle_client_alive_tracker(client, client_alive_tracker_ptr);
+            status = handle_client_alive_tracker(client, client_alive_tracker_ptr, m_logger);
             handle_activity_status(status, client_alive_tracker_ptr, is_communication_problem_detected);
 
             /// handle communication problem

--- a/vpr/src/server/gateio.h
+++ b/vpr/src/server/gateio.h
@@ -25,16 +25,16 @@ enum class ActivityStatus : int {
     COMMUNICATION_PROBLEM
 };
 
-enum class LogLevel: int {
+enum class LogLevel : int {
     Error,
     Info,
     Detail,
     Debug
 };
 
-const std::size_t CHUNK_MAX_BYTES_NUM = 2*1024*1024; // 2Mb
+const std::size_t CHUNK_MAX_BYTES_NUM = 2 * 1024 * 1024; // 2Mb
 
- /**
+/**
  * @brief Helper class aimed to help detecting a client offline.
  *
  * The ClientAliveTracker is pinged each time there is some activity from the client side.
@@ -44,12 +44,13 @@ const std::size_t CHUNK_MAX_BYTES_NUM = 2*1024*1024; // 2Mb
  * and it's time to start accepting new client connections in GateIO.
  */
 class ClientAliveTracker {
-public:
+  public:
     ClientAliveTracker(const std::chrono::milliseconds& echoIntervalMs, const std::chrono::milliseconds& clientTimeoutMs)
-        : m_echo_interval_ms(echoIntervalMs), m_client_timeout_ms(clientTimeoutMs) {
+        : m_echo_interval_ms(echoIntervalMs)
+        , m_client_timeout_ms(clientTimeoutMs) {
         reset();
     }
-    ClientAliveTracker()=default;
+    ClientAliveTracker() = default;
 
     void on_client_activity() {
         m_last_client_activity_time = std::chrono::high_resolution_clock::now();
@@ -62,13 +63,13 @@ public:
     bool is_time_to_sent_echo() const {
         return (duration_since_last_client_activity_ms() > m_echo_interval_ms) && (durationSinceLastEchoSentMs() > m_echo_interval_ms);
     }
-    bool is_client_timeout() const  { return duration_since_last_client_activity_ms() > m_client_timeout_ms; }
+    bool is_client_timeout() const { return duration_since_last_client_activity_ms() > m_client_timeout_ms; }
 
     void reset() {
         on_client_activity();
     }
 
-private:
+  private:
     std::chrono::high_resolution_clock::time_point m_last_client_activity_time;
     std::chrono::high_resolution_clock::time_point m_last_echo_sent_time;
     std::chrono::milliseconds m_echo_interval_ms;
@@ -84,10 +85,8 @@ private:
     }
 };
 
-
-
 class TLogger {
-public:
+  public:
     TLogger() {
         m_log_level = static_cast<int>(LogLevel::Info);
     }
@@ -113,7 +112,7 @@ public:
         }
     }
 
-private:
+  private:
     std::stringstream m_log_stream;
     std::mutex m_log_stream_mutex;
     std::atomic<int> m_log_level;
@@ -135,12 +134,11 @@ private:
  *   and responsiveness of the application.
  * - GateIO is not started automatically upon creation, you have to use the 'start' method with the port number.
  * - The socket is initialized in a non-blocking mode to function properly in a multithreaded environment.
-*/
-class GateIO
-{
+ */
+class GateIO {
     const int LOOP_INTERVAL_MS = 100;
 
-public:
+  public:
     /**
      * @brief Default constructor for GateIO.
      */
@@ -154,10 +152,10 @@ public:
     GateIO& operator=(GateIO&&) = delete;
 
     /**
-    * @brief Returns a bool indicating whether or not the port listening process is currently running.
-    *
-    * @return True if the port listening process is running, false otherwise.
-    */
+     * @brief Returns a bool indicating whether or not the port listening process is currently running.
+     *
+     * @return True if the port listening process is running, false otherwise.
+     */
     bool is_running() const { return m_is_running.load(); }
 
     /**
@@ -178,7 +176,7 @@ public:
      * remains empty after the operation.
      * 
      * @param tasks A reference to a vector containing the tasks to be moved to the send queue.
-    */
+     */
     void move_tasks_to_send_queue(std::vector<TaskPtr>& tasks);
 
     /**
@@ -187,7 +185,7 @@ public:
      * @note Must be called from the main thread since it's invoke std::cout.
      * Calling this method from other threads may result in unexpected behavior.
      */
-    void print_logs(); 
+    void print_logs();
 
     /**
      * @brief Starts the server on the specified port number.
@@ -210,16 +208,16 @@ public:
      */
     void stop();
 
-private:
+  private:
     int m_port_num = -1;
 
     std::atomic<bool> m_is_running; // is true when started
 
     std::thread m_thread; // thread to execute socket IO work
 
-    std::mutex m_tasks_mutex; // we used single mutex to guard both vectors m_received_tasks and m_sendTasks
+    std::mutex m_tasks_mutex;              // we used single mutex to guard both vectors m_received_tasks and m_sendTasks
     std::vector<TaskPtr> m_received_tasks; // tasks from client (requests)
-    std::vector<TaskPtr> m_send_tasks; // tasks to client (responses)
+    std::vector<TaskPtr> m_send_tasks;     // tasks to client (responses)
 
     TLogger m_logger;
 
@@ -231,4 +229,3 @@ private:
 #endif /* NO_SERVER */
 
 #endif /* GATEIO_H */
-

--- a/vpr/src/server/gateio.h
+++ b/vpr/src/server/gateio.h
@@ -17,9 +17,107 @@
 #include <utility>
 #include <optional>
 
-#include "sockpp/tcp6_acceptor.h"
-
 namespace server {
+
+enum class ActivityStatus : int {
+    WAITING_ACTIVITY,
+    CLIENT_ACTIVITY,
+    COMMUNICATION_PROBLEM
+};
+
+enum class LogLevel: int {
+    Error,
+    Info,
+    Detail,
+    Debug
+};
+
+const std::size_t CHUNK_MAX_BYTES_NUM = 2*1024*1024; // 2Mb
+
+ /**
+ * @brief Helper class aimed to help detecting a client offline.
+ *
+ * The ClientAliveTracker is pinged each time there is some activity from the client side.
+ * When the client doesn't show activity for a certain amount of time, the ClientAliveTracker generates 
+ * an event for sending an ECHO telegram to the client.
+ * If, after sending the ECHO telegram, the client does not respond with an ECHO, it means the client is absent, 
+ * and it's time to start accepting new client connections in GateIO.
+ */
+class ClientAliveTracker {
+public:
+    ClientAliveTracker(const std::chrono::milliseconds& echoIntervalMs, const std::chrono::milliseconds& clientTimeoutMs)
+        : m_echo_interval_ms(echoIntervalMs), m_client_timeout_ms(clientTimeoutMs) {
+        reset();
+    }
+    ClientAliveTracker()=default;
+
+    void on_client_activity() {
+        m_last_client_activity_time = std::chrono::high_resolution_clock::now();
+    }
+
+    void on_echo_sent() {
+        m_last_echo_sent_time = std::chrono::high_resolution_clock::now();
+    }
+
+    bool is_time_to_sent_echo() const {
+        return (duration_since_last_client_activity_ms() > m_echo_interval_ms) && (durationSinceLastEchoSentMs() > m_echo_interval_ms);
+    }
+    bool is_client_timeout() const  { return duration_since_last_client_activity_ms() > m_client_timeout_ms; }
+
+    void reset() {
+        on_client_activity();
+    }
+
+private:
+    std::chrono::high_resolution_clock::time_point m_last_client_activity_time;
+    std::chrono::high_resolution_clock::time_point m_last_echo_sent_time;
+    std::chrono::milliseconds m_echo_interval_ms;
+    std::chrono::milliseconds m_client_timeout_ms;
+
+    std::chrono::milliseconds duration_since_last_client_activity_ms() const {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_client_activity_time);
+    }
+    std::chrono::milliseconds durationSinceLastEchoSentMs() const {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_echo_sent_time);
+    }
+};
+
+
+
+class TLogger {
+public:
+    TLogger() {
+        m_log_level = static_cast<int>(LogLevel::Info);
+    }
+    ~TLogger() {}
+
+    template<typename... Args>
+    void queue(LogLevel logLevel, Args&&... args) {
+        if (static_cast<int>(logLevel) <= m_log_level) {
+            std::unique_lock<std::mutex> lock(m_log_stream_mutex);
+            if (logLevel == LogLevel::Error) {
+                m_log_stream << "ERROR:";
+            }
+            ((m_log_stream << ' ' << std::forward<Args>(args)), ...);
+            m_log_stream << "\n";
+        }
+    }
+
+    void flush() {
+        std::unique_lock<std::mutex> lock(m_log_stream_mutex);
+        if (!m_log_stream.str().empty()) {
+            VTR_LOG(m_log_stream.str().c_str());
+            m_log_stream.str("");
+        }
+    }
+
+private:
+    std::stringstream m_log_stream;
+    std::mutex m_log_stream_mutex;
+    std::atomic<int> m_log_level;
+};
 
 /**
  * @brief Implements the socket communication layer with the outside world.
@@ -37,110 +135,12 @@ namespace server {
  *   and responsiveness of the application.
  * - GateIO is not started automatically upon creation, you have to use the 'start' method with the port number.
  * - The socket is initialized in a non-blocking mode to function properly in a multithreaded environment.
- */
-class GateIO {
-    enum class ActivityStatus : int {
-        WAITING_ACTIVITY,
-        CLIENT_ACTIVITY,
-        COMMUNICATION_PROBLEM
-    };
-
-    const std::size_t CHUNK_MAX_BYTES_NUM = 2 * 1024 * 1024; // 2Mb
-
-    /**
-     * @brief Helper class aimed to help detecting a client offline.
-     *
-     * The ClientAliveTracker is pinged each time there is some activity from the client side.
-     * When the client doesn't show activity for a certain amount of time, the ClientAliveTracker generates 
-     * an event for sending an ECHO telegram to the client.
-     * If, after sending the ECHO telegram, the client does not respond with an ECHO, it means the client is absent, 
-     * and it's time to start accepting new client connections in GateIO.
-     */
-    class ClientAliveTracker {
-      public:
-        ClientAliveTracker(const std::chrono::milliseconds& echoIntervalMs, const std::chrono::milliseconds& clientTimeoutMs)
-            : m_echo_interval_ms(echoIntervalMs)
-            , m_client_timeout_ms(clientTimeoutMs) {
-            reset();
-        }
-        ClientAliveTracker() = default;
-
-        void on_client_activity() {
-            m_last_client_activity_time = std::chrono::high_resolution_clock::now();
-        }
-
-        void on_echo_sent() {
-            m_last_echo_sent_time = std::chrono::high_resolution_clock::now();
-        }
-
-        bool is_time_to_sent_echo() const {
-            return (duration_since_last_client_activity_ms() > m_echo_interval_ms) && (durationSinceLastEchoSentMs() > m_echo_interval_ms);
-        }
-        bool is_client_timeout() const { return duration_since_last_client_activity_ms() > m_client_timeout_ms; }
-
-        void reset() {
-            on_client_activity();
-        }
-
-      private:
-        std::chrono::high_resolution_clock::time_point m_last_client_activity_time;
-        std::chrono::high_resolution_clock::time_point m_last_echo_sent_time;
-        std::chrono::milliseconds m_echo_interval_ms;
-        std::chrono::milliseconds m_client_timeout_ms;
-
-        std::chrono::milliseconds duration_since_last_client_activity_ms() const {
-            auto now = std::chrono::high_resolution_clock::now();
-            return std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_client_activity_time);
-        }
-        std::chrono::milliseconds durationSinceLastEchoSentMs() const {
-            auto now = std::chrono::high_resolution_clock::now();
-            return std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_echo_sent_time);
-        }
-    };
-
-    enum class LogLevel : int {
-        Error,
-        Info,
-        Detail,
-        Debug
-    };
-
-    class TLogger {
-      public:
-        TLogger() {
-            m_log_level = static_cast<int>(LogLevel::Info);
-        }
-        ~TLogger() {}
-
-        template<typename... Args>
-        void queue(LogLevel logLevel, Args&&... args) {
-            if (static_cast<int>(logLevel) <= m_log_level) {
-                std::unique_lock<std::mutex> lock(m_log_stream_mutex);
-                if (logLevel == LogLevel::Error) {
-                    m_log_stream << "ERROR:";
-                }
-                ((m_log_stream << ' ' << std::forward<Args>(args)), ...);
-                m_log_stream << "\n";
-            }
-        }
-
-        void flush() {
-            std::unique_lock<std::mutex> lock(m_log_stream_mutex);
-            if (!m_log_stream.str().empty()) {
-                VTR_LOG(m_log_stream.str().c_str());
-                m_log_stream.str("");
-            }
-        }
-
-      private:
-        std::stringstream m_log_stream;
-        std::mutex m_log_stream_mutex;
-        std::atomic<int> m_log_level;
-    };
-
+*/
+class GateIO
+{
     const int LOOP_INTERVAL_MS = 100;
 
-  public:
+public:
     /**
      * @brief Default constructor for GateIO.
      */
@@ -154,10 +154,10 @@ class GateIO {
     GateIO& operator=(GateIO&&) = delete;
 
     /**
-     * @brief Returns a bool indicating whether or not the port listening process is currently running.
-     *
-     * @return True if the port listening process is running, false otherwise.
-     */
+    * @brief Returns a bool indicating whether or not the port listening process is currently running.
+    *
+    * @return True if the port listening process is running, false otherwise.
+    */
     bool is_running() const { return m_is_running.load(); }
 
     /**
@@ -178,7 +178,7 @@ class GateIO {
      * remains empty after the operation.
      * 
      * @param tasks A reference to a vector containing the tasks to be moved to the send queue.
-     */
+    */
     void move_tasks_to_send_queue(std::vector<TaskPtr>& tasks);
 
     /**
@@ -187,7 +187,7 @@ class GateIO {
      * @note Must be called from the main thread since it's invoke std::cout.
      * Calling this method from other threads may result in unexpected behavior.
      */
-    void print_logs();
+    void print_logs(); 
 
     /**
      * @brief Starts the server on the specified port number.
@@ -210,29 +210,20 @@ class GateIO {
      */
     void stop();
 
-  private:
+private:
     int m_port_num = -1;
 
     std::atomic<bool> m_is_running; // is true when started
 
     std::thread m_thread; // thread to execute socket IO work
 
-    std::mutex m_tasks_mutex;              // we used single mutex to guard both vectors m_received_tasks and m_sendTasks
+    std::mutex m_tasks_mutex; // we used single mutex to guard both vectors m_received_tasks and m_sendTasks
     std::vector<TaskPtr> m_received_tasks; // tasks from client (requests)
-    std::vector<TaskPtr> m_send_tasks;     // tasks to client (responses)
+    std::vector<TaskPtr> m_send_tasks; // tasks to client (responses)
 
     TLogger m_logger;
 
     void start_listening(); // thread worker function
-
-    /// helper functions to be executed inside startListening
-    ActivityStatus check_client_connection(sockpp::tcp6_acceptor& tcp_server, std::optional<sockpp::tcp6_socket>& client_opt);
-    ActivityStatus handle_sending_data(sockpp::tcp6_socket& client);
-    ActivityStatus handle_receiving_data(sockpp::tcp6_socket& client, comm::TelegramBuffer& telegram_buff, std::string& received_message);
-    ActivityStatus handle_telegrams(std::vector<comm::TelegramFramePtr>& telegram_frames, comm::TelegramBuffer& telegram_buff);
-    ActivityStatus handle_client_alive_tracker(sockpp::tcp6_socket& client, std::unique_ptr<ClientAliveTracker>& client_alive_tracker_ptr);
-    void handle_activity_status(ActivityStatus status, std::unique_ptr<ClientAliveTracker>& client_alive_tracker_ptr, bool& is_communication_problem_detected);
-    ///
 };
 
 } // namespace server
@@ -240,3 +231,4 @@ class GateIO {
 #endif /* NO_SERVER */
 
 #endif /* GATEIO_H */
+


### PR DESCRIPTION
include sockpp headers directly in gateio.cpp transaction unit, this will avoid win32 and VTR enums collision.

#### Related Issue
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/3074

#### Motivation and Context
allow use app on windows

#### How Has This Been Tested?
it was tested as a part of Aurora windows package