### PR TITLE
Updating VTR Docs -include Command

### DIFF
--- a/doc/src/vtr/run_vtr_flow.rst
+++ b/doc/src/vtr/run_vtr_flow.rst
@@ -95,7 +95,7 @@ Will run the VTR flow (default configuration) with Yosys frontend using Parmys p
     # Using the Parmys (Partial Mapper for Yosys) plugin as partial mapper with include files
     ./run_vtr_flow <path/to/Verilog/File> <path/to/arch/file> -include <path/to/include/directory>/*.v*
 
-Will run the VTR flow (default configuration) with Yosys frontend using Parmys plugin as partial mapper. In addition to the main circuit passed in with the architecture, it will also pass in every matching HDL file within the include directory.
+Will run the VTR flow (default configuration) with Yosys frontend using Parmys plugin as partial mapper. In addition to the main circuit passed in with the architecture, it will also pass in every HDL file with the specified file type within the include directory.
 
 Detailed Command-line Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/src/vtr/run_vtr_flow.rst
+++ b/doc/src/vtr/run_vtr_flow.rst
@@ -90,6 +90,13 @@ Enable Synlig tool with the ``-DSYNLIG_SYSTEMVERILOG=ON`` compile flag for the P
 
 Will run the VTR flow (default configuration) with Yosys frontend using Parmys plugin as partial mapper. To utilize the Parmys plugin, the ``-DYOSYS_PARMYS_PLUGIN=ON`` compile flag should be passed while building the VTR project with Yosys as a frontend.
 
+.. code-block:: bash
+
+    # Using the Parmys (Partial Mapper for Yosys) plugin as partial mapper with include files
+    ./run_vtr_flow <path/to/Verilog/File> <path/to/arch/file> -include <path/to/include/directory>/*.v*
+
+Will run the VTR flow (default configuration) with Yosys frontend using Parmys plugin as partial mapper. In addition to the main circuit passed in with the architecture, it will also pass in every matching HDL file within the include directory.
+
 Detailed Command-line Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -123,6 +130,15 @@ Detailed Command-line Options
       * ``vpr``
 
     **Default:** ``vpr``
+    
+.. option:: -include <path_to_file(s)>/*.<file_type(s)>
+
+    List of include files to a benchmark circuit 
+    (pass to VTR frontends as a benchmark design set).
+    
+    Include files can be any file supported by yosys+parmys (normally .v or .vh files).
+    
+    The include directory should not contain the circuit passed in with the architecture.
 
 .. option:: -power
 

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -151,7 +151,8 @@ def run(
             Circuit file to optimize
 
         include_files :
-            List of include files to a benchmark circuit (passed in through run_vtr_flow with -include command)
+            List of include files to a benchmark circuit 
+            (passed in through run_vtr_flow with -include command)
 
         output_netlist :
             File name to output the resulting circuit to

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -151,8 +151,7 @@ def run(
             Circuit file to optimize
 
         include_files :
-            List of include files to a benchmark circuit 
-            (passed in through run_vtr_flow with -include command)
+            List of include files to a benchmark circuit. Passed in through run_vtr_flow with -include command
 
         output_netlist :
             File name to output the resulting circuit to

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -151,7 +151,7 @@ def run(
             Circuit file to optimize
 
         include_files :
-            List of include files to a benchmark circuit. Passed in through run_vtr_flow with -include
+            List of include files to a benchmark circuit. Passed in by run_vtr_flow with -include
 
         output_netlist :
             File name to output the resulting circuit to

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -151,7 +151,7 @@ def run(
             Circuit file to optimize
 
         include_files :
-            List of include files to a benchmark circuit. Passed in through run_vtr_flow with -include command
+            List of include files to a benchmark circuit. Passed in through run_vtr_flow with -include
 
         output_netlist :
             File name to output the resulting circuit to

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -151,7 +151,7 @@ def run(
             Circuit file to optimize
 
         include_files :
-            list of header files
+            List of include files to a benchmark circuit (passed in through run_vtr_flow with -include command)
 
         output_netlist :
             File name to output the resulting circuit to


### PR DESCRIPTION
Updating VTR Docs -include Command

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Updated run_vtr_flow docs and VTR Flow Python Library to have documentation for the -include command to pass in more than one circuit to run_vtr_flow.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to issue #1774

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the question "How can I run multiple circuits on the same architecture in one shot with run_vtr_flow?"

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran CI tests to ensure doc building still works and had updated documentation revised by VTR mentors.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed
