### PR TITLE
fix the issue for pack pattern to recognize register connection

### DIFF
--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -1144,6 +1144,8 @@ static AtomBlockId get_sink_block(const AtomBlockId block_id,
     AtomBlockId pattern_sink_block_id = AtomBlockId::INVALID();
     for (const auto& sink_pin_id : net_sinks) {
         auto sink_block_id = atom_nlist.pin_block(sink_pin_id);
+        // If the sink block has a clock, it is considered stateful (e.g., a latch or flip-flop).
+        // Mark this so we can later decide whether to drop the block based on the net’s fanout.
         if (!atom_nlist.block_is_combinational(sink_block_id)) {
             connected_to_latch = true;
         }


### PR DESCRIPTION
This branch has a fix for a previous PR made by @amin1377:
[Issue 2991](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2991)

In that PR, we are trying to prevent a pre-packer to form molecule that both registered and unregistered outputs are used but only one of them can be routed through LE output based on the architecture. However, the condition only checks for .latch in the blif file and will not catch FFs as a register. This PR only changes the if condition to consider FFs, as well. 