### PR TITLE
[NetlistWriter] Fixed Failing Nightly Test

### DIFF
--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -1551,7 +1551,7 @@ class NetlistWriterVisitor : public NetlistVisitor {
 
                 if (port_class == "clock") {
                     VTR_ASSERT(pb_graph_node->num_clock_pins[iport] == 1); //Expect a single clock pin
-                    input_port_conns["clock"].push_back(net);
+                    input_port_conns[port->name].push_back(net);
                 } else {
                     VPR_FATAL_ERROR(VPR_ERROR_IMPL_NETLIST_WRITER,
                                     "Unrecognized input port class '%s' for primitive '%s' (%s)\n", port_class.c_str(), atom->name, pb_type->name);


### PR DESCRIPTION
The nightly test for the netlist writer was failing due to changes in the clock to Q delays. After some digging, I found that there was an oversight in the netlist writer code when it generates ram black boxes.

Someone hard-coded the name of the clock port to "clock", when in reality the port's name is "clk". This was a very simple fix.

This resolves the failures in NightlyTest2:

<img width="482" alt="image" src="https://github.com/user-attachments/assets/aaa5c97c-93a8-47b9-9bdb-63ba2cad534c" />
