### PR TITLE
[AP] Updated Timing Logging

### DIFF
--- a/vpr/src/analytical_place/global_placer.cpp
+++ b/vpr/src/analytical_place/global_placer.cpp
@@ -124,9 +124,18 @@ SimPLGlobalPlacer::SimPLGlobalPlacer(e_ap_analytical_solver analytical_solver_ty
  */
 static void print_placement_stats(const PartialPlacement& p_placement,
                                   const APNetlist& ap_netlist,
-                                  FlatPlacementDensityManager& density_manager) {
+                                  FlatPlacementDensityManager& density_manager,
+                                  const PreClusterTimingManager& pre_cluster_timing_manager) {
     // Print the placement HPWL
     VTR_LOG("\tPlacement HPWL: %f\n", p_placement.get_hpwl(ap_netlist));
+
+    // Print the timing information.
+    if (pre_cluster_timing_manager.is_valid()) {
+        float cpd_ns = pre_cluster_timing_manager.get_timing_info().least_slack_critical_path().delay() * 1e9;
+        float stns_ns = pre_cluster_timing_manager.get_timing_info().setup_total_negative_slack() * 1e9;
+        VTR_LOG("\tPlacement estimated CPD: %f ns\n", cpd_ns);
+        VTR_LOG("\tPlacement estimated sTNS: %f ns\n", stns_ns);
+    }
 
     // Print density information. Need to reset the density manager to ensure
     // the data is valid.
@@ -424,7 +433,8 @@ PartialPlacement SimPLGlobalPlacer::place() {
     VTR_LOG("Placement after Global Placement:\n");
     print_placement_stats(best_p_placement,
                           ap_netlist_,
-                          *density_manager_);
+                          *density_manager_,
+                          pre_cluster_timing_manager_);
 
     // Return the placement from the final iteration.
     return best_p_placement;

--- a/vtr_flow/parse/qor_config/qor_ap_fixed_chan_width.txt
+++ b/vtr_flow/parse/qor_config/qor_ap_fixed_chan_width.txt
@@ -2,11 +2,18 @@
 # channel width.
 
 vpr_status;output.txt;vpr_status=(.*)
-crit_path_delay;vpr.out;Critical path: (.*) ns
 post_gp_hpwl;vpr.out;\s*Placement HPWL: (.*)
 post_fl_hpwl;vpr.out;Initial placement BB estimate of wirelength: (.*)
 post_dp_hpwl;vpr.out;BB estimate of min-dist \(placement\) wire length: (.*)
 total_wirelength;vpr.out;\s*Total wirelength: (\d+)
+post_gp_cpd;vpr.out;\s*Placement estimated CPD: (.*) ns
+post_fl_cpd;vpr.out;Initial placement estimated Critical Path Delay \(CPD\): (.*) ns
+post_dp_cpd;vpr.out;Placement estimated critical path delay \(least slack\): (.*) ns
+crit_path_delay;vpr.out;Critical path: (.*) ns
+post_gp_sTNS;vpr.out;\s*Placement estimated sTNS: (.*) ns
+post_fl_sTNS;vpr.out;Initial placement estimated setup Total Negative Slack \(sTNS\): (.*) ns
+post_dp_sTNS;vpr.out;Placement estimated setup Total Negative Slack \(sTNS\): (.*) ns
+final_sTNS;vpr.out;Final setup Total Negative Slack \(sTNS\): (.*) ns
 post_gp_overfilled_bins;vpr.out;\s*Number of overfilled bins: (\d+)
 post_gp_avg_overfill;vpr.out;\s*Average overfill magnitude: (.*)
 post_gp_num_misplaced_blocks;vpr.out;\s*Number of blocks in an incompatible bin: (\d+)


### PR DESCRIPTION
The global placer printed the post-GP estimated wirelength, but it did not print the post-GP CPD or TNS. Added these values to the log file.

Also updated the QoR parse script that I use internally to grab this information throughout the flow to track timing.