### PR TITLE
[Infra] The Great VPR Pragma PR

### DIFF
--- a/vpr/src/analytical_place/analytical_placement_flow.h
+++ b/vpr/src/analytical_place/analytical_placement_flow.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
  * @date    September 2024
  * @brief   Methods for running the Analytical Placement flow.
  */
-
-#pragma once
 
 // Forward declarations
 struct t_vpr_setup;

--- a/vpr/src/analytical_place/analytical_solver.h
+++ b/vpr/src/analytical_place/analytical_solver.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer and Robert Luo
@@ -5,8 +6,6 @@
  * @brief   The declarations of the Analytical Solver base class which is used
  *          to define the functionality of all solvers used in the AP flow.
  */
-
-#pragma once
 
 #include <memory>
 #include "ap_flow_enums.h"

--- a/vpr/src/analytical_place/ap_flow_enums.h
+++ b/vpr/src/analytical_place/ap_flow_enums.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
  * @date    February 2025
  * @brief   Enumerations used by the Analytical Placement Flow.
  */
-
-#pragma once
 
 /**
  * @brief The type of an Analytical Solver.

--- a/vpr/src/analytical_place/ap_netlist.h
+++ b/vpr/src/analytical_place/ap_netlist.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -17,8 +18,6 @@
  * blocks (inferred from the atom block connectivity), where nets which are
  * unused by Analytical Placement are ignored.
  */
-
-#pragma once
 
 #include <string>
 #include "netlist.h"

--- a/vpr/src/analytical_place/ap_netlist_fwd.h
+++ b/vpr/src/analytical_place/ap_netlist_fwd.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -6,8 +7,6 @@
  *
  * Forward declares the APNetlist class, and defines common types used by it.
  */
-
-#pragma once
 
 #include "netlist_fwd.h"
 #include "vtr_strong_id.h"

--- a/vpr/src/analytical_place/detailed_placer.h
+++ b/vpr/src/analytical_place/detailed_placer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -5,8 +6,6 @@
  * @brief   Defines the DetailedPlacer class which takes a fully legal clustering
  *          and placement and optimizes them while remaining legal.
  */
-
-#pragma once
 
 #include <memory>
 #include "ap_flow_enums.h"

--- a/vpr/src/analytical_place/flat_placement_bins.h
+++ b/vpr/src/analytical_place/flat_placement_bins.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -7,8 +8,6 @@
  * This file declares a class which can bin AP Blocks spatially throughout the
  * FPGA.
  */
-
-#pragma once
 
 #include <unordered_set>
 #include "ap_netlist.h"

--- a/vpr/src/analytical_place/flat_placement_density_manager.h
+++ b/vpr/src/analytical_place/flat_placement_density_manager.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -7,8 +8,6 @@
  * This class decides how the FPGA grid is partitioned into bins and what
  * defines a bin that is "overfilled".
  */
-
-#pragma once
 
 #include <tuple>
 #include <unordered_set>

--- a/vpr/src/analytical_place/flat_placement_mass_calculator.h
+++ b/vpr/src/analytical_place/flat_placement_mass_calculator.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
  * @date    February 2024
  * @brief   Mass calculation for AP blocks and logical/physical block/tile types
  */
-
-#pragma once
 
 #include <vector>
 #include "ap_netlist_fwd.h"

--- a/vpr/src/analytical_place/full_legalizer.h
+++ b/vpr/src/analytical_place/full_legalizer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -6,8 +7,6 @@
  *          and generates a fully legal clustering and placement which can be
  *          routed by VTR.
  */
-
-#pragma once
 
 #include <memory>
 #include "ap_flow_enums.h"

--- a/vpr/src/analytical_place/gen_ap_netlist_from_atoms.h
+++ b/vpr/src/analytical_place/gen_ap_netlist_from_atoms.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -5,8 +6,6 @@
  * @brief   Declaration of the gen_ap_netlist_from_atoms function which uses the
  *          results of the prepacker to generate an APNetlist.
  */
-
-#pragma once
 
 // Forward declarations
 class APNetlist;

--- a/vpr/src/analytical_place/global_placer.h
+++ b/vpr/src/analytical_place/global_placer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -11,8 +12,6 @@
  * that optimizes for objectives subject to some of the constraints of the FPGA
  * architecture.
  */
-
-#pragma once
 
 #include <memory>
 #include "ap_flow_enums.h"

--- a/vpr/src/analytical_place/model_grouper.h
+++ b/vpr/src/analytical_place/model_grouper.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -5,8 +6,6 @@
  * @brief   Declaration of a model grouper class which groups together models
  *          that must be legalized together in a flat placement.
  */
-
-#pragma once
 
 #include <vector>
 #include "logic_types.h"

--- a/vpr/src/analytical_place/partial_legalizer.h
+++ b/vpr/src/analytical_place/partial_legalizer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer and Robert Luo
@@ -10,8 +11,6 @@
  * Placemenent and produce a more legal Partial Placement (according to
  * constraints of the architecture).
  */
-
-#pragma once
 
 #include <functional>
 #include <memory>

--- a/vpr/src/analytical_place/partial_placement.h
+++ b/vpr/src/analytical_place/partial_placement.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -9,8 +10,6 @@
  * Placement need not represent a legal placement; however, the placed blocks
  * will always be on the device and will respect fixed block locations.
  */
-
-#pragma once
 
 #include <cmath>
 #include "ap_netlist.h"

--- a/vpr/src/analytical_place/primitive_vector.h
+++ b/vpr/src/analytical_place/primitive_vector.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -7,8 +8,6 @@
  * This object is designed to store a sparse M-dimensional vector which can be
  * efficiently operated upon.
  */
-
-#pragma once
 
 #include <cmath>
 #include <cstdlib>

--- a/vpr/src/base/CheckArch.h
+++ b/vpr/src/base/CheckArch.h
@@ -1,8 +1,5 @@
-#ifndef CHECKARCH_H
-#define CHECKARCH_H
+#pragma once
 
 #include "physical_types.h"
 
 void CheckArch(const t_arch& Arch);
-
-#endif

--- a/vpr/src/base/CheckSetup.h
+++ b/vpr/src/base/CheckSetup.h
@@ -1,5 +1,4 @@
-#ifndef CHECKSETUP_H
-#define CHECKSETUP_H
+#pragma once
 
 #include "vpr_types.h"
 
@@ -12,5 +11,3 @@ void CheckSetup(const t_packer_opts& packer_opts,
                 const std::vector<t_segment_inf>& segments,
                 const t_timing_inf& timing,
                 const t_chan_width_dist& chans);
-
-#endif

--- a/vpr/src/base/SetupGrid.h
+++ b/vpr/src/base/SetupGrid.h
@@ -1,6 +1,4 @@
-#ifndef SETUPGRID_H
-#define SETUPGRID_H
-
+#pragma once
 /**
  * @file
  * @author  Jason Luu
@@ -32,5 +30,3 @@ DeviceGrid create_device_grid(const std::string& layout_name,
  *        (size of the bounding box of non-empty grid tiles)
  */
 size_t count_grid_tiles(const DeviceGrid& grid);
-
-#endif

--- a/vpr/src/base/SetupVPR.h
+++ b/vpr/src/base/SetupVPR.h
@@ -1,5 +1,5 @@
-#ifndef SETUPVPR_H
-#define SETUPVPR_H
+#pragma once
+
 #include <vector>
 #include "read_options.h"
 #include "physical_types.h"
@@ -28,4 +28,3 @@ void SetupVPR(const t_options* Options,
               std::string* GraphicsCommands,
               t_power_opts* PowerOpts,
               t_vpr_setup* vpr_setup);
-#endif

--- a/vpr/src/base/ShowSetup.h
+++ b/vpr/src/base/ShowSetup.h
@@ -1,5 +1,4 @@
-#ifndef SHOWSETUP_H
-#define SHOWSETUP_H
+#pragma once
 
 #include <ostream>
 #include <string>
@@ -35,5 +34,3 @@ struct ClusteredNetlistStats {
 
 void ShowSetup(const t_vpr_setup& vpr_setup);
 void writeClusteredNetlistStats(const std::string& block_usage_filename);
-
-#endif

--- a/vpr/src/base/atom_lookup.h
+++ b/vpr/src/base/atom_lookup.h
@@ -1,5 +1,5 @@
-#ifndef ATOM_LOOKUP_H
-#define ATOM_LOOKUP_H
+#pragma once
+
 #include "atom_lookup_fwd.h"
 
 #include "vtr_vector_map.h"
@@ -149,5 +149,3 @@ class AtomLookup {
     vtr::linear_map<AtomPinId, tatum::NodeId> atom_pin_tnode_internal_;
     vtr::linear_map<tatum::NodeId, AtomPinId> tnode_atom_pin_;
 };
-
-#endif

--- a/vpr/src/base/atom_lookup_fwd.h
+++ b/vpr/src/base/atom_lookup_fwd.h
@@ -1,5 +1,4 @@
-#ifndef VPR_ATOM_LOOKUP_FWD_H
-#define VPR_ATOM_LOOKUP_FWD_H
+#pragma once
 
 class AtomLookup;
 
@@ -7,5 +6,3 @@ enum class BlockTnode {
     INTERNAL, ///<tnodes corresponding to internal paths withing atom blocks
     EXTERNAL  ///<tnodes corresponding to external interface of atom blocks
 };
-
-#endif

--- a/vpr/src/base/atom_netlist.h
+++ b/vpr/src/base/atom_netlist.h
@@ -1,5 +1,4 @@
-#ifndef ATOM_NETLIST_H
-#define ATOM_NETLIST_H
+#pragma once
 
 /**
  * @file
@@ -65,6 +64,7 @@
  * Refer to netlist.h for more information.
  *
  */
+
 #include <vector>
 #include <unordered_map>
 
@@ -280,5 +280,3 @@ class AtomNetlist : public Netlist<AtomBlockId, AtomPortId, AtomPinId, AtomNetId
 };
 
 #include "atom_lookup.h"
-
-#endif

--- a/vpr/src/base/atom_netlist_fwd.h
+++ b/vpr/src/base/atom_netlist_fwd.h
@@ -1,5 +1,5 @@
-#ifndef ATOM_NETLIST_FWD_H
-#define ATOM_NETLIST_FWD_H
+#pragma once
+
 #include "vtr_strong_id.h"
 #include "netlist_fwd.h"
 /*
@@ -100,5 +100,3 @@ struct hash<AtomPinId> {
     }
 };
 } // namespace std
-
-#endif

--- a/vpr/src/base/atom_netlist_utils.h
+++ b/vpr/src/base/atom_netlist_utils.h
@@ -1,5 +1,5 @@
-#ifndef ATOM_NETLIST_UTILS_H
-#define ATOM_NETLIST_UTILS_H
+#pragma once
+
 #include <cstdio>
 #include <set>
 #include "atom_netlist.h"
@@ -122,4 +122,3 @@ std::set<AtomPinId> find_netlist_logical_clock_drivers(const AtomNetlist& netlis
 
 ///@brief Prints out information about netlist clocks
 void print_netlist_clock_info(const AtomNetlist& netlist, const LogicalModels& models);
-#endif

--- a/vpr/src/base/check_netlist.h
+++ b/vpr/src/base/check_netlist.h
@@ -1,6 +1,3 @@
-#ifndef CHECK_NETLIST_H
-#define CHECK_NETLIST_H
+#pragma once
 
 void check_netlist(int verbosity);
-
-#endif

--- a/vpr/src/base/clock_modeling.h
+++ b/vpr/src/base/clock_modeling.h
@@ -1,5 +1,4 @@
-#ifndef CLOCK_MODELING_H
-#define CLOCK_MODELING_H
+#pragma once
 
 enum e_clock_modeling {
     IDEAL_CLOCK,      ///<Treat the clock pins as ideal (i.e. not routed)
@@ -16,5 +15,3 @@ namespace ClockModeling {
  */
 void treat_clock_pins_as_non_globals();
 } // namespace ClockModeling
-
-#endif

--- a/vpr/src/base/clustered_netlist.h
+++ b/vpr/src/base/clustered_netlist.h
@@ -1,5 +1,4 @@
-#ifndef CLUSTERED_NETLIST_H
-#define CLUSTERED_NETLIST_H
+#pragma once
 /**
  * @file
  * @brief This file defines the ClusteredNetlist class in the ClusteredContext
@@ -340,5 +339,3 @@ class ClusteredNetlist : public Netlist<ClusterBlockId, ClusterPortId, ClusterPi
 
     //Nets
 };
-
-#endif

--- a/vpr/src/base/clustered_netlist_fwd.h
+++ b/vpr/src/base/clustered_netlist_fwd.h
@@ -1,5 +1,5 @@
-#ifndef CLUSTERED_NETLIST_FWD_H
-#define CLUSTERED_NETLIST_FWD_H
+#pragma once
+
 #include "vtr_strong_id.h"
 #include "netlist_fwd.h"
 
@@ -79,5 +79,3 @@ struct hash<ClusterPinId> {
     }
 };
 } // namespace std
-
-#endif

--- a/vpr/src/base/clustered_netlist_utils.h
+++ b/vpr/src/base/clustered_netlist_utils.h
@@ -1,5 +1,4 @@
-#ifndef CLUSTERED_NETLIST_UTILS_H
-#define CLUSTERED_NETLIST_UTILS_H
+#pragma once
 
 #include "vtr_vector.h"
 #include "vtr_range.h"
@@ -46,4 +45,3 @@ class ClusterAtomsLookup {
     //Store the atom ids of the atoms inside each cluster
     vtr::vector<ClusterBlockId, std::vector<AtomBlockId>> cluster_atoms;
 };
-#endif

--- a/vpr/src/base/constant_nets.h
+++ b/vpr/src/base/constant_nets.h
@@ -1,5 +1,4 @@
-#ifndef CONSTANT_NETS_H
-#define CONSTANT_NETS_H
+#pragma once
 
 #include "clustered_netlist_fwd.h"
 #include "atom_netlist_fwd.h"
@@ -10,5 +9,3 @@ enum e_constant_net_method {
 };
 
 void process_constant_nets(AtomNetlist& atom_nlist, const AtomLookup& atom_look_up, ClusteredNetlist& nlist, e_constant_net_method method, int verbosity);
-
-#endif

--- a/vpr/src/base/constraints_load.h
+++ b/vpr/src/base/constraints_load.h
@@ -1,9 +1,6 @@
-#ifndef CONSTRAINTS_LOAD_H_
-#define CONSTRAINTS_LOAD_H_
+#pragma once
 
 #include "user_place_constraints.h"
 
 ///@brief Used to print vpr's floorplanning constraints to an echo file "vpr_constraints.echo"
 void echo_constraints(char* filename, const UserPlaceConstraints& constraints);
-
-#endif

--- a/vpr/src/base/echo_files.h
+++ b/vpr/src/base/echo_files.h
@@ -1,5 +1,4 @@
-#ifndef ECHO_FILES_H
-#define ECHO_FILES_H
+#pragma once
 
 #include <string>
 
@@ -99,5 +98,3 @@ void setOutputFileName(enum e_output_files ename, const char* name, const char* 
 char* getOutputFileName(enum e_output_files ename);
 void alloc_and_load_output_file_names(const std::string& default_name);
 void free_output_file_names();
-
-#endif

--- a/vpr/src/base/flat_placement_types.h
+++ b/vpr/src/base/flat_placement_types.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
  * @date    March 2025
  * @brief   Declaration of flat placement types used throughout VPR.
  */
-
-#pragma once
 
 #include "atom_netlist.h"
 #include "vtr_assert.h"

--- a/vpr/src/base/flat_placement_utils.h
+++ b/vpr/src/base/flat_placement_utils.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
  * @date    March 2025
  * @brief   Utility methods for working with flat placements.
  */
-
-#pragma once
 
 #include <cstdlib>
 #include "flat_placement_types.h"

--- a/vpr/src/base/globals.h
+++ b/vpr/src/base/globals.h
@@ -1,12 +1,9 @@
+#pragma once
 /*
  * Global variables
  * Key global variables that are used everywhere in VPR:
  */
 
-#ifndef GLOBALS_H
-#define GLOBALS_H
 #include "vpr_context.h"
 
 extern VprContext g_vpr_ctx;
-
-#endif

--- a/vpr/src/base/grid_block.h
+++ b/vpr/src/base/grid_block.h
@@ -1,5 +1,4 @@
-#ifndef VTR_GRID_BLOCK_H
-#define VTR_GRID_BLOCK_H
+#pragma once
 
 #include "clustered_netlist_fwd.h"
 #include "physical_types.h"
@@ -96,5 +95,3 @@ class GridBlock {
   private:
     vtr::NdMatrix<t_grid_blocks, 3> grid_blocks_;
 };
-
-#endif //VTR_GRID_BLOCK_H

--- a/vpr/src/base/load_flat_place.h
+++ b/vpr/src/base/load_flat_place.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -7,8 +8,6 @@
  * Flat placements are atom-level placements. These utilities can read and write
  * flat placement information to different parts of the VPR flow.
  */
-
-#pragma once
 
 #include <string>
 #include <unordered_set>

--- a/vpr/src/base/logic_vec.h
+++ b/vpr/src/base/logic_vec.h
@@ -1,5 +1,4 @@
-#ifndef LOGIC_VEC_H
-#define LOGIC_VEC_H
+#pragma once
 
 #include <vector>
 #include <ostream>
@@ -45,5 +44,3 @@ class LogicVec {
   private:
     std::vector<vtr::LogicValue> values_; ///<The logic values
 };
-
-#endif

--- a/vpr/src/base/netlist.h
+++ b/vpr/src/base/netlist.h
@@ -1,6 +1,4 @@
-#ifndef NETLIST_H
-#define NETLIST_H
-
+#pragma once
 /**
  * @file
  * @brief This file defines the Netlist class, which stores the connectivity information
@@ -1160,4 +1158,3 @@ class Netlist {
 };
 
 #include "netlist.tpp"
-#endif

--- a/vpr/src/base/netlist_fwd.h
+++ b/vpr/src/base/netlist_fwd.h
@@ -1,5 +1,5 @@
-#ifndef NETLIST_FWD_H
-#define NETLIST_FWD_H
+#pragma once
+
 #include "vtr_strong_id.h"
 
 /*
@@ -44,5 +44,3 @@ enum class PinType : char {
     SINK,   ///<The pin is a net sink
     OPEN    ///<The pin is an open connection (undecided)
 };
-
-#endif

--- a/vpr/src/base/netlist_utils.h
+++ b/vpr/src/base/netlist_utils.h
@@ -1,5 +1,4 @@
-#ifndef NETLIST_UTILS_H
-#define NETLIST_UTILS_H
+#pragma once
 
 #include "vtr_vector_map.h"
 #include <set>
@@ -176,5 +175,3 @@ Container update_valid_refs(const Container& values,
     }
     return updated;
 }
-
-#endif

--- a/vpr/src/base/netlist_walker.h
+++ b/vpr/src/base/netlist_walker.h
@@ -1,5 +1,5 @@
-#ifndef NETLIST_WALKER_H
-#define NETLIST_WALKER_H
+#pragma once
+
 #include "vpr_types.h"
 
 class NetlistVisitor;
@@ -59,4 +59,3 @@ class NetlistVisitor {
 
     virtual void finish_impl();
 };
-#endif

--- a/vpr/src/base/partition.h
+++ b/vpr/src/base/partition.h
@@ -1,5 +1,4 @@
-#ifndef PARTITION_H
-#define PARTITION_H
+#pragma once
 
 #include <string>
 
@@ -59,5 +58,3 @@ class Partition {
 
 ///@brief used to print data from a Partition
 void print_partition(FILE* fp, const Partition& part);
-
-#endif /* PARTITION_H */

--- a/vpr/src/base/partition_region.h
+++ b/vpr/src/base/partition_region.h
@@ -1,5 +1,4 @@
-#ifndef PARTITION_REGIONS_H
-#define PARTITION_REGIONS_H
+#pragma once
 
 #include "region.h"
 #include "vpr_types.h"
@@ -106,5 +105,3 @@ struct hash<PartitionRegion> {
     }
 };
 } // namespace std
-
-#endif /* PARTITION_REGIONS_H */

--- a/vpr/src/base/place_and_route.h
+++ b/vpr/src/base/place_and_route.h
@@ -1,5 +1,4 @@
-#ifndef VPR_PLACE_AND_ROUTE_H
-#define VPR_PLACE_AND_ROUTE_H
+#pragma once
 
 #define INFINITE -1
 
@@ -43,5 +42,3 @@ t_chan_width init_chan(int cfactor,
                        e_graph_type graph_directionality);
 
 void post_place_sync();
-
-#endif

--- a/vpr/src/base/read_activity.h
+++ b/vpr/src/base/read_activity.h
@@ -1,10 +1,8 @@
-#ifndef READ_ACTIVITY_H
-#define READ_ACTIVITY_H
+#pragma once
+
 #include <unordered_map>
 
 #include "atom_netlist_fwd.h"
 #include "vpr_types.h"
 
 std::unordered_map<AtomNetId, t_net_power> read_activity(const AtomNetlist& netlist, const char* activity_file);
-
-#endif

--- a/vpr/src/base/read_blif.h
+++ b/vpr/src/base/read_blif.h
@@ -1,5 +1,4 @@
-#ifndef READ_BLIF_H
-#define READ_BLIF_H
+#pragma once
 
 #include <string>
 #include "atom_netlist_fwd.h"
@@ -14,5 +13,3 @@ bool is_real_param(const std::string& param);
 AtomNetlist read_blif(e_circuit_format circuit_format,
                       const char* blif_file,
                       const LogicalModels& models);
-
-#endif /*READ_BLIF_H*/

--- a/vpr/src/base/read_circuit.h
+++ b/vpr/src/base/read_circuit.h
@@ -1,5 +1,4 @@
-#ifndef VPR_READ_CIRCUIT_H
-#define VPR_READ_CIRCUIT_H
+#pragma once
 
 #include "atom_netlist_fwd.h"
 
@@ -14,4 +13,3 @@ enum class e_circuit_format {
 };
 
 AtomNetlist read_and_process_circuit(e_circuit_format circuit_format, t_vpr_setup& vpr_setup, t_arch& arch);
-#endif

--- a/vpr/src/base/read_interchange_netlist.h
+++ b/vpr/src/base/read_interchange_netlist.h
@@ -1,5 +1,4 @@
-#ifndef READ_INTERCHANGE_NETLIST_H
-#define READ_INTERCHANGE_NETLIST_H
+#pragma once
 
 #include "atom_netlist_fwd.h"
 
@@ -7,5 +6,3 @@ struct t_arch;
 
 AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
                                      t_arch& arch);
-
-#endif /*READ_INTERCHANGE_NETLIST_H*/

--- a/vpr/src/base/read_netlist.h
+++ b/vpr/src/base/read_netlist.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author Jason Luu
@@ -6,9 +7,6 @@
  * @brief Read a circuit netlist in XML format and populate
  *        the netlist data structures for VPR
  */
-
-#ifndef READ_NETLIST_H
-#define READ_NETLIST_H
 
 #include "atom_netlist_fwd.h"
 #include "clustered_netlist_fwd.h"
@@ -23,5 +21,3 @@ void set_atom_pin_mapping(const ClusteredNetlist& clb_nlist,
                           const AtomBlockId atom_blk,
                           const AtomPortId atom_port,
                           const t_pb_graph_pin* gpin);
-
-#endif

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -1,5 +1,4 @@
-#ifndef READ_OPTIONS_H
-#define READ_OPTIONS_H
+#pragma once
 
 #include "arch_types.h"
 #include "read_circuit.h"
@@ -280,5 +279,3 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
 t_options read_options(int argc, const char** argv);
 void set_conditional_defaults(t_options& args);
 bool verify_args(const t_options& args);
-
-#endif

--- a/vpr/src/base/read_place.h
+++ b/vpr/src/base/read_place.h
@@ -1,5 +1,4 @@
-#ifndef READ_PLACE_H
-#define READ_PLACE_H
+#pragma once
 
 #include "vtr_vector_map.h"
 
@@ -43,5 +42,3 @@ std::string print_place(const char* net_file,
                         const char* place_file,
                         const vtr::vector_map<ClusterBlockId, t_block_loc>& block_locs,
                         bool is_place_file = true);
-
-#endif

--- a/vpr/src/base/read_route.h
+++ b/vpr/src/base/read_route.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @brief Functions to read/write a .route file, which contains a serialized routing state.
  *
  * This is used to perform --analysis only
  */
-
-#pragma once
 
 #include "netlist.h"
 #include "vpr_types.h"

--- a/vpr/src/base/region.h
+++ b/vpr/src/base/region.h
@@ -1,5 +1,4 @@
-#ifndef REGION_H
-#define REGION_H
+#pragma once
 
 #include "vtr_geometry.h"
 #include "vpr_types.h"
@@ -130,5 +129,3 @@ struct hash<Region> {
     }
 };
 } // namespace std
-
-#endif /* REGION_H */

--- a/vpr/src/base/setup_clocks.h
+++ b/vpr/src/base/setup_clocks.h
@@ -1,10 +1,7 @@
-#ifndef SETUP_CLOCKS_H
-#define SETUP_CLOCKS_H
+#pragma once
 
 #include <vector>
 
 #include "physical_types.h"
 
 void setup_clock_networks(const t_arch& Arch, std::vector<t_segment_inf>& segment_inf);
-
-#endif

--- a/vpr/src/base/setup_noc.h
+++ b/vpr/src/base/setup_noc.h
@@ -1,6 +1,4 @@
-#ifndef SETUP_NOC
-#define SETUP_NOC
-
+#pragma once
 /**
  * @file 
  * @brief This is the setup_noc header file. The main purpose of 
@@ -129,5 +127,3 @@ void create_noc_routers(const t_noc_inf& noc_info,
  *                  routers and links that connect the routers together.
  */
 void create_noc_links(const t_noc_inf& noc_info, NocStorage* noc_model);
-
-#endif

--- a/vpr/src/base/user_place_constraints.h
+++ b/vpr/src/base/user_place_constraints.h
@@ -1,5 +1,4 @@
-#ifndef USER_PLACE_CONSTRAINTS_H
-#define USER_PLACE_CONSTRAINTS_H
+#pragma once
 
 #include "vtr_vector.h"
 #include "partition.h"
@@ -113,5 +112,3 @@ class UserPlaceConstraints {
 
 ///@brief used to print floorplanning constraints data from a VprConstraints object
 void print_placement_constraints(FILE* fp, const UserPlaceConstraints& constraints);
-
-#endif /* USER_PLACE_CONSTRAINTS_H */

--- a/vpr/src/base/user_route_constraints.h
+++ b/vpr/src/base/user_route_constraints.h
@@ -1,5 +1,4 @@
-#ifndef USER_ROUTE_CONSTRAINTS_H
-#define USER_ROUTE_CONSTRAINTS_H
+#pragma once
 
 #include "clock_modeling.h"
 #include <string>
@@ -152,4 +151,3 @@ class UserRouteConstraints {
      */
     std::unordered_map<std::string, RoutingScheme> route_constraints_;
 };
-#endif /* USER_ROUTE_CONSTRAINTS_H */

--- a/vpr/src/base/vpr_api.h
+++ b/vpr/src/base/vpr_api.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author Jason Luu
@@ -23,9 +24,6 @@
  * 2.  vpr_types.h - Very major file that defines the core data structures used in VPR.  This includes detailed architecture information, user netlist data structures, and data structures that describe the mapping between those two.
  * 3.  globals.h - Defines the global variables used by VPR.
  */
-
-#ifndef VPR_API_H
-#define VPR_API_H
 
 #include <vector>
 #include "physical_types.h"
@@ -224,5 +222,3 @@ char* vpr_get_output_file_name(enum e_output_files ename);
 
 ///@brief Prints user file or internal errors for VPR
 void vpr_print_error(const VprError& vpr_error);
-
-#endif

--- a/vpr/src/base/vpr_constraints.h
+++ b/vpr/src/base/vpr_constraints.h
@@ -1,5 +1,4 @@
-#ifndef VPR_CONSTRAINTS_H
-#define VPR_CONSTRAINTS_H
+#pragma once
 
 #include "user_place_constraints.h"
 #include "user_route_constraints.h"
@@ -49,5 +48,3 @@ class VprConstraints {
     UserRouteConstraints route_constraints_;
     UserPlaceConstraints placement_constraints_;
 };
-
-#endif /* VPR_CONSTRAINTS_H */

--- a/vpr/src/base/vpr_constraints_reader.h
+++ b/vpr/src/base/vpr_constraints_reader.h
@@ -1,10 +1,6 @@
+#pragma once
 /* Defines the function used to load a vpr constraints file written in XML format into vpr
  * The functions loads up the data structures related to placement and routing constraints
  * according to the data provided in the XML file*/
 
-#ifndef VPR_CONSTRAINTS_READER_H_
-#define VPR_CONSTRAINTS_READER_H_
-
 void load_vpr_constraints_file(const char* read_vpr_constraints_name);
-
-#endif /* VPR_CONSTRAINTS_READER_H_ */

--- a/vpr/src/base/vpr_constraints_serializer.h
+++ b/vpr/src/base/vpr_constraints_serializer.h
@@ -1,17 +1,4 @@
-#ifndef VPR_CONSTRAINTS_SERIALIZER_H_
-#define VPR_CONSTRAINTS_SERIALIZER_H_
-
-#include <regex>
-#include "region.h"
-#include "vpr_constraints.h"
-#include "partition.h"
-#include "partition_region.h"
-#include "vtr_log.h"
-#include "globals.h" //for the g_vpr_ctx
-#include "clock_modeling.h"
-
-#include "vpr_constraints_uxsdcxx_interface.h"
-
+#pragma once
 /**
  * @file
  * @brief The reading of vpr constraints is now done via uxsdcxx and the 'vpr_constraints.xsd' file.
@@ -49,6 +36,17 @@
  *
  * For more detail on how the load and write interfaces work with uxsdcxx, refer to 'vpr/src/route/SCHEMA_GENERATOR.md'
  */
+
+#include <regex>
+#include "region.h"
+#include "vpr_constraints.h"
+#include "partition.h"
+#include "partition_region.h"
+#include "vtr_log.h"
+#include "globals.h" //for the g_vpr_ctx
+#include "clock_modeling.h"
+
+#include "vpr_constraints_uxsdcxx_interface.h"
 
 /*
  * Used for the PartitionReadContext, which is used when writing out a constraints XML file.
@@ -526,5 +524,3 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     AtomBlockId atom_id_;
     std::vector<AtomBlockId> atoms_;
 };
-
-#endif /* VPR_CONSTRAINTS_SERIALIZER_H_ */

--- a/vpr/src/base/vpr_constraints_writer.h
+++ b/vpr/src/base/vpr_constraints_writer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @brief This file contains functions related to writing out a vpr constraints XML file.
@@ -21,9 +22,6 @@
  * For example, if both options are 2, the constraints file will split the grid into quadrants, dividing the blocks between
  * four partitions - two partitions in the horizontal dimension, and two partitions in the vertical dimension.
  */
-
-#ifndef VPR_SRC_BASE_VPR_CONSTRAINTS_WRITER_H_
-#define VPR_SRC_BASE_VPR_CONSTRAINTS_WRITER_H_
 
 class VprConstraints;
 
@@ -73,5 +71,3 @@ void setup_vpr_floorplan_constraints_one_loc(VprConstraints& constraints,
 void setup_vpr_floorplan_constraints_cutpoints(VprConstraints& constraints,
                                                int horizontal_cutpoints,
                                                int vertical_cutpoints);
-
-#endif /* VPR_SRC_BASE_VPR_CONSTRAINTS_WRITER_H_ */

--- a/vpr/src/base/vpr_context.cpp
+++ b/vpr/src/base/vpr_context.cpp
@@ -13,6 +13,7 @@
 #include "physical_types.h"
 #include "place_constraints.h"
 #include "place_macro.h"
+#include "rr_graph_utils.h"
 #include "vpr_types.h"
 #include "vtr_memory.h"
 

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -1,5 +1,5 @@
-#ifndef VPR_CONTEXT_H
-#define VPR_CONTEXT_H
+#pragma once
+
 #include <unordered_map>
 #include <memory>
 #include <vector>
@@ -847,5 +847,3 @@ class VprContext : public Context {
 
     PackingMultithreadingContext packing_multithreading_;
 };
-
-#endif

--- a/vpr/src/base/vpr_exit_codes.h
+++ b/vpr/src/base/vpr_exit_codes.h
@@ -1,5 +1,4 @@
-#ifndef VPR_EXIT_CODES_H
-#define VPR_EXIT_CODES_H
+#pragma once
 
 /**
  * @file
@@ -9,5 +8,3 @@ constexpr int SUCCESS_EXIT_CODE = 0;         ///<Everything OK
 constexpr int ERROR_EXIT_CODE = 1;           ///<Something went wrong internally
 constexpr int UNIMPLEMENTABLE_EXIT_CODE = 2; ///<Could not implement (e.g. unroutable)
 constexpr int INTERRUPTED_EXIT_CODE = 3;     ///<VPR was interrupted by the user (e.g. SIGINT/ctr-C)
-
-#endif

--- a/vpr/src/base/vpr_signal_handler.h
+++ b/vpr/src/base/vpr_signal_handler.h
@@ -1,6 +1,3 @@
-#ifndef SIGNAL_HANLDER_H
-#define SIGNAL_HANLDER_H
+#pragma once
 
 void vpr_install_signal_handler();
-
-#endif

--- a/vpr/src/base/vpr_tatum_error.h
+++ b/vpr/src/base/vpr_tatum_error.h
@@ -1,8 +1,6 @@
-#ifndef VPR_TATUM_ERROR_H
-#define VPR_TATUM_ERROR_H
+#pragma once
+
 #include <string>
 #include "tatum/error.hpp"
 
 std::string format_tatum_error(const tatum::Error& error);
-
-#endif

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @brief This is a core file that defines the major data types used by VPR
@@ -20,8 +21,6 @@
  * t_pb: Stores the mapping between the user netlist and the logic blocks on the FPGA architecture.  For example, if a user design has 10 clusters of 5 LUTs each, you will have 10 t_pb instances of type cluster and within each of those clusters another 5 t_pb instances of type LUT.
  * The t_pb hierarchy follows what is described by t_pb_graph_node
  */
-
-#pragma once
 
 #include <vector>
 #include <set>

--- a/vpr/src/draw/breakpoint.h
+++ b/vpr/src/draw/breakpoint.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file breakpoint.h
  * 
@@ -15,8 +16,6 @@
  * (e.g Breakpoint(BT_MOVE_NUM, 4) or Breakpoint(BT_EXPRESSION, "move_num += 3")) The == operator has also been provided which returns true when two 
  * breakpoints have the same type, and the same value corresponding to the type.
  */
-
-#pragma once
 
 #include <string>
 #include "breakpoint_state_globals.h"

--- a/vpr/src/draw/draw.h
+++ b/vpr/src/draw/draw.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw.h
  *
@@ -16,8 +17,6 @@
  * Authors: Vaughn Betz, Long Yu (Mike) Wang, Dingyu (Tina) Yang, Sebastian Lievano
  * Last updated: August 2022
  */
-
-#pragma once
 
 #include "blk_loc_registry.h"
 #include "physical_types.h"

--- a/vpr/src/draw/draw_basic.h
+++ b/vpr/src/draw/draw_basic.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw_basic.h
  * 
@@ -5,8 +6,6 @@
  * that aren't RR nodes or muxes (they have their own file).
  * All functions in this file contain the prefix draw_.
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_color.h
+++ b/vpr/src/draw/draw_color.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw_color.h
  * 
@@ -5,7 +6,6 @@
  * as well as a global vector of colors shuffled to prevent similar
  * colors from being close together
  */
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_debug.h
+++ b/vpr/src/draw/draw_debug.h
@@ -1,10 +1,10 @@
+#pragma once
 /**
  * @file draw_debug.h
  * 
  *  This file contains all functions regarding the graphics related to the setting of place and route breakpoints.
  * Manages creation of new Gtk Windows with debug options on use of the "Debug" button.
  */
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_floorplanning.h
+++ b/vpr/src/draw/draw_floorplanning.h
@@ -1,5 +1,5 @@
-/** This file contains all functions regarding the graphics related to drawing floorplanning constraints. **/
 #pragma once
+/** This file contains all functions regarding the graphics related to drawing floorplanning constraints. **/
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_global.h
+++ b/vpr/src/draw/draw_global.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw_global.h
  * This file contains declaration of accessor functions that can be used to
@@ -9,8 +10,6 @@
  * Author: Long Yu (Mike) Wang
  * Date: August 21, 2013
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_mux.h
+++ b/vpr/src/draw/draw_mux.h
@@ -1,9 +1,9 @@
+#pragma once
 /**
  * @file draw_mux.h
  * 
  * This file contains all functions related to drawing muxes
  */
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_noc.h
+++ b/vpr/src/draw/draw_noc.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw_noc.h
  * @brief This is the draw_noc header file. This file provides utilities
@@ -20,8 +21,6 @@
  * 
  * Author: Srivatsan Srinivasan
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_rr.h
+++ b/vpr/src/draw/draw_rr.h
@@ -1,10 +1,9 @@
+#pragma once
 /**
  * @file draw_rr.h
  * 
  * draw_rr.cpp contains all functions that relate to drawing routing resources.
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_rr_edges.h
+++ b/vpr/src/draw/draw_rr_edges.h
@@ -1,10 +1,9 @@
+#pragma once
 /**
  * @file draw_rr_edges.h
  * 
  * draw_rr_edges.cpp contains all functions that draw lines between RR nodes.
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_searchbar.h
+++ b/vpr/src/draw/draw_searchbar.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file draw_searchbar.h
  * 
  * draw_searchbar contains functions that draw/highlight search results,
  * and manages the selection/highlighting of currently selected options.
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_toggle_functions.h
+++ b/vpr/src/draw/draw_toggle_functions.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw_toggle_functions.h
  * 
@@ -9,8 +10,6 @@
  * 
  * Author: Sebastian Lievano
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_triangle.h
+++ b/vpr/src/draw/draw_triangle.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file draw_triangle.h
  *
  * draw_triangle.cpp contains functions that draw triangles. Used for drawing arrows for showing switching in the routing,
  * direction of signals, flylines 
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file draw_types.h
  * 
@@ -14,8 +15,6 @@
  *
  * Author: Long Yu (Mike) Wang, Sebastian Lievano
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/hsl.h
+++ b/vpr/src/draw/hsl.h
@@ -1,10 +1,9 @@
+#pragma once
 /**
  * @file hsl.h
  * 
  * This file manages conversions between color (red, green, and blue) and hsl (hue, saturation, and luminesence)
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/intra_logic_block.h
+++ b/vpr/src/draw/intra_logic_block.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file intra_logic_block.h
  * 
@@ -14,8 +15,6 @@
  * Author: Matthew J.P. Walker
  * Date: May,June 2014
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/manual_moves.h
+++ b/vpr/src/draw/manual_moves.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file manual_moves.h
  * 
@@ -6,8 +7,6 @@
  * 
  * Author: Paula Perdomo
  */
-
-#pragma once
 
 /** This file contains all functions for manual moves **/
 #ifndef NO_GRAPHICS

--- a/vpr/src/draw/save_graphics.h
+++ b/vpr/src/draw/save_graphics.h
@@ -1,10 +1,9 @@
+#pragma once
 /**
  * @file save_graphics.h
  * 
  * Manages saving of graphics in different file formats
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/search_bar.h
+++ b/vpr/src/draw/search_bar.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file search_bar.h
  * 
@@ -6,8 +7,6 @@
  * 
  * Author: Sebastian Lievano
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/draw/ui_setup.h
+++ b/vpr/src/draw/ui_setup.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file ui_setup.h
  * @brief declares ui setup functions
@@ -8,8 +9,6 @@
  * 
  * Author: Sebastian Lievano
  */
-
-#pragma once
 
 #ifndef NO_GRAPHICS
 

--- a/vpr/src/noc/bfs_routing.cpp
+++ b/vpr/src/noc/bfs_routing.cpp
@@ -1,5 +1,6 @@
 
 #include <queue>
+#include "vpr_error.h"
 
 #include "bfs_routing.h"
 

--- a/vpr/src/noc/bfs_routing.h
+++ b/vpr/src/noc/bfs_routing.h
@@ -1,6 +1,4 @@
-#ifndef BFS_ROUTING
-#define BFS_ROUTING
-
+#pragma once
 /**
  * @file 
  * @brief This file defines the BFSRouting class.
@@ -86,5 +84,3 @@ class BFSRouting : public NocRouting {
                         const NocStorage& noc_model,
                         const std::unordered_map<NocRouterId, NocLinkId>& router_parent_link);
 };
-
-#endif

--- a/vpr/src/noc/channel_dependency_graph.h
+++ b/vpr/src/noc/channel_dependency_graph.h
@@ -1,6 +1,4 @@
-#ifndef VTR_CHANNEL_DEPENDENCY_GRAPH_H
-#define VTR_CHANNEL_DEPENDENCY_GRAPH_H
-
+#pragma once
 /**
  * @file
  * @brief This file declares the ChannelDependencyGraph class.
@@ -56,5 +54,3 @@ class ChannelDependencyGraph {
     /** An adjacency list used to represent channel dependency graph.*/
     vtr::vector<NocLinkId, std::vector<NocLinkId>> adjacency_list_;
 };
-
-#endif //VTR_CHANNEL_DEPENDENCY_GRAPH_H

--- a/vpr/src/noc/negative_first_routing.h
+++ b/vpr/src/noc/negative_first_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_NEGATIVE_FIRST_ROUTING_H
-#define VTR_NEGATIVE_FIRST_ROUTING_H
-
+#pragma once
 /**
  * @file
  * @brief This file declares the NegativeFirstRouting class, which implements
@@ -44,5 +42,3 @@ class NegativeFirstRouting : public TurnModelRouting {
     bool is_turn_legal(const std::array<std::reference_wrapper<const NocRouter>, 3>& noc_routers,
                        const NocStorage& noc_model) const override;
 };
-
-#endif //VTR_NEGATIVE_FIRST_ROUTING_H

--- a/vpr/src/noc/noc_data_types.h
+++ b/vpr/src/noc/noc_data_types.h
@@ -1,6 +1,4 @@
-#ifndef NOC_DATA_TYPES_H
-#define NOC_DATA_TYPES_H
-
+#pragma once
 /** 
  * @file 
  * @brief This file contains datatype definitions which are used by the NoC data structures.
@@ -27,5 +25,3 @@ typedef vtr::StrongId<noc_traffic_flow_id_tag, int> NocTrafficFlowId;
 /** Data type to index NoC groups. */
 struct noc_group_id_tag;
 typedef vtr::StrongId<noc_group_id_tag, int> NocGroupId;
-
-#endif

--- a/vpr/src/noc/noc_link.h
+++ b/vpr/src/noc/noc_link.h
@@ -1,6 +1,4 @@
-#ifndef NOC_LINK_H
-#define NOC_LINK_H
-
+#pragma once
 /**
  * @file
  * @brief This file defines the NocLink class.
@@ -37,8 +35,6 @@
  * 
  */
 
-#include <iostream>
-#include "noc_router.h"
 #include "noc_data_types.h"
 
 class NocLink {
@@ -120,5 +116,3 @@ class NocLink {
      */
     operator NocLinkId() const;
 };
-
-#endif

--- a/vpr/src/noc/noc_router.h
+++ b/vpr/src/noc/noc_router.h
@@ -1,6 +1,4 @@
-#ifndef NOC_ROUTER_H
-#define NOC_ROUTER_H
-
+#pragma once
 /**
  * @file
  * @brief This file defines the NocRouter class.
@@ -31,10 +29,8 @@
  * between them.
  */
 
-#include <iostream>
-#include <string>
-
-#include "clustered_netlist.h"
+#include "clustered_netlist_fwd.h"
+#include "physical_types.h"
 
 class NocRouter {
   private:
@@ -118,5 +114,3 @@ class NocRouter {
      */
     void set_router_block_ref(ClusterBlockId router_block_ref_id);
 };
-
-#endif

--- a/vpr/src/noc/noc_routing.h
+++ b/vpr/src/noc/noc_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_NOCROUTING_H
-#define VTR_NOCROUTING_H
-
+#pragma once
 /**
  * @file
  * @brief This file defines the NocRouting class, which handles the
@@ -62,5 +60,3 @@ class NocRouting {
                             std::vector<NocLinkId>& flow_route,
                             const NocStorage& noc_model) = 0;
 };
-
-#endif

--- a/vpr/src/noc/noc_routing_algorithm_creator.h
+++ b/vpr/src/noc/noc_routing_algorithm_creator.h
@@ -1,6 +1,4 @@
-#ifndef NOC_ROUTING_ALGORITHM_CREATOR
-#define NOC_ROUTING_ALGORITHM_CREATOR
-
+#pragma once
 /**
  * @file
  * @brief  This file defines the NocRoutingAlgorithmCreator class, which creates
@@ -20,8 +18,8 @@
 
 #include <string>
 #include <memory>
-
 #include "noc_routing.h"
+#include "noc_storage.h"
 
 class NocRoutingAlgorithmCreator {
   public:
@@ -42,5 +40,3 @@ class NocRoutingAlgorithmCreator {
     static std::unique_ptr<NocRouting> create_routing_algorithm(const std::string& routing_algorithm_name,
                                                                 const NocStorage& noc_model);
 };
-
-#endif

--- a/vpr/src/noc/noc_storage.cpp
+++ b/vpr/src/noc/noc_storage.cpp
@@ -1,6 +1,7 @@
 
 #include "noc_storage.h"
 #include "vtr_assert.h"
+#include "vtr_log.h"
 #include "vpr_error.h"
 
 #include <algorithm>

--- a/vpr/src/noc/noc_storage.h
+++ b/vpr/src/noc/noc_storage.h
@@ -1,6 +1,4 @@
-#ifndef NOC_STORAGE_H
-#define NOC_STORAGE_H
-
+#pragma once
 /**
  * @file
  * @brief This file defines the NocStorage class.
@@ -36,9 +34,9 @@
  */
 
 #include <vector>
-#include <string>
 #include <unordered_map>
 #include "noc_data_types.h"
+#include "vpr_types.h"
 #include "vtr_vector.h"
 #include "noc_router.h"
 #include "noc_link.h"
@@ -572,5 +570,3 @@ const std::vector<std::reference_wrapper<const NocLink>>& NocStorage::get_noc_li
 
     return returnable_noc_link_const_refs_;
 }
-
-#endif

--- a/vpr/src/noc/noc_traffic_flows.cpp
+++ b/vpr/src/noc/noc_traffic_flows.cpp
@@ -1,6 +1,7 @@
 
 #include "noc_traffic_flows.h"
-#include "vpr_error.h"
+#include "vtr_assert.h"
+#include "vtr_util.h"
 
 // constructor indicates that the class has not been properly initialized yet as the user supplied traffic flows have not been added.
 NocTrafficFlows::NocTrafficFlows() {

--- a/vpr/src/noc/noc_traffic_flows.h
+++ b/vpr/src/noc/noc_traffic_flows.h
@@ -1,6 +1,4 @@
-#ifndef NOC_TRAFFIC_FLOWS_H
-#define NOC_TRAFFIC_FLOWS_H
-
+#pragma once
 /**
  * @file 
  * @brief This file defines the NocTrafficFlows class, which contains all
@@ -29,17 +27,13 @@
  * around to different tiles on the FPGA device.
  * 
  */
-#include <iostream>
+
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 #include "clustered_netlist_fwd.h"
 #include "noc_data_types.h"
 #include "vtr_vector.h"
-#include "echo_files.h"
-#include "vtr_util.h"
-#include "vtr_assert.h"
 
 /**
  * @brief Describes a traffic flow within the NoC, which is the communication
@@ -314,5 +308,3 @@ class NocTrafficFlows {
      */
     static constexpr double DEFAULT_MAX_TRAFFIC_FLOW_LATENCY = 1.;
 };
-
-#endif

--- a/vpr/src/noc/north_last_routing.h
+++ b/vpr/src/noc/north_last_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_NORTH_LAST_ROUTING_H
-#define VTR_NORTH_LAST_ROUTING_H
-
+#pragma once
 /**
  * @file
  * @brief This file declares the NorthLastRouting class, which implements
@@ -45,5 +43,3 @@ class NorthLastRouting : public TurnModelRouting {
     bool is_turn_legal(const std::array<std::reference_wrapper<const NocRouter>, 3>& noc_routers,
                        const NocStorage& noc_model) const override;
 };
-
-#endif //VTR_NORTH_LAST_ROUTING_H

--- a/vpr/src/noc/odd_even_routing.h
+++ b/vpr/src/noc/odd_even_routing.h
@@ -1,5 +1,4 @@
-#ifndef VTR_ODD_EVEN_ROUTING_H
-#define VTR_ODD_EVEN_ROUTING_H
+#pragma once
 
 #include "turn_model_routing.h"
 
@@ -90,5 +89,3 @@ class OddEvenRouting : public TurnModelRouting {
      */
     vtr::vector<NocRouterId, t_physical_tile_loc> compressed_noc_locs_;
 };
-
-#endif //VTR_ODD_EVEN_ROUTING_H

--- a/vpr/src/noc/read_xml_noc_traffic_flows_file.cpp
+++ b/vpr/src/noc/read_xml_noc_traffic_flows_file.cpp
@@ -1,6 +1,11 @@
 
 #include "read_xml_noc_traffic_flows_file.h"
+#include <regex>
+#include "ShowSetup.h"
+#include "echo_files.h"
+#include "globals.h"
 #include "physical_types_util.h"
+#include "pugixml_util.hpp"
 
 void read_xml_noc_traffic_flows_file(const char* noc_flows_file) {
     // start by checking that the provided file is a ".flows" file

--- a/vpr/src/noc/read_xml_noc_traffic_flows_file.h
+++ b/vpr/src/noc/read_xml_noc_traffic_flows_file.h
@@ -1,6 +1,4 @@
-#ifndef READ_XML_NOC_TRAFFIC_FLOWS_FILE_H
-#define READ_XML_NOC_TRAFFIC_FLOWS_FILE_H
-
+#pragma once
 /**
  *  @brief The purpose of this file is to read and parse an xml file that has 
  *         a '.flows' extension. This file contains the description of
@@ -17,24 +15,18 @@
  * 
  */
 
+#include "clustered_netlist_fwd.h"
+#include "physical_types.h"
 #include "pugixml.hpp"
-#include "pugixml_util.hpp"
-#include "read_xml_util.h"
-#include "globals.h"
+#include "pugixml_loc.hpp"
 
-#include "vtr_assert.h"
-#include "vtr_util.h"
-#include "ShowSetup.h"
-#include "vpr_error.h"
-#include "echo_files.h"
-
-#include "noc_data_types.h"
-#include "noc_traffic_flows.h"
-
-#include <iostream>
 #include <vector>
 #include <string>
 #include <float.h>
+
+struct DeviceContext;
+struct ClusteringContext;
+struct NocContext;
 
 // identifier when an integer conversion failed while reading an attribute value in an xml file
 constexpr int NUMERICAL_ATTRIBUTE_CONVERSION_FAILURE = -1;
@@ -256,5 +248,3 @@ bool check_that_all_router_blocks_have_an_associated_traffic_flow(NocContext& no
  *                                     are compatible with a NoC router tile. 
  */
 std::vector<ClusterBlockId> get_cluster_blocks_compatible_with_noc_router_tiles(const ClusteringContext& cluster_ctx, t_physical_tile_type_ptr noc_router_tile_type);
-
-#endif

--- a/vpr/src/noc/sat_routing.h
+++ b/vpr/src/noc/sat_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_SATROUTING_H
-#define VTR_SATROUTING_H
-
+#pragma once
 /**
  * @file
  * @brief SAT formulation of NoC traffic flow routing.
@@ -66,5 +64,4 @@ struct hash<std::pair<NocTrafficFlowId, NocLinkId>> {
 };
 } // namespace std
 
-#endif
 #endif

--- a/vpr/src/noc/turn_model_routing.cpp
+++ b/vpr/src/noc/turn_model_routing.cpp
@@ -1,5 +1,6 @@
 
 #include "turn_model_routing.h"
+#include "vpr_error.h"
 
 TurnModelRouting::~TurnModelRouting() = default;
 

--- a/vpr/src/noc/turn_model_routing.h
+++ b/vpr/src/noc/turn_model_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_TURN_MODEL_ROUTING_H
-#define VTR_TURN_MODEL_ROUTING_H
-
+#pragma once
 /**
  * @file
  * @brief This file declares the TurnModelRouting class, which abstract all
@@ -274,5 +272,3 @@ class TurnModelRouting : public NocRouting {
   private:
     std::vector<uint32_t> inputs_to_murmur3_hasher{4};
 };
-
-#endif //VTR_TURN_MODEL_ROUTING_H

--- a/vpr/src/noc/west_first_routing.h
+++ b/vpr/src/noc/west_first_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_WEST_FIRST_ROUTING_H
-#define VTR_WEST_FIRST_ROUTING_H
-
+#pragma once
 /**
  * @file
  * @brief This file declares the WestFirstRouting class, which implements
@@ -44,5 +42,3 @@ class WestFirstRouting : public TurnModelRouting {
     bool is_turn_legal(const std::array<std::reference_wrapper<const NocRouter>, 3>& noc_routers,
                        const NocStorage& noc_model) const override;
 };
-
-#endif //VTR_WEST_FIRST_ROUTING_H

--- a/vpr/src/noc/xy_routing.h
+++ b/vpr/src/noc/xy_routing.h
@@ -1,6 +1,4 @@
-#ifndef VTR_XYROUTING_H
-#define VTR_XYROUTING_H
-
+#pragma once
 /**
  * @file 
  * @brief This file defines the XYRouting class, which represents a direction
@@ -117,5 +115,3 @@ class XYRouting : public TurnModelRouting {
     const std::vector<TurnModelRouting::Direction> down_direction{TurnModelRouting::Direction::DOWN};
     const std::vector<TurnModelRouting::Direction> no_direction{};
 };
-
-#endif

--- a/vpr/src/pack/appack_context.h
+++ b/vpr/src/pack/appack_context.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Siner
@@ -5,8 +6,6 @@
  * @brief   Declaration of the APPack Context object which stores all the
  *          information used to configure APPack in the packer.
  */
-
-#pragma once
 
 #include "appack_max_dist_th_manager.h"
 #include "device_grid.h"

--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -5,8 +6,6 @@
  * @brief   Declaration of a class that manages the max candidate distance
  *          thresholding optimization used within APPack.
  */
-
-#pragma once
 
 #include <string>
 #include <vector>

--- a/vpr/src/pack/atom_pb_bimap.h
+++ b/vpr/src/pack/atom_pb_bimap.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file 
  * @author  Amir Poolad
@@ -7,8 +8,6 @@
  * This file declares a class called AtomPBBimap that
  * contains a two way mapping between AtomBlockIds and pb types.
  */
-
-#pragma once
 
 #include "vpr_types.h"
 

--- a/vpr/src/pack/attraction_groups.h
+++ b/vpr/src/pack/attraction_groups.h
@@ -1,12 +1,10 @@
+#pragma once
 /*
  * attraction_groups.h
  *
  *  Created on: Jun. 13, 2021
  *      Author: khalid88
  */
-
-#ifndef VPR_SRC_PACK_ATTRACTION_GROUPS_H_
-#define VPR_SRC_PACK_ATTRACTION_GROUPS_H_
 
 #include "vtr_strong_id.h"
 #include "vtr_vector.h"
@@ -135,5 +133,3 @@ inline void AttractionInfo::set_attraction_group_gain(const AttractGroupId group
 inline AttractionGroup& AttractionInfo::get_attraction_group_info(const AttractGroupId group_id) {
     return attraction_groups[group_id];
 }
-
-#endif /* VPR_SRC_PACK_ATTRACTION_GROUPS_H_ */

--- a/vpr/src/pack/cluster_feasibility_filter.h
+++ b/vpr/src/pack/cluster_feasibility_filter.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Feasibility filter used during packing that determines if various necessary conditions for legality are met
  *
@@ -19,11 +20,6 @@
  *
  */
 
-#ifndef CLUSTER_FEASIBILITY_CHECK_H
-#define CLUSTER_FEASIBILITY_CHECK_H
-
 class t_pb_graph_node;
 
 void load_pin_classes_in_pb_graph_head(t_pb_graph_node* pb_graph_node);
-
-#endif

--- a/vpr/src/pack/cluster_legalizer.h
+++ b/vpr/src/pack/cluster_legalizer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -9,8 +10,6 @@
  * designed to be self-contained to the point that it is able to be called
  * externally to the Packer in VPR.
  */
-
-#pragma once
 
 #include <vector>
 #include "atom_netlist_fwd.h"

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -1,10 +1,8 @@
+#pragma once
 /*
  * Find placement for group of atom blocks in complex block
  * Author: Jason Luu
  */
-
-#ifndef CLUSTER_PLACEMENT_H
-#define CLUSTER_PLACEMENT_H
 
 #include <vector>
 #include <unordered_map>
@@ -186,5 +184,3 @@ bool exists_free_primitive_for_atom_block(
 
 void reset_tried_but_unused_cluster_placements(
     t_intra_cluster_placement_stats* cluster_placement_stats);
-
-#endif

--- a/vpr/src/pack/cluster_router.h
+++ b/vpr/src/pack/cluster_router.h
@@ -1,11 +1,10 @@
+#pragma once
 /*
  * Intra-logic block router determines if a candidate packing solution (or intermediate solution) can route.
  *
  * Author: Jason Luu
  * Date: July 22, 2013
  */
-#ifndef CLUSTER_ROUTER_H
-#define CLUSTER_ROUTER_H
 
 #include <vector>
 #include "atom_netlist_fwd.h"
@@ -40,5 +39,3 @@ t_pb_routes alloc_and_load_pb_route(const std::vector<t_intra_lb_net>* intra_lb_
                                     t_logical_block_type_ptr logic_block_type,
                                     const IntraLbPbPinLookup& intra_lb_pb_pin_lookup);
 void free_pb_route(t_pb_route* free_pb_route);
-
-#endif

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -6,6 +6,7 @@
 #include "attraction_groups.h"
 #include "cluster_legalizer.h"
 #include "clustered_netlist.h"
+#include "echo_files.h"
 #include "globals.h"
 #include "logic_types.h"
 #include "output_clustering.h"

--- a/vpr/src/pack/cluster_util.h
+++ b/vpr/src/pack/cluster_util.h
@@ -1,5 +1,4 @@
-#ifndef CLUSTER_UTIL_H
-#define CLUSTER_UTIL_H
+#pragma once
 
 #include <unordered_set>
 #include <vector>
@@ -124,4 +123,3 @@ void print_le_count(int num_logic_le,
 void init_clb_atoms_lookup(vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>>& atoms_lookup,
                            const AtomContext& atom_ctx,
                            const ClusteredNetlist& clb_nlist);
-#endif

--- a/vpr/src/pack/constraints_report.h
+++ b/vpr/src/pack/constraints_report.h
@@ -1,8 +1,7 @@
+#pragma once
 /* Perform a check at the end of each packing iteration to see whether any
  * floorplan regions have been packed with too many clusters.
  */
-
-#pragma once
 
 #include <vector>
 

--- a/vpr/src/pack/greedy_candidate_selector.h
+++ b/vpr/src/pack/greedy_candidate_selector.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -6,8 +7,6 @@
  *          candidate molecules to pack into the given cluster. This class also
  *          maintains the gains of packing molecules into clusters.
  */
-
-#pragma once
 
 #include <map>
 #include <unordered_set>
@@ -22,7 +21,6 @@
 #include "vtr_ndmatrix.h"
 #include "vtr_vector.h"
 #include "vtr_random.h"
-#include "vtr_vector_map.h"
 #include "lazy_pop_unique_priority_queue.h"
 
 // Forward declarations

--- a/vpr/src/pack/greedy_clusterer.h
+++ b/vpr/src/pack/greedy_clusterer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -5,8 +6,6 @@
  * @brief   The declarations of the Greedy Clusterer class which is used to
  *          encapsulate the process of greedy clustering.
  */
-
-#pragma once
 
 #include <map>
 #include <unordered_set>

--- a/vpr/src/pack/greedy_seed_selector.h
+++ b/vpr/src/pack/greedy_seed_selector.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -5,8 +6,6 @@
  * @brief   The declaration of the greedy seed selector class which selects the
  *          seed molecules for starting new clusters in the greedy clusterer.
  */
-
-#pragma once
 
 #include "prepack.h"
 #include "vpr_types.h"

--- a/vpr/src/pack/lb_type_rr_graph.h
+++ b/vpr/src/pack/lb_type_rr_graph.h
@@ -1,12 +1,10 @@
+#pragma once
 /*
  * Functions to creates, manipulate, and free the lb_type_rr_node graph that represents interconnect within a logic block type.
  *
  * Author: Jason Luu
  * Date: July 22, 2013
  */
-
-#ifndef LB_TYPE_RR_GRAPH_H
-#define LB_TYPE_RR_GRAPH_H
 
 #include "pack_types.h"
 
@@ -21,5 +19,3 @@ int get_lb_type_rr_graph_edge_mode(std::vector<t_lb_type_rr_node>& lb_type_rr_gr
 
 /* Debug functions */
 void echo_lb_type_rr_graphs(char* filename, std::vector<t_lb_type_rr_node>* lb_type_rr_graphs);
-
-#endif

--- a/vpr/src/pack/noc_aware_cluster_util.h
+++ b/vpr/src/pack/noc_aware_cluster_util.h
@@ -1,6 +1,4 @@
-#ifndef VTR_NOC_AWARE_CLUSTER_UTIL_H
-#define VTR_NOC_AWARE_CLUSTER_UTIL_H
-
+#pragma once
 /**
  * @file This file includes helper functions used to find NoC groups
  * in the atom netlist and assign NoC group IDs to atom blocks.
@@ -45,5 +43,3 @@ void update_noc_reachability_partitions(const std::vector<AtomBlockId>& noc_atom
                                         const AtomNetlist& atom_netlist,
                                         const t_pack_high_fanout_thresholds& high_fanout_threshold,
                                         vtr::vector<AtomBlockId, NocGroupId>& atom_noc_grp_id);
-
-#endif

--- a/vpr/src/pack/output_clustering.h
+++ b/vpr/src/pack/output_clustering.h
@@ -1,5 +1,4 @@
-#ifndef OUTPUT_CLUSTERING_H
-#define OUTPUT_CLUSTERING_H
+#pragma once
 
 #include <unordered_set>
 #include <string>
@@ -25,5 +24,3 @@ void output_clustering(ClusterLegalizer* cluster_legalizer_ptr,
 
 void write_packing_results_to_xml(const std::string& architecture_id,
                                   const char* out_fname);
-
-#endif

--- a/vpr/src/pack/pack.h
+++ b/vpr/src/pack/pack.h
@@ -1,5 +1,4 @@
-#ifndef PACK_H
-#define PACK_H
+#pragma once
 
 #include <unordered_set>
 #include <vector>
@@ -46,5 +45,3 @@ bool try_pack(const t_packer_opts& packer_opts,
               const FlatPlacementInfo& flat_placement_info);
 
 std::unordered_set<AtomNetId> alloc_and_load_is_clock();
-
-#endif

--- a/vpr/src/pack/pack_report.h
+++ b/vpr/src/pack/pack_report.h
@@ -1,9 +1,6 @@
-#ifndef VPR_PACK_REPORT_H
-#define VPR_PACK_REPORT_H
+#pragma once
 
 #include <iosfwd>
 #include "vpr_context.h"
 
 void report_packing_pin_usage(std::ostream& os, const VprContext& ctx);
-
-#endif

--- a/vpr/src/pack/pack_types.h
+++ b/vpr/src/pack/pack_types.h
@@ -1,5 +1,4 @@
-#ifndef PACK_TYPES_H
-#define PACK_TYPES_H
+#pragma once
 /**
  * Jason Luu
  * July 22, 2013
@@ -244,5 +243,3 @@ struct t_mode_selection_status {
         return is_mode_conflict || try_expand_all_modes;
     }
 };
-
-#endif

--- a/vpr/src/pack/pb_type_graph.h
+++ b/vpr/src/pack/pb_type_graph.h
@@ -1,5 +1,4 @@
-#ifndef PB_TYPE_GRAPH_H
-#define PB_TYPE_GRAPH_H
+#pragma once
 
 #include "physical_types.h"
 
@@ -29,4 +28,3 @@ t_pb_graph_pin*** alloc_and_load_port_pin_ptrs_from_string(const int line_num,
                                                            int* num_sets,
                                                            const bool is_input_to_interc,
                                                            const bool interconnect_error_check);
-#endif

--- a/vpr/src/pack/pb_type_graph_annotations.h
+++ b/vpr/src/pack/pb_type_graph_annotations.h
@@ -1,14 +1,10 @@
+#pragma once
 /**
  * Jason Luu
  * April 15, 2011
  * pb_type_graph_annotations loads statistical information onto the different nodes/edges of a pb_type_graph.  These statistical informations include delays, capacitance, etc.
  */
 
-#ifndef PB_TYPE_GRAPH_ANNOTATIONS_H
-#define PB_TYPE_GRAPH_ANNOTATIONS_H
-
 class t_pb_graph_node;
 
 void load_pb_graph_pin_to_pin_annotations(t_pb_graph_node* pb_graph_node);
-
-#endif

--- a/vpr/src/pack/post_routing_pb_pin_fixup.h
+++ b/vpr/src/pack/post_routing_pb_pin_fixup.h
@@ -1,5 +1,4 @@
-#ifndef POST_ROUTING_PB_PIN_FIXUP_H
-#define POST_ROUTING_PB_PIN_FIXUP_H
+#pragma once
 
 /********************************************************************
  * Include header files that are required by function declaration
@@ -32,5 +31,3 @@ void sync_netlists_to_routing(const Netlist<>& net_list,
                               ClusteringContext& clustering_ctx,
                               const PlacementContext& placement_ctx,
                               const bool& verbose);
-
-#endif

--- a/vpr/src/pack/prepack.h
+++ b/vpr/src/pack/prepack.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Prepacking: Group together technology-mapped netlist blocks before packing.
  * This gives hints to the packer on what groups of blocks to keep together
@@ -6,8 +7,6 @@
  * Primary uses: 1) "Forced" packs (eg LUT+FF pair)
  *               2) Carry-chains
  */
-
-#pragma once
 
 #include <algorithm>
 #include "atom_netlist_fwd.h"

--- a/vpr/src/pack/sync_netlists_to_routing_flat.h
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.h
@@ -1,3 +1,4 @@
+#pragma once
 /********************************************************************
  * Top-level function to synchronize packing results to routing results.
  * Flat routing invalidates the ClusteredNetlist since nets may be routed

--- a/vpr/src/pack/verify_clustering.h
+++ b/vpr/src/pack/verify_clustering.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -6,8 +7,6 @@
  *          that ensure that the given clustering is valid and can be used with
  *          the rest of the VPR flow.
  */
-
-#pragma once
 
 #include <unordered_set>
 #include "vtr_vector.h"

--- a/vpr/src/pack/verify_flat_placement.h
+++ b/vpr/src/pack/verify_flat_placement.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -6,8 +7,6 @@
  *          placement that has been passed into the packer. This checks for
  *          invalid data so this does not have to be checked during packing.
  */
-
-#pragma once
 
 // Forward declarations
 class FlatPlacementInfo;

--- a/vpr/src/place/RL_agent_util.h
+++ b/vpr/src/place/RL_agent_util.h
@@ -1,5 +1,4 @@
-#ifndef RL_AGENT_UTIL_H
-#define RL_AGENT_UTIL_H
+#pragma once
 
 #include "move_generator.h"
 
@@ -45,5 +44,3 @@ MoveGenerator& select_move_generator(std::unique_ptr<MoveGenerator>& move_genera
                                      e_agent_state agent_state,
                                      const t_placer_opts& placer_opts,
                                      bool in_quench);
-
-#endif

--- a/vpr/src/place/annealer.h
+++ b/vpr/src/place/annealer.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "vpr_types.h"
@@ -6,6 +5,7 @@
 #include "move_generator.h" // movestats
 #include "net_cost_handler.h"
 #include "manual_move_generator.h"
+#include "vtr_random.h"
 
 #include <optional>
 #include <tuple>

--- a/vpr/src/place/compressed_grid.h
+++ b/vpr/src/place/compressed_grid.h
@@ -1,5 +1,4 @@
-#ifndef VPR_COMPRESSED_GRID_H
-#define VPR_COMPRESSED_GRID_H
+#pragma once
 
 #include <algorithm>
 #include "physical_types.h"
@@ -186,5 +185,3 @@ std::vector<t_compressed_block_grid> create_compressed_block_grids();
  *
  */
 void echo_compressed_grids(const char* filename, const std::vector<t_compressed_block_grid>& comp_grids);
-
-#endif

--- a/vpr/src/place/delay_model/PlacementDelayModelCreator.h
+++ b/vpr/src/place/delay_model/PlacementDelayModelCreator.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <memory>

--- a/vpr/src/place/delay_model/compute_delta_delays_utils.h
+++ b/vpr/src/place/delay_model/compute_delta_delays_utils.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "vtr_ndmatrix.h"

--- a/vpr/src/place/delay_model/delta_delay_model.h
+++ b/vpr/src/place/delay_model/delta_delay_model.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "place_delay_model.h"

--- a/vpr/src/place/delay_model/override_delay_model.h
+++ b/vpr/src/place/delay_model/override_delay_model.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "place_delay_model.h"

--- a/vpr/src/place/delay_model/place_delay_model.h
+++ b/vpr/src/place/delay_model/place_delay_model.h
@@ -1,13 +1,10 @@
+#pragma once
 /**
  * @file place_delay_model.h
  * @brief This file contains all the class and function declarations related to
  *        the placer delay model. For implementations, see place_delay_model.cpp.
  */
 
-#pragma once
-
-#include "vtr_ndmatrix.h"
-#include "vtr_flat_map.h"
 #include "vpr_types.h"
 #include "router_delay_profiling.h"
 

--- a/vpr/src/place/delay_model/simple_delay_model.h
+++ b/vpr/src/place/delay_model/simple_delay_model.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "place_delay_model.h"

--- a/vpr/src/place/grid_tile_lookup.h
+++ b/vpr/src/place/grid_tile_lookup.h
@@ -1,5 +1,4 @@
-#ifndef VPR_SRC_PLACE_GRID_TILE_LOOKUP_H_
-#define VPR_SRC_PLACE_GRID_TILE_LOOKUP_H_
+#pragma once
 
 #include <vector>
 #include "physical_types.h"
@@ -89,5 +88,3 @@ class GridTileLookup {
      */
     std::vector<int> max_placement_locations;
 };
-
-#endif /* VPR_SRC_PLACE_GRID_TILE_LOOKUP_H_ */

--- a/vpr/src/place/initial_noc_placement.cpp
+++ b/vpr/src/place/initial_noc_placement.cpp
@@ -8,6 +8,7 @@
 #include "noc_place_checkpoint.h"
 #include "place_constraints.h"
 
+#include "vtr_random.h"
 #include "vtr_time.h"
 
 /**

--- a/vpr/src/place/initial_noc_placment.h
+++ b/vpr/src/place/initial_noc_placment.h
@@ -1,6 +1,4 @@
-
-#ifndef VTR_INITIAL_NOC_PLACEMENT_H
-#define VTR_INITIAL_NOC_PLACEMENT_H
+#pragma once
 
 struct t_noc_opts;
 struct t_placer_opts;
@@ -26,5 +24,3 @@ void initial_noc_placement(const t_noc_opts& noc_opts,
                            const PlaceMacros& place_macros,
                            NocCostHandler& noc_cost_handler,
                            vtr::RngContainer& rng);
-
-#endif //VTR_INITIAL_NOC_PLACEMENT_H

--- a/vpr/src/place/initial_placement.h
+++ b/vpr/src/place/initial_placement.h
@@ -1,5 +1,4 @@
-#ifndef VPR_INITIAL_PLACEMENT_H
-#define VPR_INITIAL_PLACEMENT_H
+#pragma once
 
 class NocCostHandler;
 
@@ -173,5 +172,3 @@ bool place_one_block(const ClusterBlockId blk_id,
                      const PlaceMacros& place_macros,
                      const FlatPlacementInfo& flat_placement_info,
                      vtr::RngContainer& rng);
-
-#endif

--- a/vpr/src/place/move_generators/manual_move_generator.h
+++ b/vpr/src/place/move_generators/manual_move_generator.h
@@ -1,11 +1,10 @@
+#pragma once
 /*
  * @file 	manual_move_generator.h
  * @author	Paula Perdomo
  * @date 	2021-07-19
  * @brief 	Contains the ManualMoveGenerator class.
  */
-
-#pragma once
 
 #include "move_generator.h"
 

--- a/vpr/src/place/move_transactions.h
+++ b/vpr/src/place/move_transactions.h
@@ -1,5 +1,4 @@
-#ifndef VPR_MOVE_TRANSACTIONS_H
-#define VPR_MOVE_TRANSACTIONS_H
+#pragma once
 
 #include "vpr_types.h"
 
@@ -94,5 +93,3 @@ struct t_pl_blocks_to_be_moved {
 
     MoveAbortionLogger move_abortion_logger;
 };
-
-#endif

--- a/vpr/src/place/move_utils.h
+++ b/vpr/src/place/move_utils.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "vpr_types.h"

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -1,10 +1,9 @@
+#pragma once
 /**
  * @file net_cost_handler.h
  * @brief This file contains the declaration of NetCostHandler class used to update placement cost when a new move is proposed/committed.
  * For more details on the overall algorithm, refer to the comment at the top of the net_cost_handler.cpp
  */
-
-#pragma once
 
 #include "place_delay_model.h"
 #include "move_transactions.h"

--- a/vpr/src/place/noc_place_checkpoint.h
+++ b/vpr/src/place/noc_place_checkpoint.h
@@ -1,5 +1,4 @@
-#ifndef VTR_ROUTERPLACEMENTCHECKPOINT_H
-#define VTR_ROUTERPLACEMENTCHECKPOINT_H
+#pragma once
 
 /**
  * @brief NoC router placement checkpoint
@@ -73,5 +72,3 @@ class NoCPlacementCheckpoint {
     bool valid_ = false;
     double cost_;
 };
-
-#endif //VTR_ROUTERPLACEMENTCHECKPOINT_H

--- a/vpr/src/place/noc_place_utils.h
+++ b/vpr/src/place/noc_place_utils.h
@@ -1,5 +1,4 @@
-#ifndef NOC_PLACE_UTILS_H
-#define NOC_PLACE_UTILS_H
+#pragma once
 
 #include <string_view>
 #include "move_utils.h"
@@ -703,6 +702,4 @@ bool noc_routing_has_cycle(const vtr::vector<NocTrafficFlowId, std::vector<NocLi
  */
 #ifdef ENABLE_NOC_SAT_ROUTING
 void invoke_sat_router(t_placer_costs& costs, const t_noc_opts& noc_opts, int seed);
-#endif
-
 #endif

--- a/vpr/src/place/place.h
+++ b/vpr/src/place/place.h
@@ -1,6 +1,6 @@
-
 #pragma once
 
+#include "netlist.h"
 #include "vpr_types.h"
 
 class FlatPlacementInfo;

--- a/vpr/src/place/place_checkpoint.h
+++ b/vpr/src/place/place_checkpoint.h
@@ -1,5 +1,4 @@
-#ifndef PLACE_CHECKPOINT_H
-#define PLACE_CHECKPOINT_H
+#pragma once
 
 #include "vpr_types.h"
 #include "vtr_vector_map.h"
@@ -76,4 +75,3 @@ void restore_best_placement(PlacerState& placer_state,
                             std::unique_ptr<NetPinTimingInvalidator>& pin_timing_invalidator,
                             PlaceCritParams crit_params,
                             std::optional<NocCostHandler>& noc_cost_handler);
-#endif

--- a/vpr/src/place/place_constraints.h
+++ b/vpr/src/place/place_constraints.h
@@ -1,5 +1,4 @@
-#ifndef VPR_SRC_PLACE_PLACE_CONSTRAINTS_H_
-#define VPR_SRC_PLACE_PLACE_CONSTRAINTS_H_
+#pragma once
 
 /*
  * place_constraints.h
@@ -201,5 +200,3 @@ double get_floorplan_score(ClusterBlockId blk_id,
                            const PartitionRegion& pr,
                            t_logical_block_type_ptr block_type,
                            const GridTileLookup& grid_tiles);
-
-#endif /* VPR_SRC_PLACE_PLACE_CONSTRAINTS_H_ */

--- a/vpr/src/place/place_macro.h
+++ b/vpr/src/place/place_macro.h
@@ -1,3 +1,4 @@
+#pragma once
 /****************************************************************************************
  * Y.G.THIEN
  * 29 AUG 2012
@@ -115,9 +116,6 @@
  * A corresponding blif file that uses this direct connection is adder.blif
  *
  ****************************************************************************************/
-
-#ifndef PLACE_MACRO_H
-#define PLACE_MACRO_H
 
 #include <vector>
 
@@ -263,5 +261,3 @@ class PlaceMacros {
     void alloc_and_load_idirect_from_blk_pin_(const std::vector<t_direct_inf>& directs,
                                               const std::vector<t_physical_tile_type>& physical_tile_types);
 };
-
-#endif

--- a/vpr/src/place/place_util.h
+++ b/vpr/src/place/place_util.h
@@ -1,11 +1,9 @@
+#pragma once
 /**
  * @file place_util.h
  * @brief Utility structures representing various states of the
  *        placement and utility functions used by the placer.
  */
-
-#ifndef PLACE_UTIL_H
-#define PLACE_UTIL_H
 
 #include "vpr_types.h"
 #include "globals.h"
@@ -265,4 +263,3 @@ bool macro_can_be_placed(const t_pl_macro& pl_macro,
                          const t_pl_loc& head_pos,
                          bool check_all_legality,
                          const BlkLocRegistry& blk_loc_registry);
-#endif

--- a/vpr/src/place/placement_log_printer.cpp
+++ b/vpr/src/place/placement_log_printer.cpp
@@ -1,7 +1,9 @@
 
 #include "placement_log_printer.h"
 
+#include "echo_files.h"
 #include "place_macro.h"
+#include "timing_util.h"
 #include "vtr_log.h"
 #include "annealer.h"
 #include "place_util.h"

--- a/vpr/src/place/placement_log_printer.h
+++ b/vpr/src/place/placement_log_printer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file placement_log_printer.h
  * @brief Declares the PlacementLogPrinter class and associated utilities for logging
@@ -7,8 +8,6 @@
  * The PlacementLogPrinter class integrates with the Placer class to provide information about
  * the placement process for debugging, optimization, and analysis purposes.
  */
-
-#pragma once
 
 #include <vector>
 

--- a/vpr/src/place/placer.cpp
+++ b/vpr/src/place/placer.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <utility>
 
+#include "echo_files.h"
 #include "flat_placement_types.h"
 #include "blk_loc_registry.h"
 #include "place_macro.h"

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file placer.h
  * @brief Declares the Placer class, which encapsulates the functionality, data structures,
@@ -15,8 +16,6 @@
  * - Includes debugging and validation utilities to verify the correctness of placement.
  */
 
-#pragma once
-
 #include <functional>
 #include <memory>
 #include <optional>
@@ -31,6 +30,7 @@
 #include "PlacerSetupSlacks.h"
 #include "PlacerCriticalities.h"
 #include "NetPinTimingInvalidator.h"
+#include "vtr_random.h"
 
 class BlkLocRegistry;
 class FlatPlacementInfo;

--- a/vpr/src/place/placer_breakpoint.h
+++ b/vpr/src/place/placer_breakpoint.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "move_utils.h"

--- a/vpr/src/place/placer_state.h
+++ b/vpr/src/place/placer_state.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file placer_state.h
  * @brief Contains placer state/data structures referenced by various source files in vpr/src/place.
@@ -8,7 +9,6 @@
  * the end of the placement stage.
  */
 
-#pragma once
 #include "vpr_context.h"
 #include "vpr_net_pins_matrix.h"
 #include "vpr_types.h"

--- a/vpr/src/place/timing/PlacerCriticalities.h
+++ b/vpr/src/place/timing/PlacerCriticalities.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "vtr_vec_id_set.h"

--- a/vpr/src/place/timing/PlacerSetupSlacks.h
+++ b/vpr/src/place/timing/PlacerSetupSlacks.h
@@ -1,10 +1,8 @@
-
 #pragma once
 
 #include "vtr_vec_id_set.h"
 #include "timing_info_fwd.h"
 #include "clustered_netlist_utils.h"
-#include "place_delay_model.h"
 #include "vpr_net_pins_matrix.h"
 
 /**

--- a/vpr/src/place/timing/PlacerTimingCosts.h
+++ b/vpr/src/place/timing/PlacerTimingCosts.h
@@ -1,11 +1,4 @@
-
 #pragma once
-#include "vtr_vec_id_set.h"
-#include "timing_info_fwd.h"
-#include "clustered_netlist_utils.h"
-#include "place_delay_model.h"
-#include "vpr_net_pins_matrix.h"
-
 /**
  * @brief PlacerTimingCosts mimics a 2D array of connection timing costs running from:
  *        [0..cluster_ctx.clb_nlist.nets().size()-1][1..num_pins-1].
@@ -73,6 +66,9 @@
  * PlacerTimingCosts's invalidate() method marks the cost element's ancestors as invalid (NaN)
  * so they will be re-calculated by PlacerTimingCosts' total_cost() method.
  */
+
+#include "clustered_netlist.h"
+
 class PlacerTimingCosts {
   public:
     PlacerTimingCosts() = default;

--- a/vpr/src/place/timing/place_timing_update.h
+++ b/vpr/src/place/timing/place_timing_update.h
@@ -1,9 +1,8 @@
+#pragma once
 /**
  * @file place_timing_update.h
  * @brief Timing update routines used by the VPR placer.
  */
-
-#pragma once
 
 class PlacerState;
 class PlaceCritParams;

--- a/vpr/src/place/verify_placement.h
+++ b/vpr/src/place/verify_placement.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
@@ -11,8 +12,6 @@
  * Since these methods should be completely independent of the place flow, it
  * makes sense that they are in their own file.
  */
-
-#pragma once
 
 #include "vtr_vector.h"
 

--- a/vpr/src/power/PowerSpicedComponent.h
+++ b/vpr/src/power/PowerSpicedComponent.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -14,8 +15,6 @@
  * Field Programmable Technology, 2012.
  *
  ********************************************************************/
-
-#pragma once
 
 #include <vector>
 #include <string>

--- a/vpr/src/power/power.h
+++ b/vpr/src/power/power.h
@@ -1,5 +1,4 @@
 #pragma once
-
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *

--- a/vpr/src/power/power_callibrate.h
+++ b/vpr/src/power/power_callibrate.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -18,8 +19,6 @@
 /* This file provides functions used to verify the power estimations
  * againt SPICE.
  */
-
-#pragma once
 
 /************************* DEFINES **********************************/
 const float power_callib_period = 5e-9;

--- a/vpr/src/power/power_cmos_tech.h
+++ b/vpr/src/power/power_cmos_tech.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -21,8 +22,6 @@
  * xml file into data structures, and functions to search within
  * these data structures.
  */
-
-#pragma once
 
 /************************* INCLUDES *********************************/
 #include "power.h"

--- a/vpr/src/power/power_components.h
+++ b/vpr/src/power/power_components.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -19,8 +20,6 @@
  *  This file offers functions to estimate power of major components
  * within the FPGA (flip-flops, LUTs, interconnect structures, etc).
  */
-
-#pragma once
 
 /************************* INCLUDES *********************************/
 #include <string>

--- a/vpr/src/power/power_lowlevel.h
+++ b/vpr/src/power/power_lowlevel.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -19,8 +20,6 @@
  * This file provides functions that calculate the power of low-level
  * components (inverters, simple multiplexers, etc)
  */
-
-#pragma once
 
 /************************* INCLUDES *********************************/
 #include "physical_types.h"

--- a/vpr/src/power/power_sizing.h
+++ b/vpr/src/power/power_sizing.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -19,8 +20,6 @@
  * The functions in this file are used to count the transistors in the
  * FPGA, for physical size estimations
  */
-
-#pragma once
 
 /************************* DEFINES **********************************/
 

--- a/vpr/src/power/power_util.h
+++ b/vpr/src/power/power_util.h
@@ -1,3 +1,4 @@
+#pragma once
 /*********************************************************************
  *  The following code is part of the power modelling feature of VTR.
  *
@@ -18,8 +19,6 @@
 /**
  * This file provides utility functions used by power estimation.
  */
-
-#pragma once
 
 /************************* INCLUDES *********************************/
 #include <string>

--- a/vpr/src/route/ParallelNetlistRouter.h
+++ b/vpr/src/route/ParallelNetlistRouter.h
@@ -1,5 +1,4 @@
 #pragma once
-
 /** @file Parallel case for NetlistRouter. Builds a \ref PartitionTree from the
  * netlist according to net bounding boxes. Tree nodes are then routed in parallel
  * using tbb::task_group. Each task routes the nets inside a node serially and then adds
@@ -9,6 +8,7 @@
  * Note that the parallel router does not support graphical router breakpoints.
  *
  * [0]: "Parallel FPGA Routing with On-the-Fly Net Decomposition", FPT'24 */
+
 #include "netlist_routers.h"
 #include "vtr_optional.h"
 

--- a/vpr/src/route/annotate_routing.h
+++ b/vpr/src/route/annotate_routing.h
@@ -1,5 +1,4 @@
-#ifndef ANNOTATE_ROUTING_H
-#define ANNOTATE_ROUTING_H
+#pragma once
 
 #include "clustered_netlist_fwd.h"
 #include "rr_graph_fwd.h"
@@ -20,5 +19,3 @@ vtr::vector<RRNodeId, ClusterNetId> annotate_rr_node_nets(const ClusteringContex
                                                           const DeviceContext& device_ctx,
                                                           const AtomContext& atom_ctx,
                                                           const bool& verbose);
-
-#endif

--- a/vpr/src/route/channel_stats.h
+++ b/vpr/src/route/channel_stats.h
@@ -1,6 +1,3 @@
-#ifndef VPR_CHANNEL_STATS_H
-#define VPR_CHANNEL_STATS_H
+#pragma once
 
 void print_channel_stats(bool is_flat);
-
-#endif

--- a/vpr/src/route/check_route.cpp
+++ b/vpr/src/route/check_route.cpp
@@ -1,6 +1,7 @@
 
 #include "check_route.h"
 
+#include "describe_rr_node.h"
 #include "physical_types_util.h"
 #include "route_common.h"
 #include "vpr_utils.h"

--- a/vpr/src/route/check_route.h
+++ b/vpr/src/route/check_route.h
@@ -1,5 +1,4 @@
-#ifndef VPR_CHECK_ROUTE_H
-#define VPR_CHECK_ROUTE_H
+#pragma once
 
 #include "netlist.h"
 #include "vpr_types.h"
@@ -10,5 +9,3 @@ void check_route(const Netlist<>& net_list,
                  bool is_flat);
 
 void recompute_occupancy_from_scratch(const Netlist<>& net_list, bool is_flat);
-
-#endif

--- a/vpr/src/route/connection_based_routing.cpp
+++ b/vpr/src/route/connection_based_routing.cpp
@@ -1,6 +1,7 @@
 #include "connection_based_routing.h"
 
 #include "route_profiling.h"
+#include "timing_util.h"
 
 // incremental rerouting resources class definitions
 Connection_based_routing_resources::Connection_based_routing_resources(const Netlist<>& net_list,

--- a/vpr/src/route/connection_based_routing.h
+++ b/vpr/src/route/connection_based_routing.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include "clustered_netlist_utils.h"
 #include "timing_info.h"
 #include "vpr_net_pins_matrix.h"
 #include "connection_based_routing_fwd.h"

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -1,6 +1,4 @@
-#ifndef _CONNECTION_ROUTER_H
-#define _CONNECTION_ROUTER_H
-
+#pragma once
 /**
  * @file
  * @brief This file defines the ConnectionRouter class.
@@ -23,6 +21,7 @@
 
 #include "connection_router_interface.h"
 #include "globals.h"
+#include "route_path_manager.h"
 #include "rr_graph_storage.h"
 #include "router_lookahead.h"
 #include "route_tree.h"
@@ -356,5 +355,3 @@ class ConnectionRouter : public ConnectionRouterInterface {
 };
 
 #include "connection_router.tpp"
-
-#endif /* _CONNECTION_ROUTER_H */

--- a/vpr/src/route/connection_router_interface.h
+++ b/vpr/src/route/connection_router_interface.h
@@ -1,5 +1,4 @@
-#ifndef _CONNECTION_ROUTER_INTERFACE_H
-#define _CONNECTION_ROUTER_INTERFACE_H
+#pragma once
 
 #include "route_tree_fwd.h"
 #include "rr_graph_fwd.h"
@@ -112,5 +111,3 @@ class ConnectionRouterInterface {
     // Ensure route budgets have been calculated before enabling this
     virtual void set_rcv_enabled(bool enable) = 0;
 };
-
-#endif /* _CONNECTION_ROUTER_INTERFACE_H */

--- a/vpr/src/route/d_ary_heap.h
+++ b/vpr/src/route/d_ary_heap.h
@@ -1,5 +1,4 @@
-#ifndef _VTR_D_ARY_HEAP_H
-#define _VTR_D_ARY_HEAP_H
+#pragma once
 
 #include <vector>
 
@@ -72,5 +71,3 @@ class DAryHeap : public HeapInterface {
 
 using BinaryHeap = DAryHeap<2>;
 using FourAryHeap = DAryHeap<4>;
-
-#endif /* _VTR_D_ARY_HEAP_H */

--- a/vpr/src/route/edge_groups.h
+++ b/vpr/src/route/edge_groups.h
@@ -1,5 +1,4 @@
-#ifndef EDGE_GROUPS_H
-#define EDGE_GROUPS_H
+#pragma once
 
 #include <unordered_set>
 #include <unordered_map>
@@ -57,5 +56,3 @@ class EdgeGroups {
     // Order is arbitrary.
     std::vector<std::vector<RRNodeId>> rr_non_config_node_sets_;
 };
-
-#endif

--- a/vpr/src/route/heap_type.h
+++ b/vpr/src/route/heap_type.h
@@ -1,10 +1,8 @@
-#ifndef _HEAP_TYPE_H
-#define _HEAP_TYPE_H
+#pragma once
 
 #include <cstdint>
 #include "device_grid.h"
 #include "rr_graph_fwd.h"
-#include "route_path_manager.h"
 
 using HeapNodePriority = float;
 using HeapNodeId = RRNodeId;
@@ -117,5 +115,3 @@ enum class e_heap_type {
  * @brief Heap factory.
  */
 std::unique_ptr<HeapInterface> make_heap(e_heap_type);
-
-#endif /* _HEAP_TYPE_H */

--- a/vpr/src/route/multi_queue_d_ary_heap.h
+++ b/vpr/src/route/multi_queue_d_ary_heap.h
@@ -1,3 +1,4 @@
+#pragma once
 /********************************************************************
  * MultiQueue Implementation
  *
@@ -16,8 +17,6 @@
  *
  * Modified: February 2025
  ********************************************************************/
-
-#pragma once
 
 #include "device_grid.h"
 #include "heap_type.h"

--- a/vpr/src/route/netlist_routers.h
+++ b/vpr/src/route/netlist_routers.h
@@ -1,5 +1,4 @@
 #pragma once
-
 /** @file Interface for a netlist router.
  *
  * A NetlistRouter manages the required bits of state to complete the netlist routing process,

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -1,5 +1,4 @@
-#ifndef _PARALLEL_CONNECTION_ROUTER_H
-#define _PARALLEL_CONNECTION_ROUTER_H
+#pragma once
 
 #include "connection_router.h"
 
@@ -477,5 +476,3 @@ std::unique_ptr<ConnectionRouterInterface> make_parallel_connection_router(
     int multi_queue_num_threads,
     int multi_queue_num_queues,
     bool multi_queue_direct_draining);
-
-#endif /* _PARALLEL_CONNECTION_ROUTER_H */

--- a/vpr/src/route/route_budgets.h
+++ b/vpr/src/route/route_budgets.h
@@ -1,12 +1,12 @@
+#pragma once
 /*Defines the route_budgets class that contains the minimum, maximum,
  * target, upper bound, and lower bound budgets. These information are
  * used by the router to optimize for hold time. */
-#ifndef ROUTE_BUDGETS_H
-#define ROUTE_BUDGETS_H
 
 #include <vector>
 #include <queue>
 #include "RoutingDelayCalculator.h"
+#include "clustered_netlist_utils.h"
 #include "timing_info.h"
 
 enum analysis_type {
@@ -139,5 +139,3 @@ class route_budgets {
     std::map<ParentNetId, bool> should_reroute_for_hold;
     std::map<ParentNetId, int> hold_fac;
 };
-
-#endif /* ROUTE_BUDGETS_H */

--- a/vpr/src/route/route_net.cpp
+++ b/vpr/src/route/route_net.cpp
@@ -2,6 +2,7 @@
 
 #include "route_net.h"
 #include "connection_based_routing.h"
+#include "timing_util.h"
 
 bool check_hold(const t_router_opts& router_opts, float worst_neg_slack) {
     if (router_opts.routing_budgets_algorithm != YOYO) {

--- a/vpr/src/route/route_tree.h
+++ b/vpr/src/route/route_tree.h
@@ -1,5 +1,4 @@
 #pragma once
-
 /**
  * @file
  * @brief This file defines the RouteTree and RouteTreeNode, used to keep partial or full routing
@@ -86,6 +85,7 @@
 #include <unordered_map>
 
 #include "connection_based_routing_fwd.h"
+#include "route_path_manager.h"
 #include "route_tree_fwd.h"
 #include "spatial_route_tree_lookup.h"
 #include "vtr_dynamic_bitset.h"

--- a/vpr/src/route/route_utils.cpp
+++ b/vpr/src/route/route_utils.cpp
@@ -16,6 +16,12 @@
 #include "rr_graph.h"
 #include "tatum/TimingReporter.hpp"
 #include "stats.h"
+#include "timing_util.h"
+
+#ifdef VPR_USE_TBB
+#include <oneapi/tbb/combinable.h>
+#include <oneapi/tbb/parallel_for_each.h>
+#endif // VPR_USE_TBB
 
 #ifndef NO_GRAPHICS
 #include "draw.h"

--- a/vpr/src/route/route_utils.h
+++ b/vpr/src/route/route_utils.h
@@ -2,6 +2,7 @@
 
 /** @file Utility functions used in the top-level router (route.cpp). */
 
+#include "clustered_netlist_utils.h"
 #include "netlist_fwd.h"
 #include "router_stats.h"
 #include "timing_info.h"

--- a/vpr/src/route/router_lookahead/router_lookahead.h
+++ b/vpr/src/route/router_lookahead/router_lookahead.h
@@ -1,5 +1,5 @@
-#ifndef VPR_ROUTER_LOOKAHEAD_H
-#define VPR_ROUTER_LOOKAHEAD_H
+#pragma once
+
 #include <memory>
 #include "vpr_types.h"
 #include "vpr_error.h"
@@ -188,5 +188,3 @@ class NoOpLookahead : public RouterLookahead {
         return -1.;
     }
 };
-
-#endif

--- a/vpr/src/route/router_lookahead/router_lookahead_compressed_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_compressed_map.cpp
@@ -4,24 +4,18 @@
 
 #include <cmath>
 #include <vector>
-#include <queue>
 #include <ctime>
 #include "router_lookahead_compressed_map.h"
 #include "connection_router_interface.h"
+#include "describe_rr_node.h"
 #include "vpr_types.h"
 #include "vpr_error.h"
 #include "vpr_utils.h"
 #include "globals.h"
 #include "vtr_math.h"
-#include "vtr_log.h"
 #include "vtr_assert.h"
 #include "vtr_time.h"
-#include "vtr_geometry.h"
-#include "router_lookahead_map.h"
 #include "router_lookahead_map_utils.h"
-#include "rr_graph2.h"
-#include "rr_graph.h"
-#include "route_common.h"
 
 vtr::Matrix<int> compressed_loc_index_map;
 std::unordered_map<int, std::unordered_set<int>> sample_locations;

--- a/vpr/src/route/router_lookahead/router_lookahead_compressed_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_compressed_map.h
@@ -1,12 +1,9 @@
+#pragma once
 //
 // Created by amin on 11/27/23.
 //
 
-#ifndef VTR_ROUTER_LOOKAHEAD_COMPRESSED_MAP_H
-#define VTR_ROUTER_LOOKAHEAD_COMPRESSED_MAP_H
-
 #include <string>
-#include <limits>
 #include "vtr_ndmatrix.h"
 #include "router_lookahead.h"
 #include "router_lookahead_map_utils.h"
@@ -71,5 +68,3 @@ typedef vtr::NdMatrix<util::Cost_Entry, 5> t_compressed_wire_cost_map; //[0..num
                                                                        //[0..1] entry distinguish between CHANX/CHANY start nodes respectively
                                                                        // The first index is the layer number that the node under consideration is on, and the forth index
                                                                        // is the layer number that the target node is on.
-
-#endif //VTR_ROUTER_LOOKAHEAD_COMPRESSED_MAP_H

--- a/vpr/src/route/router_lookahead/router_lookahead_cost_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_cost_map.h
@@ -1,5 +1,4 @@
-#ifndef ROUTER_LOOKAHEAD_COST_MAP_H_
-#define ROUTER_LOOKAHEAD_COST_MAP_H_
+#pragma once
 
 #include <vector>
 #include "router_lookahead_map_utils.h"
@@ -119,5 +118,3 @@ class CostMap {
      */
     void fill_holes(vtr::NdMatrix<util::Cost_Entry, 2>& matrix, int seg_index, int bounding_box_width, int bounding_box_height, float delay_penalty);
 };
-
-#endif

--- a/vpr/src/route/router_lookahead/router_lookahead_extended_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_extended_map.h
@@ -1,12 +1,10 @@
-#ifndef EXTENDED_MAP_LOOKAHEAD_H_
-#define EXTENDED_MAP_LOOKAHEAD_H_
+#pragma once
 
 #include <vector>
 #include "physical_types.h"
 #include "router_lookahead.h"
 #include "router_lookahead_map_utils.h"
 #include "router_lookahead_cost_map.h"
-#include "vtr_geometry.h"
 
 // Implementation of RouterLookahead based on source segment and destination connection box types
 class ExtendedMapLookahead : public RouterLookahead {
@@ -108,5 +106,3 @@ class ExtendedMapLookahead : public RouterLookahead {
         return -1.;
     }
 };
-
-#endif

--- a/vpr/src/route/router_lookahead/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <vector>
 #include "connection_router_interface.h"
+#include "describe_rr_node.h"
 #include "physical_types_util.h"
 #include "vpr_types.h"
 #include "vpr_utils.h"

--- a/vpr/src/route/router_lookahead/router_lookahead_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <limits>
 #include "vtr_ndmatrix.h"
 #include "router_lookahead.h"
 #include "router_lookahead_map_utils.h"

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
@@ -1,5 +1,4 @@
-#ifndef ROUTER_LOOKAHEAD_MAP_UTILS_H_
-#define ROUTER_LOOKAHEAD_MAP_UTILS_H_
+#pragma once
 /*
  * The router lookahead provides an estimate of the cost from an intermediate node to the target node
  * during directed (A*-like) routing.
@@ -20,9 +19,7 @@
 #include <vector>
 #include <queue>
 #include <unordered_map>
-#include "vpr_types.h"
 #include "vtr_geometry.h"
-#include "rr_node.h"
 #include "rr_graph_view.h"
 
 namespace util {
@@ -362,5 +359,3 @@ std::pair<float, float> get_cost_from_src_opin(const std::map<int, util::t_reach
 
 void dump_readable_router_lookahead_map(const std::string& file_name, const std::vector<int>& dim_sizes, WireCostCallBackFunction wire_cost_func);
 } // namespace util
-
-#endif

--- a/vpr/src/route/router_lookahead/router_lookahead_sampling.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_sampling.h
@@ -1,9 +1,8 @@
-#ifndef ROUTER_LOOKAHEAD_SAMPLING_H
-#define ROUTER_LOOKAHEAD_SAMPLING_H
+#pragma once
 
 #include <vector>
+#include "rr_graph_fwd.h"
 #include "vtr_geometry.h"
-#include "globals.h"
 
 // a sample point for a segment type, contains all segments at the VPR location
 struct SamplePoint {
@@ -31,5 +30,3 @@ struct SampleRegion {
 };
 
 std::vector<SampleRegion> find_sample_regions(int num_segments);
-
-#endif

--- a/vpr/src/route/routing_predictor.h
+++ b/vpr/src/route/routing_predictor.h
@@ -1,5 +1,5 @@
-#ifndef VPR_ROUTING_PREDICTOR_H
-#define VPR_ROUTING_PREDICTOR_H
+#pragma once
+
 #include <vector>
 #include <cstddef>
 
@@ -35,5 +35,3 @@ class RoutingPredictor {
     std::vector<size_t> iteration_overused_rr_node_counts_;
     float slope_;
 };
-
-#endif

--- a/vpr/src/route/rr_graph_generation/build_switchblocks.cpp
+++ b/vpr/src/route/rr_graph_generation/build_switchblocks.cpp
@@ -127,8 +127,6 @@
 
 #include <cstring>
 #include <algorithm>
-#include <iterator>
-#include <iostream>
 
 #include "vtr_assert.h"
 #include "vtr_memory.h"
@@ -136,6 +134,7 @@
 #include "vtr_string_view.h"
 
 #include "vpr_error.h"
+#include "vpr_types.h"
 
 #include "build_switchblocks.h"
 #include "physical_types.h"

--- a/vpr/src/route/rr_graph_generation/build_switchblocks.h
+++ b/vpr/src/route/rr_graph_generation/build_switchblocks.h
@@ -1,12 +1,10 @@
-#ifndef BUILD_SWITCHBLOCKS_H
-#define BUILD_SWITCHBLOCKS_H
+#pragma once
 
 #include <unordered_map>
 #include <vector>
-#include <random>
 #include "physical_types.h"
-#include "vpr_types.h"
 #include "device_grid.h"
+#include "rr_graph_type.h"
 #include "vtr_random.h"
 #include "rr_types.h"
 
@@ -131,5 +129,3 @@ t_sb_connection_map* alloc_and_load_switchblock_permutations(const t_chan_detail
  *  @param sb_conns switch block permutation map
  */
 void free_switchblock_permutations(t_sb_connection_map* sb_conns);
-
-#endif

--- a/vpr/src/route/rr_graph_generation/cb_metrics.h
+++ b/vpr/src/route/rr_graph_generation/cb_metrics.h
@@ -1,8 +1,9 @@
-#ifndef CB_METRICS_H
-#define CB_METRICS_H
+#pragma once
 
 #include <vector>
 #include <set>
+#include "physical_types.h"
+#include "rr_graph_type.h"
 
 #define MAX_OUTER_ITERATIONS 100000
 #define MAX_INNER_ITERATIONS 10
@@ -99,5 +100,3 @@ void analyze_conn_blocks(const int***** opin_cb, const int***** ipin_cb, const t
 void make_poor_cb_pattern(const e_pin_type pin_type, const t_physical_tile_type_ptr block_type, const int* Fc_array, const t_chan_width* chan_width_inf, int***** cb);
 
 /**** END EXPERIMENTAL ****/
-
-#endif /*CB_METRICS_H*/

--- a/vpr/src/route/rr_graph_generation/clock_connection_builders.h
+++ b/vpr/src/route/rr_graph_generation/clock_connection_builders.h
@@ -1,11 +1,9 @@
-#ifndef CLOCK_CONNECTION_BUILDERS_H
-#define CLOCK_CONNECTION_BUILDERS_H
+#pragma once
 
 #include <string>
 
 #include "clock_fwd.h"
 
-#include "rr_graph2.h"
 #include "rr_graph_clock.h"
 
 class ClockRRGraphBuilder;
@@ -113,5 +111,3 @@ class ClockToPinsConnection : public ClockConnection {
     void create_switches(const ClockRRGraphBuilder& clock_graph, t_rr_edge_info_set* rr_edges_to_create) override;
     size_t estimate_additional_nodes() override;
 };
-
-#endif

--- a/vpr/src/route/rr_graph_generation/clock_fwd.h
+++ b/vpr/src/route/rr_graph_generation/clock_fwd.h
@@ -1,10 +1,7 @@
-#ifndef CLOCK_FWD
-#define CLOCK_FWD
+#pragma once
 
 struct Coordinates {
     int x = -1;
     int y = -1;
     int layer = -1;
 };
-
-#endif

--- a/vpr/src/route/rr_graph_generation/clock_network_builders.h
+++ b/vpr/src/route/rr_graph_generation/clock_network_builders.h
@@ -1,16 +1,14 @@
-#ifndef CLOCK_NETWORK_BUILDERS_H
-#define CLOCK_NETWORK_BUILDERS_H
+#pragma once
 
 #include <string>
 #include <vector>
 
 #include "clock_fwd.h"
 
-#include "vpr_types.h"
-
+#include "device_grid.h"
 #include "rr_graph_builder.h"
-#include "rr_graph2.h"
 #include "rr_graph_clock.h"
+#include "rr_graph_type.h"
 
 class t_rr_graph_storage;
 class ClockRRGraphBuilder;
@@ -281,5 +279,3 @@ class ClockHTree : private ClockNetwork {
                                                              int num_segments_x) override;
     size_t estimate_additional_nodes(const DeviceGrid& grid) override;
 };
-
-#endif

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 #include "alloc_and_load_rr_indexed_data.h"
+#include "get_parallel_segs.h"
 #include "physical_types_util.h"
 #include "rr_rc_data.h"
 #include "vtr_assert.h"

--- a/vpr/src/route/rr_graph_generation/rr_graph.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph.h
@@ -1,5 +1,4 @@
-#ifndef RR_GRAPH_H
-#define RR_GRAPH_H
+#pragma once
 
 /* Include track buffers or not. Track buffers isolate the tracks from the
  * input connection block. However, they are difficult to lay out in practice,
@@ -8,8 +7,8 @@
 
 #include "device_grid.h"
 #include "vpr_types.h"
+#include "rr_graph_builder.h"
 #include "rr_graph_type.h"
-#include "describe_rr_node.h"
 
 /* Warnings about the routing graph that can be returned.
  * This is to avoid output messages during a value sweep */
@@ -62,5 +61,3 @@ bool pins_connected(t_block_loc cluster_loc,
                     t_logical_block_type_ptr logical_block,
                     int from_pin_logical_num,
                     int to_pin_logical_num);
-
-#endif

--- a/vpr/src/route/rr_graph_generation/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph2.cpp
@@ -9,7 +9,6 @@
 #include "vpr_error.h"
 
 #include "globals.h"
-#include "rr_graph_utils.h"
 #include "rr_graph2.h"
 #include "rr_graph_sbox.h"
 #include "rr_types.h"

--- a/vpr/src/route/rr_graph_generation/rr_graph2.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph2.h
@@ -5,12 +5,9 @@
 #include "build_switchblocks.h"
 #include "rr_graph_type.h"
 #include "rr_graph_fwd.h"
-#include "rr_graph_utils.h"
-#include "rr_graph_view.h"
 #include "rr_graph_builder.h"
 #include "rr_types.h"
 #include "device_grid.h"
-#include "get_parallel_segs.h"
 
 /******************* Subroutines exported by rr_graph2.c *********************/
 

--- a/vpr/src/route/rr_graph_generation/rr_graph_area.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph_area.cpp
@@ -1,11 +1,10 @@
 #include <cmath>
 
+#include "describe_rr_node.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
 #include "vtr_math.h"
-#include "vtr_memory.h"
 
-#include "vpr_types.h"
 #include "vpr_error.h"
 
 #include "globals.h"

--- a/vpr/src/route/rr_graph_generation/rr_graph_area.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph_area.h
@@ -1,5 +1,7 @@
-#ifndef RR_GRAPH_AREA_H
-#define RR_GRAPH_AREA_H
+#pragma once
+
+#include <vector>
+#include "physical_types.h"
 
 void count_routing_transistors(enum e_directionality directionality,
                                int num_switch,
@@ -10,5 +12,3 @@ void count_routing_transistors(enum e_directionality directionality,
                                bool is_flat);
 
 float trans_per_buf(float Rbuf, float R_minW_nmos, float R_minW_pmos);
-
-#endif

--- a/vpr/src/route/rr_graph_generation/rr_graph_clock.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph_clock.cpp
@@ -1,16 +1,9 @@
 #include "rr_graph_clock.h"
 
 #include "globals.h"
-#include "rr_graph.h"
-#include "rr_graph2.h"
-#include "rr_graph_area.h"
-#include "rr_graph_utils.h"
-#include "rr_graph_indexed_data.h"
 
 #include "vtr_assert.h"
-#include "vtr_log.h"
 #include "vtr_time.h"
-#include "vpr_error.h"
 
 void ClockRRGraphBuilder::create_and_append_clock_rr_graph(int num_seg_types_x,
                                                            t_rr_edge_info_set* rr_edges_to_create) {

--- a/vpr/src/route/rr_graph_generation/rr_graph_clock.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph_clock.h
@@ -1,5 +1,4 @@
-#ifndef RR_GRAPH_CLOCK_H
-#define RR_GRAPH_CLOCK_H
+#pragma once
 
 #include <string>
 #include <vector>
@@ -9,10 +8,10 @@
 #include <utility>
 
 #include "rr_graph_builder.h"
-#include "clock_fwd.h"
 
 #include "clock_network_builders.h"
 #include "clock_connection_builders.h"
+#include "rr_graph_type.h"
 
 class ClockNetwork;
 class ClockConnection;
@@ -156,5 +155,3 @@ class ClockRRGraphBuilder {
     int chanx_ptc_idx_;
     int chany_ptc_idx_;
 };
-
-#endif

--- a/vpr/src/route/rr_graph_generation/rr_graph_indexed_data.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph_indexed_data.h
@@ -1,8 +1,3 @@
-#ifndef RR_GRAPH_INDEXED_DATA_H
-#define RR_GRAPH_INDEXED_DATA_H
-#include "physical_types.h"
-#include "alloc_and_load_rr_indexed_data.h"
+#pragma once
 
 void load_rr_index_segments(const int num_segment);
-
-#endif

--- a/vpr/src/route/rr_graph_generation/rr_graph_sbox.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph_sbox.cpp
@@ -1,12 +1,8 @@
 #include "vtr_assert.h"
 
 #include "vtr_util.h"
-#include "vtr_memory.h"
 
-#include "vpr_types.h"
 #include "rr_graph_sbox.h"
-#include "rr_graph_utils.h"
-#include "rr_graph2.h"
 #include "echo_files.h"
 
 /* Switch box:                                                             *

--- a/vpr/src/route/rr_graph_generation/rr_graph_sbox.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph_sbox.h
@@ -1,7 +1,9 @@
-#ifndef RR_GRAPH_SBOX_H
-#define RR_GRAPH_SBOX_H
+#pragma once
 
 #include <vector>
+#include "rr_graph_type.h"
+#include "rr_node_types.h"
+#include "vtr_ndmatrix.h"
 
 std::vector<int> get_switch_box_tracks(const int from_i,
                                        const int from_j,
@@ -17,5 +19,3 @@ vtr::NdMatrix<std::vector<int>, 3> alloc_and_load_switch_block_conn(t_chan_width
                                                                     int Fs);
 
 int get_simple_switch_block_track(enum e_side from_side, enum e_side to_side, int from_track, enum e_switch_block_type switch_block_type, const int from_chan_width, const int to_chan_width);
-
-#endif

--- a/vpr/src/route/rr_graph_generation/rr_graph_timing_params.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph_timing_params.h
@@ -1,1 +1,3 @@
+#pragma once
+
 void add_rr_graph_C_from_switches(float C_ipin_cblock);

--- a/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
@@ -4,6 +4,7 @@
 #include "describe_rr_node.h"
 #include "globals.h"
 #include "physical_types_util.h"
+#include "rr_graph2.h"
 #include "vpr_utils.h"
 
 /**

--- a/vpr/src/route/rr_graph_generation/rr_types.h
+++ b/vpr/src/route/rr_graph_generation/rr_types.h
@@ -1,8 +1,9 @@
-#ifndef RR_TYPES_H
-#define RR_TYPES_H
+#pragma once
 
 #include <vector>
+#include "rr_node_types.h"
 #include "vtr_ndmatrix.h"
+#include "vtr_string_view.h"
 
 /* AA: This structure stores the track connections for each physical pin. Note that num_pins refers to the # of logical pins for a tile and 
  * we use the relative x and y location (0...width and 0...height of the tile) and the side of that unit tile to locate the physical pin. 
@@ -75,7 +76,7 @@ struct t_seg_details {
     bool twisted = false;
 
     /** @brief Direction of the segment. */
-    enum Direction direction = Direction::NONE;
+    Direction direction = Direction::NONE;
 
     /** @brief Index of the first logic block in the group. */
     int group_start = 0;
@@ -182,5 +183,3 @@ typedef vtr::NdMatrix<t_chan_seg_details, 3> t_chan_details;
  * [0..3 (To side)][0...max_chan_width][0..3 (to_mux,to_trac,alt_mux,alt_track)]
  * originally initialized to UN_SET until alloc_and_load_sb is called */
 typedef vtr::NdMatrix<short, 6> t_sblock_pattern;
-
-#endif

--- a/vpr/src/route/serial_connection_router.h
+++ b/vpr/src/route/serial_connection_router.h
@@ -1,5 +1,4 @@
-#ifndef _SERIAL_CONNECTION_ROUTER_H
-#define _SERIAL_CONNECTION_ROUTER_H
+#pragma once
 
 #include "connection_router.h"
 
@@ -249,5 +248,3 @@ std::unique_ptr<ConnectionRouterInterface> make_serial_connection_router(
     const vtr::vector<RRSwitchId, t_rr_switch_inf>& rr_switch_inf,
     vtr::vector<RRNodeId, t_rr_node_route_inf>& rr_node_route_inf,
     bool is_flat);
-
-#endif /* _SERIAL_CONNECTION_ROUTER_H */

--- a/vpr/src/server/bytearray.h
+++ b/vpr/src/server/bytearray.h
@@ -1,12 +1,11 @@
-#ifndef BYTEARRAY_H
-#define BYTEARRAY_H
+#pragma once
 
 #ifndef NO_SERVER
 
-#include <vector>
-#include <string>
-#include <cstring>
 #include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <vector>
 
 namespace comm {
 
@@ -170,5 +169,3 @@ class ByteArray : public std::vector<char> {
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* BYTEARRAY_H */

--- a/vpr/src/server/commcmd.h
+++ b/vpr/src/server/commcmd.h
@@ -1,5 +1,4 @@
-#ifndef COMMCMD_H
-#define COMMCMD_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -14,5 +13,3 @@ enum class CMD : int {
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* COMMCMD_H */

--- a/vpr/src/server/commconstants.h
+++ b/vpr/src/server/commconstants.h
@@ -1,5 +1,4 @@
-#ifndef COMMCONSTS_H
-#define COMMCONSTS_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -31,5 +30,3 @@ inline const std::string KEY_HOLD_PATH_LIST{"hold"};
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* COMMCONSTS_H */

--- a/vpr/src/server/convertutils.h
+++ b/vpr/src/server/convertutils.h
@@ -1,5 +1,4 @@
-#ifndef CONVERTUTILS_H
-#define CONVERTUTILS_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -15,5 +14,3 @@ std::string get_pretty_size_str_from_bytes_num(int64_t bytesNum);
 std::string get_truncated_middle_str(const std::string& src, std::size_t num = DEFAULT_PRINT_STRING_MAX_NUM);
 
 #endif /* NO_SERVER */
-
-#endif /* CONVERTUTILS_H */

--- a/vpr/src/server/gateio.h
+++ b/vpr/src/server/gateio.h
@@ -1,5 +1,4 @@
-#ifndef GATEIO_H
-#define GATEIO_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -227,5 +226,3 @@ class GateIO {
 } // namespace server
 
 #endif /* NO_SERVER */
-
-#endif /* GATEIO_H */

--- a/vpr/src/server/pathhelper.h
+++ b/vpr/src/server/pathhelper.h
@@ -1,5 +1,4 @@
-#ifndef PATHHELPER_H
-#define PATHHELPER_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -51,5 +50,3 @@ CritPathsResultPtr calc_critical_path(const std::string& type, int crit_path_num
 } // namespace server
 
 #endif /* NO_SERVER */
-
-#endif /* PATHHELPER_H */

--- a/vpr/src/server/serverupdate.h
+++ b/vpr/src/server/serverupdate.h
@@ -1,5 +1,4 @@
-#ifndef SERVERUPDATE_H
-#define SERVERUPDATE_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -19,5 +18,3 @@ gboolean update(gpointer);
 } // namespace server
 
 #endif /* NO_SERVER */
-
-#endif /* SERVERUPDATE_H */

--- a/vpr/src/server/task.h
+++ b/vpr/src/server/task.h
@@ -1,5 +1,4 @@
-#ifndef TASK_H
-#define TASK_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -201,5 +200,3 @@ using TaskPtr = std::unique_ptr<Task>;
 } // namespace server
 
 #endif /* NO_SERVER */
-
-#endif /* TASK_H */

--- a/vpr/src/server/taskresolver.h
+++ b/vpr/src/server/taskresolver.h
@@ -1,5 +1,4 @@
-#ifndef TASKRESOLVER_H
-#define TASKRESOLVER_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -75,5 +74,3 @@ class TaskResolver {
 } // namespace server
 
 #endif /* NO_SERVER */
-
-#endif /* TASKRESOLVER_H */

--- a/vpr/src/server/telegrambuffer.h
+++ b/vpr/src/server/telegrambuffer.h
@@ -1,5 +1,4 @@
-#ifndef TELEGRAMBUFFER_H
-#define TELEGRAMBUFFER_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -97,5 +96,3 @@ class TelegramBuffer {
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* TELEGRAMBUFFER_H */

--- a/vpr/src/server/telegramframe.h
+++ b/vpr/src/server/telegramframe.h
@@ -1,5 +1,4 @@
-#ifndef TELEGRAMFRAME_H
-#define TELEGRAMFRAME_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -31,5 +30,3 @@ using TelegramFramePtr = std::shared_ptr<TelegramFrame>;
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* TELEGRAMFRAME_H */

--- a/vpr/src/server/telegramheader.h
+++ b/vpr/src/server/telegramheader.h
@@ -1,5 +1,4 @@
-#ifndef TELEGRAMHEADER_H
-#define TELEGRAMHEADER_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -141,5 +140,3 @@ class TelegramHeader {
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* TELEGRAMHEADER_H */

--- a/vpr/src/server/telegramoptions.h
+++ b/vpr/src/server/telegramoptions.h
@@ -1,5 +1,4 @@
-#ifndef TELEGRAMOPTIONS_H
-#define TELEGRAMOPTIONS_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -126,5 +125,3 @@ class TelegramOptions {
 } // namespace server
 
 #endif /* NO_SERVER */
-
-#endif /* TELEGRAMOPTIONS_H */

--- a/vpr/src/server/telegramparser.h
+++ b/vpr/src/server/telegramparser.h
@@ -1,5 +1,4 @@
-#ifndef TELEGRAMPARSER_H
-#define TELEGRAMPARSER_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -83,5 +82,3 @@ class TelegramParser {
 } // namespace comm
 
 #endif /* NO_SERVER */
-
-#endif /* TELEGRAMPARSER_H */

--- a/vpr/src/server/zlibutils.h
+++ b/vpr/src/server/zlibutils.h
@@ -1,5 +1,4 @@
-#ifndef ZLIBUTILS_H
-#define ZLIBUTILS_H
+#pragma once
 
 #ifndef NO_SERVER
 
@@ -37,5 +36,3 @@ std::optional<std::string> try_compress(const std::string& decompressed);
 std::optional<std::string> try_decompress(const std::string& compressed);
 
 #endif /* NO_SERVER */
-
-#endif /* ZLIBUTILS_H */

--- a/vpr/src/timing/AnalysisDelayCalculator.h
+++ b/vpr/src/timing/AnalysisDelayCalculator.h
@@ -1,8 +1,5 @@
-#ifndef ANALYSIS_DELAY_CALCULATOR_H
-#define ANALYSIS_DELAY_CALCULATOR_H
+#pragma once
 
 #include "PostClusterDelayCalculator.h"
 
 using AnalysisDelayCalculator = PostClusterDelayCalculator;
-
-#endif

--- a/vpr/src/timing/DelayType.h
+++ b/vpr/src/timing/DelayType.h
@@ -1,10 +1,7 @@
-#ifndef VPR_DELAY_TYPE
-#define VPR_DELAY_TYPE
+#pragma once
 
 enum class DelayType {
     MAX = 0,
     MIN,
     NUM_DELAY_TYPES
 };
-
-#endif

--- a/vpr/src/timing/DomainPair.h
+++ b/vpr/src/timing/DomainPair.h
@@ -1,5 +1,4 @@
-#ifndef VRP_DOMAIN_PAIR_H
-#define VRP_DOMAIN_PAIR_H
+#pragma once
 
 #include "tatum/TimingGraphFwd.hpp"
 
@@ -20,5 +19,3 @@ struct DomainPair {
         return std::tie(lhs.launch, lhs.capture) == std::tie(rhs.launch, rhs.capture);
     }
 };
-
-#endif

--- a/vpr/src/timing/NetPinTimingInvalidator.h
+++ b/vpr/src/timing/NetPinTimingInvalidator.h
@@ -1,15 +1,17 @@
 #pragma once
 
-#include "netlist_fwd.h"
+#include "clustered_netlist_utils.h"
+#include "netlist.h"
+#include "tatum/TimingGraph.hpp"
 #include "tatum/TimingGraphFwd.hpp"
 #include "timing_info.h"
 #include "vtr_range.h"
 #include "move_transactions.h"
 
-#include "vtr_vec_id_set.h"
-
 #ifdef VPR_USE_TBB
 #include <tbb/concurrent_unordered_set.h>
+#else
+#include "vtr_vec_id_set.h"
 #endif
 
 /** Make NetPinTimingInvalidator a virtual class since it does nothing for the general case of non-incremental

--- a/vpr/src/timing/PlacementDelayCalculator.h
+++ b/vpr/src/timing/PlacementDelayCalculator.h
@@ -1,8 +1,5 @@
-#ifndef PLACEMENT_DELAY_CALCULATOR_H
-#define PLACEMENT_DELAY_CALCULATOR_H
+#pragma once
 
 #include "PostClusterDelayCalculator.h"
 
 using PlacementDelayCalculator = PostClusterDelayCalculator;
-
-#endif

--- a/vpr/src/timing/PostClusterDelayCalculator.h
+++ b/vpr/src/timing/PostClusterDelayCalculator.h
@@ -1,14 +1,10 @@
-#ifndef POST_CLUSTER_DELAY_CALCULATOR_H
-#define POST_CLUSTER_DELAY_CALCULATOR_H
-#include "vtr_linear_map.h"
+#pragma once
 
 #include "tatum/Time.hpp"
 #include "tatum/TimingGraph.hpp"
 #include "tatum/delay_calc/DelayCalculator.hpp"
 
 #include "atom_netlist.h"
-#include "clustered_netlist.h"
-#include "vpr_utils.h"
 #include "vpr_net_pins_matrix.h"
 
 #include "atom_delay_calc.h"
@@ -90,4 +86,3 @@ class PostClusterDelayCalculator : public tatum::DelayCalculator {
 };
 
 #include "PostClusterDelayCalculator.tpp"
-#endif

--- a/vpr/src/timing/PreClusterDelayCalculator.h
+++ b/vpr/src/timing/PreClusterDelayCalculator.h
@@ -1,5 +1,5 @@
-#ifndef PRE_CLUSTER_DELAY_CALCULATOR_H
-#define PRE_CLUSTER_DELAY_CALCULATOR_H
+#pragma once
+
 #include "vtr_assert.h"
 
 #include "tatum/Time.hpp"
@@ -171,5 +171,3 @@ class PreClusterDelayCalculator : public tatum::DelayCalculator {
     const float inter_cluster_net_delay_;
     const Prepacker& prepacker_;
 };
-
-#endif

--- a/vpr/src/timing/PreClusterTimingGraphResolver.cpp
+++ b/vpr/src/timing/PreClusterTimingGraphResolver.cpp
@@ -1,6 +1,8 @@
 #include "PreClusterTimingGraphResolver.h"
+#include "DelayType.h"
 #include "atom_netlist.h"
 #include "atom_lookup.h"
+#include "globals.h"
 
 PreClusterTimingGraphResolver::PreClusterTimingGraphResolver(
     const AtomNetlist& netlist,

--- a/vpr/src/timing/PreClusterTimingGraphResolver.h
+++ b/vpr/src/timing/PreClusterTimingGraphResolver.h
@@ -1,10 +1,9 @@
-#ifndef VPR_PRE_CLUSTER_TIMING_GRAPH_RESOLVER_H_
-#define VPR_PRE_CLUSTER_TIMING_GRAPH_RESOLVER_H_
+#pragma once
 
-#include "tatum/TimingGraphNameResolver.hpp"
-#include "atom_netlist_fwd.h"
 #include "atom_lookup.h"
-#include "AnalysisDelayCalculator.h"
+#include "atom_netlist_fwd.h"
+#include "tatum/TimingGraphNameResolver.hpp"
+#include "tatum/delay_calc/DelayCalculator.hpp"
 
 class LogicalModels;
 
@@ -34,5 +33,3 @@ class PreClusterTimingGraphResolver : public tatum::TimingGraphNameResolver {
     const tatum::DelayCalculator& delay_calc_;
     e_timing_report_detail detail_level_ = e_timing_report_detail::NETLIST;
 };
-
-#endif /* VPR_PRE_CLUSTER_TIMING_GRAPH_RESOLVER_H_ */

--- a/vpr/src/timing/PreClusterTimingManager.cpp
+++ b/vpr/src/timing/PreClusterTimingManager.cpp
@@ -15,6 +15,7 @@
 #include "atom_netlist.h"
 #include "atom_netlist_fwd.h"
 #include "concrete_timing_info.h"
+#include "echo_files.h"
 #include "physical_types_util.h"
 #include "prepack.h"
 #include "tatum/TimingReporter.hpp"

--- a/vpr/src/timing/PreClusterTimingManager.h
+++ b/vpr/src/timing/PreClusterTimingManager.h
@@ -1,11 +1,10 @@
+#pragma once
 /**
  * @file
  * @author  Alex Singer
  * @date    April 2025
  * @brief   Manager class for pre-cluster (primitive-level) timing analysis.
  */
-
-#pragma once
 
 #include <memory>
 #include <string>

--- a/vpr/src/timing/RoutingDelayCalculator.h
+++ b/vpr/src/timing/RoutingDelayCalculator.h
@@ -1,8 +1,5 @@
-#ifndef ROUTING_DELAY_CALCULATOR_H
-#define ROUTING_DELAY_CALCULATOR_H
+#pragma once
 
 #include "PostClusterDelayCalculator.h"
 
 using RoutingDelayCalculator = PostClusterDelayCalculator;
-
-#endif

--- a/vpr/src/timing/VprTimingGraphResolver.h
+++ b/vpr/src/timing/VprTimingGraphResolver.h
@@ -1,5 +1,4 @@
-#ifndef VRP_TIMING_GRAPH_NAME_RESOLVER_H
-#define VRP_TIMING_GRAPH_NAME_RESOLVER_H
+#pragma once
 
 #include "tatum/TimingGraphNameResolver.hpp"
 #include "atom_netlist_fwd.h"
@@ -43,5 +42,3 @@ class VprTimingGraphResolver : public tatum::TimingGraphNameResolver {
     ///@brief contains information about the placement of clustered blocks.
     const BlkLocRegistry& blk_loc_registry_;
 };
-
-#endif

--- a/vpr/src/timing/atom_delay_calc.h
+++ b/vpr/src/timing/atom_delay_calc.h
@@ -1,9 +1,7 @@
-#ifndef VPR_ATOM_DELAY_CALC_H
-#define VPR_ATOM_DELAY_CALC_H
+#pragma once
 
 #include "atom_netlist.h"
 #include "atom_lookup.h"
-#include "vtr_hash.h"
 #include "DelayType.h"
 
 //Delay Calculator for timing edges which are internal to atoms
@@ -24,5 +22,3 @@ class AtomDelayCalc {
 };
 
 #include "atom_delay_calc.inl"
-
-#endif

--- a/vpr/src/timing/clb_delay_calc.h
+++ b/vpr/src/timing/clb_delay_calc.h
@@ -1,6 +1,9 @@
-#ifndef VPR_CLB_DELAY_CALC_H
-#define VPR_CLB_DELAY_CALC_H
+#pragma once
+
+#include "clustered_netlist_fwd.h"
 #include "DelayType.h"
+#include "physical_types.h"
+#include "vpr_utils.h"
 
 //Delay Calculator for routing internal to a clustered logic block
 class ClbDelayCalc {
@@ -28,5 +31,3 @@ class ClbDelayCalc {
 };
 
 #include "clb_delay_calc.inl"
-
-#endif

--- a/vpr/src/timing/concrete_timing_info.cpp
+++ b/vpr/src/timing/concrete_timing_info.cpp
@@ -1,6 +1,5 @@
 #include "vtr_log.h"
 
-#include "timing_info.h"
 #include "concrete_timing_info.h"
 
 void warn_unconstrained(std::shared_ptr<const tatum::TimingAnalyzer> analyzer) {

--- a/vpr/src/timing/concrete_timing_info.h
+++ b/vpr/src/timing/concrete_timing_info.h
@@ -1,14 +1,12 @@
-#ifndef VPR_CONCRETE_TIMING_INFO_H
-#define VPR_CONCRETE_TIMING_INFO_H
+#pragma once
 
-#include "vtr_log.h"
+#include "tatum/analyzer_factory.hpp"
+#include "tatum/analyzers/SetupTimingAnalyzer.hpp"
+#include "tatum/timing_paths.hpp"
 #include "timing_info.h"
 #include "timing_util.h"
-#include "vpr_error.h"
 #include "slack_evaluation.h"
 #include "globals.h"
-
-#include "tatum/report/graphviz_dot_writer.hpp"
 
 void warn_unconstrained(std::shared_ptr<const tatum::TimingAnalyzer> analyzer);
 
@@ -506,5 +504,3 @@ std::unique_ptr<SetupHoldTimingInfo> make_setup_hold_timing_info(std::shared_ptr
 inline std::unique_ptr<ConstantTimingInfo> make_constant_timing_info(const float criticality) {
     return std::make_unique<ConstantTimingInfo>(criticality);
 }
-
-#endif

--- a/vpr/src/timing/net_delay.cpp
+++ b/vpr/src/timing/net_delay.cpp
@@ -1,9 +1,5 @@
 #include <cstdio>
 
-#include "vtr_memory.h"
-#include "vtr_log.h"
-
-#include "vpr_types.h"
 #include "vpr_error.h"
 
 #include "globals.h"

--- a/vpr/src/timing/net_delay.h
+++ b/vpr/src/timing/net_delay.h
@@ -1,10 +1,6 @@
-#ifndef NET_DELAY_H
-#define NET_DELAY_H
+#pragma once
 
-#include "vtr_memory.h"
-#include "vtr_vector.h"
+#include "netlist.h"
 #include "vpr_net_pins_matrix.h"
 
 void load_net_delay_from_routing(const Netlist<>& net_list, NetPinsMatrix<float>& net_delay);
-
-#endif

--- a/vpr/src/timing/read_sdc.h
+++ b/vpr/src/timing/read_sdc.h
@@ -1,5 +1,5 @@
-#ifndef VPR_READ_SDC_H
-#define VPR_READ_SDC_H
+#pragma once
+
 #include <memory>
 
 #include "tatum/TimingConstraintsFwd.hpp"
@@ -16,5 +16,3 @@ std::unique_ptr<tatum::TimingConstraints> read_sdc(const t_timing_inf& timing_in
                                                    const AtomLookup& lookup,
                                                    const LogicalModels& models,
                                                    tatum::TimingGraph& timing_graph);
-
-#endif

--- a/vpr/src/timing/slack_evaluation.h
+++ b/vpr/src/timing/slack_evaluation.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <map>
-#include <set>
 
 #include "atom_netlist_fwd.h"
 #include "DomainPair.h"
-#include "tatum/timing_analyzers.hpp"
+#include "tatum/analyzers/HoldTimingAnalyzer.hpp"
+#include "tatum/analyzers/SetupTimingAnalyzer.hpp"
 #include "vtr_vector.h"
 
 /*

--- a/vpr/src/timing/timing_fail_error.cpp
+++ b/vpr/src/timing/timing_fail_error.cpp
@@ -1,12 +1,4 @@
-#include <fstream>
-#include <sstream>
-
-#include "vtr_log.h"
-#include "vtr_assert.h"
-#include "vtr_math.h"
-
 #include "globals.h"
-#include "timing_util.h"
 #include "timing_fail_error.h"
 
 /* Sets terminate_if_timing_fails in the timing context if the user has indicated

--- a/vpr/src/timing/timing_fail_error.h
+++ b/vpr/src/timing/timing_fail_error.h
@@ -1,13 +1,4 @@
-#ifndef VPR_FAIL_ERROR_H
-#define VPR_FAIL_ERROR_H
-#include <memory>
-
-#include "timing_info_fwd.h"
-#include "tatum/analyzer_factory.hpp"
-#include "tatum/timing_paths.hpp"
-#include "timing_util.h"
+#pragma once
 
 /* Represents whether or not VPR should fail if timing constraints aren't met. */
 void set_terminate_if_timing_fails(bool cmd_opt_terminate_if_timing_fails);
-
-#endif

--- a/vpr/src/timing/timing_graph_builder.h
+++ b/vpr/src/timing/timing_graph_builder.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 
 #include "tatum/TimingGraphFwd.hpp"

--- a/vpr/src/timing/timing_info.h
+++ b/vpr/src/timing/timing_info.h
@@ -1,11 +1,17 @@
-#ifndef VPR_TIMING_INFO_H
-#define VPR_TIMING_INFO_H
+#pragma once
+
 #include <memory>
 
+#include "atom_netlist_fwd.h"
+#include "tatum/TimingConstraints.hpp"
+#include "tatum/analyzers/HoldTimingAnalyzer.hpp"
+#include "tatum/analyzers/SetupHoldTimingAnalyzer.hpp"
+#include "tatum/analyzers/SetupTimingAnalyzer.hpp"
+#include "tatum/analyzers/TimingAnalyzer.hpp"
+#include "tatum/delay_calc/DelayCalculator.hpp"
+#include "tatum/report/TimingPath.hpp"
 #include "timing_info_fwd.h"
-#include "tatum/analyzer_factory.hpp"
-#include "tatum/timing_paths.hpp"
-#include "timing_util.h"
+#include "vtr_range.h"
 
 //Generic interface which provides functionality to update (but not
 //access) timing information.
@@ -138,5 +144,3 @@ class SetupHoldTimingInfo : public SetupTimingInfo, public HoldTimingInfo {
   public:
     virtual std::shared_ptr<const tatum::SetupHoldTimingAnalyzer> setup_hold_analyzer() const = 0;
 };
-
-#endif

--- a/vpr/src/timing/timing_info_fwd.h
+++ b/vpr/src/timing/timing_info_fwd.h
@@ -1,9 +1,6 @@
-#ifndef VPR_TIMING_INFO_FWD_H
-#define VPR_TIMING_INFO_FWD_H
+#pragma once
 
 class TimingInfo;
 class SetupTimingInfo;
 class HoldTimingInfo;
 class SetupHoldTimingInfo;
-
-#endif

--- a/vpr/src/timing/timing_util.cpp
+++ b/vpr/src/timing/timing_util.cpp
@@ -2,12 +2,12 @@
 #include <sstream>
 #include <utility>
 
+#include "tatum/timing_paths.hpp"
 #include "vtr_log.h"
 #include "vtr_assert.h"
 #include "vtr_math.h"
 
 #include "globals.h"
-#include "timing_fail_error.h"
 #include "timing_info.h"
 #include "timing_util.h"
 

--- a/vpr/src/timing/timing_util.h
+++ b/vpr/src/timing/timing_util.h
@@ -1,19 +1,18 @@
-#ifndef VPR_TIMING_UTIL_H
-#define VPR_TIMING_UTIL_H
+#pragma once
+
 #include <vector>
 #include <string_view>
 
 #include "netlist_fwd.h"
-#include "tatum/timing_analyzers.hpp"
 #include "tatum/TimingConstraints.hpp"
-#include "tatum/timing_paths.hpp"
 
 #include "histogram.h"
+#include "tatum/analyzers/HoldTimingAnalyzer.hpp"
+#include "tatum/analyzers/SetupTimingAnalyzer.hpp"
+#include "tatum/report/TimingPath.hpp"
 #include "timing_info_fwd.h"
 #include "DomainPair.h"
-#include "globals.h"
 
-#include "vpr_utils.h"
 #include "clustered_netlist_utils.h"
 
 double sec_to_nanosec(double seconds);
@@ -154,5 +153,3 @@ struct TimingStats {
 
 //Write a useful summary of timing information to JSON file
 void write_setup_timing_summary(std::string_view timing_summary_filename, const TimingStats& stats);
-
-#endif

--- a/vpr/src/util/lazy_pop_unique_priority_queue.h
+++ b/vpr/src/util/lazy_pop_unique_priority_queue.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * @file
  * @author  Rongbo Zhang
@@ -19,8 +20,6 @@
  *      LazyPopUniquePriorityQueue::size(): Returns the number of elements in the queue.
  *      LazyPopUniquePriorityQueue::contains(): Returns true if the key is in the queue, false otherwise.
  */
-
-#pragma once
 
 #include <unordered_set>
 #include <vector>

--- a/vpr/test/test_bfs_routing.cpp
+++ b/vpr/test/test_bfs_routing.cpp
@@ -1,5 +1,5 @@
+#include "catch2/matchers/catch_matchers.hpp"
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "bfs_routing.h"
 

--- a/vpr/test/test_clustered_netlist.cpp
+++ b/vpr/test/test_clustered_netlist.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "clustered_netlist.h"
 

--- a/vpr/test/test_edge_groups.cpp
+++ b/vpr/test/test_edge_groups.cpp
@@ -1,6 +1,5 @@
 #include <vector>
 #include <utility>
-#include <cstddef>
 #include <set>
 #include <random>
 #include <algorithm>

--- a/vpr/test/test_flat_placement_types.cpp
+++ b/vpr/test/test_flat_placement_types.cpp
@@ -5,7 +5,7 @@
  * @brief   Unit tests for flat placement types
  */
 
-#include <catch2/catch_approx.hpp>
+#include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "flat_placement_types.h"
 

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -1,10 +1,8 @@
+#include <random>
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "noc_place_utils.h"
-#include "noc_routing.h"
 #include "xy_routing.h"
-#include "bfs_routing.h"
 #include "vtr_math.h"
 
 // test parameters

--- a/vpr/test/test_noc_traffic_flows.cpp
+++ b/vpr/test/test_noc_traffic_flows.cpp
@@ -2,8 +2,6 @@
 
 #include "noc_traffic_flows.h"
 
-#include <random>
-
 #define NUM_OF_ROUTERS 10
 
 namespace {

--- a/vpr/test/test_odd_even_routing.cpp
+++ b/vpr/test/test_odd_even_routing.cpp
@@ -1,11 +1,9 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "odd_even_routing.h"
 #include "channel_dependency_graph.h"
 
 #include <random>
-#include <iostream>
 
 namespace {
 

--- a/vpr/test/test_read_xml_noc_traffic_flows_file.cpp
+++ b/vpr/test/test_read_xml_noc_traffic_flows_file.cpp
@@ -1,9 +1,8 @@
+#include "catch2/matchers/catch_matchers.hpp"
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
+#include "globals.h"
 #include "read_xml_noc_traffic_flows_file.h"
-
-#include <random>
 
 namespace {
 

--- a/vpr/test/test_server_convertutils.cpp
+++ b/vpr/test/test_server_convertutils.cpp
@@ -1,7 +1,6 @@
 #ifndef NO_SERVER
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "convertutils.h"
 

--- a/vpr/test/test_server_taskresolver.cpp
+++ b/vpr/test/test_server_taskresolver.cpp
@@ -1,7 +1,6 @@
 #ifndef NO_SERVER
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "taskresolver.h"
 #include <memory>

--- a/vpr/test/test_server_telegrambuffer.cpp
+++ b/vpr/test/test_server_telegrambuffer.cpp
@@ -1,7 +1,6 @@
 #ifndef NO_SERVER
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "telegrambuffer.h"
 

--- a/vpr/test/test_server_telegramoptions.cpp
+++ b/vpr/test/test_server_telegramoptions.cpp
@@ -1,7 +1,6 @@
 #ifndef NO_SERVER
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "telegramoptions.h"
 

--- a/vpr/test/test_server_telegramparser.cpp
+++ b/vpr/test/test_server_telegramparser.cpp
@@ -3,7 +3,6 @@
 #include "telegramparser.h"
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 TEST_CASE("test_server_telegram_parser_base", "[vpr]") {
     const std::string tdata{R"({"JOB_ID":"7","CMD":"2","OPTIONS":"type1:name1:value1;type2:name2:v a l u e 2;t3:n3:v3","DATA":"some_data...","STATUS":"1"})"};

--- a/vpr/test/test_server_zlibutils.cpp
+++ b/vpr/test/test_server_zlibutils.cpp
@@ -3,7 +3,6 @@
 #include "zlibutils.h"
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 TEST_CASE("test_server_zlib_utils", "[vpr]") {
     const std::string orig{"This string is going to be compressed now"};

--- a/vpr/test/test_setup_noc.cpp
+++ b/vpr/test/test_setup_noc.cpp
@@ -1,5 +1,6 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include "catch2/matchers/catch_matchers.hpp"
+#include <random>
 
 #include "setup_noc.h"
 #include "globals.h"

--- a/vpr/test/test_vpr.cpp
+++ b/vpr/test/test_vpr.cpp
@@ -8,6 +8,7 @@
 #include "vpr_api.h"
 #include "echo_files.h"
 #include <cstring>
+#include <random>
 #include <vector>
 
 namespace {

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -2,8 +2,6 @@
 
 #include "catch2/catch_test_macros.hpp"
 
-#include "vpr_api.h"
-#include "globals.h"
 #include "user_place_constraints.h"
 #include "partition.h"
 #include "region.h"

--- a/vpr/test/test_xy_routing.cpp
+++ b/vpr/test/test_xy_routing.cpp
@@ -1,5 +1,5 @@
+#include "catch2/matchers/catch_matchers.hpp"
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
 
 #include "xy_routing.h"
 


### PR DESCRIPTION
VPR is moving to a style that uses "#pragma once" instead of header gaurds. These are less error prone and may be slightly more performant.

Converted all of the header gaurds in VPR into pragma once's.

Also moved all pragma onces to the top of all header files to maintain a consistent style. It is a good idea to have them as the very first line in all header files.

While going through all header files, cleaned up any extra header includes which were including things they did not need.