### PR TITLE
Fix slang errors and warnings in Koios benchmarks

### DIFF
--- a/vtr_flow/benchmarks/verilog/koios/attention_layer.v
+++ b/vtr_flow/benchmarks/verilog/koios/attention_layer.v
@@ -164,7 +164,7 @@ wordwise_bram_2 out_buffer34
 );
 
 //Softmax layer has a parallelism of 4
-softmax soft(
+softmax softmax(
 	.inp(data_to_softmax),
 	.sub0_inp(data_to_softmax),
 	.sub1_inp(data_to_softmax),

--- a/vtr_flow/benchmarks/verilog/koios/conv_layer_hls.v
+++ b/vtr_flow/benchmarks/verilog/koios/conv_layer_hls.v
@@ -18,6 +18,7 @@
 // Abridged for VTR by: Daniel Rauch
 //////////////////////////////////////////////////////////////////////////////
 
+`timescale 1 ns / 1 ps
 
 module dpram (
 
@@ -133,8 +134,6 @@ dual_port_ram u_dual_port_ram(
 `endif
 
 endmodule
-
-`timescale 1 ns / 1 ps
 
 module td_fused_top_Block_entry_proc_proc505 (
         ap_clk,

--- a/vtr_flow/benchmarks/verilog/koios/dnnweaver.v
+++ b/vtr_flow/benchmarks/verilog/koios/dnnweaver.v
@@ -156,12 +156,15 @@ module fifo
 // ******************************************************************
 // FIFO Logic
 // ******************************************************************
+
+/*
   initial begin
     if (INITIALIZE_FIFO == "yes") begin
       $readmemh(INIT, mem, 0, RAM_DEPTH-1);
     end
   end
-
+*/
+   
   always @ (r_fifo_count)
   begin : FIFO_STATUS
     empty   = (r_fifo_count == 0);
@@ -1588,7 +1591,8 @@ module axi_master
     .s_write_ready                  ( rd_req_buf_wr_ready            ), //output
     .s_write_data                   ( rd_req_buf_data_in             ), //input
     .almost_full                    ( rd_req_buf_almost_full         ), //output
-    .almost_empty                   ( rd_req_buf_almost_empty        )  //output
+    .almost_empty                   ( rd_req_buf_almost_empty        ), //output
+    .fifo_count                     (                                )  //output
   );
 //==============================================================================
 
@@ -1622,7 +1626,8 @@ module axi_master
     .s_write_ready                  ( rx_req_id_buf_wr_ready         ), //output
     .s_write_data                   ( rx_req_id_buf_data_in          ), //input
     .almost_full                    ( rx_req_id_buf_almost_full      ), //output
-    .almost_empty                   ( rx_req_id_buf_almost_empty     )  //output
+    .almost_empty                   ( rx_req_id_buf_almost_empty     ), //output
+    .fifo_count                     (                                )  //output
   );
 
 
@@ -1799,7 +1804,8 @@ module axi_master
     .s_write_ready                  ( wr_req_buf_wr_ready            ), //output
     .s_write_data                   ( wr_req_buf_data_in             ), //input
     .almost_full                    ( wr_req_buf_almost_full         ), //output
-    .almost_empty                   ( wr_req_buf_almost_empty        )  //output
+    .almost_empty                   ( wr_req_buf_almost_empty        ), //output
+    .fifo_count                     (                                )  //output
   );
 //==============================================================================
 
@@ -1899,7 +1905,8 @@ module axi_master
     .s_write_ready                  ( wdata_req_buf_wr_ready         ), //output
     .s_write_data                   ( wdata_req_buf_data_in          ), //input
     .almost_full                    ( wdata_req_buf_almost_full      ), //output
-    .almost_empty                   ( wdata_req_buf_almost_empty     )  //output
+    .almost_empty                   ( wdata_req_buf_almost_empty     ), //output
+    .fifo_count                     (                                )  //output
   );
 //==============================================================================
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Resolve slang errors/warnings in the Koios benchmarks.

#### Description
<!--- Describe your changes in detail -->

The errors/warnings fell into the following buckets:

1.  Add reg keyword to output ports where outputs are used in LHS of always blocks.
2. Move timescale directives to top of files.
3. Add empty output port connection declarations to eliminate warnings (no functional change)
4. Change instance name to prevent namespace conflict with SystemVerilog keyword
5. Comment out an initial block that used a variable that had also been commented out.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/3169

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Eliminating slang errors allows these benchmarks to continue to be used in flows that make use of the yosys-slang plugin.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Primary method of testing has been running slang directly at the command line.  Quick research suggested there was not a single VTR regression test I could execute to try all four of these benchmarks in one push button; due to this and test runtime concerns I have deferred running VTR regression tests to validate that no synthesis results have changed.

From a synthesis standpoint, the risk of results changing due to these edits is very low.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
