### PR TITLE
OpenFPGA Patch

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -171,7 +171,8 @@ enum e_pin_type {
 enum e_interconnect {
     COMPLETE_INTERC = 1,
     DIRECT_INTERC = 2,
-    MUX_INTERC = 3
+    MUX_INTERC = 3,
+    NUM_INTERC_TYPES = 4
 };
 
 /* pin location distributions */

--- a/libs/librrgraph/src/base/rr_graph_builder.cpp
+++ b/libs/librrgraph/src/base/rr_graph_builder.cpp
@@ -188,6 +188,12 @@ void RRGraphBuilder::create_edge_in_cache(RRNodeId src, RRNodeId dest, RRSwitchI
     is_incoming_edge_dirty_ = true;
 }
 
+void RRGraphBuilder::create_edge(RRNodeId src, RRNodeId dest, RRSwitchId edge_switch, bool remapped) {
+    edges_to_build_.emplace_back(src, dest, size_t(edge_switch), remapped);
+    is_edge_dirty_ = true; /* Adding a new edge revokes the flag */
+    is_incoming_edge_dirty_ = true;
+}
+
 void RRGraphBuilder::build_edges(const bool& uniquify) {
     if (uniquify) {
         std::sort(edges_to_build_.begin(), edges_to_build_.end());

--- a/libs/librrgraph/src/base/rr_graph_builder.h
+++ b/libs/librrgraph/src/base/rr_graph_builder.h
@@ -298,6 +298,10 @@ class RRGraphBuilder {
      *  @note This will not add an edge to storage. You need to call build_edges() after all the edges are cached. */
     void create_edge_in_cache(RRNodeId src, RRNodeId dest, RRSwitchId edge_switch, bool remapped);
 
+    /** @brief Add a new edge to the cache of edges to be built 
+     *  @note This will not add an edge to storage! You need to call build_edges() after all the edges are cached! */
+    void create_edge(RRNodeId src, RRNodeId dest, RRSwitchId edge_switch, bool remapped);
+
     /** @brief Allocate and build actual edges in storage. 
      * Once called, the cached edges will be uniquified and added to routing resource nodes, 
      * while the cache will be empty once build-up is accomplished 
@@ -390,6 +394,13 @@ class RRGraphBuilder {
         const std::vector<t_arch_switch_inf>& arch_switch_inf,
         t_arch_switch_fanin& arch_switch_fanins) {
         return node_storage_.count_rr_switches(arch_switch_inf, arch_switch_fanins);
+    }
+
+    /** @brief Unlock storage; required to modify an routing resource graph after edge is read */
+    inline void unlock_storage() {
+        node_storage_.edges_read_ = false;
+        node_storage_.partitioned_ = false;
+        node_storage_.clear_node_first_edge();
     }
 
     /** @brief Reserve the lists of nodes, edges, switches etc. to be memory efficient.

--- a/libs/libvtrutil/src/vtr_geometry.tpp
+++ b/libs/libvtrutil/src/vtr_geometry.tpp
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include "vtr_assert.h"
 
 namespace vtr {

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -40,8 +40,6 @@ static AtomPinId find_atom_pin_for_pb_route_id(ClusterBlockId clb, int pb_route_
 
 static bool block_type_contains_blif_model(t_logical_block_type_ptr type, const std::regex& blif_model_regex);
 static bool pb_type_contains_blif_model(const t_pb_type* pb_type, const std::regex& blif_model_regex);
-static t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type);
-static void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type);
 
 /******************** Subroutine definitions *********************************/
 
@@ -1020,7 +1018,7 @@ static void load_pb_graph_pin_lookup_from_index_rec(t_pb_graph_pin** pb_graph_pi
 }
 
 /* Create a lookup that returns a pb_graph_pin pointer given the pb_graph_pin index */
-static t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type) {
+t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type) {
     t_pb_graph_pin** pb_graph_pin_lookup_from_type = nullptr;
 
     t_pb_graph_node* pb_graph_head = type->pb_graph_head;
@@ -1048,7 +1046,7 @@ static t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_
 }
 
 /* Free pb_graph_pin lookup array */
-static void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type) {
+void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type) {
     if (pb_graph_pin_lookup_from_type == nullptr) {
         return;
     }

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -190,7 +190,9 @@ t_pb_graph_pin* get_pb_graph_node_pin_from_model_port_pin(const t_model_ports* m
 ///        pb_graph_node.
 t_pb_graph_pin* get_pb_graph_node_pin_from_pb_graph_node(t_pb_graph_node* pb_graph_node, int ipin);
 t_pb_graph_pin* get_pb_graph_node_pin_from_block_pin(ClusterBlockId iblock, int ipin);
+t_pb_graph_pin** alloc_and_load_pb_graph_pin_lookup_from_index(t_logical_block_type_ptr type);
 vtr::vector<ClusterBlockId, t_pb**> alloc_and_load_pin_id_to_pb_mapping();
+void free_pb_graph_pin_lookup_from_index(t_pb_graph_pin** pb_graph_pin_lookup_from_type);
 void free_pin_id_to_pb_mapping(vtr::vector<ClusterBlockId, t_pb**>& pin_id_to_pb_mapping);
 
 std::tuple<t_physical_tile_type_ptr, const t_sub_tile*, int, t_logical_block_type_ptr> get_cluster_blk_physical_spec(ClusterBlockId cluster_blk_id);


### PR DESCRIPTION
This PR updates the code to work with the VTR master branch. Specifically, it removes the static identifier from a few functions and reintroduces two methods in the RR graph builder that I had previously removed by mistake (they were part of VTR but not explicitly visible earlier).
