### PR TITLE
Capnp Interchange File Directory

### DIFF
--- a/libs/libvtrcapnproto/CMakeLists.txt
+++ b/libs/libvtrcapnproto/CMakeLists.txt
@@ -32,7 +32,7 @@ capnp_generate_cpp(CAPNP_SRCS CAPNP_HDRS
 )
 
 if (VPR_ENABLE_INTERCHANGE)
-    set(IC_DIR ${CMAKE_SOURCE_DIR}/libs/EXTERNAL/libinterchange/interchange)
+    set(IC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../EXTERNAL/libinterchange/interchange)
     set(CAPNPC_SRC_PREFIX ${IC_DIR})
 
     find_program(WGET wget REQUIRED)


### PR DESCRIPTION
Use a relative path based on the current CMake directory to access interchange files. This enables VTR to be used as a submodule in other repositories.