### PR TITLE
Removing Top Module Mapping With Slang

### DIFF
--- a/vtr_flow/misc/yosys/slang_filelist.tcl
+++ b/vtr_flow/misc/yosys/slang_filelist.tcl
@@ -2,82 +2,13 @@
 # 
 # Includes a function that builds a filelist of
 # HDL files provided by the circuit list to be
-# read by read_slang. This function also identifies
-# the respective top modules of HDL files in the filelist.
+# read by read_slang.
 
-
-namespace eval ::slang {
-	# INFO: Maps HDL files to respective top module(s) 
-	# top_map insertion syntax:
-	# <file> <top module>
-	array set top_map {
-		and_latch.v and_latch
-		multiclock_output_and_latch.v multiclock_output_and_latch
-		multiclock_reader_writer.v multiclock_reader_writer
-		multiclock_separate_and_latch.v multiclock_separate_and_latch
-		arm_core.v arm_core
-		bgm.v bgm
-		blob_merge.v RLE_BlobMerging
-		boundtop.v paj_boundtop_hierarchy_no_mem
-		ch_intrinsics.v memset
-		diffeq1.v diffeq_paj_convert
-		diffeq2.v diffeq_f_systemC
-		LU8PEEng.v LU8PEEng
-		LU32PEEng.v LU32PEEng
-		LU64PEEng.v LU64PEEng
-		mcml.v mcml
-		mkDelayWorker32B.v mkDelayWorker32B
-		mkPktMerge.v mkPktMerge
-		mkSMAdapter4B.v mkSMAdapter4B
-		or1200.v or1200_flat
-		raygentop.v paj_raygentop_hierarchy_no_mem
-		sha.v sha1
-		stereovision0.v sv_chip0_hierarchy_no_mem
-		stereovision1.v sv_chip1_hierarchy_no_mem
-		stereovision2.v sv_chip2_hierarchy_no_mem
-		stereovision3.v sv_chip3_hierarchy_no_mem
-		button_controller.sv top
-		display_control.sv top
-		debounce.sv top
-		timer.sv top
-		deepfreeze.style1.sv top
-		pulse_led.v top
-		clock.sv top
-		single_ff.v top
-		single_wire.v top
-		PWM.v top
-		flattened_pulse_width_led.sv top
-		modify_count.sv top
-		time_counter.sv top
-		spree.v system
-		attention_layer.v attention_layer
-		bnn.v bnn
-		tpu_like.small.os.v top
-		tpu_like.small.ws.v top
-		dla_like.small.v DLA
-		conv_layer_hls.v top
-		conv_layer.v conv_layer
-		eltwise_layer.v eltwise_layer
-		robot_rl.v robot_maze
-		reduction_layer.v reduction_layer
-		spmv.v spmv
-		softmax.v softmax
-	}
-	# INFO: List of HDL includes files 
-	# includes_map insertion syntax:
-	# <file> include
-	array set includes_map {
-		hard_block_include.v include
-	}
-
-
-	variable top_args {}
 
 # Function - build_filelist:
 #
 #	Validates file extensions of input files and writes the names
-#	of input files to the file list to be read by yosys-slang. Also appends
-#	the respective top modules of HDL files being read by slang to the read_slang command.
+#	of input files to the file list to be read by yosys-slang.
 #
 # Parameters:
 #
@@ -85,35 +16,16 @@ namespace eval ::slang {
 #	file_list - text file being written to that will contain
 #	     		the names of circuits from circuit list.
 #
-	proc build_filelist { circuit_list file_list } {
-		variable top_args
-		variable top_map
-		variable includes_map
-		set top_args {}
-		set fh [open $file_list "w"]
-		foreach f $circuit_list {
-			set ext [string tolower [file extension $f]]
-			if {$ext == ".sv" || $ext == ".svh" || $ext == ".v" || $ext == ".vh"} {
-				if {$f != "vtr_primitives.v" && $f != "vtr_blackboxes.v"} {
-					#Includes file
-					if {[info exists includes_map($f)]} {
-						puts $fh $f	
-					#HDL file or top module isn't in top_map
-					} elseif {![info exists top_map($f)]} {
-						error "No top module set for $f"
-					#HDL file and respective top module in top_map
-					} else {
-						puts $fh $f
-						set top_name $top_map($f)
-						lappend top_args --top $top_name
-					}
-				}
-			} else {
-				close $fh
-				error "Unsupported file type. Yosys-Slang accepts .sv .svh .v .vh. File {$f}"
-			}
+proc build_filelist { circuit_list file_list } {
+	set fh [open $file_list "w"]
+	foreach f $circuit_list {
+		set ext [string tolower [file extension $f]]
+		if {$ext == ".sv" || $ext == ".svh" || $ext == ".v" || $ext == ".vh"} {
+			puts $fh $f
+		} else {
+			close $fh
+			error "Unsupported file type. Yosys-Slang accepts .sv .svh .v .vh. Failing File {$f}"
 		}
-		close $fh
-		return $top_args
 	}
+	close $fh
 }

--- a/vtr_flow/misc/yosys/synthesis.tcl
+++ b/vtr_flow/misc/yosys/synthesis.tcl
@@ -34,10 +34,10 @@ if {$env(PARSER) == "slang" } {
 	source [file join [pwd] "slang_filelist.tcl"]
 	set readfile [file join [pwd] "filelist.txt"]
 	#Writing names of circuit files to file list
-	set slang_tops [::slang::build_filelist {XXX} $readfile]
+	build_filelist {XXX} $readfile
 	puts "Using Yosys read_slang command"
 	#Read vtr_primitives library and user design verilog in same command
-	read_slang -v $env(PRIMITIVES) {*}$slang_tops -C $readfile
+	read_slang -v $env(PRIMITIVES) -C $readfile
 } elseif {$env(PARSER) == "default" } {
 	puts "Using Yosys read_verilog command"
 	read_verilog -nomem2reg +/parmys/vtr_primitives.v


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Removed all top module mapping code in synthesis.tcl and slang_filelist.tcl for Slang.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since top module mapping isn't required for slang, any unused code for this that made it to master needs to be removed to reduce clutter.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes the system verilog regression test that uses slang as a parser.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed
