### PR TITLE
[Place][InitT] Changed Default Init T Estimator to Equilibrium

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -850,7 +850,7 @@ If any of init_t, exit_t or alpha_t is specified, the user schedule, with a fixe
    * ``cost_variance``: Estimates the initial temperature using the variance of cost after a set of trial swaps. The initial temperature is set to a value proportional to the variance.
    * ``equilibrium``: Estimates the initial temperature by trying to predict the equilibrium temperature for the initial placement (i.e. the temperature that would result in no change in cost).
 
-    **Default** ``cost_variance``
+    **Default** ``equilibrium``
 
 .. option:: --init_t <float>
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2323,7 +2323,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
             "\tequilibrium: Estimates the initial temperature by trying to "
             "predict the equilibrium temperature for the initial placement "
             "(i.e. the temperature that would result in no change in cost).")
-        .default_value("cost_variance")
+        .default_value("equilibrium")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.PlaceInitT, "--init_t")


### PR DESCRIPTION
Ran both the equilibrium and variance initial temperature estimators and found that they both get similar quality; however, the equilibrium initial temperature estimator improves overall run time by 4-7% (up to 8% on the largest benchmarks). Setting it as the default for now.

Results on my test suites for both AP and No AP:

<img width="1363" height="269" alt="Screenshot from 2025-10-06 14-00-49" src="https://github.com/user-attachments/assets/edd23f31-d896-4ad6-91ca-c8a8aadfd504" />



