### PR TITLE
Clean up the usage tracking in grid blocks.

### DIFF
--- a/vpr/src/base/blk_loc_registry.cpp
+++ b/vpr/src/base/blk_loc_registry.cpp
@@ -125,9 +125,8 @@ void BlkLocRegistry::set_block_location(ClusterBlockId blk_id, const t_pl_loc& l
                   location.layer);
     }
 
-    // Mark the grid location and usage of the block
+    // Mark the grid location
     grid_blocks_.set_block_at_location(location, blk_id);
-    grid_blocks_.increment_usage({location.x, location.y, location.layer});
 
     place_sync_external_block_connections(blk_id);
 }
@@ -172,7 +171,6 @@ void BlkLocRegistry::clear_block_type_grid_locs(const std::unordered_set<int>& u
                 const t_physical_tile_type_ptr type = device_ctx.grid.get_physical_type({i, j, layer_num});
                 int itype = type->index;
                 if (clear_all_block_types || unplaced_blk_types_index.count(itype)) {
-                    grid_blocks_.set_usage({i, j, layer_num}, 0);
                     for (int k = 0; k < device_ctx.physical_tile_types[itype].capacity; k++) {
                         grid_blocks_.set_block_at_location({i, j, k, layer_num}, ClusterBlockId::INVALID());
                     }
@@ -267,14 +265,9 @@ void BlkLocRegistry::commit_move_blocks(const t_pl_blocks_to_be_moved& blocks_af
         // Remove from old location only if it hasn't already been updated by a previous block update
         if (grid_blocks_.block_at_location(from) == blk) {
             grid_blocks_.set_block_at_location(from, ClusterBlockId::INVALID());
-            grid_blocks_.decrement_usage({from.x, from.y, from.layer});
         }
 
         // Add to new location
-        if (grid_blocks_.block_at_location(to) == ClusterBlockId::INVALID()) {
-            //Only need to increase usage if previously unused
-            grid_blocks_.increment_usage({to.x, to.y, to.layer});
-        }
         grid_blocks_.set_block_at_location(to, blk);
 
     } // Finish updating clb for all blocks

--- a/vpr/src/base/grid_block.cpp
+++ b/vpr/src/base/grid_block.cpp
@@ -17,7 +17,7 @@ void GridBlock::init_grid_blocks(const DeviceGrid& device_grid) {
         for (size_t x = 0; x < grid_width; x++) {
             for (size_t y = 0; y < grid_height; y++) {
                 const t_physical_tile_loc tile_loc({(int)x, (int)y, (int)layer_num});
-                auto type = device_grid.get_physical_type(tile_loc);
+                t_physical_tile_type_ptr type = device_grid.get_physical_type(tile_loc);
                 initialized_grid_block_at_location(tile_loc, type->capacity);
             }
         }
@@ -25,16 +25,16 @@ void GridBlock::init_grid_blocks(const DeviceGrid& device_grid) {
 }
 
 void GridBlock::zero_initialize() {
-    auto& device_ctx = g_vpr_ctx.device();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
 
     /* Initialize all occupancy to zero. */
     for (int layer_num = 0; layer_num < (int)device_ctx.grid.get_num_layers(); layer_num++) {
         for (int i = 0; i < (int)device_ctx.grid.width(); i++) {
             for (int j = 0; j < (int)device_ctx.grid.height(); j++) {
-                auto tile = device_ctx.grid.get_physical_type({i, j, layer_num});
+                t_physical_tile_type_ptr tile = device_ctx.grid.get_physical_type({i, j, layer_num});
 
-                for (const auto& sub_tile : tile->sub_tiles) {
-                    auto capacity = sub_tile.capacity;
+                for (const t_sub_tile& sub_tile : tile->sub_tiles) {
+                    t_capacity_range capacity = sub_tile.capacity;
 
                     for (int k = 0; k < capacity.total(); k++) {
                         set_block_at_location({i, j, k + capacity.low, layer_num}, ClusterBlockId::INVALID());
@@ -46,8 +46,8 @@ void GridBlock::zero_initialize() {
 }
 
 void GridBlock::load_from_block_locs(const vtr::vector_map<ClusterBlockId, t_block_loc>& block_locs) {
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& device_ctx = g_vpr_ctx.device();
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
 
     zero_initialize();
 

--- a/vpr/src/base/grid_block.cpp
+++ b/vpr/src/base/grid_block.cpp
@@ -31,7 +31,6 @@ void GridBlock::zero_initialize() {
     for (int layer_num = 0; layer_num < (int)device_ctx.grid.get_num_layers(); layer_num++) {
         for (int i = 0; i < (int)device_ctx.grid.width(); i++) {
             for (int j = 0; j < (int)device_ctx.grid.height(); j++) {
-                set_usage({i, j, layer_num}, 0);
                 auto tile = device_ctx.grid.get_physical_type({i, j, layer_num});
 
                 for (const auto& sub_tile : tile->sub_tiles) {
@@ -59,20 +58,5 @@ void GridBlock::load_from_block_locs(const vtr::vector_map<ClusterBlockId, t_blo
         VTR_ASSERT(location.y < (int)device_ctx.grid.height());
 
         set_block_at_location(location, blk_id);
-        increment_usage({location.x, location.y, location.layer});
     }
-}
-
-int GridBlock::increment_usage(const t_physical_tile_loc& loc) {
-    int curr_usage = get_usage(loc);
-    int updated_usage = set_usage(loc, curr_usage + 1);
-
-    return updated_usage;
-}
-
-int GridBlock::decrement_usage(const t_physical_tile_loc& loc) {
-    int curr_usage = get_usage(loc);
-    int updated_usage = set_usage(loc, curr_usage - 1);
-
-    return updated_usage;
 }

--- a/vpr/src/base/grid_block.h
+++ b/vpr/src/base/grid_block.h
@@ -59,6 +59,12 @@ class GridBlock {
         return grid_blocks_[loc.layer_num][loc.x][loc.y].blocks.size();
     }
 
+    /**
+     * @brief Returns the number of subtiles in use at the specified grid location.
+     *
+     * Iterates over all subtiles at the given physical tile location and counts
+     * how many are currently occupied by a block.
+     */
     inline int get_usage(const t_physical_tile_loc loc) const {
         int usage = 0;
         for (size_t sub_tile = 0; sub_tile < num_blocks_at_location(loc); ++sub_tile) {

--- a/vpr/src/base/grid_block.h
+++ b/vpr/src/base/grid_block.h
@@ -8,8 +8,6 @@
 
 ///@brief Stores the clustered blocks placed at a particular grid location
 struct t_grid_blocks {
-    int usage; ///<How many valid blocks are in use at this location
-
     /**
      * @brief The clustered blocks associated with this grid location.
      *
@@ -61,12 +59,13 @@ class GridBlock {
         return grid_blocks_[loc.layer_num][loc.x][loc.y].blocks.size();
     }
 
-    inline int set_usage(const t_physical_tile_loc loc, int usage) {
-        return grid_blocks_[loc.layer_num][loc.x][loc.y].usage = usage;
-    }
-
     inline int get_usage(const t_physical_tile_loc loc) const {
-        return grid_blocks_[loc.layer_num][loc.x][loc.y].usage;
+        int usage = 0;
+        for (size_t sub_tile = 0; sub_tile < num_blocks_at_location(loc); ++sub_tile) {
+            if (!is_sub_tile_empty(loc, static_cast<int>(sub_tile)))
+                usage++;
+        }
+        return usage;
     }
 
     inline bool is_sub_tile_empty(const t_physical_tile_loc loc, int sub_tile) const {
@@ -87,10 +86,6 @@ class GridBlock {
      * @param block_locs Stores the location of each clustered block.
      */
     void load_from_block_locs(const vtr::vector_map<ClusterBlockId, t_block_loc>& block_locs);
-
-    int increment_usage(const t_physical_tile_loc& loc);
-
-    int decrement_usage(const t_physical_tile_loc& loc);
 
   private:
     vtr::NdMatrix<t_grid_blocks, 3> grid_blocks_;

--- a/vpr/src/place/noc_place_checkpoint.cpp
+++ b/vpr/src/place/noc_place_checkpoint.cpp
@@ -45,7 +45,6 @@ void NoCPlacementCheckpoint::restore_checkpoint(t_placer_costs& costs,
     for (const NocRouter& phy_router : noc_phy_routers) {
         t_physical_tile_loc phy_loc = phy_router.get_router_physical_location();
 
-        grid_blocks.set_usage(phy_loc, 0);
         auto tile = device_ctx.grid.get_physical_type(phy_loc);
 
         for (const auto& sub_tile : tile->sub_tiles) {


### PR DESCRIPTION
This PR removes the unused 'usage' member from t_grid_blocks and all associated routines  of set_usage, increment_usage, decrement_usage (get_usage changed as below).

#### Description
Changes:
- Rewrote `get_usage()` to dynamically count valid blocks based on sub-tile occupancy.
- Improves maintainability and eliminates risk of stale or inconsistent 'usage' data.


#### Related Issue
This PR resolves the issue #1607 



<!---#### How Has This Been Tested?-->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


