### PR TITLE
[AP][GP] Added Post-Global Placement Wirelength Estimation

### DIFF
--- a/vpr/src/analytical_place/global_placer.cpp
+++ b/vpr/src/analytical_place/global_placer.cpp
@@ -127,7 +127,8 @@ static void print_placement_stats(const PartialPlacement& p_placement,
                                   FlatPlacementDensityManager& density_manager,
                                   const PreClusterTimingManager& pre_cluster_timing_manager) {
     // Print the placement HPWL
-    VTR_LOG("\tPlacement HPWL: %f\n", p_placement.get_hpwl(ap_netlist));
+    VTR_LOG("\tPlacement objective HPWL: %f\n", p_placement.get_hpwl(ap_netlist));
+    VTR_LOG("\tPlacement estimated wirelength: %u\n", p_placement.estimate_post_placement_wirelength(ap_netlist));
 
     // Print the timing information.
     if (pre_cluster_timing_manager.is_valid()) {

--- a/vpr/src/analytical_place/partial_placement.h
+++ b/vpr/src/analytical_place/partial_placement.h
@@ -146,6 +146,15 @@ struct PartialPlacement {
     double get_hpwl(const APNetlist& netlist) const;
 
     /**
+     * @brief Estimate the wirelength of the current placement assuming that all
+     *        blocks will be placed exactly where they are in the partial placement.
+     *
+     * NOTE: This is an underestimate of the actual wirelength mainly due to
+     *       the placement not being legalized yet.
+     */
+    double estimate_post_placement_wirelength(const APNetlist& netlist) const;
+
+    /**
      * @brief Verify the block_x_locs and block_y_locs vectors
      *
      * Currently ensures:

--- a/vtr_flow/parse/qor_config/qor_ap_fixed_chan_width.txt
+++ b/vtr_flow/parse/qor_config/qor_ap_fixed_chan_width.txt
@@ -2,7 +2,7 @@
 # channel width.
 
 vpr_status;output.txt;vpr_status=(.*)
-post_gp_hpwl;vpr.out;\s*Placement HPWL: (.*)
+post_gp_hpwl;vpr.out;\s*Placement estimated wirelength: (.*)
 post_fl_hpwl;vpr.out;Initial placement BB estimate of wirelength: (.*)
 post_dp_hpwl;vpr.out;BB estimate of min-dist \(placement\) wire length: (.*)
 total_wirelength;vpr.out;\s*Total wirelength: (\d+)


### PR DESCRIPTION
After a recent change where we are ignoring high-fanout nets in the global placer, this caused the high-fanout nets to also be ignored during wirlength estimation in the global placement.

This wirelength is used in the global placer to decide when to stop and to print logs to the user. I would like to continue to ignore these nets when computing the objective of the global placer since it is the wirelength of the nets which are not ignored; however, for the user, I would like them to see a more accurate estimation of the wirelength.

Created a function which tries to estimate the wirelength of the global placement solution assuming all blocks can be placed exactly where their flat placement wants them to be placed.

See https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/3137 for context.