### PR TITLE
Switching to Non-Blocking Assigns in Single/Dual Port Ram Primitives

### DIFF
--- a/parmys/third_party/vtr_flow/primitives.v
+++ b/parmys/third_party/vtr_flow/primitives.v
@@ -268,7 +268,7 @@ module single_port_ram #(
         if(we) begin
             Mem[addr] <= data;
         end
-    	out <= Mem[addr]; //New data read-during write behaviour (blocking assignments)
+    	out <= Mem[addr]; //Old data read-first behaviour (non-blocking assignments)
     end
    
 endmodule // single_port_RAM
@@ -316,14 +316,14 @@ module dual_port_ram #(
         if(we1) begin
             Mem[addr1] <= data1;
         end
-        out1 <= Mem[addr1]; //New data read-during write behaviour (blocking assignments)
+        out1 <= Mem[addr1]; //Old data read-first behaviour (non-blocking assignments)
     end
 
     always@(posedge clk) begin //Port 2
         if(we2) begin
             Mem[addr2] <= data2;
         end
-        out2 <= Mem[addr2]; //New data read-during write behaviour (blocking assignments)
+        out2 <= Mem[addr2]; //Old data read-first behaviour (non-blocking assignments)
     end
    
 endmodule // dual_port_ram

--- a/vtr_flow/primitives.v
+++ b/vtr_flow/primitives.v
@@ -268,7 +268,7 @@ module single_port_ram #(
         if(we) begin
             Mem[addr] <= data;
         end
-    	out <= Mem[addr]; //New data read-during write behaviour (blocking assignments)
+    	out <= Mem[addr]; //Old data read-first behaviour (non-blocking assignments)
     end
    
 endmodule // single_port_RAM
@@ -314,16 +314,16 @@ module dual_port_ram #(
    
     always@(posedge clk) begin //Port 1
         if(we1) begin
-            Mem[addr1] = data1;
+            Mem[addr1] <= data1;
         end
-        out1 = Mem[addr1]; //New data read-during write behaviour (blocking assignments)
+        out1 <= Mem[addr1]; //Old data read-first behaviour (non-blocking assignments)
     end
 
     always@(posedge clk) begin //Port 2
         if(we2) begin
             Mem[addr2] <= data2;
         end
-        out2 <= Mem[addr2]; //New data read-during write behaviour (blocking assignments)
+        out2 <= Mem[addr2]; //Old data read-first behaviour (non-blocking assignments)
     end
    
 endmodule // dual_port_ram


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Switched read and write updates to use non-blocking assigns instead of blocking assigns for single/dual port ram primitives.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/3195

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is needed to resolve issue with block RAMs being expanded into LUTs and FFs in some cases when parsing with Slang.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with cloned version of vtr_reg_qor test that uses modified benchmarks from https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/3195 and uses Yosys-Slang as the parser. Most of these benchmarks pass the flow but still fail golden results, which is expected.

Also locally tested vtr_reg_qor with old version of benchmarks using default yosys parser. [PASSED]

Passes all existing CI tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed


**QoR Comparison Results** (Using Default Yosys Parser, comparing write-first vs. read-first):
Comparison Tables: [compare_tables.zip](https://github.com/user-attachments/files/21944737/compare_tables.zip)
Summary of Tables: [summary.xlsx](https://github.com/user-attachments/files/21971821/summary.xlsx)



**vtr_reg_qor_chain:**

- vtr_flow_elapsed_time, parmys_synth_time, abc_synth_time, pack_time, place_time, min_chan_width_route_time, and crit_path_route_time all had **5% - 7% decrease (gain)**.
- The rest (including crit_path_delay) have **minimal or no change**. **crit_path_delay has no change**
- From looking at various benchmarks in this test comparison, found **no change in the number of FFs**.

**koios_medium:**

- parmys_synth_time: **5% increase (loss)**
- abc_synth_time: **3% increase (loss)**
- place_time: **4% decrease (gain)**
- crit_path_route_time: **3% decrease (gain)**
- The rest have **minimal or no change**. **crit_path_delay has no change**
- Once again, found no change in number of FFs.