### PR TITLE
Bugfix: Update graphics after each SA outer loop iteration

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -338,6 +338,12 @@ void update_screen(ScreenUpdatePriority priority, const char* msg, enum pic_type
         }
     }
 
+    if (draw_state->show_graphics) {
+        application.update_message(msg);
+        application.refresh_drawing();
+        application.flush_drawing();
+    }
+
     if (draw_state->save_graphics) {
         std::string extension = "pdf";
         save_graphics(extension, draw_state->save_graphics_file_base);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -242,7 +242,6 @@ static void draw_main_canvas(ezgl::renderer* g) {
 }
 
 static void on_stage_change_setup(ezgl::application* app, bool is_new_window) {
-
     // default setup for new window
     if (is_new_window) {
         basic_button_setup(app);
@@ -271,10 +270,6 @@ static void on_stage_change_setup(ezgl::application* app, bool is_new_window) {
     hide_crit_path_routing(app);
 
     hide_draw_routing(app);
-
-    app->update_message(draw_state->default_message);
-    app->refresh_drawing();
-    app->flush_drawing();
 }
 
 #endif //NO_GRAPHICS


### PR DESCRIPTION
#3249 moved function calls that update the graphics to a function that is only called when the stage changes. This PR brings them back to where they were before #3249 was merged.