### PR TITLE
Removing 3D Attributes Script

### DIFF
--- a/vtr_flow/scripts/remove_3d_attributes.sh
+++ b/vtr_flow/scripts/remove_3d_attributes.sh
@@ -5,6 +5,11 @@
 # to remove all attributes related to 3D FPGA support (layer="0",
 # layer_low="0", layer_high="0"). In VPR, these values default to 0.
 
+# This also helps convert older RR graph files that used the "layer" attribute
+# instead of "layer_low" and "layer_high" for nodes, by removing the "layer" attribute
+# altogether. As a result, VPR can read the file without issues, and it slightly
+# reduces the file size for 2D architectures.
+
 # Exit if any command fails
 set -e
 


### PR DESCRIPTION
Adding a bash script that takes an RR graph file as input and removes all attributes related to 3D architecture. I considered implementing this as a Python script, but based on my experience, even with streaming, Python doesn't handle very large RR graph files efficiently. For that reason, I decided to implement it as a bash script instead.

I tested this script by writing out the RR graph for one of the titan_other benchmarks, running the script on it, verifying that there were no occurrences of "layer", "layer_high", or "layer_low" in the modified file, and then running VTR again using the updated RR graph file. The results were identical in both runs.