### PR TITLE
[Build][Version] Reverted Version Tagging Change

### DIFF
--- a/libs/libvtrutil/CMakeLists.txt
+++ b/libs/libvtrutil/CMakeLists.txt
@@ -54,7 +54,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(GetGitRevisionDescription)
 
 # Get the VCS revision.
-git_describe_working_tree(VTR_VCS_REVISION --tags --always --long)
+git_describe_working_tree(VTR_VCS_REVISION --always --long)
 string(FIND ${VTR_VCS_REVISION} "NOTFOUND" GIT_DESCRIBE_VTR_REVISION_NOTFOUND)
 if (NOT ${GIT_DESCRIBE_VTR_REVISION_NOTFOUND} EQUAL -1)
     # Git describe failed, usually this means we
@@ -64,7 +64,7 @@ if (NOT ${GIT_DESCRIBE_VTR_REVISION_NOTFOUND} EQUAL -1)
 endif()
 
 # Get the short VCS revision
-git_describe_working_tree(VTR_VCS_REVISION_SHORT --tags --always --long --exclude '*')
+git_describe_working_tree(VTR_VCS_REVISION_SHORT --always --long --exclude '*')
 string(FIND "${VTR_VCS_REVISION_SHORT}" "NOTFOUND" GIT_DESCRIBE_VTR_REVISION_SHORT_NOTFOUND)
 if (NOT ${GIT_DESCRIBE_VTR_REVISION_SHORT_NOTFOUND} EQUAL -1)
     # Git describe failed, usually this means we


### PR DESCRIPTION
A recent cleanup I made of the way VTR does its versioning added the "--tags" argument to the git describe command. The hope of this option was that it would enable VTR to point to the v9.0.0 tag instead of the v8.0.0 tag; however, this was not the case.

In some cases, it was able to find the v9.0.0 tag; however, since this tag is on another branch, many users are unable to find that tag from git describe. This caused the versioning code to fall back on v9.0.0-candidate which is the last tagged version on the branch. This tag is the branching point of v9.0.0, but we do not want to use this tag since 1) it does not use the correct naming scheme (the "-candidate" causes problems with downstream tools) and 2) this is not a complete tag (i.e. it lacks metadata).

I reverted this change, so now git describe should stably point to the last full tagged release of VTR on the master branch (which is v8.0.0). This will at least ensure that the version VTR produces is stable. We prefer a stable versioning system based off v8.0.0 over an unstable versioning system based off v9.0.0.