### PR TITLE
[CI] Removed Redundant Warning Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,38 +125,6 @@ jobs:
       run: ./.github/scripts/unittest.sh
 
 
-  Warnings:
-    name: 'W: Check Compilation Warnings'
-    runs-on: ubuntu-24.04
-    steps:
-
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3.12.3
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
-    - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v2
-      id: cpu-cores
-
-    - name: Install dependencies
-      run: ./.github/scripts/install_dependencies.sh
-
-    - uses: hendrikmuhs/ccache-action@v1.2
-
-    - name: Test
-      env:
-        #In order to get compilation warnings produced per source file, we must do a non-IPO build
-        #We also turn warnings into errors for this target by doing a strict compile
-        CMAKE_PARAMS: "-DVTR_ASSERT_LEVEL=3 -DWITH_BLIFEXPLORER=on -DVTR_ENABLE_STRICT_COMPILE=on -DVTR_IPO_BUILD=off"
-        NUM_PROC: ${{ steps.cpu-cores.outputs.count }}
-      run: |
-        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        ./.github/scripts/build.sh
-
-
   Regression:
     runs-on: ubuntu-24.04
     strategy:
@@ -517,7 +485,6 @@ jobs:
       - Build
       - Format
       - UniTests
-      - Warnings
       - Regression
       - Sanitized
       - Parmys

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ set_property(CACHE VTR_IPO_BUILD PROPERTY STRINGS auto on off)
 set(VTR_ASSERT_LEVEL "2" CACHE STRING "VTR assertion checking level. 0: no assertions, 1: fast assertions, 2: regular assertions, 3: additional assertions with noticeable run-time overhead, 4: all assertions (including those with significant run-time cost)")
 set_property(CACHE VTR_ASSERT_LEVEL PROPERTY STRINGS 0 1 2 3 4)
 
-option(VTR_ENABLE_STRICT_COMPILE "Specifies whether compiler warnings should be treated as errors (e.g. -Werror)" OFF)
 option(VTR_ENABLE_SANITIZE "Enable address/leak/undefined-behaviour sanitizers (i.e. run-time error checking)" OFF)
 option(VTR_ENABLE_PROFILING "Enable performance profiler (gprof)" OFF)
 option(VTR_ENABLE_COVERAGE "Enable code coverage tracking (gcov)" OFF)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ override CMAKE_PARAMS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -G 'Unix Makefil
 #Are we doing a strict (i.e. warnings as errors) build?
 ifneq (,$(findstring strict,$(BUILD_TYPE)))
 	#Configure for strict build with VPR warning treated as errors
-override CMAKE_PARAMS := -DVTR_ENABLE_STRICT_COMPILE=on ${CMAKE_PARAMS}
+override CMAKE_PARAMS := -DCMAKE_COMPILE_WARNING_AS_ERROR=on ${CMAKE_PARAMS}
 endif #Strict build type
 
 #Enable verbosity

--- a/odin_ii/CMakeLists.txt
+++ b/odin_ii/CMakeLists.txt
@@ -190,22 +190,5 @@ if (ODIN_USES_IPO)
     set_property(TARGET odin_ii APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
-#add strict odin compiler flags, if set
-if(VTR_ENABLE_STRICT_COMPILE)
-    message(STATUS "odin_ii: building with strict flags")
-
-    set(ODIN_STRICT_COMPILE_FLAGS_TO_CHECK
-        #GCC-like
-        "-Werror"
-        )
-
-    foreach(flag ${ODIN_STRICT_COMPILE_FLAGS_TO_CHECK})
-        message(STATUS "\tAdding CXX flag: ${flag}")
-        target_compile_options(libodin_ii PRIVATE ${flag})
-        target_compile_options(odin_ii PRIVATE ${flag})
-        target_link_libraries(odin_ii ${flag})
-    endforeach()
-endif()
-
 install(TARGETS odin_ii libodin_ii DESTINATION bin)
 install(FILES ${LIB_HEADERS} DESTINATION include/libodin_ii)

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -227,24 +227,6 @@ else()
     message(ERROR "Unsupported VPR_PGO_CONFIG '${VPR_PGO_CONFIG}'")
 endif()
 
-if (VTR_ENABLE_STRICT_COMPILE)
-    message(STATUS "VPR: building with strict flags")
-
-    set(VPR_STRICT_COMPILE_FLAGS_TO_CHECK
-        #GCC-like
-        "-Werror"
-        # due to the pointer hackery in timing_driven_route_structs and BinaryHeap.heap_
-        "-Wno-error=free-nonheap-object"
-        )
-
-    foreach(flag ${VPR_STRICT_COMPILE_FLAGS_TO_CHECK})
-        message(STATUS "\tAdding CXX flag: ${flag}")
-        target_compile_options(libvpr PRIVATE ${flag})
-        target_compile_options(vpr PRIVATE ${flag})
-        target_link_libraries(vpr ${flag})
-    endforeach()
-endif()
-
 #
 # Execution Engine Configuration
 #


### PR DESCRIPTION
Prior to the updates to the CI to make all regression tests warning clean, there was another warning test which was not as comprehensive as the tests we have now.

Since this test was superceded, removed it from the CI. The CMAKE param that enabled it was also used and replaced with a more comprehensive CMAKE option.