### PR TITLE
Upload vpr.out in nightly_test_manual artifacts

### DIFF
--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -112,4 +112,5 @@ jobs:
         name: nightly_test_results
         path: |
           vtr_flow/**/*.log
+          vtr_flow/**/vpr.out
           vtr_flow/**/parse_results*.txt


### PR DESCRIPTION
Currently nightly_test_manual uploads the vpr_stdout.log files, this PR makes it so that it also uploads the vpr.out files.