### PR TITLE
Add needed includes to vpr_signal_handler

### DIFF
--- a/vpr/src/base/vpr_signal_handler.cpp
+++ b/vpr/src/base/vpr_signal_handler.cpp
@@ -9,18 +9,20 @@
  *  - SIGHUP  : log, attempt to checkpoint, continue running
  *  - SIGTERM : log, attempt to checkpoint, then exit with INTERRUPTED_EXIT_CODE
  */
-#include "vtr_log.h"
 #include "vtr_time.h"
 
 #include "vpr_signal_handler.h"
-#include "vpr_exit_codes.h"
-#include "vpr_error.h"
 #include "globals.h"
 
 #include "read_place.h"
 #include "read_route.h"
-#include "route_export.h"
-#include <atomic>
+
+// Currenly safe_write uses the POSIX write system call. This could be extended to other platforms in the future.
+#if defined(__unix__)
+#include "unistd.h"
+#endif
+
+#include "string.h"
 
 #ifdef VPR_USE_SIGACTION
 #include <csignal>


### PR DESCRIPTION
vpr_signal_handler.cpp used some header files that were indirectly included. This commit directly adds those header files to vpr_signal_handler.

I also removed the unused includes. This file previously had some issues with the pre-release GCC-16 (See #3306)  because unistd.h was not directly included. The ifdef for unix is based on similar code in vtr_util.cpp:

```
#if defined(__unix__)
#include <unistd.h> //For getpid()
#endif
```