### PR TITLE
[Packer] Reorganized Iterative Packer Algorithm

### DIFF
--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -145,7 +145,39 @@ bool try_pack(const t_packer_opts& packer_opts,
 
     g_vpr_ctx.mutable_atom().mutable_lookup().set_atom_pb_bimap_lock(true);
 
-    while (true) {
+    /**
+     * @brief Enumeration for the state of the packer.
+     *
+     * If the packer fails to find a dense enough packing, depending on how the
+     * packer failed, the packer may iteratively retry packing with different
+     * setting to try and find a denser packing. These states represent a
+     * different type of iteration.
+     */
+    enum class e_packer_state {
+        /// @brief Default packer state.
+        DEFAULT,
+        /// @brief Succcess state for the packer.
+        SUCCESS,
+        /// @brief Standard fallback where there is not region constraints. Turns
+        ///        on unrelated clustering and balanced packing if it can.
+        UNRELATED_AND_BALANCED,
+        /// @brief Region constraints: Turns on attraction groups for overfilled regions.
+        ATTRACTION_GROUPS,
+        /// @brief Region constraints: Turns on more attraction groups for overfilled regions.
+        MORE_ATTRACTION_GROUPS,
+        /// @brief Region constraints: Turns on more attraction groups for all regions.
+        ATTRACTION_GROUPS_ALL_REGIONS,
+        /// @brief Region constraints: Turns on more attraction groups for all regions
+        ///        and increases the target density of clb blocks.
+        ATTRACTION_GROUPS_ALL_REGIONS_AND_INCREASED_TARGET_DENSITY,
+        /// @brief The failure state.
+        FAILURE
+    };
+
+    // The current state of the packer during iterative packing.
+    e_packer_state current_packer_state = e_packer_state::DEFAULT;
+
+    while (current_packer_state != e_packer_state::SUCCESS && current_packer_state != e_packer_state::FAILURE) {
         //Cluster the netlist
         //  num_used_type_instances: A map used to save the number of used
         //                           instances from each logical block type.
@@ -170,48 +202,98 @@ bool try_pack(const t_packer_opts& packer_opts,
 
         bool floorplan_not_fitting = (floorplan_regions_overfull || g_vpr_ctx.floorplanning().constraints.get_num_partitions() > 0);
 
+        // Next packer state logic
+        e_packer_state next_packer_state = e_packer_state::FAILURE;
         if (fits_on_device && !floorplan_regions_overfull) {
-            break; //Done
-        } else if (pack_iteration == 1 && !floorplan_not_fitting) {
-            //1st pack attempt was unsuccessful (i.e. not dense enough) and we have control of unrelated clustering
-            //
-            //Turn it on to increase packing density
-            if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
-                VTR_ASSERT(allow_unrelated_clustering == false);
-                allow_unrelated_clustering = true;
+            // If everything fits on the device and the floorplan regions are
+            // not overfilled, the next state is success.
+            next_packer_state = e_packer_state::SUCCESS;
+        } else {
+            if (floorplan_not_fitting) {
+                // If there are overfilled region constraints.
+                /*
+                 * When running with tight floorplan constraints, some regions may become overfull with clusters (i.e.
+                 * the number of blocks assigned to the region exceeds the number of blocks available). When this occurs, we
+                 * cluster more densely to be able to adhere to the floorplan constraints. However, we do not want to cluster more
+                 * densely unnecessarily, as this can negatively impact wirelength. So, we have iterative approach. We check at the end
+                 * of every iteration if any floorplan regions are overfull. In the first iteration, we run
+                 * with no attraction groups (not packing more densely). If regions are overfull at the end of the first iteration,
+                 * we create attraction groups for partitions with overfull regions (pack those atoms more densely). We continue this way
+                 * until the last iteration, when we create attraction groups for every partition, if needed.
+                 */
+                switch (current_packer_state) {
+                    case e_packer_state::DEFAULT:
+                        next_packer_state = e_packer_state::ATTRACTION_GROUPS;
+                        break;
+                    case e_packer_state::UNRELATED_AND_BALANCED:
+                    case e_packer_state::ATTRACTION_GROUPS:
+                        next_packer_state = e_packer_state::MORE_ATTRACTION_GROUPS;
+                        break;
+                    case e_packer_state::MORE_ATTRACTION_GROUPS:
+                        next_packer_state = e_packer_state::ATTRACTION_GROUPS_ALL_REGIONS;
+                        break;
+                    case e_packer_state::ATTRACTION_GROUPS_ALL_REGIONS:
+                        next_packer_state = e_packer_state::ATTRACTION_GROUPS_ALL_REGIONS_AND_INCREASED_TARGET_DENSITY;
+                        break;
+                    case e_packer_state::ATTRACTION_GROUPS_ALL_REGIONS_AND_INCREASED_TARGET_DENSITY:
+                    default:
+                        next_packer_state = e_packer_state::FAILURE;
+                        break;
+                }
+            } else {
+                // If there are no overfilled region constraints.
+                switch (current_packer_state) {
+                    case e_packer_state::DEFAULT:
+                        next_packer_state = e_packer_state::UNRELATED_AND_BALANCED;
+                        break;
+                    default:
+                        next_packer_state = e_packer_state::FAILURE;
+                        break;
+                }
             }
-            if (packer_opts.balance_block_type_utilization == e_balance_block_type_util::AUTO) {
-                VTR_ASSERT(balance_block_type_util == false);
-                balance_block_type_util = true;
-            }
-            VTR_LOG("Packing failed to fit on device. Re-packing with: unrelated_logic_clustering=%s balance_block_type_util=%s\n",
-                    (allow_unrelated_clustering ? "true" : "false"),
-                    (balance_block_type_util ? "true" : "false"));
-            /*
-             * When running with tight floorplan constraints, some regions may become overfull with clusters (i.e.
-             * the number of blocks assigned to the region exceeds the number of blocks available). When this occurs, we
-             * cluster more densely to be able to adhere to the floorplan constraints. However, we do not want to cluster more
-             * densely unnecessarily, as this can negatively impact wirelength. So, we have iterative approach. We check at the end
-             * of every iteration if any floorplan regions are overfull. In the first iteration, we run
-             * with no attraction groups (not packing more densely). If regions are overfull at the end of the first iteration,
-             * we create attraction groups for partitions with overfull regions (pack those atoms more densely). We continue this way
-             * until the last iteration, when we create attraction groups for every partition, if needed.
-             */
-        } else if (pack_iteration == 1 && floorplan_not_fitting) {
-            VTR_LOG("Floorplan regions are overfull: trying to pack again using cluster attraction groups. \n");
-            attraction_groups.create_att_groups_for_overfull_regions(overfull_partition_regions);
-            attraction_groups.set_att_group_pulls(1);
+        }
 
-        } else if (pack_iteration >= 2 && pack_iteration < 5 && floorplan_not_fitting) {
-            if (pack_iteration == 2) {
+        // Set up for the next packer state.
+        switch (next_packer_state) {
+            case e_packer_state::UNRELATED_AND_BALANCED: {
+                //1st pack attempt was unsuccessful (i.e. not dense enough) and we have control of unrelated clustering
+                //
+                //Turn it on to increase packing density
+                // TODO: This will have no affect if unrelated clustering and
+                //       balance block type utilization is not auto. Should update
+                //       the next state logic.
+                if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
+                    VTR_ASSERT(allow_unrelated_clustering == false);
+                    allow_unrelated_clustering = true;
+                }
+                if (packer_opts.balance_block_type_utilization == e_balance_block_type_util::AUTO) {
+                    VTR_ASSERT(balance_block_type_util == false);
+                    balance_block_type_util = true;
+                }
+                VTR_LOG("Packing failed to fit on device. Re-packing with: unrelated_logic_clustering=%s balance_block_type_util=%s\n",
+                        (allow_unrelated_clustering ? "true" : "false"),
+                        (balance_block_type_util ? "true" : "false"));
+                break;
+            }
+            case e_packer_state::ATTRACTION_GROUPS: {
+                VTR_LOG("Floorplan regions are overfull: trying to pack again using cluster attraction groups. \n");
+                attraction_groups.create_att_groups_for_overfull_regions(overfull_partition_regions);
+                attraction_groups.set_att_group_pulls(1);
+                break;
+            }
+            case e_packer_state::MORE_ATTRACTION_GROUPS: {
                 VTR_LOG("Floorplan regions are overfull: trying to pack again with more attraction groups exploration. \n");
                 attraction_groups.create_att_groups_for_overfull_regions(overfull_partition_regions);
                 VTR_LOG("Pack iteration is %d\n", pack_iteration);
-            } else if (pack_iteration == 3) {
+                break;
+            }
+            case e_packer_state::ATTRACTION_GROUPS_ALL_REGIONS: {
                 attraction_groups.create_att_groups_for_all_regions();
                 VTR_LOG("Floorplan regions are overfull: trying to pack again with more attraction groups exploration. \n");
                 VTR_LOG("Pack iteration is %d\n", pack_iteration);
-            } else if (pack_iteration == 4) {
+                break;
+            }
+            case e_packer_state::ATTRACTION_GROUPS_ALL_REGIONS_AND_INCREASED_TARGET_DENSITY: {
                 attraction_groups.create_att_groups_for_all_regions();
                 VTR_LOG("Floorplan regions are overfull: trying to pack again with more attraction groups exploration and higher target pin utilization. \n");
                 VTR_LOG("Pack iteration is %d\n", pack_iteration);
@@ -224,9 +306,18 @@ bool try_pack(const t_packer_opts& packer_opts,
                 //       do it for all block types. Doing it only for a clb
                 //       string is dangerous -VB.
                 cluster_legalizer.get_target_external_pin_util().set_block_pin_util("clb", pin_util);
+                break;
             }
+            case e_packer_state::DEFAULT:
+            case e_packer_state::SUCCESS:
+            case e_packer_state::FAILURE:
+            default:
+                // Nothing to set up.
+                break;
+        }
 
-        } else { //Unable to pack densely enough: Give Up
+        // Raise an error if the packer failed to pack.
+        if (next_packer_state == e_packer_state::FAILURE) {
             if (floorplan_regions_overfull) {
                 VPR_FATAL_ERROR(VPR_ERROR_OTHER,
                                 "Failed to find pack clusters densely enough to fit in the designated floorplan regions.\n"
@@ -255,13 +346,22 @@ bool try_pack(const t_packer_opts& packer_opts,
             VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Failed to find device which satisfies resource requirements required: %s (available %s)", resource_reqs.c_str(), resource_avail.c_str());
         }
 
-        //Reset floorplanning constraints for re-packing
-        g_vpr_ctx.mutable_floorplanning().cluster_constraints.clear();
+        // If the packer was unsuccessful, reset the packed solution and try again.
+        if (next_packer_state != e_packer_state::SUCCESS) {
+            //Reset floorplanning constraints for re-packing
+            g_vpr_ctx.mutable_floorplanning().cluster_constraints.clear();
 
-        // Reset the cluster legalizer for re-clustering.
-        cluster_legalizer.reset();
+            // Reset the cluster legalizer for re-clustering.
+            cluster_legalizer.reset();
+        }
+
+        // Set the current state to the next state.
+        current_packer_state = next_packer_state;
+
         ++pack_iteration;
     }
+
+    VTR_ASSERT(current_packer_state == e_packer_state::SUCCESS);
 
     /* Packing iterative improvement can be done here */
     /*       Use the re-cluster API to edit it        */


### PR DESCRIPTION
The packer iteratively restarts itself with different options if the packer fails to find a dense enough clustering. The way this was written was very hard to follow and was error prone.

Rewrote the iterative packer code to be more like a state-machine. This makes it easier to add new states in the future and maintain the current states.

My goal here is to be accurate to what the packer was doing before (i.e. no results will change, the packer will behave exactly as it did before). So some of the state transitions may make you say "why do that, why not this?"; those changes will come in a future PR. This is just cleanup.