### PR TITLE
Fixing documentation build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,3 +22,4 @@ build:
 python:
   install:
     - requirements: doc/requirements.txt
+    - requirements: requirements.txt


### PR DESCRIPTION

---
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Readthedocs was not correctly running sphinx autodoc on our python modules because of broken imports.  We were instructing readthedocs to install the `docs/requirements.txt`, but not the base `requirements.txt`.  The latter includes packages that are used by our Python scripts.  autodoc cannot document the Python files without having the necessary libraries available.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- There should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2059 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] Breaking change (fix would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
