### PR TITLE
[CI] Moved Sanitized Test from Debug to RelWithDebInfo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -483,7 +483,7 @@ jobs:
     - name: Test
       env:
         CMAKE_PARAMS: ${{ matrix.params }}
-        BUILD_TYPE: debug
+        BUILD_TYPE: RelWithDebInfo
         LSAN_OPTIONS: 'exitcode=42' #Use a non-standard exit code to ensure LSAN errors are detected
         # In Ubuntu 20240310.1.0, the entropy of ASLR has increased (28 -> 32). LLVM 14 in this
         # image is not compatible with this increased ASLR entropy. Apparently, memory sanitizer


### PR DESCRIPTION
I expect the sanitized test to be the tall pole for the speed of the CI due to its long run time on the testcases. After investigating with Vaughn, we realized that this test was using the debug build of VTR. This was likely making it much slower than it needed to be.

To improve the speed of this test, moved it to use the release build. We still want symbols to give good error messages.