### PR TITLE
librrgraph: add correct array operator

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_storage.cpp
+++ b/libs/librrgraph/src/base/rr_graph_storage.cpp
@@ -235,7 +235,7 @@ class edge_sort_iterator {
         return lhs.swapper_.idx_ <= rhs.swapper_.idx_;
     }
 
-    const t_rr_edge_info operator[] (ssize_t n) const {
+    t_rr_edge_info operator[] (ssize_t n) const {
       edge_sort_iterator ret = *this;
       ret.swapper_.idx_ += n;
       return ret.swapper_;


### PR DESCRIPTION
This is the correct fix for gcc-16's build error. It works and doesn't crash on two different machines tested by SPEC CPU folks.

```
error: no match for 'operator[]' (operand types are 'edge_sort_iterator' and 'long int')
```
