### PR TITLE
[Packer] Fixed NightlyTest Failure with Tight Floorplan Constr.

### DIFF
--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -105,22 +105,6 @@ static e_packer_state get_next_packer_state(e_packer_state current_packer_state,
         return e_packer_state::SUCCESS;
     }
 
-    // Check if the utilizaion of any block types is over 100%
-    if (!fits_on_device) {
-        // The utilization of some block types are too high. Need to increase the
-        // density of the block types available.
-
-        // Check if we can turn on unrelated cluster and/or balanced block type
-        // utilization.
-        if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO && packer_opts.balance_block_type_utilization == e_balance_block_type_util::AUTO) {
-
-            // Check if they are not already on. If not, set the next state to turn them on.
-            if (!using_unrelated_clustering || !using_balanced_block_type_util) {
-                return e_packer_state::SET_UNRELATED_AND_BALANCED;
-            }
-        }
-    }
-
     // Check if there are overfilled floorplan regions.
     if (floorplan_regions_overfull) {
         // If there are overfilled region constraints, try to use attraction
@@ -149,6 +133,22 @@ static e_packer_state get_next_packer_state(e_packer_state current_packer_state,
             case e_packer_state::CREATE_ATTRACTION_GROUPS_FOR_ALL_REGIONS_AND_INCREASE_PULL:
             default:
                 break;
+        }
+    }
+
+    // Check if the utilizaion of any block types is over 100%
+    if (!fits_on_device) {
+        // The utilization of some block types are too high. Need to increase the
+        // density of the block types available.
+
+        // Check if we can turn on unrelated cluster and/or balanced block type
+        // utilization.
+        if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO && packer_opts.balance_block_type_utilization == e_balance_block_type_util::AUTO) {
+
+            // Check if they are not already on. If not, set the next state to turn them on.
+            if (!using_unrelated_clustering || !using_balanced_block_type_util) {
+                return e_packer_state::SET_UNRELATED_AND_BALANCED;
+            }
         }
     }
 


### PR DESCRIPTION
The very tight floorplan constraints were failing after the recent changes to the iterative packing algorithm. After investigation I found that there is a bug with unrelated clustering and RAMs which is causing floorplan constraints to not be adhered to. The original code ignored this issue by not doing unrelated clustering when there are floorplan constraints.

To fix this issue, reimplemented what the code was originally doing to allow this testcase to proceed. This just moves the unrelated clustering to after trying all floorplan region options.