### PR TITLE
Removed twist attribute from RR graph 

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_builder.cpp
+++ b/libs/librrgraph/src/base/rr_graph_builder.cpp
@@ -26,13 +26,9 @@ void RRGraphBuilder::add_node_to_all_locs(RRNodeId node) {
     e_rr_type node_type = node_storage_.node_type(node);
     short node_ptc_num = node_storage_.node_ptc_num(node);
     short node_layer = node_storage_.node_layer(node);
-    short node_twist = node_storage_.node_ptc_twist(node);
-    int node_offset = 0;
 
     for (int ix = node_storage_.node_xlow(node); ix <= node_storage_.node_xhigh(node); ix++) {
         for (int iy = node_storage_.node_ylow(node); iy <= node_storage_.node_yhigh(node); iy++) {
-            node_ptc_num += node_twist * node_offset;
-            node_offset++;
 
             switch (node_type) {
                 case e_rr_type::SOURCE:

--- a/libs/librrgraph/src/base/rr_graph_builder.h
+++ b/libs/librrgraph/src/base/rr_graph_builder.h
@@ -205,11 +205,6 @@ class RRGraphBuilder {
         node_storage_.set_node_layer(id, layer);
     }
 
-    /** @brief set the ptc twist increment number for TILEABLE rr graphs (for more information see rr_graph_storage.h twist increment comment) */
-    inline void set_node_ptc_twist_incr(RRNodeId id, int twist){
-        node_storage_.set_node_ptc_twist_incr(id, twist);
-    }
-
 
     /** @brief set_node_pin_num() is designed for logic blocks, which are IPIN and OPIN nodes */
     inline void set_node_pin_num(RRNodeId id, int new_pin_num) {
@@ -322,11 +317,6 @@ class RRGraphBuilder {
     }
     /** @brief This function resize node storage to accomidate size RR nodes. */
     inline void resize_nodes(size_t size) {
-        node_storage_.resize(size);
-    }
-
-    /** @brief This function resize node ptc twist increment; Since it is only used for tileable rr-graph, we don't put it in general resize function*/
-    inline void resize_ptc_twist_incr(size_t size){
         node_storage_.resize(size);
     }
 

--- a/libs/librrgraph/src/base/rr_graph_storage.cpp
+++ b/libs/librrgraph/src/base/rr_graph_storage.cpp
@@ -635,11 +635,6 @@ void t_rr_graph_storage::set_node_layer(RRNodeId id, short layer) {
     node_layer_[id] = layer;
 }
 
-void t_rr_graph_storage::set_node_ptc_twist_incr(RRNodeId id, short twist_incr){
-    VTR_ASSERT(!node_ptc_twist_incr_.empty());
-    node_ptc_twist_incr_[id] = twist_incr;
-}
-
 void t_rr_graph_storage::set_node_ptc_num(RRNodeId id, int new_ptc_num) {
     node_ptc_[id].ptc_.pin_num = new_ptc_num; //TODO: eventually remove
 }
@@ -821,7 +816,6 @@ t_rr_graph_view t_rr_graph_storage::view() const {
         vtr::make_const_array_view_id(node_fan_in_),
         vtr::make_const_array_view_id(node_layer_),
         node_name_,
-        vtr::make_const_array_view_id(node_ptc_twist_incr_),
         vtr::make_const_array_view_id(edge_src_node_),
         vtr::make_const_array_view_id(edge_dest_node_),
         vtr::make_const_array_view_id(edge_switch_),

--- a/libs/librrgraph/src/base/rr_graph_storage.h
+++ b/libs/librrgraph/src/base/rr_graph_storage.h
@@ -251,18 +251,6 @@ class t_rr_graph_storage {
         return std::nullopt;  // Return an empty optional if key is not found
     }
 
-    /** @brief Find the twist number that RR node uses to change ptc number across the same track.
-     * By default this number is zero, meaning that ptc number across the same track should be the same.
-     * This number is only meaningful for CHANX/CHANY nodes, not the other nodes.
-     */
-    short node_ptc_twist(RRNodeId id) const{
-        //check whether node_ptc_twist_incr has been allocated
-        if(node_ptc_twist_incr_.empty()){
-            return 0;
-        }
-        return node_ptc_twist_incr_[id];
-    }
-
     /**
      * @brief Returns the node ID of the virtual sink for the specified clock network name.
      *
@@ -504,7 +492,6 @@ class t_rr_graph_storage {
         node_ptc_.reserve(node_storage_.capacity());
         node_ptc_.resize(node_storage_.size());
         node_layer_.resize(node_storage_.size());
-        node_ptc_twist_incr_.resize(node_storage_.size());
     }
 
     /** @brief  Reserve storage for RR nodes. */
@@ -523,11 +510,6 @@ class t_rr_graph_storage {
         node_storage_.resize(size);
         node_ptc_.resize(size);
         node_layer_.resize(size);
-    }
-
-    /** @brief We only allocate the ptc twist increment array while building tileable rr-graphs */
-    void resize_ptc_twist_incr(size_t size){
-        node_ptc_twist_incr_.resize(size);
     }
 
     /** @brief Number of RR nodes that can be accessed. */
@@ -551,7 +533,6 @@ class t_rr_graph_storage {
         node_layer_.clear();
         node_name_.clear();
         virtual_clock_network_root_idx_.clear();
-        node_ptc_twist_incr_.clear();
         edge_src_node_.clear();
         edge_dest_node_.clear();
         edge_switch_.clear();
@@ -585,7 +566,6 @@ class t_rr_graph_storage {
         node_first_edge_.shrink_to_fit();
         node_fan_in_.shrink_to_fit();
         node_layer_.shrink_to_fit();
-        node_ptc_twist_incr_.shrink_to_fit();
         edge_src_node_.shrink_to_fit();
         edge_dest_node_.shrink_to_fit();
         edge_switch_.shrink_to_fit();
@@ -620,7 +600,6 @@ class t_rr_graph_storage {
     void set_node_name(RRNodeId id, const std::string& new_name);
     void set_node_coordinates(RRNodeId id, short x1, short y1, short x2, short y2);
     void set_node_layer(RRNodeId id, short layer);
-    void set_node_ptc_twist_incr(RRNodeId id, short twist);
     void set_node_cost_index(RRNodeId, RRIndexedDataId new_cost_index);
     void set_node_rc_index(RRNodeId, NodeRCIndex new_rc_index);
     void set_node_capacity(RRNodeId, short new_capacity);
@@ -872,15 +851,6 @@ class t_rr_graph_storage {
      */
     std::unordered_map<std::string, RRNodeId> virtual_clock_network_root_idx_;
 
-    /** @brief
-     *Twist Increment number is defined for CHANX/CHANY nodes; it is useful for layout of tileable FPGAs used by openFPGA.
-     *It gives us a new track index in each tile a longer wire crosses, which enables us to make long wires with a repeated single-tile pattern that "twists" the wires as they cross the tile.
-     *For example, an L4 wire would change tracks 4 times with metal shorts [e.g. 0, 2, 4, 6] and track 6 would drive a switch -- together this implements an L4 wire with only one layout tile.
-     * Twist increment number is only meaningful for CHANX and CHANY nodes; it is 0 for other node types.
-     * We also don't bother allocating this storage if the FPGA is not specified to be tileable; instead in that case the twist for all nodes will always be returned as 0.
-     */
-    vtr::vector<RRNodeId, short> node_ptc_twist_incr_;
-
     /** @brief Edge storage */
     vtr::vector<RREdgeId, RRNodeId> edge_src_node_;
     vtr::vector<RREdgeId, RRNodeId> edge_dest_node_;
@@ -954,7 +924,6 @@ class t_rr_graph_view {
         const vtr::array_view_id<RRNodeId, const t_edge_size> node_fan_in,
         const vtr::array_view_id<RRNodeId, const short> node_layer,
         const std::unordered_map<RRNodeId, std::string>& node_name,
-        const vtr::array_view_id<RRNodeId, const short> node_ptc_twist_incr,
         const vtr::array_view_id<RREdgeId, const RRNodeId> edge_src_node,
         const vtr::array_view_id<RREdgeId, const RRNodeId> edge_dest_node,
         const vtr::array_view_id<RREdgeId, const short> edge_switch,
@@ -965,7 +934,6 @@ class t_rr_graph_view {
         , node_fan_in_(node_fan_in)
         , node_layer_(node_layer)
         , node_name_(node_name)
-        , node_ptc_twist_incr_(node_ptc_twist_incr)
         , edge_src_node_(edge_src_node)
         , edge_dest_node_(edge_dest_node)
         , edge_switch_(edge_switch)
@@ -1053,20 +1021,6 @@ class t_rr_graph_view {
             return &it->second;  // Return the value if key is found
         }
         return std::nullopt;  // Return an empty optional if key is not found
-    }
-
-    /**
-     * @brief Retrieve the twist number (if available) that the given RRNodeId used for its PTC number.
-     *
-     * @param id The RRNodeId for which to retrieve the twist number.
-     * @return The twist number used for the PTC number, or a default value if not available.
-     */
-    short node_ptc_twist_incr(RRNodeId id) const{
-        //check if ptc twist increment allocated
-        if(node_ptc_twist_incr_.empty()){
-            return 0; //if it is not allocated we just assume that is zero
-        }
-        return node_ptc_twist_incr_[id];
     }
 
     /**
@@ -1183,7 +1137,6 @@ class t_rr_graph_view {
     vtr::array_view_id<RRNodeId, const t_edge_size> node_fan_in_;
     vtr::array_view_id<RRNodeId, const short> node_layer_;
     const std::unordered_map<RRNodeId, std::string>& node_name_;
-    vtr::array_view_id<RRNodeId, const short> node_ptc_twist_incr_;
     vtr::array_view_id<RREdgeId, const RRNodeId> edge_src_node_;
     vtr::array_view_id<RREdgeId, const RRNodeId> edge_dest_node_;
     vtr::array_view_id<RREdgeId, const short> edge_switch_;

--- a/libs/librrgraph/src/base/rr_graph_view.h
+++ b/libs/librrgraph/src/base/rr_graph_view.h
@@ -223,12 +223,6 @@ class RRGraphView {
         return node_storage_.node_layer(node);
     }
 
-    /** @brief Return the ptc number twist of a specified node.
-    */
-    inline short node_ptc_twist(RRNodeId node) const {
-        return node_storage_.node_ptc_twist(node);
-    }
-
     /** @brief Return the first outgoing edge of a specified node.
     */
     inline RREdgeId node_first_edge(RRNodeId node) const {

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx.h
@@ -4,10 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcxx.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-
- * md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: dcf32619cae0c49d168a2575bdb00896
  */
 
 #include <functional>
@@ -202,15 +201,10 @@ inline void write_rr_graph_xml(T &in, Context &context, std::ostream &os){
 }
 
 
-#if defined(_MSC_VER)
-typedef const uint32_t __declspec(align(1)) triehash_uu32;
-typedef const uint64_t __declspec(align(1)) triehash_uu64;
-#else
 typedef const uint32_t __attribute__((aligned(1))) triehash_uu32;
 typedef const uint64_t __attribute__((aligned(1))) triehash_uu64;
 static_assert(alignof(triehash_uu32) == 1, "Unaligned 32-bit access not found.");
 static_assert(alignof(triehash_uu64) == 1, "Unaligned 64-bit access not found.");
-#endif
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define onechar(c, s, l) (((uint64_t)(c)) << (s))
 #else
@@ -281,8 +275,8 @@ constexpr const char *atok_lookup_t_grid_loc[] = {"block_type_id", "height_offse
 enum class gtok_t_grid_locs {GRID_LOC};
 constexpr const char *gtok_lookup_t_grid_locs[] = {"grid_loc"};
 
-enum class atok_t_node_loc {LAYER, PTC, SIDE, TWIST, XHIGH, XLOW, YHIGH, YLOW};
-constexpr const char *atok_lookup_t_node_loc[] = {"layer", "ptc", "side", "twist", "xhigh", "xlow", "yhigh", "ylow"};
+enum class atok_t_node_loc {LAYER, PTC, SIDE, XHIGH, XLOW, YHIGH, YLOW};
+constexpr const char *atok_lookup_t_node_loc[] = {"layer", "ptc", "side", "xhigh", "xlow", "yhigh", "ylow"};
 
 
 enum class atok_t_node_timing {C, R};
@@ -1166,14 +1160,6 @@ inline atok_t_node_loc lex_attr_t_node_loc(const char *in, const std::function<v
 			switch(in[4]){
 			case onechar('r', 0, 8):
 				return atok_t_node_loc::LAYER;
-			break;
-			default: break;
-			}
-		break;
-		case onechar('t', 0, 32) | onechar('w', 8, 32) | onechar('i', 16, 32) | onechar('s', 24, 32):
-			switch(in[4]){
-			case onechar('t', 0, 8):
-				return atok_t_node_loc::TWIST;
 			break;
 			default: break;
 			}
@@ -2475,7 +2461,7 @@ inline void load_grid_loc_required_attributes(const pugi::xml_node &root, int * 
 }
 
 inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * ptc, int * xhigh, int * xlow, int * yhigh, int * ylow, const std::function<void(const char *)> * report_error){
-	std::bitset<8> astate = 0;
+	std::bitset<7> astate = 0;
 	for(pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()){
 		atok_t_node_loc in = lex_attr_t_node_loc(attr.name(), report_error);
 		if(astate[(int)in] == 0) astate[(int)in] = 1;
@@ -2489,9 +2475,6 @@ inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * 
 			break;
 		case atok_t_node_loc::SIDE:
 			/* Attribute side set after element init */
-			break;
-		case atok_t_node_loc::TWIST:
-			/* Attribute twist set after element init */
 			break;
 		case atok_t_node_loc::XHIGH:
 			*xhigh = load_int(attr.value(), report_error);
@@ -2508,7 +2491,7 @@ inline void load_node_loc_required_attributes(const pugi::xml_node &root, int * 
 		default: break; /* Not possible. */
 		}
 	}
-	std::bitset<8> test_astate = astate | std::bitset<8>(0b00001101);
+	std::bitset<7> test_astate = astate | std::bitset<7>(0b0000101);
 	if(!test_astate.all()) attr_error(test_astate, atok_lookup_t_node_loc, report_error);
 }
 
@@ -3432,9 +3415,6 @@ inline void load_node_loc(const pugi::xml_node &root, T &out, Context &context, 
 		case atok_t_node_loc::SIDE:
 			out.set_node_loc_side(lex_enum_loc_side(attr.value(), true, report_error), context);
 			break;
-		case atok_t_node_loc::TWIST:
-			out.set_node_loc_twist(load_int(attr.value(), report_error), context);
-			break;
 		case atok_t_node_loc::XHIGH:
 			/* Attribute xhigh is already set */
 			break;
@@ -4175,8 +4155,6 @@ inline void write_node(T &in, std::ostream &os, Context &context){
 		os << " ptc=\"" << in.get_node_loc_ptc(child_context) << "\"";
 		if((bool)in.get_node_loc_side(child_context))
 			os << " side=\"" << lookup_loc_side[(int)in.get_node_loc_side(child_context)] << "\"";
-		if((bool)in.get_node_loc_twist(child_context))
-			os << " twist=\"" << in.get_node_loc_twist(child_context) << "\"";
 		os << " xhigh=\"" << in.get_node_loc_xhigh(child_context) << "\"";
 		os << " xlow=\"" << in.get_node_loc_xlow(child_context) << "\"";
 		os << " yhigh=\"" << in.get_node_loc_yhigh(child_context) << "\"";

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_capnp.h
@@ -4,10 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcap.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-
- * md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
+ * Cmdline: uxsdcxx/uxsdcap.py /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: dcf32619cae0c49d168a2575bdb00896
  */
 
 #include <functional>
@@ -764,7 +763,6 @@ inline void load_node_loc_capnp_type(const ucap::NodeLoc::Reader &root, T &out, 
 
 	out.set_node_loc_layer(root.getLayer(), context);
 	out.set_node_loc_side(conv_enum_loc_side(root.getSide(), report_error), context);
-	out.set_node_loc_twist(root.getTwist(), context);
 }
 
 template<class T, typename Context>
@@ -1224,8 +1222,6 @@ inline void write_node_capnp_type(T &in, ucap::Node::Builder &root, Context &con
 		node_loc.setPtc(in.get_node_loc_ptc(child_context));
 		if((bool)in.get_node_loc_side(child_context))
 			node_loc.setSide(conv_to_enum_loc_side(in.get_node_loc_side(child_context)));
-		if((bool)in.get_node_loc_twist(child_context))
-			node_loc.setTwist(in.get_node_loc_twist(child_context));
 		node_loc.setXhigh(in.get_node_loc_xhigh(child_context));
 		node_loc.setXlow(in.get_node_loc_xlow(child_context));
 		node_loc.setYhigh(in.get_node_loc_yhigh(child_context));

--- a/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
+++ b/libs/librrgraph/src/io/gen/rr_graph_uxsdcxx_interface.h
@@ -4,10 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx/uxsdcxx.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
- * Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-
- * md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
+ * Cmdline: uxsdcxx/uxsdcxx.py /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * Input file: /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+ * md5sum of input file: dcf32619cae0c49d168a2575bdb00896
  */
 
 #include <functional>
@@ -141,8 +140,8 @@ public:
 	 * <xs:complexType name="channels">
 	 *   <xs:sequence>
 	 *     <xs:element name="channel" type="channel" />
-	 *     <xs:element maxOccurs="unbounded" name="x_list" type="x_list" />
-	 *     <xs:element maxOccurs="unbounded" name="y_list" type="y_list" />
+	 *     <xs:element name="x_list" type="x_list" maxOccurs="unbounded" />
+	 *     <xs:element name="y_list" type="y_list" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 * </xs:complexType>
 	*/
@@ -193,7 +192,7 @@ public:
 	/** Generated for complex type "switch":
 	 * <xs:complexType name="switch">
 	 *   <xs:all>
-	 *     <xs:element minOccurs="0" name="timing" type="timing" />
+	 *     <xs:element name="timing" type="timing" minOccurs="0" />
 	 *     <xs:element name="sizing" type="sizing" />
 	 *   </xs:all>
 	 *   <xs:attribute name="id" type="xs:int" use="required" />
@@ -219,7 +218,7 @@ public:
 	/** Generated for complex type "switches":
 	 * <xs:complexType name="switches">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" name="switch" type="switch" />
+	 *     <xs:element name="switch" type="switch" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 * </xs:complexType>
 	*/
@@ -243,7 +242,7 @@ public:
 	/** Generated for complex type "segment":
 	 * <xs:complexType name="segment">
 	 *   <xs:all>
-	 *     <xs:element minOccurs="0" name="timing" type="segment_timing" />
+	 *     <xs:element name="timing" type="segment_timing" minOccurs="0" />
 	 *   </xs:all>
 	 *   <xs:attribute name="id" type="xs:int" use="required" />
 	 *   <xs:attribute name="length" type="xs:int" />
@@ -266,7 +265,7 @@ public:
 	/** Generated for complex type "segments":
 	 * <xs:complexType name="segments">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" name="segment" type="segment" />
+	 *     <xs:element name="segment" type="segment" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 * </xs:complexType>
 	*/
@@ -292,7 +291,7 @@ public:
 	/** Generated for complex type "pin_class":
 	 * <xs:complexType name="pin_class">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" name="pin" type="pin" />
+	 *     <xs:element name="pin" type="pin" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 *   <xs:attribute name="type" type="pin_type" use="required" />
 	 * </xs:complexType>
@@ -307,7 +306,7 @@ public:
 	/** Generated for complex type "block_type":
 	 * <xs:complexType name="block_type">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" minOccurs="0" name="pin_class" type="pin_class" />
+	 *     <xs:element name="pin_class" type="pin_class" minOccurs="0" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 *   <xs:attribute name="id" type="xs:int" use="required" />
 	 *   <xs:attribute name="name" type="xs:string" use="required" />
@@ -329,7 +328,7 @@ public:
 	/** Generated for complex type "block_types":
 	 * <xs:complexType name="block_types">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" name="block_type" type="block_type" />
+	 *     <xs:element name="block_type" type="block_type" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 * </xs:complexType>
 	*/
@@ -341,7 +340,7 @@ public:
 
 	/** Generated for complex type "grid_loc":
 	 * <xs:complexType name="grid_loc">
-	 *   <xs:attribute default="0" name="layer" type="xs:int" />
+	 *   <xs:attribute name="layer" type="xs:int" default="0" />
 	 *   <xs:attribute name="x" type="xs:int" use="required" />
 	 *   <xs:attribute name="y" type="xs:int" use="required" />
 	 *   <xs:attribute name="block_type_id" type="xs:int" use="required" />
@@ -360,7 +359,7 @@ public:
 	/** Generated for complex type "grid_locs":
 	 * <xs:complexType name="grid_locs">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" name="grid_loc" type="grid_loc" />
+	 *     <xs:element name="grid_loc" type="grid_loc" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 * </xs:complexType>
 	*/
@@ -372,14 +371,13 @@ public:
 
 	/** Generated for complex type "node_loc":
 	 * <xs:complexType name="node_loc">
-	 *   <xs:attribute default="0" name="layer" type="xs:int" />
+	 *   <xs:attribute name="layer" type="xs:int" default="0" />
 	 *   <xs:attribute name="xlow" type="xs:int" use="required" />
 	 *   <xs:attribute name="ylow" type="xs:int" use="required" />
 	 *   <xs:attribute name="xhigh" type="xs:int" use="required" />
 	 *   <xs:attribute name="yhigh" type="xs:int" use="required" />
 	 *   <xs:attribute name="side" type="loc_side" />
 	 *   <xs:attribute name="ptc" type="xs:int" use="required" />
-	 *   <xs:attribute name="twist" type="xs:int" />
 	 * </xs:complexType>
 	*/
 	virtual inline int get_node_loc_layer(typename ContextTypes::NodeLocReadContext &ctx) = 0;
@@ -387,8 +385,6 @@ public:
 	virtual inline int get_node_loc_ptc(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 	virtual inline enum_loc_side get_node_loc_side(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 	virtual inline void set_node_loc_side(enum_loc_side side, typename ContextTypes::NodeLocWriteContext &ctx) = 0;
-	virtual inline int get_node_loc_twist(typename ContextTypes::NodeLocReadContext &ctx) = 0;
-	virtual inline void set_node_loc_twist(int twist, typename ContextTypes::NodeLocWriteContext &ctx) = 0;
 	virtual inline int get_node_loc_xhigh(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 	virtual inline int get_node_loc_xlow(typename ContextTypes::NodeLocReadContext &ctx) = 0;
 	virtual inline int get_node_loc_yhigh(typename ContextTypes::NodeLocReadContext &ctx) = 0;
@@ -427,7 +423,7 @@ public:
 	/** Generated for complex type "metadata":
 	 * <xs:complexType name="metadata">
 	 *   <xs:sequence>
-	 *     <xs:element maxOccurs="unbounded" name="meta" type="meta" />
+	 *     <xs:element name="meta" type="meta" maxOccurs="unbounded" />
 	 *   </xs:sequence>
 	 * </xs:complexType>
 	*/
@@ -441,9 +437,9 @@ public:
 	 * <xs:complexType name="node">
 	 *   <xs:all>
 	 *     <xs:element name="loc" type="node_loc" />
-	 *     <xs:element minOccurs="0" name="timing" type="node_timing" />
-	 *     <xs:element minOccurs="0" name="segment" type="node_segment" />
-	 *     <xs:element minOccurs="0" name="metadata" type="metadata" />
+	 *     <xs:element name="timing" type="node_timing" minOccurs="0" />
+	 *     <xs:element name="segment" type="node_segment" minOccurs="0" />
+	 *     <xs:element name="metadata" type="metadata" minOccurs="0" />
 	 *   </xs:all>
 	 *   <xs:attribute name="id" type="xs:unsignedInt" use="required" />
 	 *   <xs:attribute name="type" type="node_type" use="required" />
@@ -494,7 +490,7 @@ public:
 	/** Generated for complex type "edge":
 	 * <xs:complexType name="edge">
 	 *   <xs:all>
-	 *     <xs:element minOccurs="0" name="metadata" type="metadata" />
+	 *     <xs:element name="metadata" type="metadata" minOccurs="0" />
 	 *   </xs:all>
 	 *   <xs:attribute name="src_node" type="xs:unsignedInt" use="required" />
 	 *   <xs:attribute name="sink_node" type="xs:unsignedInt" use="required" />

--- a/libs/librrgraph/src/io/rr_graph.xsd
+++ b/libs/librrgraph/src/io/rr_graph.xsd
@@ -282,7 +282,6 @@
     <xs:attribute name="yhigh" type="xs:int" use="required"/>
     <xs:attribute name="side" type="loc_side"/>
     <xs:attribute name="ptc" type="xs:int" use="required"/>
-    <xs:attribute name="twist" type="xs:int"/>
   </xs:complexType>
 
   <xs:complexType name="node_timing">

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -712,9 +712,6 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     inline int get_node_loc_layer(const t_rr_node& node) final {
         return rr_graph_->node_layer(node.id());
     }
-    inline int get_node_loc_twist(const t_rr_node& node) final{
-        return rr_graph_->node_ptc_twist(node.id());
-    }
     inline int get_node_loc_xhigh(const t_rr_node& node) final {
         return rr_graph_->node_xhigh(node.id());
     }
@@ -757,12 +754,6 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
                 }
             }
         }
-    }
-
-    inline void set_node_loc_twist(int twist, int& inode) final {
-        auto node = (*rr_nodes_)[inode];
-        RRNodeId node_id = node.id();
-        rr_graph_builder_->set_node_ptc_twist_incr(node_id,twist);
     }
 
     inline uxsd::enum_loc_side get_node_loc_side(const t_rr_node& node) final {

--- a/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
+++ b/libs/libvtrcapnproto/gen/rr_graph_uxsdcxx.capnp
@@ -2,12 +2,11 @@
 # https://github.com/duck2/uxsdcxx
 # Modify only if your build process doesn't involve regenerating this file.
 #
-# Cmdline: uxsdcxx/uxsdcap.py /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
-# Input file: /home/mohagh18/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# Cmdline: uxsdcxx/uxsdcap.py /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# Input file: /home/smahmoudi/vtr-verilog-to-routing/libs/librrgraph/src/io/rr_graph.xsd
+# md5sum of input file: dcf32619cae0c49d168a2575bdb00896
 
-# md5sum of input file: 65eddcc840064bbb91d7f4cf0b8bf821
-
-@0xe787bf7696810419;
+@0xbc43d9d3589ccc58;
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ucap");
 
@@ -180,11 +179,10 @@ struct NodeLoc {
 	layer @0 :Int32 = 0;
 	ptc @1 :Int32;
 	side @2 :LocSide;
-	twist @3 :Int32;
-	xhigh @4 :Int32;
-	xlow @5 :Int32;
-	yhigh @6 :Int32;
-	ylow @7 :Int32;
+	xhigh @3 :Int32;
+	xlow @4 :Int32;
+	yhigh @5 :Int32;
+	ylow @6 :Int32;
 }
 
 struct NodeTiming {

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -1473,26 +1473,6 @@ static void build_rr_graph(e_graph_type graph_type,
         }
     }
 
-    /*Update rr_nodes ptc_twist_incr number if we are creating tileable graph*/
-    if (graph_type == e_graph_type::UNIDIR_TILEABLE) {
-        device_ctx.rr_graph_builder.resize_ptc_twist_incr(num_rr_nodes);
-        for (int rr_node_id = 0; rr_node_id < num_rr_nodes; rr_node_id++) {
-            auto node_type = rr_graph.node_type(RRNodeId(rr_node_id));
-            auto node_dir = rr_graph.node_direction(RRNodeId(rr_node_id));
-            if (node_type != e_rr_type::CHANX && node_type != e_rr_type::CHANY) { //SRC/SINK/IPIN/OPIN
-                device_ctx.rr_graph_builder.set_node_ptc_twist_incr(RRNodeId(rr_node_id), 0);
-            } else {
-                //The current ptc twist increment number in UNDIR TILEABLE RRGraph is 2 and -2
-                //The assumption should be synced up with openFPGA branch
-                if (node_dir == Direction::INC) {
-                    device_ctx.rr_graph_builder.set_node_ptc_twist_incr(RRNodeId(rr_node_id), 2);
-                } else {
-                    device_ctx.rr_graph_builder.set_node_ptc_twist_incr(RRNodeId(rr_node_id), -2);
-                }
-            }
-        }
-    }
-
     update_chan_width(&nodes_per_chan);
 
     /* Allocate and load routing resource switches, which are derived from the switches from the architecture file,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
While ago, we added a new attribute called "twist" to handle tileable rr-graph ptc numbers in [this PR](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2378). As OpenFPGA branch has fixed the issue in another way, this attribute is no longer needed, thus I cleaned up the code and remove all unnecessary functions that uses this values.
