### PR TITLE
Cleanups in RR graph generation

### DIFF
--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -53,7 +53,8 @@ class DeviceGrid {
     void clear();
 
     /**
-     * @brief Return the number of instances of the specified tile type on the specified layer. If the layer_num is -1, return the total number of instances of the specified tile type on all layers.
+     * @brief Return the number of instances of the specified tile type on the specified layer.
+     * If the layer_num is -1, return the total number of instances of the specified tile type on all layers.
      * @note This function should be used if count_instances() is called in the constructor.
      */
     size_t num_instances(t_physical_tile_type_ptr type, int layer_num) const;
@@ -82,6 +83,16 @@ class DeviceGrid {
     inline bool is_root_location(const t_physical_tile_loc& tile_loc) const {
         return get_width_offset(tile_loc) == 0 && get_height_offset(tile_loc) == 0;
     }
+
+    ///@brief Given a location, return the root location (bottom-left corner) of the tile instance
+    inline t_physical_tile_loc get_root_location(const t_physical_tile_loc& tile_loc) const {
+        t_physical_tile_loc root_loc;
+        root_loc.layer_num = tile_loc.layer_num;
+        root_loc.x = tile_loc.x - get_width_offset(tile_loc);
+        root_loc.y = tile_loc.y - get_height_offset(tile_loc);
+        return root_loc;
+    }
+
 
     ///@brief Returns a rectangle which represents the bounding box of the tile at the given location.
     inline vtr::Rect<int> get_tile_bb(const t_physical_tile_loc& tile_loc) const {

--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -32,10 +32,9 @@ class DeviceGrid {
     const std::string& name() const { return name_; }
 
     ///@brief Return the number of layers(number of dies)
-    inline int get_num_layers() const {
-        return (int)grid_.dim_size(0);
+    inline size_t get_num_layers() const {
+        return grid_.dim_size(0);
     }
-
     ///@brief Return the width of the grid at the specified layer
     size_t width() const { return grid_.dim_size(1); }
     ///@brief Return the height of the grid at the specified layer

--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -137,10 +137,10 @@ class DeviceGrid {
         }
 
         bool operator==(const loc_const_iterator& o) const {
-            return g_ == o.g_
+            return loc_.x == o.loc_.x
+                   && loc_.y == o.loc_.y
                    && loc_.layer_num == o.loc_.layer_num
-                   && loc_.x == o.loc_.x
-                   && loc_.y == o.loc_.y;
+                   && g_ == o.g_;
         }
         bool operator!=(const loc_const_iterator& o) const { return !(*this == o); }
 

--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -93,7 +93,6 @@ class DeviceGrid {
         return root_loc;
     }
 
-
     ///@brief Returns a rectangle which represents the bounding box of the tile at the given location.
     inline vtr::Rect<int> get_tile_bb(const t_physical_tile_loc& tile_loc) const {
         t_physical_tile_type_ptr tile_type = get_physical_type(tile_loc);
@@ -108,7 +107,7 @@ class DeviceGrid {
 
     // Forward const-iterator over (layer, x, y)
     class loc_const_iterator {
-    public:
+      public:
         using value_type = t_physical_tile_loc;
         using difference_type = std::ptrdiff_t;
         using iterator_category = std::forward_iterator_tag;
@@ -139,13 +138,13 @@ class DeviceGrid {
 
         bool operator==(const loc_const_iterator& o) const {
             return g_ == o.g_
-                && loc_.layer_num == o.loc_.layer_num
-                && loc_.x == o.loc_.x
-                && loc_.y == o.loc_.y;
+                   && loc_.layer_num == o.loc_.layer_num
+                   && loc_.x == o.loc_.x
+                   && loc_.y == o.loc_.y;
         }
         bool operator!=(const loc_const_iterator& o) const { return !(*this == o); }
 
-    private:
+      private:
         const DeviceGrid* g_ = nullptr;
         t_physical_tile_loc loc_{0, 0, 0};
     };
@@ -153,11 +152,10 @@ class DeviceGrid {
     /// Iterate every (layer, x, y) location
     inline auto all_locations() const {
         return vtr::make_range(
-            loc_const_iterator(this, /*layer*/0, /*x*/0, /*y*/0),
-            loc_const_iterator(this, /*layer*/get_num_layers(), /*x*/0, /*y*/0) // end sentinel
+            loc_const_iterator(this, /*layer*/ 0, /*x*/ 0, /*y*/ 0),
+            loc_const_iterator(this, /*layer*/ get_num_layers(), /*x*/ 0, /*y*/ 0) // end sentinel
         );
     }
-
 
     ///@brief Return the metadata of the tile at the specified location
     inline const t_metadata_dict* get_metadata(const t_physical_tile_loc& tile_loc) const {

--- a/libs/libarchfpga/src/physical_types_util.cpp
+++ b/libs/libarchfpga/src/physical_types_util.cpp
@@ -78,7 +78,6 @@ static std::vector<int> get_pb_pin_src_pins(t_physical_tile_type_ptr physical_ty
                                             const t_pb_graph_pin* pin);
 
 /**
- *
  * @param physical_type physical tile which pin belongs to
  * @param sub_tile  sub_tile in which physical tile located
  * @param logical_block logical block mapped to the sub_tile
@@ -108,20 +107,12 @@ static t_pb_graph_pin* get_mutable_tile_pin_pb_pin(t_physical_tile_type* physica
                                                    int pin_physical_num);
 
 /**
- *
- * @param physical_tile
- * @param class_physical_num
  * @return A vector containing all of the parent pb_graph_nodes and the pb_graph_node of the class_physical_num itself
  */
 static std::vector<const t_pb_graph_node*> get_sink_hierarchical_parents(t_physical_tile_type_ptr physical_tile,
                                                                          int class_physical_num);
 
 /**
- *
- * @param physical_tile
- * @param pin_physcial_num
- * @param ref_sink_num
- * @param sink_grp
  * @return Return zero if the ref_sink_num is not reachable by pin_physical_num, otherwise return the number sinks in sink_grp
  * reachable by pin_physical_num
  */
@@ -618,21 +609,21 @@ bool is_opin(int ipin, t_physical_tile_type_ptr type) {
         return false;
 }
 
-bool is_pin_conencted_to_layer(t_physical_tile_type_ptr type, int ipin, int from_layer, int to_layer, int num_of_avail_layer) {
-    if (type->is_empty()) { //if type is empty, there is no pins
+bool is_pin_conencted_to_layer(t_physical_tile_type_ptr type, int ipin, int from_layer, int to_layer, unsigned num_of_avail_layer) {
+    // if type is empty, there is no pins
+    if (type->is_empty()) {
         return false;
     }
-    //ipin should be a valid pin in physical type
+
+    // ipin should be a valid pin in physical type
     VTR_ASSERT(ipin < type->num_pins);
-    int pin_layer = from_layer + type->pin_layer_offset[ipin];
-    //if pin_offset specifies a layer that doesn't exist in arch file, we do a wrap around
+    unsigned pin_layer = from_layer + type->pin_layer_offset[ipin];
+    // if pin_offset specifies a layer that doesn't exist in arch file, we do a wrap around
     pin_layer = (pin_layer < num_of_avail_layer) ? pin_layer : pin_layer % num_of_avail_layer;
-    if (from_layer == to_layer || pin_layer == to_layer) {
+    if (from_layer == to_layer || int(pin_layer) == to_layer) {
         return true;
-    } else {
-        return false;
     }
-    //not reachable
+
     return false;
 }
 
@@ -643,7 +634,7 @@ std::string block_type_pin_index_to_name(t_physical_tile_type_ptr type, int pin_
     std::string pin_name = type->name;
 
     int sub_tile_index, inst_num, logical_num, pb_type_idx;
-    std::tie<int, int, int, int, int>(pin_index, sub_tile_index, inst_num, logical_num, pb_type_idx) = get_pin_index_for_inst(type, pin_physical_num, is_flat);
+    std::tie(pin_index, sub_tile_index, inst_num, logical_num, pb_type_idx) = get_pin_index_for_inst(type, pin_physical_num, is_flat);
     if (type->sub_tiles[sub_tile_index].capacity.total() > 1) {
         pin_name += "[" + std::to_string(inst_num) + "]";
     }

--- a/libs/libarchfpga/src/physical_types_util.h
+++ b/libs/libarchfpga/src/physical_types_util.h
@@ -116,7 +116,7 @@
 bool is_opin(int ipin, t_physical_tile_type_ptr type);
 
 ///@brief Returns true if the specified pin is located at "from_layer" and it is connected to "to_layer"
-bool is_pin_conencted_to_layer(t_physical_tile_type_ptr type, int ipin, int from_layer, int to_layer, int num_of_avail_layer);
+bool is_pin_conencted_to_layer(t_physical_tile_type_ptr type, int ipin, int from_layer, int to_layer, unsigned num_of_avail_layer);
 
 /**
  * @brief Returns the corresponding physical pin based on the input parameters:

--- a/libs/libvtrutil/src/vtr_math.h
+++ b/libs/libvtrutil/src/vtr_math.h
@@ -83,7 +83,7 @@ ResultTy median(Container c) {
 ///@brief Returns the median of a whole container, assuming that it is already
 ///       sorted.
 template<typename ResultTy = double, typename Container>
-ResultTy median_presorted(const Container &c) {
+ResultTy median_presorted(const Container& c) {
     return median_presorted<ResultTy>(std::begin(c), std::end(c));
 }
 
@@ -116,7 +116,7 @@ double geomean(const InputIterator first, const InputIterator last, double init 
 
 ///@brief Returns the geometric mean of a whole container
 template<typename Container>
-double geomean(const Container &c) {
+double geomean(const Container& c) {
     return geomean(std::begin(c), std::end(c));
 }
 
@@ -139,7 +139,7 @@ double arithmean(const InputIterator first, const InputIterator last, double ini
 
 ///@brief Returns the aritmatic mean of a whole container
 template<typename Container>
-double arithmean(const Container &c) {
+double arithmean(const Container& c) {
     return arithmean(std::begin(c), std::end(c));
 }
 

--- a/vpr/src/analytical_place/analytical_placement_flow.cpp
+++ b/vpr/src/analytical_place/analytical_placement_flow.cpp
@@ -111,9 +111,9 @@ static void convert_flat_to_partial_placement(const FlatPlacementInfo& flat_plac
             } else {
                 if (current_loc_x != -1 && current_loc_y != -1) {
                     atom_loc_x = std::clamp(current_loc_x, 0.0f,
-                                            static_cast<float>(g_vpr_ctx.device().grid.width() -1));
+                                            static_cast<float>(g_vpr_ctx.device().grid.width() - 1));
                     atom_loc_y = std::clamp(current_loc_y, 0.0f,
-                                            static_cast<float>(g_vpr_ctx.device().grid.height() -1));
+                                            static_cast<float>(g_vpr_ctx.device().grid.height() - 1));
                     // If current_loc_layer or current_loc_sub_tile are unset (-1), default to layer 0 and sub_tile 0.
                     if (current_loc_layer == -1)
                         current_loc_layer = 0;
@@ -155,7 +155,7 @@ static void convert_flat_to_partial_placement(const FlatPlacementInfo& flat_plac
         }
     }
     VTR_LOG("%zu of %zu molecules placed at device center (no atoms of these molecules found in flat placement).\n",
-        num_mols_assigned_to_center, ap_netlist.blocks().size());
+            num_mols_assigned_to_center, ap_netlist.blocks().size());
 }
 
 /**

--- a/vpr/src/analytical_place/full_legalizer.cpp
+++ b/vpr/src/analytical_place/full_legalizer.cpp
@@ -60,7 +60,6 @@
 #include "setup_grid.h"
 #include "stats.h"
 
-
 std::unique_ptr<FullLegalizer> make_full_legalizer(e_ap_full_legalizer full_legalizer_type,
                                                    const APNetlist& ap_netlist,
                                                    const AtomNetlist& atom_netlist,
@@ -299,8 +298,8 @@ static LegalizationClusterId create_new_cluster(PackMoleculeId seed_molecule_id,
  *
  */
 static t_logical_block_type_ptr infer_molecule_logical_block_type(PackMoleculeId mol_id,
-                                                                const Prepacker& prepacker,
-                                                                const vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types) {
+                                                                  const Prepacker& prepacker,
+                                                                  const vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>& primitive_candidate_block_types) {
     // Get the root atom and its model id. Ensure that both is valid.
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
     const t_pack_molecule& molecule = prepacker.get_molecule(mol_id);
@@ -352,16 +351,16 @@ FlatRecon::sort_and_group_blocks_by_tile(const PartialPlacement& p_placement) {
     //    by descending number of external input pins. (empirically best for reconstructing
     //    dense clusters compared to external outputs or external total pins).
     std::sort(sorted_blocks.begin(), sorted_blocks.end(),
-            [](const BlockInformation& a, const BlockInformation& b) {
-                // Long chains should always come before non-long chains
-                if (a.is_long_chain && !b.is_long_chain)
-                    return true;
-                if (!a.is_long_chain && b.is_long_chain)
-                    return false;
+              [](const BlockInformation& a, const BlockInformation& b) {
+                  // Long chains should always come before non-long chains
+                  if (a.is_long_chain && !b.is_long_chain)
+                      return true;
+                  if (!a.is_long_chain && b.is_long_chain)
+                      return false;
 
-                // If both blocks are chains / not chains, sort in decreasing order of external inputs.
-                return a.ext_inps > b.ext_inps;
-            });
+                  // If both blocks are chains / not chains, sort in decreasing order of external inputs.
+                  return a.ext_inps > b.ext_inps;
+              });
 
     // Group the molecules by root tile. Any non-zero offset gets
     // pulled back to its root.
@@ -442,7 +441,7 @@ void FlatRecon::self_clustering(ClusterLegalizer& cluster_legalizer,
         // Check legality of clusters created with fast pass. Store the
         // illegal cluster molecules for full strategy pass.
         std::vector<PackMoleculeId> illegal_cluster_mols;
-        for (LegalizationClusterId cluster_id: created_clusters) {
+        for (LegalizationClusterId cluster_id : created_clusters) {
             if (!cluster_legalizer.check_cluster_legality(cluster_id)) {
                 for (PackMoleculeId mol_id : cluster_legalizer.get_cluster_molecules(cluster_id)) {
                     illegal_cluster_mols.push_back(mol_id);
@@ -510,14 +509,14 @@ FlatRecon::neighbor_clustering(ClusterLegalizer& cluster_legalizer,
         // Also remove empty neighbor tiles from neighbor_tile_locs.
         std::unordered_map<t_physical_tile_loc, double> avg_mols_in_tile;
         avg_mols_in_tile.reserve(neighbor_tile_locs.size());
-        for (auto it = neighbor_tile_locs.begin(); it != neighbor_tile_locs.end(); ) {
+        for (auto it = neighbor_tile_locs.begin(); it != neighbor_tile_locs.end();) {
             const std::unordered_set<LegalizationClusterId>& clusters = tile_clusters_matrix[it->layer_num][it->x][it->y];
             if (clusters.empty()) {
                 it = neighbor_tile_locs.erase(it);
                 continue;
             }
             size_t total_molecules_in_tile = 0;
-            for (const LegalizationClusterId& cluster_id: clusters) {
+            for (const LegalizationClusterId& cluster_id : clusters) {
                 total_molecules_in_tile += cluster_legalizer.get_num_molecules_in_cluster(cluster_id);
             }
             avg_mols_in_tile[*it] = double(total_molecules_in_tile) / clusters.size();
@@ -526,21 +525,21 @@ FlatRecon::neighbor_clustering(ClusterLegalizer& cluster_legalizer,
 
         // Sort tile locations by increasing average molecule count.
         std::sort(neighbor_tile_locs.begin(), neighbor_tile_locs.end(),
-            [&](const t_physical_tile_loc& a, const t_physical_tile_loc& b) {
-                return avg_mols_in_tile[a] < avg_mols_in_tile[b];
-            });
+                  [&](const t_physical_tile_loc& a, const t_physical_tile_loc& b) {
+                      return avg_mols_in_tile[a] < avg_mols_in_tile[b];
+                  });
 
         // Try to fit the unclustered molecule to sorted neighbor tile clusters.
         // Note: This pass opens a cluster, try to add one molecule to it, then close it again. This might cost CPU
         // time if many molecules are packed in the same cluster in this pass, vs. just opening it once and adding
         // them all.
         bool fit_in_a_neighbor = false;
-        for (const t_physical_tile_loc& neighbor_tile_loc: neighbor_tile_locs) {
+        for (const t_physical_tile_loc& neighbor_tile_loc : neighbor_tile_locs) {
             // Get the current neighbor tile clusters.
             std::unordered_set<LegalizationClusterId>& clusters = tile_clusters_matrix[neighbor_tile_loc.layer_num][neighbor_tile_loc.x][neighbor_tile_loc.y];
 
             // Iterate over the current tile clusters until unclustered molecule fit in one.
-            for (auto it = clusters.begin(); it != clusters.end() && !fit_in_a_neighbor; ) {
+            for (auto it = clusters.begin(); it != clusters.end() && !fit_in_a_neighbor;) {
                 LegalizationClusterId cluster_id = *it;
                 if (!cluster_id.is_valid()) {
                     ++it;
@@ -553,13 +552,13 @@ FlatRecon::neighbor_clustering(ClusterLegalizer& cluster_legalizer,
 
                 // Set the legalization strategy to speculative for fast try.
                 cluster_legalizer.set_legalization_strategy(ClusterLegalizationStrategy::SKIP_INTRA_LB_ROUTE);
-                
+
                 // Use the first molecule as seed to recreate the cluster.
                 PackMoleculeId seed_mol = cluster_molecules[0];
-                LegalizationClusterId new_cluster_id = create_new_cluster(seed_mol, prepacker_, cluster_legalizer, primitive_candidate_block_types); 
+                LegalizationClusterId new_cluster_id = create_new_cluster(seed_mol, prepacker_, cluster_legalizer, primitive_candidate_block_types);
 
                 // Add remaining old molecules to the new cluster.
-                for (PackMoleculeId mol_id: cluster_molecules) {
+                for (PackMoleculeId mol_id : cluster_molecules) {
                     if (mol_id == seed_mol)
                         continue;
                     if (!cluster_legalizer.is_molecule_compatible(mol_id, new_cluster_id))
@@ -574,8 +573,8 @@ FlatRecon::neighbor_clustering(ClusterLegalizer& cluster_legalizer,
                 // If recreated cluster is illegal, try again with full strategy.
                 if (!cluster_legalizer.check_cluster_legality(new_cluster_id)) {
                     cluster_legalizer.destroy_cluster(new_cluster_id);
-                    new_cluster_id = create_new_cluster(seed_mol, prepacker_, cluster_legalizer, primitive_candidate_block_types); 
-                    for (PackMoleculeId mol_id: cluster_molecules) {
+                    new_cluster_id = create_new_cluster(seed_mol, prepacker_, cluster_legalizer, primitive_candidate_block_types);
+                    for (PackMoleculeId mol_id : cluster_molecules) {
                         if (mol_id == seed_mol)
                             continue;
                         if (!cluster_legalizer.is_molecule_compatible(mol_id, new_cluster_id))
@@ -585,7 +584,7 @@ FlatRecon::neighbor_clustering(ClusterLegalizer& cluster_legalizer,
                 }
 
                 // Lastly, try to add the new unclustered molecule to the recreated cluster.
-                if (cluster_legalizer.is_molecule_compatible(molecule_id, new_cluster_id)){
+                if (cluster_legalizer.is_molecule_compatible(molecule_id, new_cluster_id)) {
                     e_block_pack_status pack_status = cluster_legalizer.add_mol_to_cluster(molecule_id, new_cluster_id);
                     if (pack_status == e_block_pack_status::BLK_PASSED)
                         fit_in_a_neighbor = true;
@@ -603,7 +602,7 @@ FlatRecon::neighbor_clustering(ClusterLegalizer& cluster_legalizer,
                 mols_clustered.insert(molecule_id);
                 break;
             }
-        }   
+        }
     }
     return mols_clustered;
 }
@@ -620,7 +619,7 @@ FlatRecon::orphan_window_clustering(ClusterLegalizer& cluster_legalizer,
     auto [layer_num, width, height] = device_grid_.dim_sizes();
     vtr::NdMatrix<std::unordered_set<PackMoleculeId>, 3> unclustered_tile_molecules({layer_num, width, height});
     std::vector<PackMoleculeId> unclustered_blocks;
-    for (APBlockId blk_id: ap_netlist_.blocks()) {
+    for (APBlockId blk_id : ap_netlist_.blocks()) {
         PackMoleculeId mol_id = ap_netlist_.block_molecule(blk_id);
         if (cluster_legalizer.is_mol_clustered(mol_id))
             continue;
@@ -631,14 +630,14 @@ FlatRecon::orphan_window_clustering(ClusterLegalizer& cluster_legalizer,
 
     // Sort unclustered blocks by highest external input pins.
     std::sort(unclustered_blocks.begin(), unclustered_blocks.end(),
-            [this](const PackMoleculeId& a, const PackMoleculeId& b) {
-                int ext_pins_a = prepacker_.calc_molecule_stats(a, atom_netlist_, arch_.models).num_used_ext_inputs;
-                int ext_pins_b = prepacker_.calc_molecule_stats(b, atom_netlist_, arch_.models).num_used_ext_inputs;
-                return ext_pins_a > ext_pins_b;
-            });
+              [this](const PackMoleculeId& a, const PackMoleculeId& b) {
+                  int ext_pins_a = prepacker_.calc_molecule_stats(a, atom_netlist_, arch_.models).num_used_ext_inputs;
+                  int ext_pins_b = prepacker_.calc_molecule_stats(b, atom_netlist_, arch_.models).num_used_ext_inputs;
+                  return ext_pins_a > ext_pins_b;
+              });
 
     std::unordered_set<LegalizationClusterId> created_clusters;
-    for (PackMoleculeId seed_mol_id: unclustered_blocks) {
+    for (PackMoleculeId seed_mol_id : unclustered_blocks) {
         if (cluster_legalizer.is_mol_clustered(seed_mol_id))
             continue;
 
@@ -659,7 +658,7 @@ FlatRecon::orphan_window_clustering(ClusterLegalizer& cluster_legalizer,
         std::queue<t_physical_tile_loc> loc_queue;
         loc_queue.push(seed_tile_loc);
 
-        while(!loc_queue.empty()) {
+        while (!loc_queue.empty()) {
             // Get the first location and try to add molecules in that tile to cluster created with seed molecule.
             t_physical_tile_loc current_tile_loc = loc_queue.front();
             loc_queue.pop();
@@ -671,12 +670,12 @@ FlatRecon::orphan_window_clustering(ClusterLegalizer& cluster_legalizer,
 
             // Skip this location if it is out of our range. This will stop expanding beyond scope.
             int distance = std::abs(seed_tile_loc.x - current_tile_loc.x) + std::abs(seed_tile_loc.y - current_tile_loc.y) + std::abs(seed_tile_loc.layer_num - current_tile_loc.layer_num);
-            if (distance> search_radius)
+            if (distance > search_radius)
                 continue;
 
             // Try to add each unclustered molecule in that tile to the current cluster.
             std::unordered_set<PackMoleculeId>& tile_molecules = unclustered_tile_molecules[current_tile_loc.layer_num][current_tile_loc.x][current_tile_loc.y];
-            for (auto it = tile_molecules.begin(); it != tile_molecules.end(); ) {
+            for (auto it = tile_molecules.begin(); it != tile_molecules.end();) {
                 if (!cluster_legalizer.is_molecule_compatible(*it, cluster_id)) {
                     ++it;
                     continue;
@@ -732,13 +731,13 @@ void FlatRecon::report_clustering_summary(ClusterLegalizer& cluster_legalizer,
     std::unordered_map<std::string, size_t> cluster_type_count_self_pass,
         cluster_type_count_orphan_window_pass;
     size_t num_of_mols_clustered_in_self_pass = 0,
-        num_of_mols_clustered_in_orphan_window_pass = 0;
+           num_of_mols_clustered_in_orphan_window_pass = 0;
     size_t num_of_clusters_in_self_pass = 0,
-        num_of_clusters_in_orphan_window_pass = 0;
+           num_of_clusters_in_orphan_window_pass = 0;
 
     // Collect statistics.
     for (LegalizationClusterId cluster_id : cluster_legalizer.clusters()) {
-        if (!cluster_id.is_valid())  continue;
+        if (!cluster_id.is_valid()) continue;
 
         t_logical_block_type_ptr block_type = cluster_legalizer.get_cluster_type(cluster_id);
         std::string block_name = block_type->name;
@@ -828,7 +827,7 @@ void FlatRecon::create_clusters(ClusterLegalizer& cluster_legalizer,
     std::vector<int> orphan_window_search_radii = {8, 16, static_cast<int>(device_grid.width() + device_grid.height())};
     bool fits_on_device = false;
     std::unordered_set<LegalizationClusterId> orphan_window_clusters;
-    for (int orphan_window_search_radius: orphan_window_search_radii) {
+    for (int orphan_window_search_radius : orphan_window_search_radii) {
         orphan_window_clusters = orphan_window_clustering(cluster_legalizer,
                                                           primitive_candidate_block_types,
                                                           orphan_window_search_radius);
@@ -854,7 +853,7 @@ void FlatRecon::create_clusters(ClusterLegalizer& cluster_legalizer,
 
         // Destroy the orphan window clusters to recreate with bigger search radius.
         VTR_LOG("Clusters did not fit on device with orphan window search radius of %d.\n", orphan_window_search_radius);
-        for (LegalizationClusterId cluster_id: orphan_window_clusters) {
+        for (LegalizationClusterId cluster_id : orphan_window_clusters) {
             if (!cluster_id.is_valid())
                 continue;
             cluster_legalizer.destroy_cluster(cluster_id);
@@ -934,21 +933,21 @@ void FlatRecon::place_clusters(const PartialPlacement& p_placement) {
     //       in neighbor pass and atoms misplaced might not match exactly. It might be safer
     //       to write FlatRecon's own placer in that case.
     initial_placement(vpr_setup_.PlacerOpts,
-                        vpr_setup_.PlacerOpts.constraints_file.c_str(),
-                        vpr_setup_.NocOpts,
-                        blk_loc_registry,
-                        *g_vpr_ctx.placement().place_macros,
-                        noc_cost_handler,
-                        flat_placement_info,
-                        rng);
+                      vpr_setup_.PlacerOpts.constraints_file.c_str(),
+                      vpr_setup_.NocOpts,
+                      blk_loc_registry,
+                      *g_vpr_ctx.placement().place_macros,
+                      noc_cost_handler,
+                      flat_placement_info,
+                      rng);
 
     // Log some information on how good the reconstruction was.
     log_flat_placement_reconstruction_info(flat_placement_info,
-                                            blk_loc_registry.block_locs(),
-                                            g_vpr_ctx.clustering().atoms_lookup,
-                                            g_vpr_ctx.atom().lookup(),
-                                            atom_netlist_,
-                                            g_vpr_ctx.clustering().clb_nlist);
+                                           blk_loc_registry.block_locs(),
+                                           g_vpr_ctx.clustering().atoms_lookup,
+                                           g_vpr_ctx.atom().lookup(),
+                                           atom_netlist_,
+                                           g_vpr_ctx.clustering().clb_nlist);
 
     // Verify that the placement is valid for the VTR flow.
     unsigned num_errors = verify_placement(blk_loc_registry,

--- a/vpr/src/base/blk_loc_registry.cpp
+++ b/vpr/src/base/blk_loc_registry.cpp
@@ -154,27 +154,21 @@ void BlkLocRegistry::clear_block_type_grid_locs(const std::unordered_set<int>& u
 
     bool clear_all_block_types = false;
 
-    /* check if all types should be cleared
-     * logical_block_types contain empty type, needs to be ignored.
-     * Not having any type in unplaced_blk_types_index means that it is the first iteration, hence all grids needs to be cleared
-     */
+    // check if all types should be cleared
+    // logical_block_types contain empty type, needs to be ignored.
+    // Not having any type in unplaced_blk_types_index means that it is the first iteration, hence all grids needs to be cleared
     if (unplaced_blk_types_index.size() == device_ctx.logical_block_types.size() - 1) {
         clear_all_block_types = true;
     }
 
-    /* We'll use the grid to record where everything goes. Initialize to the grid has no
-     * blocks placed anywhere.
-     */
-    for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
-        for (int i = 0; i < (int)device_ctx.grid.width(); i++) {
-            for (int j = 0; j < (int)device_ctx.grid.height(); j++) {
-                const t_physical_tile_type_ptr type = device_ctx.grid.get_physical_type({i, j, layer_num});
-                int itype = type->index;
-                if (clear_all_block_types || unplaced_blk_types_index.count(itype)) {
-                    for (int k = 0; k < device_ctx.physical_tile_types[itype].capacity; k++) {
-                        grid_blocks_.set_block_at_location({i, j, k, layer_num}, ClusterBlockId::INVALID());
-                    }
-                }
+    // We'll use the grid to record where everything goes. Initialize to the grid has no
+    // blocks placed anywhere.
+    for (const t_physical_tile_loc loc : device_ctx.grid.all_locations()) {
+        const t_physical_tile_type_ptr type = device_ctx.grid.get_physical_type(loc);
+        int itype = type->index;
+        if (clear_all_block_types || unplaced_blk_types_index.count(itype)) {
+            for (int k = 0; k < device_ctx.physical_tile_types[itype].capacity; k++) {
+                grid_blocks_.set_block_at_location({loc, k}, ClusterBlockId::INVALID());
             }
         }
     }

--- a/vpr/src/base/load_flat_place.cpp
+++ b/vpr/src/base/load_flat_place.cpp
@@ -259,7 +259,7 @@ void log_flat_placement_reconstruction_info(
         VTR_ASSERT(flat_placement_info.blk_layer[atom_blk_id] != FlatPlacementInfo::UNDEFINED_POS);
         VTR_ASSERT(flat_placement_info.blk_sub_tile[atom_blk_id] != FlatPlacementInfo::UNDEFINED_SUB_TILE);
 
-         // Get the (x, y, layer) position of the block.
+        // Get the (x, y, layer) position of the block.
         float blk_x = flat_placement_info.blk_x_pos[atom_blk_id];
         float blk_y = flat_placement_info.blk_y_pos[atom_blk_id];
         float blk_layer = flat_placement_info.blk_layer[atom_blk_id];

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -177,9 +177,9 @@ typedef std::pair<DelayTriple, std::string> sequential_port_delay_pair;
  * @brief Information needed to describe a delay on a port in an SDF file.
  */
 struct PortDelay {
-    std::string port_name;          ///<The name of the port to annotate with delay.
-    int ipin;                       ///<The pin in the port to annotate (if a multi-pin port).
-    DelayTriple port_delay_triple;  ///<The delay triple to annotate.
+    std::string port_name;         ///<The name of the port to annotate with delay.
+    int ipin;                      ///<The pin in the port to annotate (if a multi-pin port).
+    DelayTriple port_delay_triple; ///<The delay triple to annotate.
 };
 
 /*enum class PortType {
@@ -1981,7 +1981,6 @@ class NetlistWriterVisitor : public NetlistVisitor {
 
                                 ipin_port_delay_triple = new_port_delay_time;
                             }
-
                         }
                     }
 
@@ -2007,7 +2006,6 @@ class NetlistWriterVisitor : public NetlistVisitor {
                                                              atom_netlist.pin_port_bit(clk_pin_id),
                                                              DelayTriple(thld, thld, thld));
                             }
-
                         }
                     }
 
@@ -2116,7 +2114,6 @@ class NetlistWriterVisitor : public NetlistVisitor {
                                                         port->name,
                                                         ipin,
                                                         total_cq_delay_triple);
-
                         }
                     }
                 }

--- a/vpr/src/base/setup_grid.cpp
+++ b/vpr/src/base/setup_grid.cpp
@@ -35,7 +35,7 @@ static std::vector<t_logical_block_type_ptr> grid_overused_resources(const Devic
 static bool grid_satisfies_instance_counts(const DeviceGrid& grid, const std::map<t_logical_block_type_ptr, size_t>& instance_counts, float maximum_utilization);
 static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t width, size_t height, bool warn_out_of_range = true, const std::vector<t_logical_block_type_ptr>& limiting_resources = std::vector<t_logical_block_type_ptr>());
 
-///@brief Check grid is valid
+///@brief Check if grid is valid
 static void check_grid(const DeviceGrid& grid);
 
 static void set_grid_block_type(int priority,
@@ -118,7 +118,7 @@ DeviceGrid create_device_grid(const std::string& layout_name, const std::vector<
             return build_device_grid(*layout, layout->width, layout->height);
         }
     } else {
-        //Use the specified device
+        // Use the specified device
         auto cmp = [&](const t_grid_def& grid_def) {
             return grid_def.name == layout_name;
         };

--- a/vpr/src/base/setup_grid.cpp
+++ b/vpr/src/base/setup_grid.cpp
@@ -704,12 +704,12 @@ static void check_grid(const DeviceGrid& grid) {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has invalid width offset (%d).\n",
                             tile_loc.layer_num, tile_loc.x, tile_loc.y,
                             width_offset);
-            }
+        }
         if ((grid.get_height_offset(tile_loc) < 0) || (grid.get_height_offset(tile_loc) >= type->height)) {
             VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has invalid height offset (%d).\n",
                             tile_loc.layer_num, tile_loc.x, tile_loc.y,
                             height_offset);
-            }
+        }
 
         // Verify that type and width/height offsets are correct (e.g. for dimension > 1 blocks)
         if (grid.get_width_offset(tile_loc) == 0 && grid.get_height_offset(tile_loc) == 0) {

--- a/vpr/src/base/setup_grid.cpp
+++ b/vpr/src/base/setup_grid.cpp
@@ -35,7 +35,8 @@ static std::vector<t_logical_block_type_ptr> grid_overused_resources(const Devic
 static bool grid_satisfies_instance_counts(const DeviceGrid& grid, const std::map<t_logical_block_type_ptr, size_t>& instance_counts, float maximum_utilization);
 static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t width, size_t height, bool warn_out_of_range = true, const std::vector<t_logical_block_type_ptr>& limiting_resources = std::vector<t_logical_block_type_ptr>());
 
-static void CheckGrid(const DeviceGrid& grid);
+///@brief Check grid is valid
+static void check_grid(const DeviceGrid& grid);
 
 static void set_grid_block_type(int priority,
                                 const t_physical_tile_type* type,
@@ -545,7 +546,7 @@ static DeviceGrid build_device_grid(const t_grid_def& grid_def, size_t grid_widt
 
     auto device_grid = DeviceGrid(grid_def.name, grid, limiting_resources);
 
-    CheckGrid(device_grid);
+    check_grid(device_grid);
 
     return device_grid;
 }
@@ -615,8 +616,8 @@ static void set_grid_block_type(int priority,
             priority, type->name.c_str());
     }
 
-    //Mark all the grid tiles 'covered' by this block with the appropriate type
-    //and width/height offsets
+    // Mark all the grid tiles 'covered' by this block with the appropriate type
+    // and width/height offsets
     std::set<TypeLocation> root_blocks_to_rip_up;
     auto& device_ctx = g_vpr_ctx.device();
     for (size_t x = x_root; x < x_root + type->width; ++x) {
@@ -654,9 +655,9 @@ static void set_grid_block_type(int priority,
         }
     }
 
-    //Rip-up any invalidated blocks
+    // Rip-up any invalidated blocks
     for (auto invalidated_root : root_blocks_to_rip_up) {
-        //Mark all the grid locations used by this root block as empty
+        // Mark all the grid locations used by this root block as empty
         for (size_t x = invalidated_root.x; x < invalidated_root.x + invalidated_root.type->width; ++x) {
             int x_offset = x - invalidated_root.x;
             for (size_t y = invalidated_root.y; y < invalidated_root.y + invalidated_root.type->height; ++y) {
@@ -690,65 +691,53 @@ static void set_grid_block_type(int priority,
     }
 }
 
-///@brief Check grid is valid
-static void CheckGrid(const DeviceGrid& grid) {
-    for (int layer_num = 0; layer_num < grid.get_num_layers(); layer_num++) { //Check each die individually
-        for (int i = 0; i < (int)grid.width(); ++i) {
-            for (int j = 0; j < (int)grid.height(); ++j) {
-                const t_physical_tile_loc tile_loc(i, j, layer_num);
-                const auto& type = grid.get_physical_type(tile_loc);
-                int width_offset = grid.get_width_offset(tile_loc);
-                int height_offset = grid.get_height_offset(tile_loc);
-                if (nullptr == type) {
-                    VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has no type.\n", i, j, layer_num);
-                }
+static void check_grid(const DeviceGrid& grid) {
+    for (const t_physical_tile_loc tile_loc : grid.all_locations()) {
+        const t_physical_tile_type_ptr type = grid.get_physical_type(tile_loc);
+        int width_offset = grid.get_width_offset(tile_loc);
+        int height_offset = grid.get_height_offset(tile_loc);
+        if (nullptr == type) {
+            VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has no type.\n", tile_loc.layer_num, tile_loc.x, tile_loc.y);
+        }
 
-                if ((grid.get_width_offset(tile_loc) < 0)
-                    || (grid.get_width_offset(tile_loc) >= type->width)) {
-                    VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has invalid width offset (%d).\n",
-                                    i,
-                                    j,
-                                    layer_num,
-                                    width_offset);
-                }
-                if ((grid.get_height_offset(tile_loc) < 0)
-                    || (grid.get_height_offset(tile_loc) >= type->height)) {
-                    VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has invalid height offset (%d).\n",
-                                    i,
-                                    j,
-                                    layer_num,
-                                    height_offset);
-                }
+        if ((grid.get_width_offset(tile_loc) < 0) || (grid.get_width_offset(tile_loc) >= type->width)) {
+            VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has invalid width offset (%d).\n",
+                            tile_loc.layer_num, tile_loc.x, tile_loc.y,
+                            width_offset);
+            }
+        if ((grid.get_height_offset(tile_loc) < 0) || (grid.get_height_offset(tile_loc) >= type->height)) {
+            VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Grid Location (%d,%d,%d) has invalid height offset (%d).\n",
+                            tile_loc.layer_num, tile_loc.x, tile_loc.y,
+                            height_offset);
+            }
 
-                //Verify that type and width/height offsets are correct (e.g. for dimension > 1 blocks)
-                if (grid.get_width_offset(tile_loc) == 0 && grid.get_height_offset(tile_loc) == 0) {
-                    //From the root block check that all other blocks are correct
-                    for (int x = i; x < i + type->width; ++x) {
-                        int x_offset = x - i;
-                        for (int y = j; y < j + type->height; ++y) {
-                            int y_offset = y - j;
-                            const t_physical_tile_loc tile_loc_offset(x, y, layer_num);
-                            const auto& tile_type = grid.get_physical_type(tile_loc_offset);
-                            int tile_width_offset = grid.get_width_offset(tile_loc_offset);
-                            int tile_height_offset = grid.get_height_offset(tile_loc_offset);
-                            if (tile_type != type) {
-                                VPR_FATAL_ERROR(VPR_ERROR_OTHER,
-                                                "Grid Location (%d,%d,%d) should have type '%s' (based on root location) but has type '%s'\n",
-                                                i, j, layer_num, type->name.c_str(), type->name.c_str());
-                            }
+        // Verify that type and width/height offsets are correct (e.g. for dimension > 1 blocks)
+        if (grid.get_width_offset(tile_loc) == 0 && grid.get_height_offset(tile_loc) == 0) {
+            // From the root block check that all other blocks are correct
+            for (int x = tile_loc.x; x < tile_loc.x + type->width; ++x) {
+                int x_offset = x - tile_loc.x;
+                for (int y = tile_loc.y; y < tile_loc.y + type->height; ++y) {
+                    int y_offset = y - tile_loc.y;
+                    const t_physical_tile_loc tile_loc_offset(x, y, tile_loc.layer_num);
+                    const auto& tile_type = grid.get_physical_type(tile_loc_offset);
+                    int tile_width_offset = grid.get_width_offset(tile_loc_offset);
+                    int tile_height_offset = grid.get_height_offset(tile_loc_offset);
+                    if (tile_type != type) {
+                        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                                        "Grid Location (%d,%d,%d) should have type '%s' (based on root location) but has type '%s'\n",
+                                        tile_loc.layer_num, tile_loc.x, tile_loc.y, type->name.c_str(), type->name.c_str());
+                    }
 
-                            if (tile_width_offset != x_offset) {
-                                VPR_FATAL_ERROR(VPR_ERROR_OTHER,
-                                                "Grid Location (%d,%d,%d) of type '%s' should have width offset '%d' (based on root location) but has '%d'\n",
-                                                i, j, layer_num, type->name.c_str(), x_offset, tile_width_offset);
-                            }
+                    if (tile_width_offset != x_offset) {
+                        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                                        "Grid Location (%d,%d,%d) of type '%s' should have width offset '%d' (based on root location) but has '%d'\n",
+                                        tile_loc.layer_num, tile_loc.x, tile_loc.y, type->name.c_str(), x_offset, tile_width_offset);
+                    }
 
-                            if (tile_height_offset != y_offset) {
-                                VPR_FATAL_ERROR(VPR_ERROR_OTHER,
-                                                "Grid Location (%d,%d,%d)  of type '%s' should have height offset '%d' (based on root location) but has '%d'\n",
-                                                i, j, layer_num, type->name.c_str(), y_offset, tile_height_offset);
-                            }
-                        }
+                    if (tile_height_offset != y_offset) {
+                        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                                        "Grid Location (%d,%d,%d)  of type '%s' should have height offset '%d' (based on root location) but has '%d'\n",
+                                        tile_loc.layer_num, tile_loc.x, tile_loc.y, type->name.c_str(), y_offset, tile_height_offset);
                     }
                 }
             }

--- a/vpr/src/base/stats.cpp
+++ b/vpr/src/base/stats.cpp
@@ -96,7 +96,7 @@ void routing_stats(const Netlist<>& net_list,
             } else {
                 area += type->area;
             }
-    }
+        }
     }
     /* Todo: need to add pitch of routing to blocks with height > 3 */
     VTR_LOG("\tTotal logic block area (Warning, need to add pitch of routing to blocks with height > 3): %g\n", area);

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -342,7 +342,7 @@ class t_pb {
 ///@brief Representation of intra-logic block routing
 struct t_pb_route {
     AtomNetId atom_net_id;                        ///<which net in the atom netlist uses this pin
-    int driver_pb_pin_id = UNDEFINED;                  ///<The pb_pin id of the pb_pin that drives this pin
+    int driver_pb_pin_id = UNDEFINED;             ///<The pb_pin id of the pb_pin that drives this pin
     std::vector<int> sink_pb_pin_ids;             ///<The pb_pin id's of the pb_pins driven by this node
     const t_pb_graph_pin* pb_graph_pin = nullptr; ///<The graph pin associated with this node
 };

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -299,7 +299,7 @@ void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type
     /* If it's the type of picture displayed has changed, set up the proper  *
      * buttons.                                                              */
     if (draw_state->pic_on_screen != pic_on_screen_val) { //State changed
-        
+
         state_change = true;
 
         if (draw_state->pic_on_screen == NO_PICTURE) {
@@ -312,7 +312,6 @@ void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type
         draw_state->pic_on_screen = pic_on_screen_val;
     }
 
-    
     bool should_pause = int(priority) >= draw_state->gr_automode;
 
     //If there was a state change, we must call ezgl::application::run() to update the buttons.
@@ -1150,7 +1149,7 @@ static void run_graphics_commands(const std::string& commands) {
                            "Expect show critical path delay (bool), show critical path flylines (bool), and show critical path routing (bool) after 'set_cpd'");
             draw_state->show_crit_path = true;
             draw_state->show_crit_path_flylines = true;
-            draw_state->show_crit_path_delays= (bool)vtr::atoi(cmd[1]);
+            draw_state->show_crit_path_delays = (bool)vtr::atoi(cmd[1]);
             VTR_LOG("%d\n", (int)draw_state->show_crit_path);
         } else if (cmd[0] == "set_routing_util") {
             VTR_ASSERT_MSG(cmd.size() == 2,

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -976,9 +976,9 @@ void draw_crit_path(ezgl::renderer* g) {
                     g->set_line_dash(ezgl::line_dash::none);
                     g->set_line_width(0);
                 }
-            } 
-            
-            if(draw_state->show_crit_path_routing) {
+            }
+
+            if (draw_state->show_crit_path_routing) {
                 //Draw the routed version of the timing edge
                 draw_routed_timing_edge_connection(prev_node, node, color, g);
             }

--- a/vpr/src/draw/draw_toggle_functions.cpp
+++ b/vpr/src/draw/draw_toggle_functions.cpp
@@ -301,9 +301,7 @@ void placement_macros_cbk(GtkComboBoxText* self, ezgl::application* app) {
     app->refresh_drawing();
 }
 
-
 void toggle_crit_path_cbk(GtkSwitch*, gboolean state, ezgl::application* app) {
-
 
     t_draw_state* draw_state = get_draw_state_vars();
 
@@ -312,7 +310,7 @@ void toggle_crit_path_cbk(GtkSwitch*, gboolean state, ezgl::application* app) {
     gtk_widget_set_sensitive(GTK_WIDGET(app->get_object("ToggleCritPathFlylines")), state);
     gtk_widget_set_sensitive(GTK_WIDGET(app->get_object("ToggleCritPathDelays")), state);
 
-    if(draw_state->setup_timing_info && draw_state->pic_on_screen == ROUTING) {
+    if (draw_state->setup_timing_info && draw_state->pic_on_screen == ROUTING) {
         gtk_widget_set_sensitive(GTK_WIDGET(app->get_object("ToggleCritPathRouting")), state);
     }
 

--- a/vpr/src/draw/draw_toggle_functions.h
+++ b/vpr/src/draw/draw_toggle_functions.h
@@ -98,7 +98,6 @@ void toggle_router_util_cbk(GtkComboBoxText* self, ezgl::application* app);
  */
 void toggle_crit_path_cbk(GtkSwitch*, gboolean state, ezgl::application* app);
 
-
 /* Callback function for main.ui created toggle_router_expansion_costs in ui_setup.cpp.
  * Draws different router expansion costs based on user input. Changes value of draw_state->show_router_expansion_cost. */
 void toggle_expansion_cost_cbk(GtkComboBoxText* self, ezgl::application* app);

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -32,7 +32,6 @@
 #include "ezgl/color.hpp"
 #include "ezgl/application.hpp"
 
-
 /// @brief Whether to draw routed nets or flylines (direct lines between sources and sinks).
 enum e_draw_nets {
     DRAW_ROUTED_NETS,

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -236,8 +236,6 @@ bool highlight_rr_nodes(RRNodeId hit_node) {
         VTR_LOG("%s\n", describe_rr_node(device_ctx.rr_graph, device_ctx.grid, device_ctx.rr_indexed_data, node, draw_state->is_flat).c_str());
     }
 
-    
-
     //Show info about *only* hit node to graphics
     std::string info = describe_rr_node(device_ctx.rr_graph, device_ctx.grid, device_ctx.rr_indexed_data, hit_node, draw_state->is_flat);
     sprintf(message, "Selected %s", info.c_str());

--- a/vpr/src/draw/ui_setup.cpp
+++ b/vpr/src/draw/ui_setup.cpp
@@ -255,7 +255,7 @@ void crit_path_button_setup(ezgl::application* app) {
 
     t_draw_state* draw_state = get_draw_state_vars();
 
-     //Toggle Critical Path
+    //Toggle Critical Path
     GtkSwitch* toggle_nets_switch = GTK_SWITCH(app->get_object("ToggleCritPath"));
     g_signal_connect(toggle_nets_switch, "state-set", G_CALLBACK(toggle_crit_path_cbk), app);
 

--- a/vpr/src/draw/ui_setup.cpp
+++ b/vpr/src/draw/ui_setup.cpp
@@ -246,7 +246,7 @@ void search_setup(ezgl::application* app) {
     gtk_entry_completion_set_match_func(wildcardComp, (GtkEntryCompletionMatchFunc)customMatchingFunction, NULL, NULL);
 }
 
-/*
+/**
  * @brief connects critical path button to its cbk fn
  *
  * @param app ezgl application
@@ -255,7 +255,7 @@ void crit_path_button_setup(ezgl::application* app) {
 
     t_draw_state* draw_state = get_draw_state_vars();
 
-    //Toggle Critical Path
+    // Toggle Critical Path
     GtkSwitch* toggle_nets_switch = GTK_SWITCH(app->get_object("ToggleCritPath"));
     g_signal_connect(toggle_nets_switch, "state-set", G_CALLBACK(toggle_crit_path_cbk), app);
 
@@ -265,7 +265,7 @@ void crit_path_button_setup(ezgl::application* app) {
     setup_checkbox_button("ToggleCritPathDelays", app, &draw_state->show_crit_path_delays);
 }
 
-/*
+/**
  * @brief Hides or displays critical path routing / routing delay UI elements
  *
  * @param app ezgl app

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -1271,7 +1271,7 @@ PackMoleculeId GreedyCandidateSelector::get_unrelated_candidate_for_cluster_appa
     vtr::NdMatrix<bool, 3> visited({flat_grid_num_layers,
                                     flat_grid_width,
                                     flat_grid_height},
-                                    false);
+                                   false);
 
     t_physical_tile_loc cluster_tile_loc(cluster_gain_stats.flat_cluster_position.x,
                                          cluster_gain_stats.flat_cluster_position.y,

--- a/vpr/src/place/delay_model/compute_delta_delays_utils.cpp
+++ b/vpr/src/place/delay_model/compute_delta_delays_utils.cpp
@@ -403,7 +403,7 @@ static bool verify_delta_delays(const vtr::NdMatrix<float, 4>& delta_delays) {
 
                     if (delta_delay < 0.) {
                         VPR_ERROR(VPR_ERROR_PLACE,
-                                  "Found invalid negative delay %g for delta [%d,%d,%d,%d]",
+                                  "Found invalid negative delay %g for delta [%u,%u,%u,%u]",
                                   delta_delay, from_layer_num, to_layer_num, x, y);
                     }
                 }

--- a/vpr/src/place/delay_model/compute_delta_delays_utils.cpp
+++ b/vpr/src/place/delay_model/compute_delta_delays_utils.cpp
@@ -395,8 +395,8 @@ static bool verify_delta_delays(const vtr::NdMatrix<float, 4>& delta_delays) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& grid = device_ctx.grid;
 
-    for (int from_layer_num = 0; from_layer_num < grid.get_num_layers(); ++from_layer_num) {
-        for (int to_layer_num = 0; to_layer_num < grid.get_num_layers(); ++to_layer_num) {
+    for (size_t from_layer_num = 0; from_layer_num < grid.get_num_layers(); ++from_layer_num) {
+        for (size_t to_layer_num = 0; to_layer_num < grid.get_num_layers(); ++to_layer_num) {
             for (size_t x = 0; x < grid.width(); ++x) {
                 for (size_t y = 0; y < grid.height(); ++y) {
                     float delta_delay = delta_delays[from_layer_num][to_layer_num][x][y];
@@ -838,7 +838,7 @@ bool find_direct_connect_sample_locations(const t_direct_inf* direct,
     bool found = false;
     int found_layer_num = -1;
     //TODO: Function *FOR NOW* assumes that from/to blocks are at same die and have a same layer nums
-    for (int layer_num = 0; layer_num < grid.get_num_layers() && !found; ++layer_num) {
+    for (int layer_num = 0; layer_num < (int)grid.get_num_layers() && !found; ++layer_num) {
         for (int x = 0; x < (int)grid.width() && !found; ++x) {
             to_x = x + direct->x_offset;
             if (to_x < 0 || to_x >= (int)grid.width()) continue;

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -494,7 +494,7 @@ void NetCostHandler::get_non_updatable_cube_bb_(ClusterNetId net_id, bool use_ts
     bb_coord_new.ymax = source_pin_loc.y;
     bb_coord_new.layer_max = source_pin_loc.layer_num;
 
-    for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
+    for (size_t layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
         num_sink_pin_layer[layer_num] = 0;
     }
 
@@ -1096,9 +1096,11 @@ static void update_bb_pin_sink_count(const t_physical_tile_loc& pin_old_loc,
                                      vtr::NdMatrixProxy<int, 1> bb_pin_sink_count_new,
                                      bool is_output_pin) {
     VTR_ASSERT_SAFE(curr_layer_pin_sink_count[pin_old_loc.layer_num] > 0 || is_output_pin);
-    for (int layer_num = 0; layer_num < g_vpr_ctx.device().grid.get_num_layers(); layer_num++) {
+
+    for (size_t layer_num = 0; layer_num < g_vpr_ctx.device().grid.get_num_layers(); layer_num++) {
         bb_pin_sink_count_new[layer_num] = curr_layer_pin_sink_count[layer_num];
     }
+
     if (!is_output_pin) {
         bb_pin_sink_count_new[pin_old_loc.layer_num] -= 1;
         bb_pin_sink_count_new[pin_new_loc.layer_num] += 1;
@@ -1197,7 +1199,7 @@ void NetCostHandler::get_bb_from_scratch_(ClusterNetId net_id, bool use_ts) {
     int ymax_edge = 1;
     int layer_max_edge = 1;
 
-    for (int layer_num = 0; layer_num < grid.get_num_layers(); layer_num++) {
+    for (size_t layer_num = 0; layer_num < grid.get_num_layers(); layer_num++) {
         num_sink_pin_layer[layer_num] = 0;
     }
 
@@ -1549,7 +1551,7 @@ void NetCostHandler::update_move_nets() {
 
         set_ts_bb_coord_(net_id);
 
-        for (int layer_num = 0; layer_num < g_vpr_ctx.device().grid.get_num_layers(); layer_num++) {
+        for (size_t layer_num = 0; layer_num < g_vpr_ctx.device().grid.get_num_layers(); layer_num++) {
             num_sink_pin_layer_[size_t(net_id)][layer_num] = ts_layer_sink_pin_count_[size_t(net_id)][layer_num];
         }
 

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -1255,8 +1255,8 @@ void NetCostHandler::get_bb_from_scratch_(ClusterNetId net_id, bool use_ts) {
     coords.ymax = ymax;
     coords.layer_min = layer_min;
     coords.layer_max = layer_max;
-    VTR_ASSERT_DEBUG(layer_min >= 0 && layer_min < device_ctx.grid.get_num_layers());
-    VTR_ASSERT_DEBUG(layer_max >= 0 && layer_max < device_ctx.grid.get_num_layers());
+    VTR_ASSERT_DEBUG(layer_min >= 0 && layer_min < (int)device_ctx.grid.get_num_layers());
+    VTR_ASSERT_DEBUG(layer_max >= 0 && layer_max < (int)device_ctx.grid.get_num_layers());
 
     num_on_edges.xmin = xmin_edge;
     num_on_edges.xmax = xmax_edge;

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -1424,7 +1424,7 @@ double NetCostHandler::get_net_wirelength_from_layer_bb_(ClusterNetId net_id) co
     const vtr::NdMatrixProxy<int, 1> net_layer_pin_sink_count = num_sink_pin_layer_[size_t(net_id)];
 
     double ncost = 0.;
-    VTR_ASSERT_SAFE((int)bb.size() == g_vpr_ctx.device().grid.get_num_layers());
+    VTR_ASSERT_SAFE(bb.size() == g_vpr_ctx.device().grid.get_num_layers());
 
     for (size_t layer_num = 0; layer_num < bb.size(); layer_num++) {
         VTR_ASSERT_SAFE(net_layer_pin_sink_count[layer_num] != UNDEFINED);

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -129,33 +129,26 @@ void alloc_and_load_legal_placement_locations(std::vector<std::vector<std::vecto
         legal_pos[type.index].resize(type.sub_tiles.size());
     }
 
-    //load the legal placement positions
-    for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
-        for (int i = 0; i < (int)device_ctx.grid.width(); i++) {
-            for (int j = 0; j < (int)device_ctx.grid.height(); j++) {
-                auto tile = device_ctx.grid.get_physical_type({i, j, layer_num});
+    // load the legal placement positions
+    for (const t_physical_tile_loc tile_loc : device_ctx.grid.all_locations()) {
+        auto tile = device_ctx.grid.get_physical_type(tile_loc);
 
-                for (const auto& sub_tile : tile->sub_tiles) {
-                    auto capacity = sub_tile.capacity;
+        for (const auto& sub_tile : tile->sub_tiles) {
+            auto capacity = sub_tile.capacity;
 
-                    for (int k = 0; k < capacity.total(); k++) {
-                        // If this is the anchor position of a block, add it to the legal_pos.
-                        // Otherwise, don't, so large blocks aren't added multiple times.
-                        if (device_ctx.grid.get_width_offset({i, j, layer_num}) == 0 && device_ctx.grid.get_height_offset({i, j, layer_num}) == 0) {
-                            int itype = tile->index;
-                            int isub_tile = sub_tile.index;
-                            t_pl_loc temp_loc;
-                            temp_loc.x = i;
-                            temp_loc.y = j;
-                            temp_loc.sub_tile = k + capacity.low;
-                            temp_loc.layer = layer_num;
-                            legal_pos[itype][isub_tile].push_back(temp_loc);
-                        }
-                    }
+            for (int k = 0; k < capacity.total(); k++) {
+                // If this is the anchor position of a block, add it to the legal_pos.
+                // Otherwise, don't, so large blocks aren't added multiple times.
+                if (device_ctx.grid.is_root_location(tile_loc)) {
+                    int itype = tile->index;
+                    int isub_tile = sub_tile.index;
+                    t_pl_loc temp_loc {tile_loc, k + capacity.low};
+                    legal_pos[itype][isub_tile].push_back(temp_loc);
                 }
             }
         }
     }
+
     //avoid any memory waste
     legal_pos.shrink_to_fit();
 }

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -125,16 +125,16 @@ void alloc_and_load_legal_placement_locations(std::vector<std::vector<std::vecto
     int num_tile_types = device_ctx.physical_tile_types.size();
     legal_pos.resize(num_tile_types);
 
-    for (const auto& type : device_ctx.physical_tile_types) {
+    for (const t_physical_tile_type& type : device_ctx.physical_tile_types) {
         legal_pos[type.index].resize(type.sub_tiles.size());
     }
 
     // load the legal placement positions
     for (const t_physical_tile_loc tile_loc : device_ctx.grid.all_locations()) {
-        auto tile = device_ctx.grid.get_physical_type(tile_loc);
+        t_physical_tile_type_ptr tile = device_ctx.grid.get_physical_type(tile_loc);
 
-        for (const auto& sub_tile : tile->sub_tiles) {
-            auto capacity = sub_tile.capacity;
+        for (const t_sub_tile& sub_tile : tile->sub_tiles) {
+            const t_capacity_range& capacity = sub_tile.capacity;
 
             for (int k = 0; k < capacity.total(); k++) {
                 // If this is the anchor position of a block, add it to the legal_pos.

--- a/vpr/src/place/place_util.cpp
+++ b/vpr/src/place/place_util.cpp
@@ -142,7 +142,7 @@ void alloc_and_load_legal_placement_locations(std::vector<std::vector<std::vecto
                 if (device_ctx.grid.is_root_location(tile_loc)) {
                     int itype = tile->index;
                     int isub_tile = sub_tile.index;
-                    t_pl_loc temp_loc {tile_loc, k + capacity.low};
+                    t_pl_loc temp_loc{tile_loc, k + capacity.low};
                     legal_pos[itype][isub_tile].push_back(temp_loc);
                 }
             }

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -605,38 +605,32 @@ static void power_usage_blocks(t_power_usage* power_usage) {
 
     t_logical_block_type_ptr logical_block;
 
-    /* Loop through all grid locations */
-    for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
-        for (int x = 0; x < (int)device_ctx.grid.width(); x++) {
-            for (int y = 0; y < (int)device_ctx.grid.height(); y++) {
-                auto physical_tile = device_ctx.grid.get_physical_type({x, y, layer_num});
-                int width_offset = device_ctx.grid.get_width_offset({x, y, layer_num});
-                int height_offset = device_ctx.grid.get_height_offset({x, y, layer_num});
+    // Loop through all grid locations
+    for (const t_physical_tile_loc tile_loc :  device_ctx.grid.all_locations()) {
+        t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type(tile_loc);
+        int width_offset = device_ctx.grid.get_width_offset(tile_loc);
+        int height_offset = device_ctx.grid.get_height_offset(tile_loc);
 
-                if ((width_offset != 0)
-                    || (height_offset != 0)
-                    || is_empty_type(physical_tile)) {
-                    continue;
-                }
+        if (width_offset != 0 || height_offset != 0 || is_empty_type(physical_tile)) {
+            continue;
+        }
 
-                for (int z = 0; z < physical_tile->capacity; z++) {
-                    t_pb* pb = nullptr;
-                    t_power_usage pb_power;
+        for (int z = 0; z < physical_tile->capacity; z++) {
+            t_pb* pb = nullptr;
+            t_power_usage pb_power;
 
-                    ClusterBlockId iblk = place_ctx.grid_blocks().block_at_location({x, y, z, layer_num});
+            ClusterBlockId iblk = place_ctx.grid_blocks().block_at_location({tile_loc, z});
 
-                    if (iblk) {
-                        pb = cluster_ctx.clb_nlist.block_pb(iblk);
-                        logical_block = cluster_ctx.clb_nlist.block_type(iblk);
-                    } else {
-                        logical_block = pick_logical_type(physical_tile);
-                    }
-
-                    /* Calculate power of this CLB */
-                    power_usage_pb(&pb_power, pb, logical_block->pb_graph_head, iblk);
-                    power_add_usage(power_usage, &pb_power);
-                }
+            if (iblk) {
+                pb = cluster_ctx.clb_nlist.block_pb(iblk);
+                logical_block = cluster_ctx.clb_nlist.block_type(iblk);
+            } else {
+                logical_block = pick_logical_type(physical_tile);
             }
+
+            // Calculate power of this CLB
+            power_usage_pb(&pb_power, pb, logical_block->pb_graph_head, iblk);
+            power_add_usage(power_usage, &pb_power);
         }
     }
 }

--- a/vpr/src/power/power.cpp
+++ b/vpr/src/power/power.cpp
@@ -606,7 +606,7 @@ static void power_usage_blocks(t_power_usage* power_usage) {
     t_logical_block_type_ptr logical_block;
 
     // Loop through all grid locations
-    for (const t_physical_tile_loc tile_loc :  device_ctx.grid.all_locations()) {
+    for (const t_physical_tile_loc tile_loc : device_ctx.grid.all_locations()) {
         t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type(tile_loc);
         int width_offset = device_ctx.grid.get_width_offset(tile_loc);
         int height_offset = device_ctx.grid.get_height_offset(tile_loc);

--- a/vpr/src/route/edge_groups.h
+++ b/vpr/src/route/edge_groups.h
@@ -43,7 +43,7 @@ class EdgeGroups {
   private:
     struct node_data {
         std::unordered_set<RRNodeId> edges; // Set of indices into graph_
-        int set = UNDEFINED;                     // Index into rr_non_config_node_sets_
+        int set = UNDEFINED;                // Index into rr_non_config_node_sets_
     };
 
     // Perform a DFS traversal marking everything reachable with the same set id

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -43,17 +43,13 @@ static void log_single_overused_node_status(int overuse_index, RRNodeId inode);
  *
  * @param os The output stream to write the information to.
  * @param physical_type The physical type of the block.
- * @param layer The layer number of the block.
- * @param root_x The x coordinate of the root of the block.
- * @param root_y The y coordinate of the root of the block.
+ * @param root_loc The coordinates of the root of the block.
  * @param pin_physical_num The physical number of the pin.
  * @param rr_node_to_net_map A map of RR nodes to the nets that pass through them.
  */
 static void print_block_pins_nets(std::ostream& os,
                                   t_physical_tile_type_ptr physical_type,
-                                  int layer,
-                                  int root_x,
-                                  int root_y,
+                                  const t_physical_tile_loc& root_loc,
                                   int pin_physical_num,
                                   const std::map<RRNodeId, std::set<ParentNetId>>& rr_node_to_net_map);
 /**
@@ -231,31 +227,29 @@ static void report_overused_ipin_opin(std::ostream& os,
     const auto& rr_graph = device_ctx.rr_graph;
     const auto& place_ctx = g_vpr_ctx.placement();
 
-    auto grid_x = rr_graph.node_xlow(node_id);
-    auto grid_y = rr_graph.node_ylow(node_id);
-    auto grid_layer = rr_graph.node_layer(node_id);
+    t_physical_tile_loc grid_loc;
+    grid_loc.x = rr_graph.node_xlow(node_id);
+    grid_loc.y = rr_graph.node_ylow(node_id);
+    grid_loc.layer_num = rr_graph.node_layer(node_id);
+    const t_physical_tile_type_ptr physical_type = device_ctx.grid.get_physical_type(grid_loc);
 
-    VTR_ASSERT_MSG(
-        grid_x == rr_graph.node_xhigh(node_id) && grid_y == rr_graph.node_yhigh(node_id),
-        "Non-track RR node should not span across multiple grid blocks.");
+    VTR_ASSERT_MSG(grid_loc.x == rr_graph.node_xhigh(node_id) && grid_loc.y == rr_graph.node_yhigh(node_id),
+                   "Non-track RR node should not span across multiple grid blocks.");
 
     os << "Pin physical number = " << rr_graph.node_pin_num(node_id) << '\n';
     if (is_inter_cluster_node(rr_graph, node_id)) {
         os << "On Tile Pin"
            << "\n";
     } else {
-        auto pb_type_name = get_pb_graph_node_from_pin_physical_num(device_ctx.grid.get_physical_type({grid_x, grid_y, grid_layer}),
+        auto pb_type_name = get_pb_graph_node_from_pin_physical_num(device_ctx.grid.get_physical_type(grid_loc),
                                                                     rr_graph.node_ptc_num(node_id))
                                 ->pb_type->name;
-        auto pb_pin = get_pb_pin_from_pin_physical_num(device_ctx.grid.get_physical_type({grid_x, grid_y, grid_layer}),
-                                                       rr_graph.node_ptc_num(node_id));
+        auto pb_pin = get_pb_pin_from_pin_physical_num(physical_type, rr_graph.node_ptc_num(node_id));
         os << "Intra-Tile Pin - Port : " << pb_pin->port->name << " - PB Type : " << std::string(pb_type_name) << "\n";
     }
     print_block_pins_nets(os,
-                          device_ctx.grid.get_physical_type({grid_x, grid_y, grid_layer}),
-                          grid_layer,
-                          grid_x - device_ctx.grid.get_width_offset({grid_x, grid_y, grid_layer}),
-                          grid_y - device_ctx.grid.get_height_offset({grid_x, grid_y, grid_layer}),
+                          physical_type,
+                          device_ctx.grid.get_root_location(grid_loc),
                           rr_graph.node_ptc_num(node_id),
                           rr_node_to_net_map);
     os << "Side = " << rr_graph.node_side_string(node_id) << "\n\n";
@@ -264,19 +258,19 @@ static void report_overused_ipin_opin(std::ostream& os,
     const auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     const auto& grid_info = place_ctx.grid_blocks();
 
-    os << "Grid location: X = " << grid_x << ", Y = " << grid_y << '\n';
-    os << "Number of blocks currently occupying this grid location = " << grid_info.get_usage({grid_x, grid_y, grid_layer}) << '\n';
+    os << "Grid location: X = " << grid_loc.x << ", Y = " << grid_loc.y << '\n';
+    os << "Number of blocks currently occupying this grid location = " << grid_info.get_usage(grid_loc) << '\n';
 
     size_t iblock = 0;
-    for (int isubtile = 0; isubtile < (int)grid_info.num_blocks_at_location({grid_x, grid_y, grid_layer}); ++isubtile) {
+    for (int isubtile = 0; isubtile < (int)grid_info.num_blocks_at_location(grid_loc); ++isubtile) {
         //Check if there is a valid block at this subtile location
-        if (grid_info.is_sub_tile_empty({grid_x, grid_y, grid_layer}, isubtile)) {
+        if (grid_info.is_sub_tile_empty(grid_loc, isubtile)) {
             continue;
         }
 
         //Print out the block index, name and type
         // TODO: Needs to be updated when RR Graph Nodes know their layer_num
-        ClusterBlockId block_id = grid_info.block_at_location({grid_x, grid_y, isubtile, grid_layer});
+        ClusterBlockId block_id = grid_info.block_at_location({grid_loc, isubtile});
         os << "Block #" << iblock << ": ";
         os << "Block name = " << clb_nlist.block_pb(block_id)->name << ", ";
         os << "Block type = " << clb_nlist.block_type(block_id)->name << '\n';
@@ -459,9 +453,7 @@ static void log_single_overused_node_status(int overuse_index, RRNodeId node_id)
 
 static void print_block_pins_nets(std::ostream& os,
                                   t_physical_tile_type_ptr physical_type,
-                                  int layer,
-                                  int root_x,
-                                  int root_y,
+                                  const t_physical_tile_loc& root_loc,
                                   int pin_physical_num,
                                   const std::map<RRNodeId, std::set<ParentNetId>>& rr_node_to_net_map) {
     const auto& rr_graph = g_vpr_ctx.device().rr_graph;
@@ -489,7 +481,7 @@ static void print_block_pins_nets(std::ostream& os,
 
     for (int pin = pin_num_range.low; pin <= pin_num_range.high; pin++) {
         e_rr_type rr_type = (get_pin_type_from_pin_physical_num(physical_type, pin) == e_pin_type::DRIVER) ? e_rr_type::OPIN : e_rr_type::IPIN;
-        RRNodeId node_id = get_pin_rr_node_id(rr_graph.node_lookup(), physical_type, layer, root_x, root_y, pin);
+        RRNodeId node_id = get_pin_rr_node_id(rr_graph.node_lookup(), physical_type, root_loc, pin);
         // When flat router is enabled, RR Node chains collapse into a single node. Thus, when
         // looking up the RR Node ID, it may return an invalid node ID. In this case, we skip
         // this pin.

--- a/vpr/src/route/overuse_report.cpp
+++ b/vpr/src/route/overuse_report.cpp
@@ -241,10 +241,8 @@ static void report_overused_ipin_opin(std::ostream& os,
         os << "On Tile Pin"
            << "\n";
     } else {
-        auto pb_type_name = get_pb_graph_node_from_pin_physical_num(device_ctx.grid.get_physical_type(grid_loc),
-                                                                    rr_graph.node_ptc_num(node_id))
-                                ->pb_type->name;
-        auto pb_pin = get_pb_pin_from_pin_physical_num(physical_type, rr_graph.node_ptc_num(node_id));
+        const char* pb_type_name = get_pb_graph_node_from_pin_physical_num(physical_type, rr_graph.node_ptc_num(node_id)) ->pb_type->name;
+        const t_pb_graph_pin* pb_pin = get_pb_pin_from_pin_physical_num(physical_type, rr_graph.node_ptc_num(node_id));
         os << "Intra-Tile Pin - Port : " << pb_pin->port->name << " - PB Type : " << std::string(pb_type_name) << "\n";
     }
     print_block_pins_nets(os,

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -789,7 +789,7 @@ t_bb load_net_route_bb(const Netlist<>& net_list,
         VTR_ASSERT(rr_graph.node_ylow(sink_rr) <= rr_graph.node_yhigh(sink_rr));
 
         VTR_ASSERT(rr_graph.node_layer(sink_rr) >= 0);
-        VTR_ASSERT(rr_graph.node_layer(sink_rr) <= device_ctx.grid.get_num_layers() - 1);
+        VTR_ASSERT(rr_graph.node_layer(sink_rr) <= (int)device_ctx.grid.get_num_layers() - 1);
 
         vtr::Rect<int> tile_bb = device_ctx.grid.get_tile_bb({rr_graph.node_xlow(sink_rr),
                                                               rr_graph.node_ylow(sink_rr),
@@ -803,12 +803,11 @@ t_bb load_net_route_bb(const Netlist<>& net_list,
         layer_max = std::max<int>(layer_max, rr_graph.node_layer(sink_rr));
     }
 
-    /* Want the channels on all 4 sides to be usable, even if bb_factor = 0. */
+    // Want the channels on all 4 sides to be usable, even if bb_factor = 0.
     xmin -= 1;
     ymin -= 1;
 
-    /* Expand the net bounding box by bb_factor, then clip to the physical *
-     * chip area.                                                          */
+    // Expand the net bounding box by bb_factor, then clip to the physical chip area.
 
     t_bb bb;
 

--- a/vpr/src/route/route_utils.cpp
+++ b/vpr/src/route/route_utils.cpp
@@ -460,7 +460,12 @@ vtr::vector<ParentNetId, std::vector<std::unordered_map<RRNodeId, int>>> set_net
                 std::for_each(sink_grp.begin(), sink_grp.end(), [&rr_graph](int& sink_rr_num) {
                     sink_rr_num = rr_graph.node_ptc_num(RRNodeId(sink_rr_num));
                 });
-                auto physical_type = device_ctx.grid.get_physical_type({blk_loc.loc.x, blk_loc.loc.y, blk_loc.loc.layer});
+
+                t_physical_tile_loc grid_loc;
+                grid_loc.x = blk_loc.loc.x;
+                grid_loc.y = blk_loc.loc.y;
+                grid_loc.layer_num = blk_loc.loc.layer;
+                t_physical_tile_type_ptr physical_type = device_ctx.grid.get_physical_type(grid_loc);
                 // Get the choke points of the sink corresponds to pin_count given the sink group
                 auto sink_choking_spots = get_sink_choking_points(physical_type,
                                                                   rr_graph.node_ptc_num(RRNodeId(net_rr_terminal[net_id][pin_count])),
@@ -471,9 +476,7 @@ vtr::vector<ParentNetId, std::vector<std::unordered_map<RRNodeId, int>>> set_net
                     int num_reachable_sinks = choking_spot.second;
                     auto pin_rr_node_id = get_pin_rr_node_id(rr_graph.node_lookup(),
                                                              physical_type,
-                                                             blk_loc.loc.layer,
-                                                             blk_loc.loc.x,
-                                                             blk_loc.loc.y,
+                                                             grid_loc,
                                                              pin_physical_num);
                     if (pin_rr_node_id != RRNodeId::INVALID()) {
                         choking_spots[net_id][pin_count].insert(std::make_pair(pin_rr_node_id, num_reachable_sinks));

--- a/vpr/src/route/router_lookahead/router_lookahead_compressed_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_compressed_map.cpp
@@ -134,7 +134,7 @@ static void compute_router_wire_compressed_lookahead(const std::vector<t_segment
         sorted_sample_loc[sample_loc.first] = std::set<int>(sample_loc.second.begin(), sample_loc.second.end());
     }
     //Profile each wire segment type
-    for (int from_layer_num = 0; from_layer_num < grid.get_num_layers(); from_layer_num++) {
+    for (size_t from_layer_num = 0; from_layer_num < grid.get_num_layers(); from_layer_num++) {
         for (const auto& segment_inf : segment_inf_vec) {
             std::map<e_rr_type, std::vector<RRNodeId>> sample_nodes;
             std::vector<e_rr_type> chan_types;
@@ -204,11 +204,13 @@ static void fill_in_missing_compressed_lookahead_entries(const std::map<int, std
     }
 
     auto& device_ctx = g_vpr_ctx.device();
-    int grid_width = static_cast<int>(device_ctx.grid.width());
-    int grid_height = static_cast<int>(device_ctx.grid.height());
-    /* find missing cost entries and fill them in by copying a nearby cost entry */
-    for (int from_layer_num = 0; from_layer_num < device_ctx.grid.get_num_layers(); from_layer_num++) {
-        for (int to_layer_num = 0; to_layer_num < device_ctx.grid.get_num_layers(); ++to_layer_num) {
+    const int grid_width = static_cast<int>(device_ctx.grid.width());
+    const int grid_height = static_cast<int>(device_ctx.grid.height());
+    const int grid_layers = static_cast<int>(device_ctx.grid.get_num_layers());
+
+    // find missing cost entries and fill them in by copying a nearby cost entry
+    for (int from_layer_num = 0; from_layer_num < grid_layers; from_layer_num++) {
+        for (int to_layer_num = 0; to_layer_num < grid_layers; ++to_layer_num) {
             for (int ix = 0; ix < grid_width; ix++) {
                 for (int iy = 0; iy < grid_height; iy++) {
                     if (sample_locations.find(ix) == sample_locations.end() || sample_locations.at(ix).find(iy) == sample_locations[ix].end()) {

--- a/vpr/src/route/router_lookahead/router_lookahead_compressed_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_compressed_map.cpp
@@ -203,7 +203,7 @@ static void fill_in_missing_compressed_lookahead_entries(const std::map<int, std
         chan_index = 1;
     }
 
-    auto& device_ctx = g_vpr_ctx.device();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
     const int grid_width = static_cast<int>(device_ctx.grid.width());
     const int grid_height = static_cast<int>(device_ctx.grid.height());
     const int grid_layers = static_cast<int>(device_ctx.grid.get_num_layers());

--- a/vpr/src/route/router_lookahead/router_lookahead_extended_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_extended_map.h
@@ -10,7 +10,8 @@
 class ExtendedMapLookahead : public RouterLookahead {
   public:
     ExtendedMapLookahead(bool is_flat, int route_verbosity)
-        : is_flat_(is_flat), route_verbosity_(route_verbosity) {}
+        : is_flat_(is_flat)
+        , route_verbosity_(route_verbosity) {}
 
   private:
     bool is_flat_;

--- a/vpr/src/route/router_lookahead/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.cpp
@@ -133,8 +133,12 @@ static void read_intra_cluster_router_lookahead(std::unordered_map<int, util::t_
 static void write_intra_cluster_router_lookahead(const std::string& file,
                                                  const std::unordered_map<int, util::t_ipin_primitive_sink_delays>& intra_tile_pin_primitive_pin_delay);
 
-/* sets the lookahead cost map entries based on representative cost entries from routing_cost_map */
-static void set_lookahead_map_costs(int from_layer_num, int segment_index, e_rr_type chan_type, util::t_routing_cost_map& routing_cost_map);
+///@brief Sets the lookahead cost map entries based on representative cost entries from routing_cost_map.
+static void set_lookahead_map_costs(unsigned from_layer_num,
+                                    int segment_index,
+                                    e_rr_type chan_type,
+                                    util::t_routing_cost_map& routing_cost_map);
+
 /* fills in missing lookahead map entries by copying the cost of the closest valid entry */
 static void fill_in_missing_lookahead_entries(int segment_index, e_rr_type chan_type);
 /* returns a cost entry in the f_wire_cost_map that is near the specified coordinates (and preferably towards (0,0)) */
@@ -326,16 +330,14 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
                                                                                      from_layer_num});
 
         auto from_tile_index = std::distance(&device_ctx.physical_tile_types[0], from_tile_type);
+        int from_ptc = rr_graph.node_ptc_num(from_node);
 
-        auto from_ptc = rr_graph.node_ptc_num(from_node);
-
-        /* We could reach the sink by using an intermediate wire on any reachable layer. We consider all these options and return the minimum cost one. 
-         * get_cost_from_src_opin iterates over all routing segments passed to it (the first argument) and returns 
-         * the minimum cost among them. In the following for loop, we iterate over each layer and pass it the 
-         * routing segments on that layer reachable from the OPIN/SOURCE to segments on that layer. This for loop then calculates and returns 
-         * the minimum cost from the given OPIN/SOURCE to the specified SINK considering routing options across all layers.
-         */
-        for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
+        // We could reach the sink by using an intermediate wire on any reachable layer. We consider all these options and return the minimum cost one.
+        // get_cost_from_src_opin iterates over all routing segments passed to it (the first argument) and returns
+        // the minimum cost among them. In the following for loop, we iterate over each layer and pass it the
+        // routing segments on that layer reachable from the OPIN/SOURCE to segments on that layer. This for loop then calculates and returns
+        //  the minimum cost from the given OPIN/SOURCE to the specified SINK considering routing options across all layers.
+        for (size_t layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
             const auto [this_delay_cost, this_cong_cost] = util::get_cost_from_src_opin(src_opin_delays[from_layer_num][from_tile_index][from_ptc][layer_num],
                                                                                         delta_x,
                                                                                         delta_y,
@@ -515,9 +517,9 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
         longest_seg_length = std::max(longest_seg_length, seg_inf.length);
     }
 
-    //Profile each wire segment type
-    for (int from_layer_num = 0; from_layer_num < grid.get_num_layers(); from_layer_num++) {
-        for (const auto& segment_inf : segment_inf_vec) {
+    // Profile each wire segment type
+    for (size_t from_layer_num = 0; from_layer_num < grid.get_num_layers(); from_layer_num++) {
+        for (const t_segment_inf& segment_inf : segment_inf_vec) {
             std::vector<e_rr_type> chan_types;
             if (segment_inf.parallel_axis == e_parallel_axis::X_AXIS)
                 chan_types.push_back(e_rr_type::CHANX);
@@ -538,8 +540,8 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
                     continue;
                 }
 
-                /* boil down the cost list in routing_cost_map at each coordinate to a representative cost entry and store it in the lookahead
-                 * cost map */
+                // boil down the cost list in routing_cost_map at each coordinate to a representative cost entry
+                // and store it in the lookahead cost map
                 set_lookahead_map_costs(from_layer_num, segment_inf.seg_index, chan_type, routing_cost_map);
 
                 /* fill in missing entries in the lookahead cost map by copying the closest cost entries (cost map was computed based on
@@ -550,11 +552,13 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
     }
 }
 
-/* sets the lookahead cost map entries based on representative cost entries from routing_cost_map */
-static void set_lookahead_map_costs(int from_layer_num, int segment_index, e_rr_type chan_type, util::t_routing_cost_map& routing_cost_map) {
+static void set_lookahead_map_costs(unsigned from_layer_num,
+                                    int segment_index,
+                                    e_rr_type chan_type,
+                                    util::t_routing_cost_map& routing_cost_map) {
     int chan_index = (chan_type == e_rr_type::CHANX) ? 0 : 1;
 
-    /* set the lookahead cost map entries with a representative cost entry from routing_cost_map */
+    // set the lookahead cost map entries with a representative cost entry from routing_cost_map
     for (unsigned to_layer = 0; to_layer < routing_cost_map.dim_size(0); to_layer++) {
         for (unsigned ix = 0; ix < routing_cost_map.dim_size(1); ix++) {
             for (unsigned iy = 0; iy < routing_cost_map.dim_size(2); iy++) {
@@ -572,17 +576,21 @@ static void fill_in_missing_lookahead_entries(int segment_index, e_rr_type chan_
 
     auto& device_ctx = g_vpr_ctx.device();
 
-    /* find missing cost entries and fill them in by copying a nearby cost entry */
-    for (int from_layer_num = 0; from_layer_num < device_ctx.grid.get_num_layers(); from_layer_num++) {
-        for (int to_layer_num = 0; to_layer_num < device_ctx.grid.get_num_layers(); ++to_layer_num) {
-            for (unsigned ix = 0; ix < device_ctx.grid.width(); ix++) {
-                for (unsigned iy = 0; iy < device_ctx.grid.height(); iy++) {
+    const int num_layers = device_ctx.grid.get_num_layers();
+    const int grid_width = device_ctx.grid.width();
+    const int grid_height = device_ctx.grid.height();
+
+    // Find missing cost entries and fill them in by copying a nearby cost entry
+    for (int from_layer_num = 0; from_layer_num < num_layers; from_layer_num++) {
+        for (int to_layer_num = 0; to_layer_num < num_layers; ++to_layer_num) {
+            for (int ix = 0; ix < grid_width; ix++) {
+                for (int iy = 0; iy < grid_height; iy++) {
                     util::Cost_Entry cost_entry = f_wire_cost_map[from_layer_num][to_layer_num][chan_index][segment_index][ix][iy];
 
                     if (std::isnan(cost_entry.delay) && std::isnan(cost_entry.congestion)) {
                         util::Cost_Entry copied_entry = get_nearby_cost_entry_average_neighbour(from_layer_num,
-                                                                                                static_cast<int>(ix),
-                                                                                                static_cast<int>(iy),
+                                                                                                ix,
+                                                                                                iy,
                                                                                                 to_layer_num,
                                                                                                 segment_index,
                                                                                                 chan_index);
@@ -713,15 +721,13 @@ static void compute_tile_lookahead(std::unordered_map<int, util::t_ipin_primitiv
                                    const t_det_routing_arch& det_routing_arch,
                                    const int delayless_switch) {
     RRGraphBuilder rr_graph_builder;
-    int layer = 0;
-    int x = 1;
-    int y = 1;
+
+    t_physical_tile_loc tile_loc(1, 1, 0);
+
     build_tile_rr_graph(rr_graph_builder,
                         det_routing_arch,
                         physical_tile,
-                        layer,
-                        x,
-                        y,
+                        tile_loc,
                         delayless_switch);
 
     RRGraphView rr_graph{rr_graph_builder.rr_nodes(),
@@ -737,9 +743,7 @@ static void compute_tile_lookahead(std::unordered_map<int, util::t_ipin_primitiv
 
     util::t_ipin_primitive_sink_delays pin_delays = util::compute_intra_tile_dijkstra(rr_graph,
                                                                                       physical_tile,
-                                                                                      layer,
-                                                                                      x,
-                                                                                      y);
+                                                                                      tile_loc);
 
     auto insert_res = intra_tile_pin_primitive_pin_delay.insert(std::make_pair(physical_tile->index, pin_delays));
     VTR_ASSERT(insert_res.second);

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
@@ -476,12 +476,12 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead(int route_verbosity) {
     t_chan_ipins_delays chan_ipins_delays;
 
     chan_ipins_delays.resize(device_ctx.grid.get_num_layers());
-    for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
+    for (size_t layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
         chan_ipins_delays[layer_num].resize(device_ctx.physical_tile_types.size());
     }
 
-    //We assume that the routing connectivity of each instance of a physical tile is the same,
-    //and so only measure one instance of each type
+    // We assume that the routing connectivity of each instance of a physical tile is the same,
+    // and so only measure one instance of each type
     for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
         for (const t_physical_tile_type& tile_type : device_ctx.physical_tile_types) {
             if (device_ctx.grid.num_instances(&tile_type, layer_num) == 0) {
@@ -523,10 +523,8 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead(int route_verbosity) {
 
 t_ipin_primitive_sink_delays compute_intra_tile_dijkstra(const RRGraphView& rr_graph,
                                                          t_physical_tile_type_ptr physical_tile,
-                                                         int layer,
-                                                         int x,
-                                                         int y) {
-    auto tile_pins_vec = get_flat_tile_pins(physical_tile);
+                                                         const t_physical_tile_loc& tile_loc) {
+    std::vector<int> tile_pins_vec = get_flat_tile_pins(physical_tile);
     int max_ptc_num = get_tile_pin_max_ptc(physical_tile, true);
 
     t_ipin_primitive_sink_delays pin_delays;
@@ -535,9 +533,7 @@ t_ipin_primitive_sink_delays compute_intra_tile_dijkstra(const RRGraphView& rr_g
     for (int pin_physical_num : tile_pins_vec) {
         RRNodeId pin_node_id = get_pin_rr_node_id(rr_graph.node_lookup(),
                                                   physical_tile,
-                                                  layer,
-                                                  x,
-                                                  y,
+                                                  tile_loc,
                                                   pin_physical_num);
         VTR_ASSERT(pin_node_id != RRNodeId::INVALID());
 
@@ -695,7 +691,7 @@ std::pair<int, int> get_xy_deltas(RRNodeId from_node, RRNodeId to_node) {
 }
 
 t_routing_cost_map get_routing_cost_map(int longest_seg_length,
-                                        int from_layer_num,
+                                        unsigned from_layer_num,
                                         const e_rr_type& chan_type,
                                         const t_segment_inf& segment_inf,
                                         const std::unordered_map<int, std::unordered_set<int>>& sample_locs,

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
@@ -482,7 +482,7 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead(int route_verbosity) {
 
     // We assume that the routing connectivity of each instance of a physical tile is the same,
     // and so only measure one instance of each type
-    for (int layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
+    for (int layer_num = 0; layer_num < (int)device_ctx.grid.get_num_layers(); layer_num++) {
         for (const t_physical_tile_type& tile_type : device_ctx.physical_tile_types) {
             if (device_ctx.grid.num_instances(&tile_type, layer_num) == 0) {
                 continue;
@@ -756,7 +756,7 @@ t_routing_cost_map get_routing_cost_map(int longest_seg_length,
                 continue;
             }
             // TODO: Temporary - After testing benchmarks this can be deleted
-            VTR_ASSERT(rr_graph.node_layer(start_node) == from_layer_num);
+            VTR_ASSERT(rr_graph.node_layer(start_node) == (int)from_layer_num);
 
             sample_nodes.emplace_back(start_node);
         }
@@ -767,13 +767,13 @@ t_routing_cost_map get_routing_cost_map(int longest_seg_length,
     //This is to ensure we sample 'unusual' wire types which may not exist in all channels
     //(e.g. clock routing)
     if (sample_nodes.empty()) {
-        //Try an exhaustive search to find a suitable sample point
+        // Try an exhaustive search to find a suitable sample point
         for (RRNodeId rr_node : rr_graph.nodes()) {
-            auto rr_type = rr_graph.node_type(rr_node);
+            e_rr_type rr_type = rr_graph.node_type(rr_node);
             if (rr_type != chan_type) continue;
-            if (rr_graph.node_layer(rr_node) != from_layer_num) continue;
+            if (rr_graph.node_layer(rr_node) != (int)from_layer_num) continue;
 
-            auto cost_index = rr_graph.node_cost_index(rr_node);
+            RRIndexedDataId cost_index = rr_graph.node_cost_index(rr_node);
             VTR_ASSERT(cost_index != RRIndexedDataId(UNDEFINED));
 
             int seg_index = device_ctx.rr_indexed_data[cost_index].seg_index;

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
@@ -316,9 +316,7 @@ t_chan_ipins_delays compute_router_chan_ipin_lookahead(int route_verbosity);
 
 t_ipin_primitive_sink_delays compute_intra_tile_dijkstra(const RRGraphView& rr_graph,
                                                          t_physical_tile_type_ptr physical_tile,
-                                                         int layer,
-                                                         int x,
-                                                         int y);
+                                                         const t_physical_tile_loc& tile_loc);
 
 /* returns index of a node from which to start routing */
 RRNodeId get_start_node(int layer, int start_x, int start_y, int target_x, int target_y, e_rr_type rr_type, int seg_index, int track_offset);
@@ -334,7 +332,7 @@ RRNodeId get_start_node(int layer, int start_x, int start_y, int target_x, int t
 std::pair<int, int> get_xy_deltas(RRNodeId from_node, RRNodeId to_node);
 
 t_routing_cost_map get_routing_cost_map(int longest_seg_length,
-                                        int from_layer_num,
+                                        unsigned from_layer_num,
                                         const e_rr_type& chan_type,
                                         const t_segment_inf& segment_inf,
                                         const std::unordered_map<int, std::unordered_set<int>>& sample_locs,

--- a/vpr/src/route/rr_graph_generation/build_switchblocks.cpp
+++ b/vpr/src/route/rr_graph_generation/build_switchblocks.cpp
@@ -453,7 +453,7 @@ t_sb_connection_map* alloc_and_load_switchblock_permutations(const t_chan_detail
         }
 
         // Iterate over the x,y, layer coordinates spanning the FPGA, filling in all the switch blocks that exist
-        for (int layer_coord = 0; layer_coord < grid.get_num_layers(); layer_coord++) {
+        for (size_t layer_coord = 0; layer_coord < grid.get_num_layers(); layer_coord++) {
             for (size_t x_coord = 0; x_coord < grid.width(); x_coord++) {
                 for (size_t y_coord = 0; y_coord <= grid.height(); y_coord++) {
                     if (sb_not_here(grid, inter_cluster_rr, x_coord, y_coord, layer_coord, sb)) {
@@ -571,7 +571,7 @@ static bool is_core_sb(const DeviceGrid& grid, const std::vector<bool>& inter_cl
 static bool is_prog_routing_avail(const DeviceGrid& grid, const std::vector<bool>& inter_cluster_rr, int layer) {
     bool is_prog_avail = true;
     //make sure layer number is legal
-    VTR_ASSERT(layer >= 0 && layer < grid.get_num_layers());
+    VTR_ASSERT(layer >= 0 && layer < (int)grid.get_num_layers());
     //check if the current layer has programmable routing resources before trying to build a custom switch blocks
     if (!inter_cluster_rr.at(layer)) {
         is_prog_avail = false;
@@ -1106,7 +1106,7 @@ static bool coords_out_of_bounds(const DeviceGrid& grid, int x_coord, int y_coor
     bool result = true;
 
     /* the layer that channel is located at must be legal regardless of chan_type*/
-    if (layer_coord < 0 || layer_coord > grid.get_num_layers()) {
+    if (layer_coord < 0 || layer_coord > (int)grid.get_num_layers()) {
         return result;
     }
 

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -2029,7 +2029,7 @@ static std::function<void(t_chan_width*)> alloc_and_load_rr_graph(RRGraphBuilder
     num_edges = 0;
     // Build opins
     int rr_edges_before_directs = 0;
-    for (int layer = 0; layer < grid.get_num_layers(); layer++) {
+    for (size_t layer = 0; layer < grid.get_num_layers(); layer++) {
         for (size_t i = 0; i < grid.width(); ++i) {
             for (size_t j = 0; j < grid.height(); ++j) {
                 for (e_side side : TOTAL_2D_SIDES) {
@@ -3345,7 +3345,7 @@ static vtr::NdMatrix<int, 6> alloc_and_load_pin_to_seg_type(const e_pin_type pin
 
     // Total the number of physical pins
     std::vector<int> num_phys_pins_per_layer;
-    for (int layer = 0; layer < grid.get_num_layers(); layer++) {
+    for (int layer = 0; layer < (int)grid.get_num_layers(); layer++) {
         int num_phys_pins = 0;
         for (int width = 0; width < tile_type->width; ++width) {
             for (int height = 0; height < tile_type->height; ++height) {
@@ -3364,7 +3364,7 @@ static vtr::NdMatrix<int, 6> alloc_and_load_pin_to_seg_type(const e_pin_type pin
     // (potentially in other C blocks) connect to the remaining tracks first. Doesn't matter for large Fc,
     // but should make a fairly good low Fc block that leverages the fact that usually lots of pins are logically equivalent.
 
-    for (int layer_index = 0; layer_index < grid.get_num_layers(); layer_index++) {
+    for (int layer_index = 0; layer_index < (int)grid.get_num_layers(); layer_index++) {
         const e_side init_side = LEFT;
         const int init_width = 0;
         const int init_height = 0;

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -394,7 +394,6 @@ static void build_cluster_internal_edges(RRGraphBuilder& rr_graph_builder,
                                          bool is_flat,
                                          bool load_rr_graph);
 
-
 /// @brief Connect the pins of the given t_pb to their drivers - It doesn't add the edges going in/out of pins on a chain
 static void add_pb_edges(RRGraphBuilder& rr_graph_builder,
                          t_rr_edge_info_set& rr_edges_to_create,
@@ -831,7 +830,7 @@ static void add_intra_cluster_edges_rr_graph(RRGraphBuilder& rr_graph_builder,
     int num_collapsed_nodes = 0;
     for (ClusterBlockId cluster_blk_id : cluster_net_list.blocks()) {
         t_pl_loc block_loc = block_locs[cluster_blk_id].loc;
-        t_physical_tile_loc loc(block_loc.x,  block_loc.y, block_loc.layer);
+        t_physical_tile_loc loc(block_loc.x, block_loc.y, block_loc.layer);
         int abs_cap = block_loc.sub_tile;
         build_cluster_internal_edges(rr_graph_builder,
                                      num_collapsed_nodes,

--- a/vpr/src/route/rr_graph_generation/rr_graph.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph.h
@@ -36,9 +36,7 @@ void create_rr_graph(e_graph_type graph_type,
 void build_tile_rr_graph(RRGraphBuilder& rr_graph_builder,
                          const t_det_routing_arch& det_routing_arch,
                          t_physical_tile_type_ptr physical_tile,
-                         int layer,
-                         int x,
-                         int y,
+                         const t_physical_tile_loc& tile_loc,
                          const int delayless_switch);
 
 void free_rr_graph();

--- a/vpr/src/route/rr_graph_generation/rr_graph2.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph2.cpp
@@ -140,7 +140,7 @@ static int get_track_to_chan_seg(RRGraphBuilder& rr_graph_builder,
  *
  * @return true if the connection going to another layer, false otherwise.
  */
-static bool is_sb_conn_layer_crossing(enum e_side src_side, enum e_side dest_side);
+static bool is_sb_conn_layer_crossing(e_side src_side, e_side dest_side);
 
 /**
  * @brief finds corresponding RR nodes for a 3D SB edge and fill 3D custom switch block information (offset to correct extra CHANX nodes, source tracks, ..)
@@ -1015,12 +1015,12 @@ void dump_track_to_pin_map(t_track_to_pin_lookup& track_to_pin_map,
         auto& device_ctx = g_vpr_ctx.device();
         for (unsigned int i = 0; i < types.size(); i++) {
             if (!track_to_pin_map[i].empty()) {
-                for (int layer = 0; layer < device_ctx.grid.get_num_layers(); layer++) {
+                for (size_t layer = 0; layer < device_ctx.grid.get_num_layers(); layer++) {
                     for (int track = 0; track < max_chan_width; ++track) {
                         for (int width = 0; width < types[i].width; ++width) {
                             for (int height = 0; height < types[i].height; ++height) {
                                 for (int side = 0; side < 4; ++side) {
-                                    fprintf(fp, "\nTYPE:%s width:%d height:%d layer:%d\n", types[i].name.c_str(), width, height, layer);
+                                    fprintf(fp, "\nTYPE:%s width:%d height:%d layer:%lu\n", types[i].name.c_str(), width, height, layer);
                                     fprintf(fp, "\nSIDE:%d TRACK:%d \n", side, track);
                                     for (size_t con = 0; con < track_to_pin_map[i][track][width][height][layer][side].size(); con++) {
                                         fprintf(fp, "%d ", track_to_pin_map[i][track][width][height][layer][side][con]);
@@ -1036,7 +1036,7 @@ void dump_track_to_pin_map(t_track_to_pin_lookup& track_to_pin_map,
     }
 }
 
-static bool is_sb_conn_layer_crossing(enum e_side src_side, enum e_side dest_side) {
+static bool is_sb_conn_layer_crossing(e_side src_side, e_side dest_side) {
     if (src_side < NUM_2D_SIDES && dest_side < NUM_2D_SIDES) {
         return false;
     }
@@ -1075,7 +1075,7 @@ vtr::NdMatrix<int, 2> get_number_track_to_track_inter_die_conn(t_sb_connection_m
 
     for (size_t y = 0; y < grid_ctx.height(); y++) {
         for (size_t x = 0; x < grid_ctx.width(); x++) {
-            for (int layer = 0; layer < grid_ctx.get_num_layers(); layer++) {
+            for (int layer = 0; layer < (int)grid_ctx.get_num_layers(); layer++) {
 
                 int num_of_3d_conn = 0;
                 for (e_side from_side : TOTAL_3D_SIDES) {
@@ -1158,9 +1158,9 @@ int get_track_to_pins(RRGraphBuilder& rr_graph_builder,
                     side = (0 == pass ? RIGHT : LEFT);
                 }
 
-                for (int layer_index = 0; layer_index < device_ctx.grid.get_num_layers(); layer_index++) {
+                for (int layer_index = 0; layer_index < (int)device_ctx.grid.get_num_layers(); layer_index++) {
                     /* PAJ - if the pointed to is an EMPTY then shouldn't look for ipins */
-                    auto type = device_ctx.grid.get_physical_type({x, y, layer_index});
+                    t_physical_tile_type_ptr type = device_ctx.grid.get_physical_type({x, y, layer_index});
                     if (type == device_ctx.EMPTY_PHYSICAL_TILE_TYPE)
                         continue;
 
@@ -1570,8 +1570,8 @@ static void get_switchblocks_edges(RRGraphBuilder& rr_graph_builder,
                 VTR_ASSERT(to_layer != layer);
                 // Check if current connection is valid, since switch block pattern is very general,
                 // we might see invalid layer in connection, so we just skip those
-                if ((layer < 0 || layer >= device_ctx.grid.get_num_layers())
-                    || (to_layer < 0 || to_layer >= device_ctx.grid.get_num_layers())) {
+                if ((layer < 0 || layer >= (int)device_ctx.grid.get_num_layers())
+                    || (to_layer < 0 || to_layer >= (int)device_ctx.grid.get_num_layers())) {
                     continue;
                 }
 

--- a/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
@@ -172,7 +172,7 @@ static void load_chan_rr_indices(const int max_chan_width,
                                  int* index) {
     const auto& device_ctx = g_vpr_ctx.device();
 
-    for (int layer = 0; layer < grid.get_num_layers(); layer++) {
+    for (size_t layer = 0; layer < grid.get_num_layers(); layer++) {
         // Skip the current die if architecture file specifies that it doesn't require global resource routing
         if (!device_ctx.inter_cluster_prog_routing_resources.at(layer)) {
             continue;
@@ -335,7 +335,7 @@ void alloc_and_load_inter_die_rr_node_indices(RRGraphBuilder& rr_graph_builder,
     // 4) direction = NONE
     const auto& device_ctx = g_vpr_ctx.device();
 
-    for (int layer = 0; layer < grid.get_num_layers(); layer++) {
+    for (size_t layer = 0; layer < grid.get_num_layers(); layer++) {
         // Skip the current die if architecture file specifies that it doesn't have global resource routing
         if (!device_ctx.inter_cluster_prog_routing_resources.at(layer)) {
             continue;

--- a/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
@@ -51,9 +51,7 @@ static void load_chan_rr_indices(const int max_chan_width,
 static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
                                        t_physical_tile_type_ptr physical_type_ptr,
                                        const std::vector<int>& class_num_vec,
-                                       int layer,
-                                       int x,
-                                       int y,
+                                       const t_physical_tile_loc& root_loc,
                                        int block_width,
                                        int block_height,
                                        int* index);
@@ -61,9 +59,7 @@ static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
 static void add_pins_spatial_lookup(RRGraphBuilder& rr_graph_builder,
                                     t_physical_tile_type_ptr physical_type_ptr,
                                     const std::vector<int>& pin_num_vec,
-                                    int layer,
-                                    int root_x,
-                                    int root_y,
+                                    const t_physical_tile_loc& root_loc,
                                     int* index,
                                     const std::vector<e_side>& wanted_sides);
 
@@ -87,89 +83,81 @@ static void load_block_rr_indices(RRGraphBuilder& rr_graph_builder,
                                   const DeviceGrid& grid,
                                   int* index) {
     // Walk through the grid assigning indices to SOURCE/SINK IPIN/OPIN
-    for (int layer = 0; layer < grid.get_num_layers(); layer++) {
-        for (int x = 0; x < (int)grid.width(); x++) {
-            for (int y = 0; y < (int)grid.height(); y++) {
-                //Process each block from its root location
-                if (grid.is_root_location({x, y, layer})) {
-                    t_physical_tile_type_ptr physical_type = grid.get_physical_type({x, y, layer});
+    for (const t_physical_tile_loc grid_loc : grid.all_locations()) {
+        //Process each block from its root location
+        if (grid.is_root_location(grid_loc)) {
+            t_physical_tile_type_ptr physical_type = grid.get_physical_type(grid_loc);
 
-                    // Assign indices for SINKs and SOURCEs
-                    // Note that SINKS/SOURCES have no side, so we always use side 0
-                    std::vector<int> class_num_vec = get_tile_root_classes(physical_type);
-                    std::vector<int> pin_num_vec = get_tile_root_pins(physical_type);
+            // Assign indices for SINKs and SOURCEs
+            // Note that SINKS/SOURCES have no side, so we always use side 0
+            std::vector<int> class_num_vec = get_tile_root_classes(physical_type);
+            std::vector<int> pin_num_vec = get_tile_root_pins(physical_type);
 
-                    add_classes_spatial_lookup(rr_graph_builder,
-                                               physical_type,
-                                               class_num_vec,
-                                               layer,
-                                               x,
-                                               y,
-                                               physical_type->width,
-                                               physical_type->height,
-                                               index);
+            add_classes_spatial_lookup(rr_graph_builder,
+                                       physical_type,
+                                       class_num_vec,
+                                       grid_loc,
+                                       physical_type->width,
+                                       physical_type->height,
+                                       index);
 
-                    /* Limited sides for grids
-                     *   The wanted side depends on the location of the grid.
-                     *   In particular for perimeter grid,
-                     *   -------------------------------------------------------
-                     *   Grid location |  IPIN side
-                     *   -------------------------------------------------------
-                     *   TOP           |  BOTTOM
-                     *   -------------------------------------------------------
-                     *   RIGHT         |  LEFT
-                     *   -------------------------------------------------------
-                     *   BOTTOM        |  TOP
-                     *   -------------------------------------------------------
-                     *   LEFT          |  RIGHT
-                     *   -------------------------------------------------------
-                     *   TOP-LEFT      |  BOTTOM & RIGHT
-                     *   -------------------------------------------------------
-                     *   TOP-RIGHT     |  BOTTOM & LEFT
-                     *   -------------------------------------------------------
-                     *   BOTTOM-LEFT   |  TOP & RIGHT
-                     *   -------------------------------------------------------
-                     *   BOTTOM-RIGHT  |  TOP & LEFT
-                     *   -------------------------------------------------------
-                     *   Other         |  First come first fit
-                     *   -------------------------------------------------------
-                     *
-                     * Special for IPINs:
-                     *   If there are multiple wanted sides, first come first fit is applied
-                     *   This guarantee that there is only a unique rr_node
-                     *   for the same input pin on multiple sides, and thus avoid multiple driver problems
-                     */
-                    std::vector<e_side> wanted_sides;
-                    if ((int)grid.height() - 1 == y) { // TOP side
-                        wanted_sides.push_back(BOTTOM);
-                    }
-                    if ((int)grid.width() - 1 == x) { // RIGHT side
-                        wanted_sides.push_back(LEFT);
-                    }
-                    if (0 == y) { // BOTTOM side
-                        wanted_sides.push_back(TOP);
-                    }
-                    if (0 == x) { // LEFT side
-                        wanted_sides.push_back(RIGHT);
-                    }
+            /* Limited sides for grids
+             *   The wanted side depends on the location of the grid.
+             *   In particular for perimeter grid,
+             *   -------------------------------------------------------
+             *   Grid location |  IPIN side
+             *   -------------------------------------------------------
+             *   TOP           |  BOTTOM
+             *   -------------------------------------------------------
+             *   RIGHT         |  LEFT
+             *   -------------------------------------------------------
+             *   BOTTOM        |  TOP
+             *   -------------------------------------------------------
+             *   LEFT          |  RIGHT
+             *   -------------------------------------------------------
+             *   TOP-LEFT      |  BOTTOM & RIGHT
+             *   -------------------------------------------------------
+             *   TOP-RIGHT     |  BOTTOM & LEFT
+             *   -------------------------------------------------------
+             *   BOTTOM-LEFT   |  TOP & RIGHT
+             *   -------------------------------------------------------
+             *   BOTTOM-RIGHT  |  TOP & LEFT
+             *   -------------------------------------------------------
+             *   Other         |  First come first fit
+             *   -------------------------------------------------------
+             *
+             * Special for IPINs:
+             *   If there are multiple wanted sides, first come first fit is applied
+             *   This guarantee that there is only a unique rr_node
+             *   for the same input pin on multiple sides, and thus avoid multiple driver problems
+             */
+            std::vector<e_side> wanted_sides;
+            if ((int)grid.height() - 1 == grid_loc.y) { // TOP side
+                wanted_sides.push_back(BOTTOM);
+            }
+            if ((int)grid.width() - 1 == grid_loc.x) { // RIGHT side
+                wanted_sides.push_back(LEFT);
+            }
+            if (0 == grid_loc.y) { // BOTTOM side
+                wanted_sides.push_back(TOP);
+            }
+            if (0 == grid_loc.x) { // LEFT side
+                wanted_sides.push_back(RIGHT);
+            }
 
-                    // If wanted sides is empty still, this block does not have specific wanted sides, Deposit all the sides
-                    if (wanted_sides.empty()) {
-                        for (e_side side : TOTAL_2D_SIDES) {
-                            wanted_sides.push_back(side);
-                        }
-                    }
-
-                    add_pins_spatial_lookup(rr_graph_builder,
-                                            physical_type,
-                                            pin_num_vec,
-                                            layer,
-                                            x,
-                                            y,
-                                            index,
-                                            wanted_sides);
+            // If wanted sides is empty still, this block does not have specific wanted sides, Deposit all the sides
+            if (wanted_sides.empty()) {
+                for (e_side side : TOTAL_2D_SIDES) {
+                    wanted_sides.push_back(side);
                 }
             }
+
+            add_pins_spatial_lookup(rr_graph_builder,
+                                    physical_type,
+                                    pin_num_vec,
+                                    grid_loc,
+                                    index,
+                                    wanted_sides);
         }
     }
 }
@@ -228,16 +216,14 @@ static void load_chan_rr_indices(const int max_chan_width,
 static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
                                        t_physical_tile_type_ptr physical_type_ptr,
                                        const std::vector<int>& class_num_vec,
-                                       int layer,
-                                       int root_x,
-                                       int root_y,
+                                       const t_physical_tile_loc& root_loc,
                                        int block_width,
                                        int block_height,
                                        int* index) {
-    for (int x_tile = root_x; x_tile < (root_x + block_width); x_tile++) {
-        for (int y_tile = root_y; y_tile < (root_y + block_height); y_tile++) {
-            rr_graph_builder.node_lookup().reserve_nodes(layer, x_tile, y_tile, e_rr_type::SOURCE, class_num_vec.size(), TOTAL_2D_SIDES[0]);
-            rr_graph_builder.node_lookup().reserve_nodes(layer, x_tile, y_tile, e_rr_type::SINK, class_num_vec.size(), TOTAL_2D_SIDES[0]);
+    for (int x_tile = root_loc.x; x_tile < (root_loc.x + block_width); x_tile++) {
+        for (int y_tile = root_loc.y; y_tile < (root_loc.y + block_height); y_tile++) {
+            rr_graph_builder.node_lookup().reserve_nodes(root_loc.layer_num, x_tile, y_tile, e_rr_type::SOURCE, class_num_vec.size(), TOTAL_2D_SIDES[0]);
+            rr_graph_builder.node_lookup().reserve_nodes(root_loc.layer_num, x_tile, y_tile, e_rr_type::SINK, class_num_vec.size(), TOTAL_2D_SIDES[0]);
         }
     }
 
@@ -252,10 +238,10 @@ static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
 
         for (int x_offset = 0; x_offset < block_width; x_offset++) {
             for (int y_offset = 0; y_offset < block_height; y_offset++) {
-                int curr_x = root_x + x_offset;
-                int curr_y = root_y + y_offset;
+                int curr_x = root_loc.x + x_offset;
+                int curr_y = root_loc.y + y_offset;
 
-                rr_graph_builder.node_lookup().add_node(RRNodeId(*index), layer, curr_x, curr_y, node_type, class_num);
+                rr_graph_builder.node_lookup().add_node(RRNodeId(*index), root_loc.layer_num, curr_x, curr_y, node_type, class_num);
             }
         }
 
@@ -266,19 +252,17 @@ static void add_classes_spatial_lookup(RRGraphBuilder& rr_graph_builder,
 static void add_pins_spatial_lookup(RRGraphBuilder& rr_graph_builder,
                                     t_physical_tile_type_ptr physical_type_ptr,
                                     const std::vector<int>& pin_num_vec,
-                                    int layer,
-                                    int root_x,
-                                    int root_y,
+                                    const t_physical_tile_loc& root_loc,
                                     int* index,
                                     const std::vector<e_side>& wanted_sides) {
     for (e_side side : wanted_sides) {
         for (int width_offset = 0; width_offset < physical_type_ptr->width; ++width_offset) {
-            int x_tile = root_x + width_offset;
+            int x_tile = root_loc.x + width_offset;
             for (int height_offset = 0; height_offset < physical_type_ptr->height; ++height_offset) {
-                int y_tile = root_y + height_offset;
+                int y_tile = root_loc.y + height_offset;
                 // only nodes on the tile may be located in a location other than the root-location
-                rr_graph_builder.node_lookup().reserve_nodes(layer, x_tile, y_tile, e_rr_type::OPIN, physical_type_ptr->num_pins, side);
-                rr_graph_builder.node_lookup().reserve_nodes(layer, x_tile, y_tile, e_rr_type::IPIN, physical_type_ptr->num_pins, side);
+                rr_graph_builder.node_lookup().reserve_nodes(root_loc.layer_num, x_tile, y_tile, e_rr_type::OPIN, physical_type_ptr->num_pins, side);
+                rr_graph_builder.node_lookup().reserve_nodes(root_loc.layer_num, x_tile, y_tile, e_rr_type::IPIN, physical_type_ptr->num_pins, side);
             }
         }
     }
@@ -288,15 +272,15 @@ static void add_pins_spatial_lookup(RRGraphBuilder& rr_graph_builder,
         const auto [x_offset, y_offset, pin_sides] = get_pin_coordinates(physical_type_ptr, pin_num, wanted_sides);
         e_pin_type pin_type = get_pin_type_from_pin_physical_num(physical_type_ptr, pin_num);
         for (int pin_coord_idx = 0; pin_coord_idx < (int)pin_sides.size(); pin_coord_idx++) {
-            int x_tile = root_x + x_offset[pin_coord_idx];
-            int y_tile = root_y + y_offset[pin_coord_idx];
+            int x_tile = root_loc.x + x_offset[pin_coord_idx];
+            int y_tile = root_loc.y + y_offset[pin_coord_idx];
             e_side side = pin_sides[pin_coord_idx];
             if (pin_type == e_pin_type::DRIVER) {
-                rr_graph_builder.node_lookup().add_node(RRNodeId(*index), layer, x_tile, y_tile, e_rr_type::OPIN, pin_num, side);
+                rr_graph_builder.node_lookup().add_node(RRNodeId(*index), root_loc.layer_num, x_tile, y_tile, e_rr_type::OPIN, pin_num, side);
                 assigned_to_rr_node = true;
             } else {
                 VTR_ASSERT(pin_type == e_pin_type::RECEIVER);
-                rr_graph_builder.node_lookup().add_node(RRNodeId(*index), layer, x_tile, y_tile, e_rr_type::IPIN, pin_num, side);
+                rr_graph_builder.node_lookup().add_node(RRNodeId(*index), root_loc.layer_num, x_tile, y_tile, e_rr_type::IPIN, pin_num, side);
                 assigned_to_rr_node = true;
             }
         }
@@ -384,9 +368,7 @@ void alloc_and_load_inter_die_rr_node_indices(RRGraphBuilder& rr_graph_builder,
 
 void alloc_and_load_tile_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                          t_physical_tile_type_ptr physical_tile,
-                                         int layer,
-                                         int x,
-                                         int y,
+                                         const t_physical_tile_loc& root_loc,
                                          int* num_rr_nodes) {
     std::vector<e_side> wanted_sides{TOP, BOTTOM, LEFT, RIGHT};
     auto class_num_range = get_flat_tile_primitive_classes(physical_tile);
@@ -398,9 +380,7 @@ void alloc_and_load_tile_rr_node_indices(RRGraphBuilder& rr_graph_builder,
     add_classes_spatial_lookup(rr_graph_builder,
                                physical_tile,
                                class_num_vec,
-                               layer,
-                               x,
-                               y,
+                               root_loc,
                                physical_tile->width,
                                physical_tile->height,
                                num_rr_nodes);
@@ -408,9 +388,7 @@ void alloc_and_load_tile_rr_node_indices(RRGraphBuilder& rr_graph_builder,
     add_pins_spatial_lookup(rr_graph_builder,
                             physical_tile,
                             pin_num_vec,
-                            layer,
-                            x,
-                            y,
+                            root_loc,
                             num_rr_nodes,
                             wanted_sides);
 }
@@ -420,45 +398,37 @@ void alloc_and_load_intra_cluster_rr_node_indices(RRGraphBuilder& rr_graph_build
                                                   const vtr::vector<ClusterBlockId, t_cluster_pin_chain>& pin_chains,
                                                   const vtr::vector<ClusterBlockId, std::unordered_set<int>>& pin_chains_num,
                                                   int* index) {
-    for (int layer = 0; layer < grid.get_num_layers(); layer++) {
-        for (int x = 0; x < (int)grid.width(); x++) {
-            for (int y = 0; y < (int)grid.height(); y++) {
-                // Process each block from its root location
-                if (grid.is_root_location({x, y, layer})) {
-                    t_physical_tile_type_ptr physical_type = grid.get_physical_type({x, y, layer});
-                    // Assign indices for SINKs and SOURCEs
-                    // Note that SINKS/SOURCES have no side, so we always use side 0
-                    std::vector<int> class_num_vec;
-                    std::vector<int> pin_num_vec;
-                    class_num_vec = get_cluster_netlist_intra_tile_classes_at_loc(layer, x, y, physical_type);
-                    pin_num_vec = get_cluster_netlist_intra_tile_pins_at_loc(layer,
-                                                                             x,
-                                                                             y,
-                                                                             pin_chains,
-                                                                             pin_chains_num,
-                                                                             physical_type);
-                    add_classes_spatial_lookup(rr_graph_builder,
-                                               physical_type,
-                                               class_num_vec,
-                                               layer,
-                                               x,
-                                               y,
-                                               physical_type->width,
-                                               physical_type->height,
-                                               index);
 
-                    std::vector<e_side> wanted_sides;
-                    wanted_sides.push_back(e_side::TOP);
-                    add_pins_spatial_lookup(rr_graph_builder,
-                                            physical_type,
-                                            pin_num_vec,
-                                            layer,
-                                            x,
-                                            y,
-                                            index,
-                                            wanted_sides);
-                }
-            }
+    for (const t_physical_tile_loc grid_loc : grid.all_locations()) {
+
+        // Process each block from its root location
+        if (grid.is_root_location(grid_loc)) {
+            t_physical_tile_type_ptr physical_type = grid.get_physical_type(grid_loc);
+            // Assign indices for SINKs and SOURCEs
+            // Note that SINKS/SOURCES have no side, so we always use side 0
+            std::vector<int> class_num_vec;
+            std::vector<int> pin_num_vec;
+            class_num_vec = get_cluster_netlist_intra_tile_classes_at_loc(grid_loc, physical_type);
+            pin_num_vec = get_cluster_netlist_intra_tile_pins_at_loc(grid_loc,
+                                                                     pin_chains,
+                                                                     pin_chains_num,
+                                                                     physical_type);
+            add_classes_spatial_lookup(rr_graph_builder,
+                                       physical_type,
+                                       class_num_vec,
+                                       grid_loc,
+                                       physical_type->width,
+                                       physical_type->height,
+                                       index);
+
+            std::vector<e_side> wanted_sides;
+            wanted_sides.push_back(e_side::TOP);
+            add_pins_spatial_lookup(rr_graph_builder,
+                                    physical_type,
+                                    pin_num_vec,
+                                    grid_loc,
+                                    index,
+                                    wanted_sides);
         }
     }
 }

--- a/vpr/src/route/rr_graph_generation/rr_node_indices.h
+++ b/vpr/src/route/rr_graph_generation/rr_node_indices.h
@@ -53,16 +53,12 @@ void alloc_and_load_inter_die_rr_node_indices(RRGraphBuilder& rr_graph_builder,
  *
  * @param rr_graph_builder Reference to the RR graph builder with spatial lookup.
  * @param physical_tile Pointer to the physical tile type being processed.
- * @param layer Layer index of the tile in the device grid.
- * @param x X-coordinate of the tile's root position in the grid.
- * @param y Y-coordinate of the tile's root position in the grid.
+ * @param root_loc Tile's root position in the grid.
  * @param num_rr_nodes Pointer to the global RR node index counter (will be incremented).
  */
 void alloc_and_load_tile_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                          t_physical_tile_type_ptr physical_tile,
-                                         int layer,
-                                         int x,
-                                         int y,
+                                         const t_physical_tile_loc& root_loc,
                                          int* num_rr_nodes);
 
 void alloc_and_load_intra_cluster_rr_node_indices(RRGraphBuilder& rr_graph_builder,

--- a/vpr/src/route/serial_connection_router.cpp
+++ b/vpr/src/route/serial_connection_router.cpp
@@ -241,7 +241,7 @@ void SerialConnectionRouter<Heap>::timing_driven_expand_neighbour(const RTExplor
                                                                   const t_bb& bounding_box,
                                                                   RRNodeId target_node,
                                                                   const t_bb& target_bb) {
-    VTR_ASSERT(bounding_box.layer_max < g_vpr_ctx.device().grid.get_num_layers());
+    VTR_ASSERT(bounding_box.layer_max < (int)g_vpr_ctx.device().grid.get_num_layers());
 
     const RRNodeId& from_node = current.index;
 

--- a/vpr/src/timing/net_delay.cpp
+++ b/vpr/src/timing/net_delay.cpp
@@ -91,7 +91,7 @@ static void load_one_net_delay(const Netlist<>& net_list,
 static void load_one_net_delay_recurr(const RouteTreeNode& rt_node, ParentNetId net_id) {
     /* This routine recursively traverses the route tree, and copies the Tdel of the sink_type nodes *
      * into the map.                                                                                 */
-    if (rt_node.net_pin_index != UNDEFINED) {                        // value of UNDEFINED indicates a non-SINK
+    if (rt_node.net_pin_index != UNDEFINED) {                   // value of UNDEFINED indicates a non-SINK
         ipin_to_Tdel_map[rt_node.net_pin_index] = rt_node.Tdel; // add to the map, process current sink-type node
     }
 

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1630,7 +1630,7 @@ std::vector<const t_pb_graph_node*> get_all_pb_graph_node_primitives(const t_pb_
 
 bool is_inter_cluster_node(const RRGraphView& rr_graph_view,
                            RRNodeId node_id) {
-    auto node_type = rr_graph_view.node_type(node_id);
+    e_rr_type node_type = rr_graph_view.node_type(node_id);
     if (node_type == e_rr_type::CHANX || node_type == e_rr_type::CHANY || node_type == e_rr_type::CHANZ || node_type == e_rr_type::MUX) {
         return true;
     } else {
@@ -1669,11 +1669,9 @@ int get_rr_node_max_ptc(const RRGraphView& rr_graph_view,
 
 RRNodeId get_pin_rr_node_id(const RRSpatialLookup& rr_spatial_lookup,
                             t_physical_tile_type_ptr physical_tile,
-                            const int layer,
-                            const int root_i,
-                            const int root_j,
+                            const t_physical_tile_loc& root_loc,
                             int pin_physical_num) {
-    auto pin_type = get_pin_type_from_pin_physical_num(physical_tile, pin_physical_num);
+    e_pin_type pin_type = get_pin_type_from_pin_physical_num(physical_tile, pin_physical_num);
     e_rr_type node_type = (pin_type == e_pin_type::DRIVER) ? e_rr_type::OPIN : e_rr_type::IPIN;
     std::vector<int> x_offset;
     std::vector<int> y_offset;
@@ -1682,9 +1680,9 @@ RRNodeId get_pin_rr_node_id(const RRSpatialLookup& rr_spatial_lookup,
     VTR_ASSERT(!x_offset.empty());
     RRNodeId node_id = RRNodeId::INVALID();
     for (int coord_idx = 0; coord_idx < (int)pin_sides.size(); coord_idx++) {
-        node_id = rr_spatial_lookup.find_node(layer,
-                                              root_i + x_offset[coord_idx],
-                                              root_j + y_offset[coord_idx],
+        node_id = rr_spatial_lookup.find_node(root_loc.layer_num,
+                                              root_loc.x + x_offset[coord_idx],
+                                              root_loc.y + y_offset[coord_idx],
                                               node_type,
                                               pin_physical_num,
                                               pin_sides[coord_idx]);
@@ -1696,14 +1694,12 @@ RRNodeId get_pin_rr_node_id(const RRSpatialLookup& rr_spatial_lookup,
 
 RRNodeId get_class_rr_node_id(const RRSpatialLookup& rr_spatial_lookup,
                               t_physical_tile_type_ptr physical_tile,
-                              const int layer,
-                              const int i,
-                              const int j,
+                              const t_physical_tile_loc& root_loc,
                               int class_physical_num) {
-    auto class_type = get_class_type_from_class_physical_num(physical_tile, class_physical_num);
+    e_pin_type class_type = get_class_type_from_class_physical_num(physical_tile, class_physical_num);
     VTR_ASSERT(class_type == e_pin_type::DRIVER || class_type == e_pin_type::RECEIVER);
     e_rr_type node_type = (class_type == e_pin_type::DRIVER) ? e_rr_type::SOURCE : e_rr_type::SINK;
-    return rr_spatial_lookup.find_node(layer, i, j, node_type, class_physical_num);
+    return rr_spatial_lookup.find_node(root_loc.layer_num, root_loc.x, root_loc.y, node_type, class_physical_num);
 }
 
 RRNodeId get_atom_pin_rr_node_id(AtomPinId atom_pin_id) {
@@ -1712,30 +1708,27 @@ RRNodeId get_atom_pin_rr_node_id(AtomPinId atom_pin_id) {
     auto& place_ctx = g_vpr_ctx.placement();
     auto& device_ctx = g_vpr_ctx.device();
 
-    /*
-     * To get the RRNodeId for an atom pin, we need to:
-     * 1. Find the atom block that the pin belongs to
-     * 2. Find the cluster block that the atom block is a part of
-     * 3. Find the physical tile that the cluster block is located on
-     * 4. Find the physical pin number of the atom pin (corresponds to ptc number of the RR node)
-     * 5. Call get_pin_rr_node_id to get the RRNodeId for the pin
-     */
+    // To get the RRNodeId for an atom pin, we need to:
+    // 1. Find the atom block that the pin belongs to
+    // 2. Find the cluster block that the atom block is a part of
+    // 3. Find the physical tile that the cluster block is located on
+    // 4. Find the physical pin number of the atom pin (corresponds to ptc number of the RR node)
+    // 5. Call get_pin_rr_node_id to get the RRNodeId for the pin
 
     AtomBlockId atom_blk_id = atom_nlist.pin_block(atom_pin_id);
     ClusterBlockId clb_blk_id = atom_lookup.atom_clb(atom_blk_id);
 
     t_pl_loc clb_blk_loc = place_ctx.block_locs()[clb_blk_id].loc;
+    t_physical_tile_loc tile_loc(clb_blk_loc.x, clb_blk_loc.y, clb_blk_loc.layer);
 
-    t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type({clb_blk_loc.x, clb_blk_loc.y, clb_blk_loc.layer});
+    t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type(tile_loc);
 
     const t_pb_graph_pin* atom_pb_pin = atom_lookup.atom_pin_pb_graph_pin(atom_pin_id);
     int pin_physical_num = physical_tile->pb_pin_to_pin_num.at(atom_pb_pin);
 
     RRNodeId rr_node_id = get_pin_rr_node_id(device_ctx.rr_graph.node_lookup(),
                                              physical_tile,
-                                             clb_blk_loc.layer,
-                                             clb_blk_loc.x,
-                                             clb_blk_loc.y,
+                                             tile_loc,
                                              pin_physical_num);
 
     return rr_node_id;
@@ -1839,9 +1832,7 @@ bool directconnect_exists(RRNodeId src_rr_node, RRNodeId sink_rr_node) {
     return false;
 }
 
-std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(int layer,
-                                                               int i,
-                                                               int j,
+std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(const t_physical_tile_loc& tile_loc,
                                                                t_physical_tile_type_ptr physical_type) {
     std::vector<int> class_num_vec;
 
@@ -1851,17 +1842,17 @@ std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(int layer,
 
     class_num_vec.reserve(physical_type->primitive_class_inf.size());
 
-    //iterate over different sub tiles inside a tile
+    // iterate over different sub tiles inside a tile
     for (int abs_cap = 0; abs_cap < physical_type->capacity; abs_cap++) {
-        if (grid_block.is_sub_tile_empty({i, j, layer}, abs_cap)) {
+        if (grid_block.is_sub_tile_empty(tile_loc, abs_cap)) {
             continue;
         }
-        auto cluster_blk_id = grid_block.block_at_location({i, j, abs_cap, layer});
+        auto cluster_blk_id = grid_block.block_at_location({tile_loc, abs_cap});
         VTR_ASSERT(cluster_blk_id != ClusterBlockId::INVALID());
 
         auto primitive_classes = get_cluster_internal_class_pairs(atom_lookup,
                                                                   cluster_blk_id);
-        /* Initialize SINK/SOURCE nodes and connect them to their respective pins */
+        // Initialize SINK/SOURCE nodes and connect them to their respective pins
         for (auto class_num : primitive_classes) {
             class_num_vec.push_back(class_num);
         }
@@ -1871,9 +1862,7 @@ std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(int layer,
     return class_num_vec;
 }
 
-std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const int layer,
-                                                            const int i,
-                                                            const int j,
+std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const t_physical_tile_loc& tile_loc,
                                                             const vtr::vector<ClusterBlockId, t_cluster_pin_chain>& pin_chains,
                                                             const vtr::vector<ClusterBlockId, std::unordered_set<int>>& pin_chains_num,
                                                             t_physical_tile_type_ptr physical_type) {
@@ -1886,10 +1875,10 @@ std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const int layer,
     for (int abs_cap = 0; abs_cap < physical_type->capacity; abs_cap++) {
         std::vector<int> cluster_internal_pins;
 
-        if (grid_block.is_sub_tile_empty({i, j, layer}, abs_cap)) {
+        if (grid_block.is_sub_tile_empty(tile_loc, abs_cap)) {
             continue;
         }
-        auto cluster_blk_id = grid_block.block_at_location({i, j, abs_cap, layer});
+        auto cluster_blk_id = grid_block.block_at_location({tile_loc, abs_cap});
         VTR_ASSERT(cluster_blk_id != ClusterBlockId::INVALID());
 
         cluster_internal_pins = get_cluster_internal_pins(cluster_blk_id);
@@ -1897,7 +1886,7 @@ std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const int layer,
         const auto& cluster_chain_sinks = pin_chains[cluster_blk_id].chain_sink;
         const auto& cluster_pin_chain_idx = pin_chains[cluster_blk_id].pin_chain_idx;
         // remove common elements between cluster_pin_chains.
-        for (auto pin : cluster_internal_pins) {
+        for (int pin : cluster_internal_pins) {
             auto it = cluster_pin_chains.find(pin);
             if (it == cluster_pin_chains.end()) {
                 pin_num_vec.push_back(pin);

--- a/vpr/src/util/vpr_utils.cpp
+++ b/vpr/src/util/vpr_utils.cpp
@@ -1847,13 +1847,12 @@ std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(const t_physical_
         if (grid_block.is_sub_tile_empty(tile_loc, abs_cap)) {
             continue;
         }
-        auto cluster_blk_id = grid_block.block_at_location({tile_loc, abs_cap});
+        ClusterBlockId cluster_blk_id = grid_block.block_at_location({tile_loc, abs_cap});
         VTR_ASSERT(cluster_blk_id != ClusterBlockId::INVALID());
 
-        auto primitive_classes = get_cluster_internal_class_pairs(atom_lookup,
-                                                                  cluster_blk_id);
+        std::vector<int> primitive_classes = get_cluster_internal_class_pairs(atom_lookup, cluster_blk_id);
         // Initialize SINK/SOURCE nodes and connect them to their respective pins
-        for (auto class_num : primitive_classes) {
+        for (int class_num : primitive_classes) {
             class_num_vec.push_back(class_num);
         }
     }
@@ -1878,13 +1877,13 @@ std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const t_physical_til
         if (grid_block.is_sub_tile_empty(tile_loc, abs_cap)) {
             continue;
         }
-        auto cluster_blk_id = grid_block.block_at_location({tile_loc, abs_cap});
+        ClusterBlockId cluster_blk_id = grid_block.block_at_location({tile_loc, abs_cap});
         VTR_ASSERT(cluster_blk_id != ClusterBlockId::INVALID());
 
         cluster_internal_pins = get_cluster_internal_pins(cluster_blk_id);
-        const auto& cluster_pin_chains = pin_chains_num[cluster_blk_id];
-        const auto& cluster_chain_sinks = pin_chains[cluster_blk_id].chain_sink;
-        const auto& cluster_pin_chain_idx = pin_chains[cluster_blk_id].pin_chain_idx;
+        const std::unordered_set<int>& cluster_pin_chains = pin_chains_num[cluster_blk_id];
+        const std::vector<int>& cluster_chain_sinks = pin_chains[cluster_blk_id].chain_sink;
+        const std::vector<int>& cluster_pin_chain_idx = pin_chains[cluster_blk_id].pin_chain_idx;
         // remove common elements between cluster_pin_chains.
         for (int pin : cluster_internal_pins) {
             auto it = cluster_pin_chains.find(pin);

--- a/vpr/src/util/vpr_utils.h
+++ b/vpr/src/util/vpr_utils.h
@@ -248,9 +248,7 @@ int get_rr_node_max_ptc(const RRGraphView& rr_graph_view,
 
 RRNodeId get_pin_rr_node_id(const RRSpatialLookup& rr_spatial_lookup,
                             t_physical_tile_type_ptr physical_tile,
-                            const int layer,
-                            const int root_i,
-                            const int root_j,
+                            const t_physical_tile_loc& root_loc,
                             int pin_physical_num);
 
 /**
@@ -286,9 +284,7 @@ AtomPinId get_rr_node_atom_pin_id(RRNodeId rr_node_id);
 
 RRNodeId get_class_rr_node_id(const RRSpatialLookup& rr_spatial_lookup,
                               t_physical_tile_type_ptr physical_tile,
-                              const int layer,
-                              const int i,
-                              const int j,
+                              const t_physical_tile_loc& root_loc,
                               int class_physical_num);
 
 /// @brief Check whether the given nodes are in the same cluster
@@ -313,17 +309,13 @@ bool node_in_same_physical_tile(RRNodeId node_first, RRNodeId node_second);
 
 bool directconnect_exists(RRNodeId src_rr_node, RRNodeId sink_rr_node);
 
-std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(int layer,
-                                                               int i,
-                                                               int j,
+std::vector<int> get_cluster_netlist_intra_tile_classes_at_loc(const t_physical_tile_loc& tile_loc,
                                                                t_physical_tile_type_ptr physical_type);
 
 /**
- * @brief Returns the list of pins inside the tile located at (layer, i, j), except for the ones which are on a chain
+ * @brief Returns the list of pins inside the tile located at tile_loc, except for the ones which are on a chain
  */
-std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const int layer,
-                                                            const int i,
-                                                            const int j,
+std::vector<int> get_cluster_netlist_intra_tile_pins_at_loc(const t_physical_tile_loc& tile_loc,
                                                             const vtr::vector<ClusterBlockId, t_cluster_pin_chain>& pin_chains,
                                                             const vtr::vector<ClusterBlockId, std::unordered_set<int>>& pin_chains_num,
                                                             t_physical_tile_type_ptr physical_type);
@@ -342,7 +334,7 @@ void add_pb_child_to_list(std::list<const t_pb*>& pb_list, const t_pb* parent_pb
  * The 'net_is_global_' flag is used to identify global nets, which can be either clock signals or specified as global by user constraints.
  * The 'net_is_ignored_' flag ensures that the router will ignore routing for the net.
  *
- * @param route_constraints User-defined route constraints to guide the application of constraints.
+ * @param constraint User-defined route constraints to guide the application of constraints.
  */
 void apply_route_constraints(const UserRouteConstraints& constraint);
 


### PR DESCRIPTION
Whenever we want to iterate over all tile locations, we use a nested loop with three variables for x, y, and layer. This causes three levels of indentation. In RR graph generation code, additional conditional statements and loops incease indentation level to as high as 6-7, making some lines really long. This PR adds a new function to DeviceGrid to allow iterating over all tile location using a single loop.

In addition, the root location of tiles are passed in deep function call hierarchies using three separate arguments for x, y, and layer. I replaces these three arguments with a `t_physical_tile_loc` argument to make function calls more concise.

I also changed the return type of `DeviceGrid::get_num_layers()` to `size_t` to be consistent with `width()` and `height()` methods.