### PR TITLE
Skip syncing netlist to routing resutls

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -720,6 +720,7 @@ static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysi
 
     analysis_opts.timing_update_type = Options.timing_update_type;
     analysis_opts.write_timing_summary = Options.write_timing_summary;
+    analysis_opts.skip_sync_clustering_and_routing_results = Options.skip_sync_clustering_and_routing_results;
     analysis_opts.generate_net_timing_report = Options.generate_net_timing_report;
 }
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -3098,7 +3098,9 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
     analysis_grp.add_argument<bool, ParseOnOff>(args.skip_sync_clustering_and_routing_results, "--skip_sync_clustering_and_routing_results")
         .help(
             "Select to skip the synchronization on clustering results based on routing optimization results."
-            "Note that when this sync-up is disabled, clustering results may be wrong (leading to incorrect bitstreams)!");
+            "Note that when this sync-up is disabled, clustering results may be wrong (leading to incorrect bitstreams)!")
+        .default_value("off")
+        .show_in(argparse::ShowIn::HELP_ONLY);
 
     analysis_grp.add_argument<bool, ParseOnOff>(args.generate_net_timing_report, "--generate_net_timing_report")
         .help(

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -3095,6 +3095,11 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .help("Writes implemented design final timing summary to the specified JSON, XML or TXT file.")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    analysis_grp.add_argument<bool, ParseOnOff>(args.skip_sync_clustering_and_routing_results, "--skip_sync_clustering_and_routing_results")
+        .help(
+            "Select to skip the synchronization on clustering results based on routing optimization results."
+            "Note that when this sync-up is disabled, clustering results may be wrong (leading to incorrect bitstreams)!");
+
     analysis_grp.add_argument<bool, ParseOnOff>(args.generate_net_timing_report, "--generate_net_timing_report")
         .help(
             "Generates a net timing report in CSV format, reporting the delay and slack\n"

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -273,6 +273,7 @@ struct t_options {
     argparse::ArgValue<e_post_synth_netlist_unconn_handling> post_synth_netlist_unconn_output_handling;
     argparse::ArgValue<bool> post_synth_netlist_module_parameters;
     argparse::ArgValue<std::string> write_timing_summary;
+    argparse::ArgValue<bool> skip_sync_clustering_and_routing_results;
     argparse::ArgValue<bool> generate_net_timing_report;
 };
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1440,12 +1440,12 @@ bool vpr_analysis_flow(const Netlist<>& net_list,
                 sync_netlists_to_routing_flat();
             } else {
                 sync_netlists_to_routing(net_list,
-                                        g_vpr_ctx.device(),
-                                        g_vpr_ctx.mutable_atom(),
-                                        g_vpr_ctx.mutable_clustering(),
-                                        g_vpr_ctx.placement(),
-                                        vpr_setup.PackerOpts.pack_verbosity > 2);
-                }
+                                         g_vpr_ctx.device(),
+                                         g_vpr_ctx.mutable_atom(),
+                                         g_vpr_ctx.mutable_clustering(),
+                                         g_vpr_ctx.placement(),
+                                         vpr_setup.PackerOpts.pack_verbosity > 2);
+            }
         } else {
             VTR_LOG_WARN("Synchronization between packing and routing results was not applied due to skip_sync_clustering_and_routing_results being set to true\n");
         }

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1447,14 +1447,14 @@ bool vpr_analysis_flow(const Netlist<>& net_list,
                                         vpr_setup.PackerOpts.pack_verbosity > 2);
                 }
         } else {
-            VTR_LOG_WARN("Sychronization between packing and routing results is not applied due to users select to skip it\n");
+            VTR_LOG_WARN("Synchronization between packing and routing results was not applied due to skip_sync_clustering_and_routing_results being set to true\n");
         }
 
         std::string post_routing_packing_output_file_name = vpr_setup.PackerOpts.output_file + ".post_routing";
         write_packing_results_to_xml(Arch.architecture_id,
                                      post_routing_packing_output_file_name.c_str());
     } else {
-        VTR_LOG_WARN("Synchronization between packing and routing results is not applied due to illegal circuit implementation\n");
+        VTR_LOG_WARN("Synchronization between packing and routing results was not applied due to illegal circuit implementation\n");
     }
     VTR_LOG("\n");
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1426,7 +1426,8 @@ bool vpr_analysis_flow(const Netlist<>& net_list,
         VTR_LOG("*****************************************************************************************\n");
     }
 
-    /* If routing is successful, apply post-routing annotations
+    /* If routing is successful and users do not force to skip the sync-up, 
+     * - apply post-routing annotations
      * - apply logic block pin fix-up
      *
      * Note:
@@ -1434,15 +1435,19 @@ bool vpr_analysis_flow(const Netlist<>& net_list,
      *     for packer (default verbosity is set to 2 for compact logs)
      */
     if (route_status.success()) {
-        if (is_flat) {
-            sync_netlists_to_routing_flat();
+        if (!analysis_opts.skip_sync_clustering_and_routing_results) {
+            if (is_flat) {
+                sync_netlists_to_routing_flat();
+            } else {
+                sync_netlists_to_routing(net_list,
+                                        g_vpr_ctx.device(),
+                                        g_vpr_ctx.mutable_atom(),
+                                        g_vpr_ctx.mutable_clustering(),
+                                        g_vpr_ctx.placement(),
+                                        vpr_setup.PackerOpts.pack_verbosity > 2);
+                }
         } else {
-            sync_netlists_to_routing(net_list,
-                                     g_vpr_ctx.device(),
-                                     g_vpr_ctx.mutable_atom(),
-                                     g_vpr_ctx.mutable_clustering(),
-                                     g_vpr_ctx.placement(),
-                                     vpr_setup.PackerOpts.pack_verbosity > 2);
+            VTR_LOG_WARN("Sychronization between packing and routing results is not applied due to users select to skip it\n");
         }
 
         std::string post_routing_packing_output_file_name = vpr_setup.PackerOpts.output_file + ".post_routing";

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1352,6 +1352,7 @@ struct t_analysis_opts {
     bool generate_net_timing_report;
 
     e_timing_update_type timing_update_type;
+    bool skip_sync_clustering_and_routing_results;
 };
 
 /// Stores NoC specific options, when supplied as an input by the user


### PR DESCRIPTION
There may be cases where the user doesn’t want to sync the netlist to the routing results. This situation may especially arise when the flat router is enabled and global signals are not routed. Since the pins reserved for global nets are not visible to the flat router, it may use them, which can lead to crashes.

For this case, the current workaround is to enable skipping netlist syncing. However, the long-term solution would be to make these pins visible to the flat router.