### PR TITLE
[CI] Added GCC-15 to CI Test Coverage

### DIFF
--- a/.github/scripts/install_dependencies.sh
+++ b/.github/scripts/install_dependencies.sh
@@ -43,6 +43,8 @@ sudo apt install -y \
   gcc-13 \
   g++-14 \
   gcc-14 \
+  g++-15 \
+  gcc-15 \
   clang-15 \
   clang-16 \
   clang-17 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -632,6 +632,7 @@ jobs:
         include:
         - { name: 'GCC 12 (Ubuntu Noble - 24.04)',    CC: 'gcc-12',   CXX: 'g++-12',     }
         - { name: 'GCC 14 (Ubuntu Noble - 24.04)',    CC: 'gcc-14',   CXX: 'g++-14',     }
+        - { name: 'GCC 15 (Ubuntu Noble - 24.04)',    CC: 'gcc-15',   CXX: 'g++-15',     }
         - { name: 'Clang 16 (Ubuntu Noble - 24.04)',  CC: 'clang-16', CXX: 'clang++-16', }
         - { name: 'Clang 17 (Ubuntu Noble - 24.04)',  CC: 'clang-17', CXX: 'clang++-17', }
         - { name: 'Clang 18 (Ubuntu Noble - 24.04)',  CC: 'clang-18', CXX: 'clang++-18', }


### PR DESCRIPTION
GCC-15 will likely be the next default C/C++ compiler in Ubuntu. It is a good idea to lock in support for this compiler. Added GCC-15 to the test coverage.