### PR TITLE
[Build] Locked Version Tag Reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,13 @@ set(VTR_VERSION_MAJOR 9)
 set(VTR_VERSION_MINOR 0)
 set(VTR_VERSION_PATCH 0)
 set(VTR_VERSION_PRERELEASE "dev")
+# Git describe is used to get the detailed version of VTR. Git describe returns
+# a string which is of the form <tag>-<num_commmits_since_tag>-<commit-hash>.
+# The number of commits since the tag is used to make the version unique and
+# should guarantee a unique version for each commit on the head of master.
+# This variable sets the tag that the version should be relative to. This should
+# always be of the form v9.0.0, v10.1.2, etc.
+set(VTR_VERSION_TAG_REF "v9.0.0")
 
 include(FilesToDirs)
 

--- a/libs/libvtrutil/CMakeLists.txt
+++ b/libs/libvtrutil/CMakeLists.txt
@@ -22,6 +22,10 @@ if(NOT DEFINED VTR_VERSION_PATCH)
     set(VTR_VERSION_PATCH 0)
 endif()
 
+if(NOT DEFINED VTR_VERSION_TAG_REF)
+    set(VTR_VERSION_TAG_REF "*")
+endif()
+
 set(VTR_BUILD_INFO "${CMAKE_BUILD_TYPE}")
 if (CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     set(VTR_BUILD_INFO "${VTR_BUILD_INFO} IPO")
@@ -54,7 +58,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(GetGitRevisionDescription)
 
 # Get the VCS revision.
-git_describe_working_tree(VTR_VCS_REVISION --tags --always --long)
+git_describe_working_tree(VTR_VCS_REVISION --match=${VTR_VERSION_TAG_REF} --tags --always --long)
 string(FIND ${VTR_VCS_REVISION} "NOTFOUND" GIT_DESCRIBE_VTR_REVISION_NOTFOUND)
 if (NOT ${GIT_DESCRIBE_VTR_REVISION_NOTFOUND} EQUAL -1)
     # Git describe failed, usually this means we
@@ -64,7 +68,7 @@ if (NOT ${GIT_DESCRIBE_VTR_REVISION_NOTFOUND} EQUAL -1)
 endif()
 
 # Get the short VCS revision
-git_describe_working_tree(VTR_VCS_REVISION_SHORT --tags --always --long --exclude '*')
+git_describe_working_tree(VTR_VCS_REVISION_SHORT --match=${VTR_VERSION_TAG_REF} --tags --always --long --exclude '*')
 string(FIND "${VTR_VCS_REVISION_SHORT}" "NOTFOUND" GIT_DESCRIBE_VTR_REVISION_SHORT_NOTFOUND)
 if (NOT ${GIT_DESCRIBE_VTR_REVISION_SHORT_NOTFOUND} EQUAL -1)
     # Git describe failed, usually this means we


### PR DESCRIPTION
To get a unique version for every commit on Master, git describe is used. This produces a unique (monotonically increasing) string by getting the number of commits since a tag.

We originally let git decide which tag to use, which I assumed was the most recent tag; however, some users have been noticing that the version has been relative to different tags (like v9.0.0-candidate). In the future, we may want to also control when we want to move the tag this version is relative to manually, instead of letting Git decide.

To make this more robust and controllable, forced the git describe to be relative to a specific tag which is set in VTR's CMake (similar to the major version number).