### PR TITLE
RR Edge ID Verification

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -516,6 +516,8 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->has_choke_point = Options.router_opt_choke_points;
     RouterOpts->custom_3d_sb_fanin_fanout = Options.custom_3d_sb_fanin_fanout;
     RouterOpts->with_timing_analysis = Options.timing_analysis;
+
+    RouterOpts->verify_rr_switch_id = Options.verify_rr_switch_id;
 }
 
 static void SetupAnnealSched(const t_options& Options,

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1637,6 +1637,16 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("on")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    gen_grp.add_argument<bool, ParseOnOff>(args.verify_rr_switch_id, "--verify_rr_switch_id")
+        .help(
+            "Verify that the switch IDs in the routing file are consistent with those in the RR Graph."
+            "Set this to false when switch IDs in the routing file may differ from the RR Graph."
+            "For example, when analyzing different timing corners using the same netlist, placement, and routing files,"
+            "the RR switch IDs in the RR Graph may differ due to changes in delays."
+            "In such cases, set this option to false so that the switch IDs from the RR Graph are used, and those in the routing file are ignored.")
+        .default_value("on")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     gen_grp.add_argument(args.target_device_utilization, "--target_utilization")
         .help(
             "Sets the target device utilization."

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -73,6 +73,7 @@ struct t_options {
     argparse::ArgValue<e_timing_update_type> timing_update_type;
     argparse::ArgValue<bool> CreateEchoFile;
     argparse::ArgValue<bool> verify_file_digests;
+    argparse::ArgValue<bool> verify_rr_switch_id;
     argparse::ArgValue<std::string> device_layout;
     argparse::ArgValue<float> target_device_utilization;
     argparse::ArgValue<e_constant_net_method> constant_net_method;

--- a/vpr/src/base/read_route.h
+++ b/vpr/src/base/read_route.h
@@ -9,5 +9,12 @@
 #include "netlist.h"
 #include "vpr_types.h"
 
-bool read_route(const char* route_file, const t_router_opts& RouterOpts, bool verify_file_digests, bool is_flat);
-void print_route(const Netlist<>& net_list, const char* placement_file, const char* route_file, bool is_flat);
+bool read_route(const char* route_file,
+                const t_router_opts& RouterOpts,
+                bool verify_file_digests,
+                bool is_flat);
+
+void print_route(const Netlist<>& net_list,
+                 const char* placement_file,
+                 const char* route_file,
+                 bool is_flat);

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1152,7 +1152,10 @@ RouteStatus vpr_load_routing(t_vpr_setup& vpr_setup,
     auto& filename_opts = vpr_setup.FileNameOpts;
 
     //Load the routing from a file
-    bool is_legal = read_route(filename_opts.RouteFile.c_str(), vpr_setup.RouterOpts, filename_opts.verify_file_digests, is_flat);
+    bool is_legal = read_route(filename_opts.RouteFile.c_str(),
+                               vpr_setup.RouterOpts,
+                               filename_opts.verify_file_digests,
+                               is_flat);
     const Netlist<>& router_net_list = is_flat ? (const Netlist<>&)g_vpr_ctx.atom().netlist() : (const Netlist<>&)g_vpr_ctx.clustering().clb_nlist;
     if (vpr_setup.Timing.timing_analysis_enabled) {
         //Update timing info

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1343,6 +1343,8 @@ struct t_router_opts {
 
     bool with_timing_analysis;
 
+    bool verify_rr_switch_id;
+
     // Options related to rr_node reordering, for testing and possible cache optimization
     e_rr_node_reorder_algorithm reorder_rr_graph_nodes_algorithm = DONT_REORDER;
     int reorder_rr_graph_nodes_threshold = 0;


### PR DESCRIPTION
#### Description
In a `.route` file, each edge between two nodes includes a switch ID, which is used to retrieve the electrical characteristics of that edge. When reading the `.route` file, this switch ID is compared against the corresponding switch ID from the RR Graph for consistency. If they do not match, an error is raised.

This consistency check is generally helpful. However, when analyzing multiple timing corners, each corner may have a different RR Graph with varying timing information (graph topologies are the same). As a result, the number and ordering of switch **types** may differ between corners. To allow reuse of the same `.route` file for fair comparisons across different timing corners, this strict verification can become a limitation.

To address this issue, a new CLI parameter `verify_rr_switch_id` has been introduced. By default, it is set to `on`, enforcing the consistency check. When set to `off`, the switch ID from the `.route` file is ignored, and the switch ID from the RR Graph is used instead.

