### PR TITLE
[Pack][Legalizer] Added get_cluster_name Method

### DIFF
--- a/vpr/src/pack/cluster_legalizer.h
+++ b/vpr/src/pack/cluster_legalizer.h
@@ -11,6 +11,7 @@
  * externally to the Packer in VPR.
  */
 
+#include <string>
 #include <vector>
 #include "atom_netlist_fwd.h"
 #include "noc_data_types.h"
@@ -431,6 +432,13 @@ class ClusterLegalizer {
         VTR_ASSERT_SAFE(cluster_id.is_valid() && (size_t)cluster_id < legalization_clusters_.size());
         const LegalizationCluster& cluster = legalization_clusters_[cluster_id];
         return cluster.pb;
+    }
+
+    /// @brief Gets the name of the given cluster.
+    inline std::string get_cluster_name(LegalizationClusterId cluster_id) const {
+        VTR_ASSERT_SAFE(cluster_id.is_valid() && (size_t)cluster_id < legalization_clusters_.size());
+        const LegalizationCluster& cluster = legalization_clusters_[cluster_id];
+        return cluster.pb->name;
     }
 
     /// @brief Gets the logical block type of the given cluster.

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -39,8 +39,9 @@ static void echo_clusters(char* filename, const ClusterLegalizer& cluster_legali
     }
 
     for (auto& cluster_atom : cluster_atoms) {
-        const std::string& cluster_name = cluster_legalizer.get_cluster_pb(cluster_atom.first)->name;
-        fprintf(fp, "Cluster %s Id: %zu \n", cluster_name.c_str(), size_t(cluster_atom.first));
+        fprintf(fp, "Cluster %s Id: %zu \n",
+                cluster_legalizer.get_cluster_name(cluster_atom.first).c_str(),
+                size_t(cluster_atom.first));
         fprintf(fp, "\tAtoms in cluster: \n");
 
         int num_atoms = cluster_atom.second.size();

--- a/vpr/src/pack/greedy_clusterer.cpp
+++ b/vpr/src/pack/greedy_clusterer.cpp
@@ -443,7 +443,7 @@ LegalizationClusterId GreedyClusterer::start_new_cluster(
 
     VTR_LOGV(log_verbosity_ > 2,
              "Complex block %zu: '%s' (%s) ", size_t(new_cluster_id),
-             cluster_legalizer.get_cluster_pb(new_cluster_id)->name,
+             cluster_legalizer.get_cluster_name(new_cluster_id).c_str(),
              cluster_legalizer.get_cluster_type(new_cluster_id)->name.c_str());
     VTR_LOGV(log_verbosity_ > 2, ".");
     //Progress dot for seed-block


### PR DESCRIPTION
I am trying to reduce the exposed state from the cluster legalizer, in particular how t_pb pointers are being used outside of the legalizer class.

I found a very easy cleanup where a few of the usages were just getting the name of the cluster. This makes sense to expose through an API.