### PR TITLE
[Arch] Added Artix-7-like Devices on the Xilinx 7 Series Capture

### DIFF
--- a/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
+++ b/vtr_flow/arch/xilinx/7series_BRAM_DSP_carry.xml
@@ -364,28 +364,23 @@
 
     <!-- Artix-7 12k Logic Cell device.
                     Data sheet     |   Actual
-                - 2,000 CLB slices | 950 CLB tiles
+                - 2,000 CLB slices | 1015 CLB tiles
                 - 40 DSP slices    | 20 DSP tiles
                 - 20 BRAM blocks   | 20 BRAM tiles
                 - 150 IOs          | 19 IO tiles
     -->
     <fixed_layout name="XC7A12T-like" width="37" height="37">
-      <!-- 150 IOs (or around 19 tiles). Distribute them evenly around the border (5ish per side) -->
+      <!-- 150 IOs (or around 19 tiles). 10 on one side, 9 on the other. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="8" priority="100" />
-      <col type="io" startx="36" starty="1" incry="8" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="8" priority="100" />
-      <row type="io" startx="1" starty="36" incrx="9" priority="100" />
+      <col type="io" startx="0" starty="4" incry="3" priority="100" />
+      <single type="EMPTY" x="0" y="34" priority="101" />
+      <col type="io" startx="36" starty="1" incry="4" priority="100" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove 3 DSPs from one column, 2 from all others each column to bring the total number of DSP slices to 20 -->
@@ -409,22 +404,24 @@
                 - 250 IOs          | 32 IO tiles
     -->
     <fixed_layout name="XC7A15T-like" width="42" height="42">
-      <!-- 250 IOs (or around 32 tiles). Distribute them evenly around the border (8 per side) -->
+      <!-- 250 IOs (or around 32 tiles). 16 on the left and 16 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="5" priority="100" />
-      <col type="io" startx="41" starty="1" incry="5" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="5" priority="100" />
-      <row type="io" startx="1" starty="41" incrx="5" priority="100" />
+      <col type="io" startx="0" starty="1" incry="2" priority="100" />
+      <single type="EMPTY" x="0" y="9" priority="101" />
+      <single type="EMPTY" x="0" y="17" priority="101" />
+      <single type="EMPTY" x="0" y="25" priority="101" />
+      <single type="EMPTY" x="0" y="37" priority="101" />
+      <col type="io" startx="41" starty="1" incry="2" priority="100" />
+      <single type="EMPTY" x="41" y="9" priority="101" />
+      <single type="EMPTY" x="41" y="17" priority="101" />
+      <single type="EMPTY" x="41" y="25" priority="101" />
+      <single type="EMPTY" x="41" y="37" priority="101" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove 6 DSPs from each column to bring the total number of DSP slices to 44 -->
@@ -449,22 +446,17 @@
                 - 150 IOs          | 19 IO tiles
     -->
     <fixed_layout name="XC7A25T-like" width="49" height="49">
-      <!-- 150 IOs (or around 19 tiles). Distribute them evenly around the border (5ish per side) -->
+      <!-- 150 IOs (or around 19 tiles). 10 on the left and 9 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="11" priority="100" />
-      <col type="io" startx="48" starty="1" incry="11" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="11" priority="100" />
-      <row type="io" startx="1" starty="48" incrx="12" priority="100" />
+      <col type="io" startx="0" starty="1" incry="5" priority="100" />
+      <col type="io" startx="48" starty="1" incry="5" priority="100" />
+      <single type="EMPTY" x="48" y="46" priority="101" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove 2 DSPs from each column to bring the total number of DSP slices to 40 -->
@@ -479,28 +471,26 @@
 
     <!-- Artix-7 35k Logic Cell device.
                     Data sheet     |   Actual
-                - 5,200 CLB slices | 2,570 CLB tiles
+                - 5,200 CLB slices | 2,576 CLB tiles
                 - 90 DSP slices    | 45 DSP tiles
                 - 50 BRAM blocks   | 50 BRAM tiles
-                - 250 IOs          | 31 IO tiles
+                - 250 IOs          | 32 IO tiles
     -->
     <fixed_layout name="XC7A35T-like" width="58" height="58">
-      <!-- 250 IOs (or around 31 tiles). Distribute them evenly around the border (8ish per side) -->
+      <!-- 250 IOs (or around 32 tiles). 16 on the left and 16 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="7" priority="100" />
-      <col type="io" startx="57" starty="1" incry="7" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="7" priority="100" />
-      <row type="io" startx="1" starty="57" incrx="8" priority="100" />
+      <col type="io" startx="0" starty="1" incry="4" priority="100" />
+      <single type="io" x="0" y="18" priority="100" />
+      <single type="io" x="0" y="42" priority="100" />
+      <col type="io" startx="57" starty="1" incry="4" priority="100" />
+      <single type="io" x="57" y="18" priority="100" />
+      <single type="io" x="57" y="42" priority="100" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove 6 DSPs from each column to bring the total number of DSP slices to 90 -->
@@ -525,25 +515,23 @@
                 - 8,150 CLB slices | 4,060 CLB tiles
                 - 120 DSP slices   | 60 DSP tiles
                 - 75 BRAM blocks   | 75 BRAM tiles
-                - 250 IOs          | 31 IO tiles
+                - 250 IOs          | 32 IO tiles
     -->
     <fixed_layout name="XC7A50T-like" width="72" height="72">
-      <!-- 250 IOs (or around 31 tiles). Distribute them evenly around the border (8ish per side) -->
+      <!-- 250 IOs (or around 32 tiles). 16 on the left and 16 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="9" priority="100" />
-      <col type="io" startx="71" starty="1" incry="9" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="9" priority="100" />
-      <row type="io" startx="1" starty="71" incrx="10" priority="100" />
+      <col type="io" startx="0" starty="1" incry="5" priority="100" />
+      <single type="io" x="0" y="24" priority="100" />
+      <single type="io" x="0" y="48" priority="100" />
+      <col type="io" startx="71" starty="1" incry="5" priority="100" />
+      <single type="io" x="71" y="24" priority="100" />
+      <single type="io" x="71" y="48" priority="100" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove 8 DSPs from each column to bring the total number of DSP slices to 120 -->
@@ -573,22 +561,24 @@
                 - 300 IOs           | 38 IO tiles
     -->
     <fixed_layout name="XC7A75T-like" width="87" height="87">
-      <!-- 300 IOs (or around 38 tiles). Distribute them evenly around the border (9ish per side) -->
+      <!-- 300 IOs (or around 38 tiles). 19 on the left and 19 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="9" priority="100" />
-      <col type="io" startx="86" starty="1" incry="9" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="10" priority="100" />
-      <row type="io" startx="1" starty="86" incrx="10" priority="100" />
+      <col type="io" startx="0" starty="1" incry="6" priority="100" />
+      <single type="io" x="0" y="17" priority="100" />
+      <single type="io" x="0" y="35" priority="100" />
+      <single type="io" x="0" y="52" priority="100" />
+      <single type="io" x="0" y="70" priority="100" />
+      <col type="io" startx="86" starty="1" incry="6" priority="100" />
+      <single type="io" x="86" y="17" priority="100" />
+      <single type="io" x="86" y="35" priority="100" />
+      <single type="io" x="86" y="52" priority="100" />
+      <single type="io" x="86" y="70" priority="100" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove DSPs -->
@@ -621,22 +611,20 @@
                 - 300 IOs           | 38 IO tiles
     -->
     <fixed_layout name="XC7A100T-like" width="100" height="100">
-      <!-- 300 IOs (or around 38 tiles). Distribute them evenly around the border (9ish per side) -->
+      <!-- 300 IOs (or around 38 tiles). 19 on the left and 19 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="10" priority="100" />
-      <col type="io" startx="99" starty="1" incry="10" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="12" priority="100" />
-      <row type="io" startx="1" starty="99" incrx="12" priority="100" />
+      <col type="io" startx="0" starty="1" incry="6" priority="100" />
+      <single type="io" x="0" y="33" priority="100" />
+      <single type="io" x="0" y="66" priority="100" />
+      <col type="io" startx="99" starty="1" incry="6" priority="100" />
+      <single type="io" x="99" y="33" priority="100" />
+      <single type="io" x="99" y="66" priority="100" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove DSPs -->
@@ -672,22 +660,21 @@
                 - 500 IOs           | 63 IO tiles
     -->
     <fixed_layout name="XC7A200T-like" width="145" height="145">
-      <!-- 500 IOs (or around 63 tiles). Distribute them evenly around the border (9ish per side) -->
+      <!-- 500 IOs (or around 63 tiles). 32 on the left and 31 on the right. -->
       <perimeter type="EMPTY" priority="99" />
       <corners type="EMPTY" priority="101" />
-      <col type="io" startx="0" starty="1" incry="9" priority="100" />
-      <col type="io" startx="144" starty="1" incry="9" priority="100" />
-      <row type="io" startx="1" starty="0" incrx="9" priority="100" />
-      <row type="io" startx="1" starty="144" incrx="10" priority="100" />
+      <col type="io" startx="0" starty="1" incry="5" priority="100" />
+      <single type="io" x="0" y="37" priority="100" />
+      <single type="io" x="0" y="72" priority="100" />
+      <single type="io" x="0" y="109" priority="100" />
+      <col type="io" startx="144" starty="1" incry="5" priority="100" />
+      <single type="io" x="144" y="48" priority="100" />
+      <single type="io" x="144" y="97" priority="100" />
 
       <!--Fill
         with 'CLB'-->
       <fill type="CLB" priority="10" />
 
-      <!-- In the actual 7-series BRAM and DSP are almost always placed 4 tiles apart from each
-        other. The actual repeatx for each of these block types is slightly different from the bellow due
-        to differences in how Xilinx lays out BRAM and DSP on the physical chip. The values given
-        bellow are the average spacing between DSP and BRAM columns.-->
       <col type="DSP" startx="10" starty="1" repeatx="11" priority="20" />
       <col type="EMPTY" startx="10" repeatx="11" starty="1" priority="19" />
       <!-- Remove DSPs -->


### PR DESCRIPTION
For testing Analytical Placement, we currently need fixed-sized devices. To get the 7-Series architecture capture through the AP flow, I selected fixed device sizes that matched the Artix-7 device family in resource utilization.

The fixed layouts were obtained by performing the following process:

1) The device was auto-sized to the FPGA with the closest number of CLB
   slices to the target device.

2) Extra RAMs, DSPs, and IOs were dropped out evenly across the device.

The RAMs and DSPs usually needed to be dropped out, and their numbers were often cut in half relative to their auto-sized resource counts.

The IOs majorly needed to be dropped out. The number of IOs in the auto-sized devices were around 10x their Artix-7 equivalent (with matching CLB resources).

These devices likely do not model the layout of the Artix-7 devices faithfully; however, my goal was to simulate the resource utilization of the Artix-7 device family on our Xilinx 7-Series capture.

For those interested, here are the VTR benchmarks mapped to the smallest Artix-7 device that they can fit on and their resource utilization:

Circuit | Minimum Device | Device Utilization | Limiting Resource Utilization | Limiting Resource
-- | -- | -- | -- | --
arm_core.v | XC7A200T | 0.06 | 0.62 | io
bgm.v | XC7A75T | 0.45 | 0.95 | io
blob_merge.v | XC7A12T | 0.71 | 0.94 | CLB
boundtop.v | XC7A200T | 0.01 | 0.77 | io
ch_intrinsics.v | XC7A15T | 0.06 | 0.89 | io
diffeq1.v | XC7A75T | 0.02 | 0.85 | io
diffeq2.v | **Yosys crash** | - | - | -
LU32PEEng.v | XC7A200T | 0.52 | 0.61 | CLB
LU8PEEng.v | XC7A50T | 0.61 | 0.87 | io
mcml.v | XC7A200T | 0.68 | 0.79 | CLB
mkDelayWorker32B.v | **Did not fit** | - | - | io (Needs 1059)
mkPktMerge.v | XC7A200T | 0.01 | 0.93 | io
mkSMAdapter4B.v | XC7A200T | 0.01 | 0.79 | io
or1200.v | **Did not fit** | - | - | io (Needs 747)
raygentop.v | **Did not fit** | - | - | io (Needs 541)
sha.v | XC7A12T | 0.15 | 0.49 | io
spree.v | XC7A12T | 0.08 | 0.51 | io
stereovision0.v | XC7A200T | 0.06 | 0.73 | io
stereovision1.v | XC7A75T | 0.2 | 0.89 | DSP
stereovision2.v | XC7A200T | 0.21 | 0.66 | io
stereovision3.v | XC7A12T | 0.02 | 0.09 | io

Of specific interest to me are the 8 largest VTR benchmark circuits, which I have pulled out below:

Circuit | Minimum Device | Device Utilization | Limiting Resource Utilization | Limiting Resource
-- | -- | -- | -- | --
arm_core.v | XC7A200T | 0.06 | 0.62 | io
stereovision0.v | XC7A200T | 0.06 | 0.73 | io
LU8PEEng.v | XC7A50T | 0.61 | 0.87 | io
bgm.v | XC7A75T | 0.45 | 0.95 | io
stereovision1.v | XC7A75T | 0.2 | 0.89 | DSP
stereovision2.v | XC7A200T | 0.21 | 0.66 | io
LU32PEEng.v | XC7A200T | 0.52 | 0.61 | CLB
mcml.v | XC7A200T | 0.68 | 0.79 | CLB
