### PR TITLE
[Place] Added an Initial Placement Checkpoint

### DIFF
--- a/vpr/src/place/place_checkpoint.h
+++ b/vpr/src/place/place_checkpoint.h
@@ -8,6 +8,7 @@
 #include "place_delay_model.h"
 #include "place_timing_update.h"
 
+class NetCostHandler;
 class NocCostHandler;
 
 /**
@@ -74,4 +75,7 @@ void restore_best_placement(PlacerState& placer_state,
                             std::shared_ptr<PlaceDelayModel>& place_delay_model,
                             std::unique_ptr<NetPinTimingInvalidator>& pin_timing_invalidator,
                             PlaceCritParams crit_params,
+                            NetCostHandler& net_cost_handler,
+                            const t_placer_opts& placer_opts,
+                            const t_noc_opts& noc_opts,
                             std::optional<NocCostHandler>& noc_cost_handler);


### PR DESCRIPTION
I found that the annealer may sometimes pick a temperature so high that it destroys the quality of the initial placement. This behavior is most aparent with the AP flow, since its initial placement quality is much better than the default flow.

Added a checkpoint at the start of the anneal that saves the initial placement and, after 20 iterations, if the quality of the current anneal is worse than the initial placement, it will restore that placement and continue at that temperature.

This is the last change that I had locally for the standard AP flow.