### PR TITLE
[AP][DP] Added Option to Scale Init T in Annealer

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -810,6 +810,22 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
 
     **Default:** ``circuit``
 
+.. option:: --anneal_auto_init_t_scale <float>
+
+    A scale on the starting temperature of the anneal for the automatic annealing
+    schedule.
+
+    When in the automatic annealing schedule, the annealer will select a good
+    initial temperature based on the quality of the initial placement. This option
+    allows you to scale that initial temperature up or down by multiplying the
+    initial temperature by the given scale. Increasing this number
+    will increase the initial temperature which will have the annealer potentially
+    explore more of the space at the expense of run time. Depending on the quality
+    of the initial placement, this may improve or hurt the quality of the final
+    placement.
+
+    **Default:** ``1.0``
+
 .. option:: --init_t <float>
 
     The starting temperature of the anneal for the manual annealing schedule.

--- a/vpr/src/analytical_place/detailed_placer.cpp
+++ b/vpr/src/analytical_place/detailed_placer.cpp
@@ -75,6 +75,19 @@ AnnealerDetailedPlacer::AnnealerDetailedPlacer(const BlkLocRegistry& curr_cluste
         }
     }
 
+    // The solution produced by the AP flow is significantly better than the
+    // initial placement solution produced by the initial placer in the default
+    // flow. Even though the annealer auto-selects its initial temperature based
+    // on the quality of the placement, we found that the initial temperatute was
+    // still too high and it was hurting quality. This scales down the initial
+    // temperature auto-selected by the annealer to prevent this and improve
+    // runtime.
+    // Here we still scale by whatever the user passed in to scale the initial
+    // temperature by, but we also scale it down further. This allows AP to scale
+    // the initial temperature down by default, while still allowing the user
+    // some control.
+    float anneal_auto_init_t_scale = vpr_setup.PlacerOpts.place_auto_init_t_scale * 0.5f;
+
     placer_ = std::make_unique<Placer>((const Netlist<>&)clustered_netlist,
                                        curr_clustered_placement,
                                        vpr_setup.PlacerOpts,
@@ -84,6 +97,7 @@ AnnealerDetailedPlacer::AnnealerDetailedPlacer(const BlkLocRegistry& curr_cluste
                                        netlist_pin_lookup_,
                                        FlatPlacementInfo(),
                                        place_delay_model,
+                                       anneal_auto_init_t_scale,
                                        g_vpr_ctx.placement().cube_bb,
                                        false /*is_flat*/,
                                        false /*quiet*/);

--- a/vpr/src/base/CheckSetup.cpp
+++ b/vpr/src/base/CheckSetup.cpp
@@ -69,6 +69,11 @@ void CheckSetup(const t_packer_opts& packer_opts,
                         NUM_PL_MOVE_TYPES);
     }
 
+    if (placer_opts.place_auto_init_t_scale < 0.0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                        "Cannot have negative annealer auto initial temperature scale.\n");
+    }
+
     // Rules for doing Analytical Placement
     if (ap_opts.doAP) {
         // Make sure that the --place option was not set.

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -703,6 +703,8 @@ static void SetupPlacerOpts(const t_options& Options, t_placer_opts* PlacerOpts)
 
     PlacerOpts->placer_debug_block = Options.placer_debug_block;
     PlacerOpts->placer_debug_net = Options.placer_debug_net;
+
+    PlacerOpts->place_auto_init_t_scale = Options.place_auto_init_t_scale.value();
 }
 
 static void SetupAnalysisOpts(const t_options& Options, t_analysis_opts& analysis_opts) {

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2200,6 +2200,22 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("circuit")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    place_grp.add_argument(args.place_auto_init_t_scale, "--anneal_auto_init_t_scale")
+        .help(
+            "A scale on the starting temperature of the anneal for the automatic annealing "
+            "schedule.\n"
+            "\n"
+            "When in the automatic annealing schedule, the annealer will select a good "
+            "initial temperature based on the quality of the initial placement. This option "
+            "allows you to scale that initial temperature up or down by multiplying the "
+            "initial temperature by the given scale. Increasing this number "
+            "will increase the initial temperature which will have the annealer potentially "
+            "explore more of the space at the expense of run time. Depending on the quality "
+            "of the initial placement, this may improve or hurt the quality of the final "
+            "placement.")
+        .default_value("1.0")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     place_grp.add_argument(args.PlaceInitT, "--init_t")
         .help("Initial temperature for manual annealing schedule")
         .default_value("100.0")

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -129,6 +129,7 @@ struct t_options {
     argparse::ArgValue<int> Seed;
     argparse::ArgValue<bool> ShowPlaceTiming;
     argparse::ArgValue<float> PlaceInnerNum;
+    argparse::ArgValue<float> place_auto_init_t_scale;
     argparse::ArgValue<float> PlaceInitT;
     argparse::ArgValue<float> PlaceExitT;
     argparse::ArgValue<float> PlaceAlphaT;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1004,8 +1004,9 @@ enum class e_move_type;
  *   @param place_constraint_subtile
  *              True if subtiles should be specified when printing floorplan
  *              constraints. False if not.
- *
- *
+ *   @param place_auto_init_t_scale
+ *              When the annealer is using the automatic schedule, this option
+ *              scales the initial temperature selected.
  */
 struct t_placer_opts {
     t_place_algorithm place_algorithm;
@@ -1077,6 +1078,8 @@ struct t_placer_opts {
     std::string allowed_tiles_for_delay_model;
 
     e_place_delta_delay_algorithm place_delta_delay_matrix_calculation_method;
+
+    float place_auto_init_t_scale;
 };
 
 /******************************************************************

--- a/vpr/src/place/annealer.cpp
+++ b/vpr/src/place/annealer.cpp
@@ -206,6 +206,7 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
                                      PlacerSetupSlacks* setup_slacks,
                                      SetupTimingInfo* timing_info,
                                      NetPinTimingInvalidator* pin_timing_invalidator,
+                                     float auto_init_t_scale,
                                      int move_lim)
     : placer_opts_(placer_opts)
     , placer_state_(placer_state)
@@ -285,7 +286,8 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
     move_type_stats_.rejected_moves.resize({device_ctx.logical_block_types.size(), (int)e_move_type::NUMBER_OF_AUTO_MOVES}, 0);
 
     // Update the starting temperature for placement annealing to a more appropriate value
-    annealing_state_.t = estimate_starting_temperature_();
+    VTR_ASSERT_SAFE_MSG(auto_init_t_scale >= 0, "Initial temperature scale cannot be negative.");
+    annealing_state_.t = estimate_starting_temperature_() * auto_init_t_scale;
 }
 
 float PlacementAnnealer::estimate_starting_temperature_() {

--- a/vpr/src/place/annealer.h
+++ b/vpr/src/place/annealer.h
@@ -185,6 +185,7 @@ class PlacementAnnealer {
                       PlacerSetupSlacks* setup_slacks,
                       SetupTimingInfo* timing_info,
                       NetPinTimingInvalidator* pin_timing_invalidator,
+                      float auto_init_t_scale,
                       int move_lim);
 
     /**

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -112,7 +112,8 @@ void try_place(const Netlist<>& net_list,
     ClusteredPinAtomPinsLookup netlist_pin_lookup(cluster_ctx.clb_nlist, atom_ctx.netlist(), pb_gpin_lookup);
 
     Placer placer(net_list, {}, placer_opts, analysis_opts, noc_opts, pb_gpin_lookup, netlist_pin_lookup,
-                  flat_placement_info, place_delay_model, mutable_placement.cube_bb, is_flat, /*quiet=*/false);
+                  flat_placement_info, place_delay_model, placer_opts.place_auto_init_t_scale,
+                  mutable_placement.cube_bb, is_flat, /*quiet=*/false);
 
     placer.place();
 

--- a/vpr/src/place/placer.cpp
+++ b/vpr/src/place/placer.cpp
@@ -35,6 +35,7 @@ Placer::Placer(const Netlist<>& net_list,
                const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
                const FlatPlacementInfo& flat_placement_info,
                std::shared_ptr<PlaceDelayModel> place_delay_model,
+               float anneal_auto_init_t_scale,
                bool cube_bb,
                bool is_flat,
                bool quiet)
@@ -152,6 +153,7 @@ Placer::Placer(const Netlist<>& net_list,
     annealer_ = std::make_unique<PlacementAnnealer>(placer_opts_, placer_state_, place_macros, costs_, net_cost_handler_, noc_cost_handler_,
                                                     noc_opts_, rng_, std::move(move_generator), std::move(move_generator2), place_delay_model_.get(),
                                                     placer_criticalities_.get(), placer_setup_slacks_.get(), timing_info_.get(), pin_timing_invalidator_.get(),
+                                                    anneal_auto_init_t_scale,
                                                     move_lim);
 }
 

--- a/vpr/src/place/placer.h
+++ b/vpr/src/place/placer.h
@@ -49,6 +49,7 @@ class Placer {
            const ClusteredPinAtomPinsLookup& netlist_pin_lookup,
            const FlatPlacementInfo& flat_placement_info,
            std::shared_ptr<PlaceDelayModel> place_delay_model,
+           float anneal_auto_init_t_scale,
            bool cube_bb,
            bool is_flat,
            bool quiet);


### PR DESCRIPTION
Since the AP flow produces an initial placement that has 4x improved estimated wirelength and 2x improved CPD, the initial temperature of the annealer is too high. From experimentation, I have found that reducing the initial temperature in half improves quality slightly and reduces runtime.

Added an option to the Placer to scale up or down the initial temperature. The default flow just sets this scale to 1.0, but the AP flow sets this scale to 0.5 currently.

I have also exposed this option to the command-line so this option can be swept more easily.

Results on VTR with AP (timing driven, no fixed IOs):

Init T Scale | Post-DP HPWL | Post-DP CPD | Final Wirelength | Final CPD | DP Run Time | Routing Run Time | Total Run Time
-- | -- | -- | -- | -- | -- | -- | --
1.0000 | 1.00 | 1.00 | 1.00 | 1.00 | 1.00 | 1.00 | 1.00
0.5000 | 0.99 | 0.99 | 0.99 | 1.00 | 0.85 | 1.01 | 0.96
0.2500 | 1.02 | 1.00 | 1.01 | 1.01 | 0.70 | 1.01 | 0.92
0.1250 | 1.04 | 1.00 | 1.03 | 1.01 | 0.57 | 1.02 | 0.88
0.0625 | 1.05 | 1.00 | 1.04 | 1.01 | 0.47 | 1.07 | 0.84

Scaling the initial temperature does hurt wirelength and CPD; however, reducing it by 0.5 hits a minimum point. Refarding run time, decreasing the initial temperature greatly reduces the runtime of DP which results in an overall runtime improvement. Routing takes more and more time, which implies to me that the circuit may be becoming more difficult to route, but that may just be caused by the increase in wirelength.

Overall, setting the initial temperature scale to 0.5 for AP makes sense since it improves on practically all metrics. I am running Titan now. I predict that Titan may prefer to set the scale to 0.25 (which I would prefer too).

Future work is to investigate sweeping inner_num with this scale to find a good combination of the two to get better quality and run time.