### PR TITLE
Move std::map initialization outside of draw_rr_edges() to avoid redundant reinitialization.

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1543,11 +1543,11 @@ enum class e_stat {
 /// @note  If detailed routing is performed, only a uniform (all channels in a given direction are the same width)
 /// distribution is supported.
 struct t_chan {
-    e_stat type;  ///< Distribution type
-    float peak;   ///< Peak value. For a UNIFORM distribution, this is the value for all channels (in a given direction).
-    float width;  ///< Standard deviation (Gaussian)
-    float xpeak;  ///< Peak location (Gaussian)
-    float dc;     ///< DC offset (Gaussian, pulse)
+    e_stat type; ///< Distribution type
+    float peak;  ///< Peak value. For a UNIFORM distribution, this is the value for all channels (in a given direction).
+    float width; ///< Standard deviation (Gaussian)
+    float xpeak; ///< Peak location (Gaussian)
+    float dc;    ///< DC offset (Gaussian, pulse)
 };
 
 /* chan_x_dist: Describes the x-directed channel width distribution.         *

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -244,10 +244,10 @@ struct BlifAllocCallback : public blifparse::Callback {
         VTR_ASSERT(ports.size() == nets.size());
 
         LogicalModelId blk_model_id = models_.get_model_by_name(subckt_model);
-        if(!blk_model_id.is_valid()) {
+        if (!blk_model_id.is_valid()) {
             vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_,
-              "Subckt instantiates model '%s', but no such model exists in the architecture file.",
-              subckt_model.c_str());
+                      "Subckt instantiates model '%s', but no such model exists in the architecture file.",
+                      subckt_model.c_str());
         }
         const t_model& blk_model = models_.get_model(blk_model_id);
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -165,9 +165,7 @@ void drawplace(ezgl::renderer* g) {
                         if (draw_state->draw_block_text) {
                             /* Draw text if the space has parts of the netlist */
                             if (bnum) {
-                                std::string name = cluster_ctx.clb_nlist.block_name(
-                                                       bnum)
-                                                   + vtr::string_fmt(" (#%zu)", size_t(bnum));
+                                std::string name = cluster_ctx.clb_nlist.block_name(bnum) + vtr::string_fmt(" (#%zu)", size_t(bnum));
 
                                 g->draw_text(center, name.c_str(), abs_clb_bbox.width(),
                                              abs_clb_bbox.height());

--- a/vpr/src/draw/draw_debug.cpp
+++ b/vpr/src/draw/draw_debug.cpp
@@ -772,7 +772,7 @@ bool valid_expression(std::string exp) {
     vtr::t_formula_data dummy;
     try {
         int result = fp.parse_formula(exp, dummy, true);
-        (void)result; 
+        (void)result;
     } catch (const vtr::VtrError& e) {
         return false;
     }

--- a/vpr/src/draw/draw_mux.cpp
+++ b/vpr/src/draw/draw_mux.cpp
@@ -19,31 +19,32 @@
 //Draws a mux, height/width define the bounding box, scale [0.,1.] controls the slope of the muxes sides
 ezgl::rectangle draw_mux(ezgl::point2d origin, e_side orientation, float height, float width, float scale, ezgl::renderer* g) {
     std::vector<ezgl::point2d> mux_polygon;
+    mux_polygon.reserve(4);
 
     switch (orientation) {
         case TOP:
-            //Clock-wise from bottom left
+            // Clock-wise from bottom left
             mux_polygon.emplace_back(origin.x - height / 2, origin.y - width / 2);
             mux_polygon.emplace_back(origin.x - (scale * height) / 2, origin.y + width / 2);
             mux_polygon.emplace_back(origin.x + (scale * height) / 2, origin.y + width / 2);
             mux_polygon.emplace_back(origin.x + height / 2, origin.y - width / 2);
             break;
         case BOTTOM:
-            //Clock-wise from bottom left
+            // Clock-wise from bottom left
             mux_polygon.emplace_back(origin.x - (scale * height) / 2, origin.y - width / 2);
             mux_polygon.emplace_back(origin.x - height / 2, origin.y + width / 2);
             mux_polygon.emplace_back(origin.x + height / 2, origin.y + width / 2);
             mux_polygon.emplace_back(origin.x + (scale * height) / 2, origin.y - width / 2);
             break;
         case LEFT:
-            //Clock-wise from bottom left
+            // Clock-wise from bottom left
             mux_polygon.emplace_back(origin.x - width / 2, origin.y - (scale * height) / 2);
             mux_polygon.emplace_back(origin.x - width / 2, origin.y + (scale * height) / 2);
             mux_polygon.emplace_back(origin.x + width / 2, origin.y + height / 2);
             mux_polygon.emplace_back(origin.x + width / 2, origin.y - height / 2);
             break;
         case RIGHT:
-            //Clock-wise from bottom left
+            // Clock-wise from bottom left
             mux_polygon.emplace_back(origin.x - width / 2, origin.y - height / 2);
             mux_polygon.emplace_back(origin.x - width / 2, origin.y + height / 2);
             mux_polygon.emplace_back(origin.x + width / 2, origin.y + (scale * height) / 2);
@@ -57,7 +58,7 @@ ezgl::rectangle draw_mux(ezgl::point2d origin, e_side orientation, float height,
 
     ezgl::point2d min((float)mux_polygon[0].x, (float)mux_polygon[0].y);
     ezgl::point2d max((float)mux_polygon[0].x, (float)mux_polygon[0].y);
-    for (const auto& point : mux_polygon) {
+    for (const ezgl::point2d& point : mux_polygon) {
         min.x = std::min((float)min.x, (float)point.x);
         min.y = std::min((float)min.y, (float)point.y);
         max.x = std::max((float)max.x, (float)point.x);

--- a/vpr/src/draw/draw_rr.cpp
+++ b/vpr/src/draw/draw_rr.cpp
@@ -233,14 +233,11 @@ void draw_rr_chan(RRNodeId inode, const ezgl::color color, ezgl::renderer* g) {
     g->set_color(color, transparency_factor); //Ensure color is still set correctly if we drew any arrows/text
 }
 
-/* Draws all the edges that the user wants shown between inode and what it
- * connects to.  inode is assumed to be a CHANX, CHANY, or IPIN.           */
 void draw_rr_edges(RRNodeId inode, ezgl::renderer* g) {
     t_draw_state* draw_state = get_draw_state_vars();
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const RRGraphView& rr_graph = device_ctx.rr_graph;
 
-    e_rr_type to_type;
     e_rr_type from_type = rr_graph.node_type(inode);
 
     // Currently don't visualize source or sinks.
@@ -250,7 +247,7 @@ void draw_rr_edges(RRNodeId inode, ezgl::renderer* g) {
 
     for (t_edge_size iedge = 0, l = rr_graph.num_edges(inode); iedge < l; iedge++) {
         RRNodeId to_node = rr_graph.edge_sink_node(inode, iedge);
-        to_type = rr_graph.node_type(to_node);
+        e_rr_type to_type = rr_graph.node_type(to_node);
         bool edge_configurable = rr_graph.edge_is_configurable(inode, iedge);
 
         // Currently don't visualize source or sinks.
@@ -259,36 +256,14 @@ void draw_rr_edges(RRNodeId inode, ezgl::renderer* g) {
         }
 
         ezgl::color color = DEFAULT_RR_NODE_COLOR;
-        e_edge_type edge_type;
         bool draw_edge = true;
         bool inode_inter_cluster = is_inter_cluster_node(rr_graph, inode);
         bool to_node_inter_cluster = is_inter_cluster_node(rr_graph, to_node);
 
-        // Color map for edges based on {from_type, to_type}
-        const std::map<std::pair<e_rr_type, e_rr_type>, e_edge_type> edge_type_map = {
-            // Pin to pin connections
-            {{e_rr_type::IPIN, e_rr_type::IPIN}, e_edge_type::PIN_TO_IPIN},
-            {{e_rr_type::OPIN, e_rr_type::IPIN}, e_edge_type::PIN_TO_IPIN},
-            {{e_rr_type::OPIN, e_rr_type::OPIN}, e_edge_type::PIN_TO_OPIN},
-            {{e_rr_type::IPIN, e_rr_type::OPIN}, e_edge_type::PIN_TO_OPIN},
-
-            // Channel to pin connections
-            {{e_rr_type::OPIN, e_rr_type::CHANX}, e_edge_type::OPIN_TO_CHAN},
-            {{e_rr_type::OPIN, e_rr_type::CHANY}, e_edge_type::OPIN_TO_CHAN},
-            {{e_rr_type::CHANX, e_rr_type::IPIN}, e_edge_type::CHAN_TO_IPIN},
-            {{e_rr_type::CHANY, e_rr_type::IPIN}, e_edge_type::CHAN_TO_IPIN},
-
-            // Channel to channel connections
-            {{e_rr_type::CHANX, e_rr_type::CHANX}, e_edge_type::CHAN_TO_CHAN},
-            {{e_rr_type::CHANX, e_rr_type::CHANY}, e_edge_type::CHAN_TO_CHAN},
-            {{e_rr_type::CHANY, e_rr_type::CHANY}, e_edge_type::CHAN_TO_CHAN},
-            {{e_rr_type::CHANY, e_rr_type::CHANX}, e_edge_type::CHAN_TO_CHAN},
-        };
-
-        if (edge_type_map.find({from_type, to_type}) == edge_type_map.end()) {
+        if (EDGE_TYPE_COLOR_MAP.find({from_type, to_type}) == EDGE_TYPE_COLOR_MAP.end()) {
             continue; // Unsupported edge type
         }
-        edge_type = edge_type_map.at({from_type, to_type});
+        e_edge_type edge_type = EDGE_TYPE_COLOR_MAP.at({from_type, to_type});
 
         // Determine whether to draw the edge based on user options
 

--- a/vpr/src/draw/draw_rr.cpp
+++ b/vpr/src/draw/draw_rr.cpp
@@ -255,7 +255,6 @@ void draw_rr_edges(RRNodeId inode, ezgl::renderer* g) {
             continue;
         }
 
-        ezgl::color color = DEFAULT_RR_NODE_COLOR;
         bool draw_edge = true;
         bool inode_inter_cluster = is_inter_cluster_node(rr_graph, inode);
         bool to_node_inter_cluster = is_inter_cluster_node(rr_graph, to_node);
@@ -284,17 +283,11 @@ void draw_rr_edges(RRNodeId inode, ezgl::renderer* g) {
             draw_edge = draw_state->draw_connection_box_edges;
         }
 
-        // Select edge colors
-        const std::map<e_edge_type, ezgl::color> edge_color_map = {
-            {e_edge_type::PIN_TO_OPIN, ezgl::LIGHT_PINK},
-            {e_edge_type::PIN_TO_IPIN, ezgl::MEDIUM_PURPLE},
-            {e_edge_type::OPIN_TO_CHAN, ezgl::PINK},
-            {e_edge_type::CHAN_TO_IPIN, ezgl::PURPLE},
-            {e_edge_type::CHAN_TO_CHAN, blk_DARKGREEN}};
+        ezgl::color color = EDGE_COLOR_MAP.at(edge_type);
 
-        color = edge_color_map.at(edge_type);
-
-        if (!edge_configurable) color = blk_DARKGREY;
+        if (!edge_configurable) {
+            color = blk_DARKGREY;
+        }
 
         if ((from_type == e_rr_type::CHANX || from_type == e_rr_type::CHANY)
             && (to_type == e_rr_type::IPIN)

--- a/vpr/src/draw/draw_rr.h
+++ b/vpr/src/draw/draw_rr.h
@@ -23,9 +23,28 @@
  */
 void draw_rr(ezgl::renderer* g);
 
-/* Draws all the edges that the user wants shown between inode and what it
- * connects to.  inode is assumed to be a CHANX, CHANY, or IPIN. */
+/// @brief Draws all the edges that the user wants shown between @p from_node and what it
+/// connects to. @p from_node is assumed to be a CHANX, CHANY, or IPIN.
 void draw_rr_edges(RRNodeId from_node, ezgl::renderer* g);
+
+/// Color map for edges based on {from_type, to_type}
+inline const std::map<std::pair<e_rr_type, e_rr_type>, e_edge_type> EDGE_TYPE_COLOR_MAP = {
+    // Pin to pin connections
+    {{e_rr_type::IPIN, e_rr_type::IPIN}, e_edge_type::PIN_TO_IPIN},
+    {{e_rr_type::OPIN, e_rr_type::IPIN}, e_edge_type::PIN_TO_IPIN},
+    {{e_rr_type::OPIN, e_rr_type::OPIN}, e_edge_type::PIN_TO_OPIN},
+    {{e_rr_type::IPIN, e_rr_type::OPIN}, e_edge_type::PIN_TO_OPIN},
+    // Channel to pin connections
+    {{e_rr_type::OPIN, e_rr_type::CHANX}, e_edge_type::OPIN_TO_CHAN},
+    {{e_rr_type::OPIN, e_rr_type::CHANY}, e_edge_type::OPIN_TO_CHAN},
+    {{e_rr_type::CHANX, e_rr_type::IPIN}, e_edge_type::CHAN_TO_IPIN},
+    {{e_rr_type::CHANY, e_rr_type::IPIN}, e_edge_type::CHAN_TO_IPIN},
+    // Channel to channel connections
+    {{e_rr_type::CHANX, e_rr_type::CHANX}, e_edge_type::CHAN_TO_CHAN},
+    {{e_rr_type::CHANX, e_rr_type::CHANY}, e_edge_type::CHAN_TO_CHAN},
+    {{e_rr_type::CHANY, e_rr_type::CHANY}, e_edge_type::CHAN_TO_CHAN},
+    {{e_rr_type::CHANY, e_rr_type::CHANX}, e_edge_type::CHAN_TO_CHAN},
+};
 
 void draw_rr_chan(RRNodeId inode, const ezgl::color color, ezgl::renderer* g);
 

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -31,6 +31,7 @@
 #include "ezgl/rectangle.hpp"
 #include "ezgl/color.hpp"
 #include "ezgl/application.hpp"
+#include "draw_color.h"
 
 /// @brief Whether to draw routed nets or flylines (direct lines between sources and sinks).
 enum e_draw_nets {
@@ -123,6 +124,14 @@ enum class e_edge_type {
     CHAN_TO_CHAN, // channel to channel
     NUM_EDGE_TYPES
 };
+
+/// Maps edge types to the color with which they are visualized
+inline const vtr::array<e_edge_type, ezgl::color, (size_t)e_edge_type::NUM_EDGE_TYPES> EDGE_COLOR_MAP{
+    ezgl::LIGHT_PINK,
+    ezgl::MEDIUM_PURPLE,
+    ezgl::PINK,
+    ezgl::PURPLE,
+    blk_DARKGREEN};
 
 /**
  * @brief Structure used to hold data passed into the toggle checkbox callback function.

--- a/vpr/src/route/rr_graph_generation/build_scatter_gathers.cpp
+++ b/vpr/src/route/rr_graph_generation/build_scatter_gathers.cpp
@@ -210,12 +210,11 @@ std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const s
                 scatter_loc.y = gather_loc.y + sg_link.y_offset;
                 scatter_loc.layer_num = gather_loc.layer_num + sg_link.z_offset;
 
-                const std::vector<t_segment_inf>& segment_inf = (sg_link.x_offset != 0) ? segment_inf_x :
-                                                                (sg_link.y_offset != 0) ? segment_inf_y : segment_inf_z;
+                const std::vector<t_segment_inf>& segment_inf = (sg_link.x_offset != 0) ? segment_inf_x : (sg_link.y_offset != 0) ? segment_inf_y
+                                                                                                                                  : segment_inf_z;
 
-                const e_rr_type chan_type = (sg_link.x_offset != 0) ? e_rr_type::CHANX :
-                                            (sg_link.y_offset != 0) ? e_rr_type::CHANY : e_rr_type::CHANZ;
-
+                const e_rr_type chan_type = (sg_link.x_offset != 0) ? e_rr_type::CHANX : (sg_link.y_offset != 0) ? e_rr_type::CHANY
+                                                                                                                 : e_rr_type::CHANZ;
 
                 auto seg_it = std::ranges::find_if(segment_inf,
                                                    [&](const t_segment_inf& seg) noexcept {
@@ -224,7 +223,6 @@ std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const s
 
                 VTR_ASSERT(seg_it != segment_inf.end());
                 const t_segment_inf& wire_segment = *seg_it;
-
 
                 index_to_correct_sg_channels(sg_pattern.gather_pattern, gather_loc, chan_details_x, chan_details_y, gather_channels);
                 index_to_correct_sg_channels(sg_pattern.scatter_pattern, scatter_loc, chan_details_x, chan_details_y, scatter_channels);

--- a/vpr/src/route/rr_graph_generation/build_scatter_gathers.h
+++ b/vpr/src/route/rr_graph_generation/build_scatter_gathers.h
@@ -29,9 +29,9 @@ struct t_sg_candidate {
 /// This data structure is used in RR graph generation to model a node that is
 /// driven by wires at a gather location and drives wires at a scatter location.
 struct t_bottleneck_link {
-    t_physical_tile_loc gather_loc;                         ///< Source switchblock location.
-    t_physical_tile_loc scatter_loc;                        ///< Destination switchblock location.
-    int arch_wire_switch;                                   ///< The switch (mux) used to drive the bottleneck wire.
+    t_physical_tile_loc gather_loc;  ///< Source switchblock location.
+    t_physical_tile_loc scatter_loc; ///< Destination switchblock location.
+    int arch_wire_switch;            ///< The switch (mux) used to drive the bottleneck wire.
     int parallel_segment_index;
     e_rr_type chan_type;
     std::vector<t_sg_candidate> gather_fanin_connections;   ///< Wires driving the bottleneck link at  `gather_loc`


### PR DESCRIPTION
This made graphics more responsive when edges are drawn.