### PR TITLE
[AP][GP] Tuning Parameters

### DIFF
--- a/vpr/src/analytical_place/analytical_solver.h
+++ b/vpr/src/analytical_place/analytical_solver.h
@@ -436,14 +436,14 @@ class B2BSolver : public AnalyticalSolver {
     ///        solved solution HPWL).
     /// Decreasing this number toward zero would cause the B2B solver to run
     /// more iterations to try and reduce the HPWL further.
-    static constexpr double b2b_convergence_gap_fac_ = 0.001;
+    static constexpr double b2b_convergence_gap_fac_ = 0.0001;
 
     /// @brief The number of times the B2B loop should "converge" before stopping
     ///        the loop. Due to numerical inaccuracies, it is possible for the
     ///        HPWL to bounce up and down as it converges. Increasing this number
     ///        will allow more bounces which may get better quality; however
     ///        more iterations will need to be run.
-    static constexpr unsigned target_num_b2b_convergences_ = 2;
+    static constexpr unsigned target_num_b2b_convergences_ = 1;
 
     /// @brief Max number of bound update / solve iterations. Increasing this
     ///        number will yield better quality at the expense of runtime.
@@ -460,7 +460,7 @@ class B2BSolver : public AnalyticalSolver {
     ///        to prevent this behaviour and get good runtime.
     // TODO: Need to investigate this more to find a good number for this.
     // TODO: Should this be a proportion of the design size?
-    static constexpr unsigned max_cg_iterations_ = 150;
+    static constexpr unsigned max_cg_iterations_ = 100;
 
     // The following constants are used to configure the anchor weighting.
     // The weights of anchors grow exponentially each iteration by the following

--- a/vpr/src/analytical_place/global_placer.h
+++ b/vpr/src/analytical_place/global_placer.h
@@ -127,7 +127,7 @@ class SimPLGlobalPlacer : public GlobalPlacer {
     ///        between the two bounds, normalized to the upper-bound, is smaller
     ///        than this number.
     ///        This number was empircally found to work well.
-    static constexpr double target_hpwl_relative_gap_ = 0.05;
+    static constexpr double target_hpwl_relative_gap_ = 0.01;
 
     /// @brief The solver which generates the lower-bound placement.
     std::unique_ptr<AnalyticalSolver> solver_;


### PR DESCRIPTION
Tuned some of the parameters for the global placement stage. The goal of this tuning was to speed up the global placer as much as reasonable, while retaining similar quality.

Reduced the B2B convergence gap slightly to allow the B2B solver to converge on a more accurate solution.

Reduced the number of B2B convergences required before stopping from 2 to 1. I found that this did not provide as much quality, and reducing this greatly improved the solver's speed.

Reduced the max number of CG iterations. This should further improve the speed of the solver.

Reduced the relative gap between the upper and lower bound solutions in the global placer from 5% to 1%.