### PR TITLE
[Infra] Fixed False Forward Declarations

### DIFF
--- a/vpr/src/analytical_place/analytical_solver.h
+++ b/vpr/src/analytical_place/analytical_solver.h
@@ -28,7 +28,7 @@
 #endif // EIGEN_INSTALLED
 
 // Forward declarations
-class PartialPlacement;
+struct PartialPlacement;
 class APNetlist;
 class AtomNetlist;
 class PreClusterTimingManager;

--- a/vpr/src/analytical_place/full_legalizer.h
+++ b/vpr/src/analytical_place/full_legalizer.h
@@ -16,7 +16,7 @@ class APNetlist;
 class AtomNetlist;
 class ClusteredNetlist;
 class DeviceGrid;
-class PartialPlacement;
+struct PartialPlacement;
 class PlaceMacros;
 class PreClusterTimingManager;
 class Prepacker;

--- a/vpr/src/base/ShowSetup.h
+++ b/vpr/src/base/ShowSetup.h
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-class t_logical_block_type;
-class t_vpr_setup;
+struct t_logical_block_type;
+struct t_vpr_setup;
 
 struct ClusteredNetlistStats {
   private:

--- a/vpr/src/pack/greedy_clusterer.h
+++ b/vpr/src/pack/greedy_clusterer.h
@@ -17,11 +17,11 @@
 #include "vtr_vector.h"
 
 // Forward declarations
-class APPackContext;
+struct APPackContext;
 class AtomNetId;
 class AtomNetlist;
 class AttractionInfo;
-class DeviceContext;
+struct DeviceContext;
 class GreedyCandidateSelector;
 class PreClusterTimingManager;
 class t_pack_high_fanout_thresholds;

--- a/vpr/src/pack/pack_types.h
+++ b/vpr/src/pack/pack_types.h
@@ -12,7 +12,7 @@
 #include "atom_netlist_fwd.h"
 #include "physical_types.h"
 
-struct t_pack_molecule;
+class t_pack_molecule;
 
 /**************************************************************************
  * Packing Algorithm Enumerations

--- a/vpr/src/place/timing/place_timing_update.h
+++ b/vpr/src/place/timing/place_timing_update.h
@@ -5,13 +5,13 @@
  */
 
 class PlacerState;
-class PlaceCritParams;
+struct PlaceCritParams;
 class PlacerCriticalities;
 class PlacerSetupSlacks;
 class NetPinTimingInvalidator;
 class PlaceDelayModel;
 class SetupTimingInfo;
-struct t_placer_costs;
+class t_placer_costs;
 
 ///@brief Initialize the timing information and structures in the placer.
 void initialize_timing_info(const PlaceCritParams& crit_params,


### PR DESCRIPTION
The Clang builds were warning that there were several forward declarations of structs which were supposed to be classes and vice-versa.

This is not necessarily a problem since in C++ classes and structs end up being basically the same from the compiler's perspective, but its still incorrect. Fixed the cases I could see in the Clang builds.