### PR TITLE
Skip Invalid Atom Blocks

### DIFF
--- a/vpr/src/pack/greedy_seed_selector.cpp
+++ b/vpr/src/pack/greedy_seed_selector.cpp
@@ -153,6 +153,9 @@ static inline void print_seed_gains(const char* fname,
     fprintf(fp, "\n");
     for (auto mol_id : seed_mols) {
         for (AtomBlockId blk_id : prepacker.get_molecule(mol_id).atom_block_ids) {
+            if (!blk_id.is_valid()) {
+                continue;
+            }
             std::string name = atom_netlist.block_name(blk_id);
             fprintf(fp, "%-*s ", max_name_len, name.c_str());
 


### PR DESCRIPTION
When echo file generation is enabled, a crash occurs during molecule printing. This is caused by not checking the validity of an atom's block while iterating over the atoms in a molecule. This PR adds a check to ensure the block is valid before accessing it, preventing the crash.