### PR TITLE
Fix Ninja build failure by escaping $(MAKE) in Yosys build command

### DIFF
--- a/libs/EXTERNAL/CMakeLists.txt
+++ b/libs/EXTERNAL/CMakeLists.txt
@@ -47,7 +47,7 @@ if (${WITH_PARMYS})
 	SET(YOSYS_BUILD_DIR ${CMAKE_BINARY_DIR}/bin/yosys)
 
     add_definitions("-D_YOSYS_")
-    set(MAKE_PROGRAM "$(MAKE)")
+    set(MAKE_PROGRAM "$$MAKE")
 	set(CURRENT_CPPFLAGS "$(CPPFLAGS)-w")
 	if(${CMAKE_GENERATOR} STREQUAL "Ninja")
 	    set(CURRENT_CPPFLAGS "-w")


### PR DESCRIPTION
Fixes a Ninja build error caused by unescaped $(MAKE) in the Yosys build command. Ninja treats $ as a variable escape, so the line now sets MAKE_PROGRAM to $$MAKE.