### PR TITLE
[Draw][Breakpoint] Fix debug breakpoints to work in placement and routing

### DIFF
--- a/vpr/src/draw/breakpoint.cpp
+++ b/vpr/src/draw/breakpoint.cpp
@@ -61,15 +61,15 @@ bool check_for_breakpoints(bool in_placer) {
     //goes through the breakpoints vector
     t_draw_state* draw_state = get_draw_state_vars();
     for (size_t i = 0; i < draw_state->list_of_breakpoints.size(); i++) {
-        if (draw_state->list_of_breakpoints[i].type == BT_MOVE_NUM && draw_state->list_of_breakpoints[i].active)
+        if (draw_state->list_of_breakpoints[i].type == BT_MOVE_NUM && draw_state->list_of_breakpoints[i].active && in_placer)
             return check_for_moves_breakpoints(draw_state->list_of_breakpoints[i].bt_moves);
-        else if (draw_state->list_of_breakpoints[i].type == BT_FROM_BLOCK && draw_state->list_of_breakpoints[i].active)
+        else if (draw_state->list_of_breakpoints[i].type == BT_FROM_BLOCK && draw_state->list_of_breakpoints[i].active && in_placer)
             return check_for_block_breakpoints(draw_state->list_of_breakpoints[i].bt_from_block);
-        else if (draw_state->list_of_breakpoints[i].type == BT_TEMP_NUM && draw_state->list_of_breakpoints[i].active)
+        else if (draw_state->list_of_breakpoints[i].type == BT_TEMP_NUM && draw_state->list_of_breakpoints[i].active && in_placer)
             return check_for_temperature_breakpoints(draw_state->list_of_breakpoints[i].bt_temps);
-        else if (draw_state->list_of_breakpoints[i].type == BT_ROUTER_ITER && draw_state->list_of_breakpoints[i].active)
+        else if (draw_state->list_of_breakpoints[i].type == BT_ROUTER_ITER && draw_state->list_of_breakpoints[i].active && !in_placer)
             return check_for_router_iter_breakpoints(draw_state->list_of_breakpoints[i].bt_router_iter);
-        else if (draw_state->list_of_breakpoints[i].type == BT_ROUTE_NET_ID && draw_state->list_of_breakpoints[i].active)
+        else if (draw_state->list_of_breakpoints[i].type == BT_ROUTE_NET_ID && draw_state->list_of_breakpoints[i].active && !in_placer)
             return check_for_route_net_id_iter_breakpoints(draw_state->list_of_breakpoints[i].bt_route_net_id);
         else if (draw_state->list_of_breakpoints[i].type == BT_EXPRESSION && draw_state->list_of_breakpoints[i].active)
             return check_for_expression_breakpoints(draw_state->list_of_breakpoints[i].bt_expression, in_placer);

--- a/vpr/src/route/route.cpp
+++ b/vpr/src/route/route.cpp
@@ -12,6 +12,7 @@
 #include "rr_graph.h"
 #include "router_lookahead_report.h"
 #include "vtr_time.h"
+#include "vtr_expr_eval.h"
 
 bool route(const Netlist<>& net_list,
            int width_fac,
@@ -251,6 +252,10 @@ bool route(const Netlist<>& net_list,
     int rcv_finished_count = RCV_FINISH_EARLY_COUNTDOWN;
 
     print_route_status_header();
+#ifndef NO_GRAPHICS
+    // Reset router iteration in the current route attempt.
+    get_bp_state_globals()->get_glob_breakpoint_state()->router_iter = 0;
+#endif
     for (itry = 1; itry <= router_opts.max_router_iterations; ++itry) {
         /* Reset "is_routed" and "is_fixed" flags to indicate nets not pre-routed (yet) */
         for (auto net_id : net_list.nets()) {
@@ -267,6 +272,11 @@ bool route(const Netlist<>& net_list,
         if (budgeting_inf.if_set()) {
             worst_negative_slack = timing_info->hold_total_negative_slack();
         }
+
+#ifndef NO_GRAPHICS
+        // Update router information and check breakpoint.
+        update_router_info_and_check_bp(BP_ROUTE_ITER, -1);
+#endif
 
         /* Initial criticalities: set to 1 on the first iter if the user asked for it */
         if (router_opts.initial_timing == e_router_initial_timing::ALL_CRITICAL && itry == 1)
@@ -400,9 +410,6 @@ bool route(const Netlist<>& net_list,
         if (legal_convergence_count >= router_opts.max_convergence_count
             || iter_results.stats.connections_routed == 0
             || early_reconvergence_exit_heuristic(router_opts, itry_since_last_convergence, timing_info, best_routing_metrics)) {
-#ifndef NO_GRAPHICS
-            update_router_info_and_check_bp(BP_ROUTE_ITER, -1);
-#endif
             break; //Done routing
         }
 
@@ -410,9 +417,6 @@ bool route(const Netlist<>& net_list,
          * Abort checks: Should we give-up because this routing problem is unlikely to converge to a legal routing?
          */
         if (itry == 1 && early_exit_heuristic(router_opts, wirelength_info)) {
-#ifndef NO_GRAPHICS
-            update_router_info_and_check_bp(BP_ROUTE_ITER, -1);
-#endif
             //Abort
             break;
         }
@@ -423,18 +427,12 @@ bool route(const Netlist<>& net_list,
 
             if (!std::isnan(est_success_iteration) && est_success_iteration > abort_iteration_threshold && router_opts.routing_budgets_algorithm != YOYO) {
                 VTR_LOG("Routing aborted, the predicted iteration for a successful route (%.1f) is too high.\n", est_success_iteration);
-#ifndef NO_GRAPHICS
-                update_router_info_and_check_bp(BP_ROUTE_ITER, -1);
-#endif
                 break; //Abort
             }
         }
 
         if (itry == 1 && router_opts.exit_after_first_routing_iteration) {
             VTR_LOG("Exiting after first routing iteration as requested\n");
-#ifndef NO_GRAPHICS
-            update_router_info_and_check_bp(BP_ROUTE_ITER, -1);
-#endif
             break;
         }
 

--- a/vpr/src/route/route_utils.cpp
+++ b/vpr/src/route/route_utils.cpp
@@ -673,16 +673,14 @@ void update_draw_pres_fac(const float /*new_pres_fac*/) {
 #ifndef NO_GRAPHICS
 void update_router_info_and_check_bp(bp_router_type type, int net_id) {
     t_draw_state* draw_state = get_draw_state_vars();
-    if (!draw_state->list_of_breakpoints.empty()) {
-        if (type == BP_ROUTE_ITER)
-            get_bp_state_globals()->get_glob_breakpoint_state()->router_iter++;
-        else if (type == BP_NET_ID)
-            get_bp_state_globals()->get_glob_breakpoint_state()->route_net_id = net_id;
-        f_router_debug = check_for_breakpoints(false);
-        if (f_router_debug) {
-            breakpoint_info_window(get_bp_state_globals()->get_glob_breakpoint_state()->bp_description, *get_bp_state_globals()->get_glob_breakpoint_state(), false);
-            update_screen(ScreenUpdatePriority::MAJOR, "Breakpoint Encountered", ROUTING, nullptr);
-        }
+    if (type == BP_ROUTE_ITER)
+        get_bp_state_globals()->get_glob_breakpoint_state()->router_iter++;
+    else if (type == BP_NET_ID)
+        get_bp_state_globals()->get_glob_breakpoint_state()->route_net_id = net_id;
+    f_router_debug = check_for_breakpoints(false);
+    if (f_router_debug) {
+        breakpoint_info_window(get_bp_state_globals()->get_glob_breakpoint_state()->bp_description, *get_bp_state_globals()->get_glob_breakpoint_state(), false);
+        update_screen(ScreenUpdatePriority::MAJOR, "Breakpoint Encountered", ROUTING, nullptr);
     }
 }
 #endif


### PR DESCRIPTION
This PR fixes the debug breakpoint so that breakpoints are triggered under the intended conditions in both placement and routing.

- Previously, the router iteration breakpoint was not triggered correctly because the counter was not being updated properly.
- In addition, if placement breakpoints were still active during routing, none of the routing breakpoints would trigger since they weren’t being guarded against.


Both issues are addressed in this PR.

#### Related Issue
See comments in the PR #3278

