### PR TITLE
[Build] Resolved All IPO Warnings in VTR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,18 +227,17 @@ foreach(flag ${FLEX_BISON_WARN_SUPPRESS_FLAGS_TO_CHECK})
     endif()
 endforeach()
 
-#Suppress IPO link warnings
-set(IPO_LINK_WARN_SUPRESS_FLAGS " ")
-set(IPO_LINK_WARN_SUPRESS_FLAGS_TO_CHECK
-    "-Wno-null-dereference"
-    )
-foreach(flag ${IPO_LINK_WARN_SUPRESS_FLAGS_TO_CHECK})
-    CHECK_CXX_COMPILER_FLAG(${flag} CXX_COMPILER_SUPPORTS_${flag})
-    if(CXX_COMPILER_SUPPORTS_${flag})
-        #Flag supported, so enable it
-        set(IPO_LINK_WARN_SUPRESS_FLAGS "${IPO_LINK_WARN_SUPRESS_FLAGS} ${flag}")
-    endif()
-endforeach()
+# Suppress IPO link warnings.
+# When IPO is turned on, it sometimes leads to false positives for warnings
+# since it checks for warnings after some of the source files have been compiled.
+# We globally suppress these warnings here. Any CMake executable which is added
+# after this line.
+if (CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+    message(STATUS "IPO: Suppressing known VTR warnings.")
+    add_link_options(-Wno-alloc-size-larger-than  # libarchfpga allocates C-style arrays using integers.
+                     -Wno-stringop-overflow       # EXTERNAL/capnproto has some string overflow warnings.
+                     )
+endif()
 
 #
 # Sanitizer flags

--- a/blifexplorer/CMakeLists.txt
+++ b/blifexplorer/CMakeLists.txt
@@ -56,13 +56,6 @@ else()
                             ${CMAKE_DL_LIBS}
     )
 
-    #Supress IPO link warnings if IPO is enabled
-    get_target_property(TEST_BLIFEXPLORER_USES_IPO blifexplorer INTERPROCEDURAL_OPTIMIZATION)
-    if (TEST_BLIFEXPLORER_USES_IPO)
-        set_property(TARGET blifexplorer APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-    endif()
-
-
     install(TARGETS blifexplorer DESTINATION bin)
 
 endif()

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -53,27 +53,9 @@ endif()
 
 target_compile_definitions(libarchfpga PUBLIC ${INTERCHANGE_SCHEMA_HEADERS})
 
-# Supress IPO link warnings if IPO is enabled
-get_target_property(LIBARCHFPGA_USES_IPO libarchfpga INTERPROCEDURAL_OPTIMIZATION)
-if(LIBARCHFPGA_USES_IPO)
-    # LibArchFPGA uses ints in many of its data structures instead of size_t for
-    # the size of arrays which are used to allocate arrays. At link-time, this
-    # causes many false allocation warnings when IPO is enabled.
-    # In order to suppress these warnings, we must make this PUBLIC so that not
-    # only we suppress the warning for libarchfpga, but also anything else that
-    # links with it.
-    target_link_options(libarchfpga PUBLIC -Wno-alloc-size-larger-than)
-endif()
-
 #Create the test executable
 add_executable(read_arch ${READ_ARCH_EXEC_SRC})
 target_link_libraries(read_arch libarchfpga)
-
-#Supress IPO link warnings if IPO is enabled
-get_target_property(READ_ARCH_USES_IPO read_arch INTERPROCEDURAL_OPTIMIZATION)
-if(READ_ARCH_USES_IPO)
-    set_property(TARGET read_arch APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
 
 install(TARGETS libarchfpga DESTINATION bin)
 install(FILES ${LIB_HEADERS} DESTINATION include/libarchfpga)

--- a/libs/libarchfpga/CMakeLists.txt
+++ b/libs/libarchfpga/CMakeLists.txt
@@ -53,6 +53,18 @@ endif()
 
 target_compile_definitions(libarchfpga PUBLIC ${INTERCHANGE_SCHEMA_HEADERS})
 
+# Supress IPO link warnings if IPO is enabled
+get_target_property(LIBARCHFPGA_USES_IPO libarchfpga INTERPROCEDURAL_OPTIMIZATION)
+if(LIBARCHFPGA_USES_IPO)
+    # LibArchFPGA uses ints in many of its data structures instead of size_t for
+    # the size of arrays which are used to allocate arrays. At link-time, this
+    # causes many false allocation warnings when IPO is enabled.
+    # In order to suppress these warnings, we must make this PUBLIC so that not
+    # only we suppress the warning for libarchfpga, but also anything else that
+    # links with it.
+    target_link_options(libarchfpga PUBLIC -Wno-alloc-size-larger-than)
+endif()
+
 #Create the test executable
 add_executable(read_arch ${READ_ARCH_EXEC_SRC})
 target_link_libraries(read_arch libarchfpga)

--- a/odin_ii/CMakeLists.txt
+++ b/odin_ii/CMakeLists.txt
@@ -184,11 +184,5 @@ foreach(ODIN_LINK_FLAG ${ODIN_EXTRA_LINK_FLAGS})
         target_link_libraries(odin_ii ${ODIN_LINK_FLAG})
 endforeach()
 
-#Supress IPO link warnings if IPO is enabled
-get_target_property(ODIN_USES_IPO odin_ii INTERPROCEDURAL_OPTIMIZATION)
-if (ODIN_USES_IPO)
-    set_property(TARGET odin_ii APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
-
 install(TARGETS odin_ii libodin_ii DESTINATION bin)
 install(FILES ${LIB_HEADERS} DESTINATION include/libodin_ii)

--- a/utils/fasm/CMakeLists.txt
+++ b/utils/fasm/CMakeLists.txt
@@ -27,12 +27,6 @@ target_link_libraries(fasm
 add_executable(genfasm src/main.cpp)
 target_link_libraries(genfasm fasm)
 
-#Supress IPO link warnings if IPO is enabled
-get_target_property(GENFASM_USES_IPO genfasm INTERPROCEDURAL_OPTIMIZATION)
-if (GENFASM_USES_IPO)
-    set_property(TARGET genfasm APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
-
 #Specify link-time dependencies
 install(TARGETS genfasm DESTINATION bin)
 
@@ -48,12 +42,6 @@ set(TEST_SOURCES
   )
 add_executable(test_fasm ${TEST_SOURCES})
 target_link_libraries(test_fasm fasm Catch2::Catch2WithMain)
-
-#Suppress IPO link warnings if IPO is enabled
-get_target_property(TEST_FASM_USES_IPO test_fasm INTERPROCEDURAL_OPTIMIZATION)
-if (TEST_FASM_USES_IPO)
-    set_property(TARGET test_fasm APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
 
 add_test(
   NAME test_fasm

--- a/utils/route_diag/CMakeLists.txt
+++ b/utils/route_diag/CMakeLists.txt
@@ -8,9 +8,3 @@ target_link_libraries(route_diag
   libvpr
   )
 
-#Suppress IPO link warnings if IPO is enabled
-get_target_property(TEST_ROUTE_DIAG_USES_IPO route_diag INTERPROCEDURAL_OPTIMIZATION)
-if (TEST_ROUTE_DIAG_USES_IPO)
-    set_property(TARGET route_diag APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
-

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -175,14 +175,6 @@ add_executable(vpr ${EXEC_SOURCES})
 target_link_libraries(vpr libvpr)
 
 
-#Suppress IPO link warnings if IPO is enabled
-get_target_property(VPR_USES_IPO vpr INTERPROCEDURAL_OPTIMIZATION)
-if (VPR_USES_IPO)
-    set_property(TARGET vpr APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
-
-
-
 #
 # Profile Guilded Optimization Configuration
 #
@@ -302,12 +294,6 @@ add_executable(test_vpr ${TEST_SOURCES})
 target_link_libraries(test_vpr
                         Catch2::Catch2WithMain
                         libvpr)
-
-#Suppress IPO link warnings if IPO is enabled
-get_target_property(TEST_VPR_USES_IPO vpr INTERPROCEDURAL_OPTIMIZATION)
-if (TEST_VPR_USES_IPO)
-    set_property(TARGET test_vpr APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
 
 add_test(NAME test_vpr
     COMMAND test_vpr --colour-mode ansi


### PR DESCRIPTION
VTR is built with IPO by default. IPO tends to reveal false warnings in the compiler. This was causing many warnings when VTR was built by default.

Most of these warnings were coming from libarchfpga due to how it allocates arrays. Suppressed these warnings when IPO is turned on.

There are still link-time warnings coming from CapNProto; however, since this library is external, it is a harder to supress these warnings. We could suppress the warnings by globally setting the link option to ignore the warning, but that may be overkill.

Edit:

See discussion below, decided to globally suppress all known IPO warnings in VTR.