### PR TITLE
Move BLIF model existence check in architecture from end of BLIF parse to corresponding blackbox definition line

### DIFF
--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -311,6 +311,12 @@ struct BlifAllocCallback : public blifparse::Callback {
     }
 
     void blackbox() override {
+        LogicalModelId arch_model_id = models_.get_model_by_name(curr_model().netlist_name());
+        if (!arch_model_id.is_valid()) {
+            vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_, "Blackbox BLIF model '%s' has no equivalent architecture model.",
+                      curr_model().netlist_name().c_str());
+        }
+
         //We treat black-boxes as netlists during parsing so they should contain
         //only inpads/outpads
         for (const auto& blk_id : curr_model().blocks()) {
@@ -537,12 +543,6 @@ struct BlifAllocCallback : public blifparse::Callback {
 
     bool verify_blackbox_model(AtomNetlist& blif_model) {
         LogicalModelId arch_model_id = models_.get_model_by_name(blif_model.netlist_name());
-
-        if (!arch_model_id.is_valid()) {
-            vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_, "BLIF model '%s' has no equivalent architecture model.",
-                      blif_model.netlist_name().c_str());
-        }
-
         const t_model& arch_model = models_.get_model(arch_model_id);
 
         //Verify each port on the model


### PR DESCRIPTION
Moves BLIF model existence check in arch.xml from end of BLIF parse to point where corresponding blackbox model is read. 

### Old Behaviour
Throw an error if the blackbox BLIF model was not found in the architecture at the end of parsing.  This gives the name of the mismatching blackbox model but was pointing the user to the end of BLIF file.

### New Behaviour
Throw an error when we read that current model is a blackbox model and not found in architecture. This gives the name of the mismatching blackbox model and also points the user to line where current model is defined to be a blackbox model.

### Related Issue
Some BLIF errors point to the wrong line number (end of file) - https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/3215 

### Note:
The throws checking the existence of a main model (we should have a non-blackbox) and checking the number of non-blackbox model (we should have only 1 non-blackbox model) are still pointing to the end of BLIF file. These makes sense to me to be at the end of file as design decisions but open to review.