### PR TITLE
librrgraph: add array operator

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_storage.cpp
+++ b/libs/librrgraph/src/base/rr_graph_storage.cpp
@@ -173,6 +173,10 @@ class edge_sort_iterator {
         return &this->swapper_;
     }
 
+    edge_swapper& operator[](ssize_t n) const {
+        return *(*this + n);
+    }
+
     edge_sort_iterator& operator+=(ssize_t n) {
         swapper_.idx_ += n;
         return *this;


### PR DESCRIPTION
This fixes a build error with gcc-16, found via testing of the SPEC CPU code. @amin1377 

```
error: no match for 'operator[]' (operand types are 'edge_sort_iterator' and 'long int')
```

We think it is related to this: https://gcc.gnu.org/pipermail/libstdc++/2025-September/063655.html


