### PR TITLE
[CI] Moved Sanitized Build Test from Odin to Parmys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -471,8 +471,8 @@ jobs:
         include: [
           {
             name: 'Basic',
-            params: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off -DWITH_BLIFEXPLORER=on -DWITH_PARMYS=OFF -DWITH_ODIN=on',
-            suite: 'vtr_reg_basic_odin'
+            params: '-DVTR_ASSERT_LEVEL=3 -DVTR_ENABLE_SANITIZE=on -DVTR_IPO_BUILD=off',
+            suite: 'vtr_reg_basic'
           }
           #- { name: 'Strong', suite: 'vtr_reg_strong' } # SKIP Too long to run on GitHub Actions (max 6h)
         ]
@@ -484,6 +484,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.12.3
+
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
@@ -511,9 +512,8 @@ jobs:
         # when github deploys a more stable Ubuntu image.
         NUM_PROC: ${{ steps.cpu-cores.outputs.count }}
       run: |
-        sudo sysctl -w vm.mmap_rnd_bits=28
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        ./.github/scripts/build.sh
+        make -j${{ steps.cpu-cores.outputs.count}}
         # We skip QoR since we are only checking for errors in sanitizer runs
         ./run_reg_test.py ${{ matrix.suite }} -show_failures -j${{ steps.cpu-cores.outputs.count }} -skip_qor
 


### PR DESCRIPTION
The sanitized build test was testing the Odin build and not the parmys build (which is the default). Moved the test to Parmys.

Resolves #3191 