### PR TITLE
Hotfix on a corner case of tileable rr_graph direct connections 

### DIFF
--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_gsb.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_gsb.cpp
@@ -1761,6 +1761,10 @@ void build_direct_connections_for_one_gsb(const RRGraphView& rr_graph,
 
                     /* directs[i].sub_tile_offset is added to from_capacity(z) to get the target_capacity */
                     int to_subtile_cap = z + directs[i].sub_tile_offset;
+                    /* If the destination subtile is out of range, there is no qualified IPINs */
+                    if (to_subtile_cap < 0 || to_subtile_cap >= to_grid_type->capacity) {
+                      continue;
+                    }
                     /* Iterate over all sub_tiles to get the sub_tile which the target_cap belongs to. */
                     const t_sub_tile* to_sub_tile = nullptr;
                     for (const t_sub_tile& sub_tile : to_grid_type->sub_tiles) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

This is to fix a corner case where the sub tile index of IPIN may not be out of range when adding direct connections. 
In such case, the builder should continue, instead of keep searching and finally abort.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
