### PR TITLE
attempt to load arch xml file without extension leads to segfault 

### DIFF
--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -404,7 +404,7 @@ void xml_read_arch(std::string_view arch_file,
         VTR_LOG_WARN(
             "Architecture file '%s' may be in incorrect format. "
             "Expecting .xml format for architecture files.\n",
-            arch_file);
+            arch_file.data());
     }
 
     // Create a unique identifier for this architecture file based on it's contents


### PR DESCRIPTION
issue to link with this PR
https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/3334

#### How Has This Been Tested?
loading arch file without xml extension in it's name

#### Types of changes
- [x ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
