### PR TITLE
[WIP] Fixing Subtraction CIN Bug

### DIFF
--- a/parmys/parmys-plugin/parmys.cc
+++ b/parmys/parmys-plugin/parmys.cc
@@ -817,17 +817,6 @@ struct ParMYSPass : public Pass {
         log("\nTechmap Time: ");
         log_time(techmap_time);
         log("\n--------------------------------------------------------------------\n");
-
-        fprintf(stderr, "[BLIF-OUT] POs=%d\n", odin_netlist->num_top_output_nodes);
-        for (int k=0; k<odin_netlist->num_top_output_nodes; ++k) {
-            npin_t* in = odin_netlist->top_output_nodes[k]->input_pins[0];
-            fprintf(stderr, "  PO[%d]: net=%s driver=%s.pin%d\n",
-                k,
-                in->net && in->net->name ? in->net->name : "(noname)",
-                (in->net && in->net->driver_pins[0]->node &&
-                in->net->driver_pins[0]->node->name) ? in->net->driver_pins[0]->node->name : "(null)",
-                in->net ? in->net->driver_pins[0]->pin_node_idx : -1);
-        }
     }
 
     static void report(netlist_t *odin_netlist)

--- a/vtr_flow/misc/yosys/synthesis.tcl
+++ b/vtr_flow/misc/yosys/synthesis.tcl
@@ -80,15 +80,11 @@ techmap -map +/parmys/aldffe2dff.v
 
 opt -full
 
-write_verilog -noexpr pre_parmys.v
-
 # Separate options for Parmys execution (Verilog or SystemVerilog)
 if {$env(PARSER) == "default" || $env(PARSER) == "slang"} {
     # For Verilog, use -nopass for a simpler, faster flow
     parmys -a QQQ -nopass -c CCC YYY
 } 
-
-write_verilog -noexpr post_parmys.v
 
 opt -full
 
@@ -102,7 +98,5 @@ opt -fast -noff
 stat
 
 hierarchy -check -auto-top -purge_lib
-
-write_verilog -noexpr post_everything.v
 
 write_blif -true + vcc -false + gnd -undef + unconn -blackbox ZZZ


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When doing a 4-bit input a and b subtraction to get a 5 bit output, we must compute as 2's complement = (1's complement + 1)
See as a + (1's comp. of b) + 1 = a + (2's comp. of b).

The subtraction carry chain was originally computing 2's complement as 1's complement (a + (1's comp. of b)). The reason for this is that when the original wide hard adder was split into a 1-bit adder chain, the head adder of the chain was supposed to seed the rest of the chain with a carry-in of 1. Instead it computed GND (0) + VCC (1) + GND (0), which gives a cout of 0, seeding the rest of the chain with a carry-in of 0, resulting in a + (1's comp. of b). **This was fixed to compute VCC + VCC + GND, which seeds a carry-in of 1 to the rest of the chain.**

There is also an additional adder added to the tail end of the chain. This adder takes in GND and VCC and CIN as inputs and is supposed to output the correct sign bit out[4]. **This is currently broken** in the code as I was having trouble connecting the correct output back to the original wide hard adder.

See the issue below for a diagram of the bug and further explanation.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2266

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No in depth testing done yet as the code still needs some fixing up.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
