### PR TITLE
[CI] Added Spell Checking to CI

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,51 @@
+[codespell]
+# These are a list of files that should skip spell-checking.
+skip = ./build,
+       # File types that we do not need to spell-check.
+       *.pdf,
+       *.svg,
+       *.log,
+       # External projects that do not belong to us.
+       ./libs/EXTERNAL,
+       ./parmys,
+       ./abc,
+       # Sub-projects which are not as maintained.
+       ./odin_ii,
+       ./ace2,
+       ./blifexplorer,
+       ./verilog_preprocessor,
+       # WIP spelling cleanups.
+       ./vtr_flow,
+       ./utils/vqm2blif,
+       # Temporary as we wait for some PRs to merge.
+       *_graph_uxsdcxx_capnp.h,
+       ./vpr/src/route/rr_graph_generation/rr_graph.cpp,
+       ./vpr/src/route/rr_graph_generation/rr_graph2.cpp,
+
+# Show a count of the number of spelling mistakes when codespell is run.
+count = true
+
+# Only show critical information.
+quiet-level = 3
+
+# Words to ignore for spell-checking. These are words that we know are spelled
+# correctly.
+ignore-words-list = subtile,
+                    subtiles,
+                    fle,
+                    EArch,
+                    FPT,
+                    Synopsys,
+                    inout,
+                    INOUT,
+                    Dout,
+                    dout,
+                    DATIN,
+                    ShowIn,
+                    # Special case: pres fac / pres cost for example.
+                    Pres,
+                    pres,
+                    # This is another special case. This happens due to string
+                    # formatting code "%shold". This can be fixed when std::format
+                    # is better supported in C++20.
+                    shold,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  spelling:
+    name: Check Spelling
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v5
+
+      - name: Install Requirements
+        run: |
+          python3 -m pip install --upgrade pip
+          # NOTE: There is nothing special about this version. We just need to
+          #       fix it to something.
+          pip install codespell==2.4.1
+
+      - name: Check Spelling
+        run: codespell

--- a/libs/libarchfpga/src/vib_inf.h
+++ b/libs/libarchfpga/src/vib_inf.h
@@ -60,7 +60,7 @@ struct t_from_or_to_inf {
 struct t_first_stage_mux_inf {
     std::string mux_name;
     std::vector<std::vector<std::string>> from_tokens;
-    std::vector<t_from_or_to_inf> froms;
+    std::vector<t_from_or_to_inf> from_infos;
 };
 
 struct t_second_stage_mux_inf : t_first_stage_mux_inf {

--- a/vpr/src/base/vib_grid/setup_vib_utils.cpp
+++ b/vpr/src/base/vib_grid/setup_vib_utils.cpp
@@ -5,7 +5,7 @@
 static void process_from_or_to_tokens(const std::vector<std::string> tokens,
                                       const std::vector<t_physical_tile_type>& physical_tile_types,
                                       const std::vector<t_segment_inf> segments,
-                                      std::vector<t_from_or_to_inf>& froms);
+                                      std::vector<t_from_or_to_inf>& from_infos);
 
 static void parse_pin_name(const char* src_string,
                            int* start_pin_index,
@@ -16,7 +16,7 @@ static void parse_pin_name(const char* src_string,
 static void process_from_or_to_tokens(const std::vector<std::string> tokens,
                                       const std::vector<t_physical_tile_type>& physical_tile_types,
                                       const std::vector<t_segment_inf> segments,
-                                      std::vector<t_from_or_to_inf>& froms) {
+                                      std::vector<t_from_or_to_inf>& from_infos) {
     for (int i_token = 0; i_token < (int)tokens.size(); i_token++) {
         std::string curr_token = tokens[i_token];
         const char* Token_char = curr_token.c_str();
@@ -25,7 +25,7 @@ static void process_from_or_to_tokens(const std::vector<std::string> tokens,
             t_from_or_to_inf from_inf;
             from_inf.type_name = splitted_tokens[0];
             from_inf.from_type = e_multistage_mux_from_or_to_type::MUX;
-            froms.push_back(from_inf);
+            from_infos.push_back(from_inf);
         } else if (splitted_tokens.size() == 2) {
             std::string from_type_name = splitted_tokens[0];
             e_multistage_mux_from_or_to_type from_type;
@@ -83,7 +83,7 @@ static void process_from_or_to_tokens(const std::vector<std::string> tokens,
                         from_inf.from_type = from_type;
                         from_inf.type_index = i_phy_type;
                         from_inf.phy_pin_index = all_sub_tile_to_tile_pin_indices[i];
-                        froms.push_back(from_inf);
+                        from_infos.push_back(from_inf);
                     }
                 }
             }
@@ -102,7 +102,7 @@ static void process_from_or_to_tokens(const std::vector<std::string> tokens,
                         from_inf.type_index = i_seg_type;
                         from_inf.seg_dir = dir;
                         from_inf.seg_index = seg_index;
-                        froms.push_back(from_inf);
+                        from_infos.push_back(from_inf);
                     }
 
                     break;
@@ -217,7 +217,7 @@ void setup_vib_inf(const std::vector<t_physical_tile_type>& physical_tile_types,
         for (t_first_stage_mux_inf& first_stage : first_stages) {
             std::vector<std::vector<std::string>>& from_tokens = first_stage.from_tokens;
             for (const std::vector<std::string>& from_token : from_tokens) {
-                process_from_or_to_tokens(from_token, physical_tile_types, segments, first_stage.froms);
+                process_from_or_to_tokens(from_token, physical_tile_types, segments, first_stage.from_infos);
             }
         }
         vib_inf.set_first_stages(first_stages);
@@ -235,7 +235,7 @@ void setup_vib_inf(const std::vector<t_physical_tile_type>& physical_tile_types,
 
             std::vector<std::vector<std::string>> from_tokens = second_stage.from_tokens;
             for (const std::vector<std::string>& from_token : from_tokens) {
-                process_from_or_to_tokens(from_token, physical_tile_types, segments, second_stage.froms);
+                process_from_or_to_tokens(from_token, physical_tile_types, segments, second_stage.from_infos);
             }
         }
         vib_inf.set_second_stages(second_stages);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -508,7 +508,7 @@ void init_draw_coords(float clb_width, const BlkLocRegistry& blk_loc_registry) {
         for (size_t x_loc = 0; x_loc < grid.width() - 1; x_loc++) {
             for (size_t y_loc = 0; y_loc < grid.height() - 1; y_loc++) {
 
-                // Get all chanx nodes at location (x_loc, y_loc), find largest ptc_num accross all nodes
+                // Get all chanx nodes at location (x_loc, y_loc), find largest ptc_num across all nodes
                 std::vector<RRNodeId> chanx_nodes = rr_graph.node_lookup().find_channel_nodes(layer, x_loc, y_loc, e_rr_type::CHANX);
                 int max_chanx_ptc_num = 0;
                 if (!chanx_nodes.empty()) {

--- a/vpr/src/draw/search_bar.cpp
+++ b/vpr/src/draw/search_bar.cpp
@@ -508,7 +508,7 @@ GdkEvent simulate_keypress(char key, GdkWindow* window) {
  * Correlation between key length and time is shaky; there might be some correlation to
  * how many strings are similar to it. All tests are performed with the key "1" - pretty common
  * Tests are searched three times then average
- * MODEL 1: EARCH + TSENG.BLIF
+ * MODEL 1: EArch + TSENG.BLIF
  * NETS         1483
  * NET SRCH.    19392
  * BLOCKS       1835

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_gsb.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_gsb.cpp
@@ -1835,11 +1835,11 @@ t_vib_map build_vib_map(const RRGraphView& rr_graph,
     VTR_ASSERT(vib->get_pbtype_name() == phy_type->name);
     const std::vector<t_first_stage_mux_inf> first_stages = vib->get_first_stages();
     for (size_t i_first_stage = 0; i_first_stage < first_stages.size(); i_first_stage++) {
-        std::vector<t_from_or_to_inf> froms = first_stages[i_first_stage].froms;
+        const std::vector<t_from_or_to_inf>& from_infos = first_stages[i_first_stage].from_infos;
         RRNodeId to_node = rr_graph.node_lookup().find_node(layer, actual_coordinate.x(), actual_coordinate.y(), e_rr_type::MUX, i_first_stage);
         VTR_ASSERT(to_node.is_valid());
         VTR_ASSERT(rr_gsb.is_mux_node(to_node));
-        for (auto from : froms) {
+        for (auto from : from_infos) {
             RRNodeId from_node;
             if (from.from_type == e_multistage_mux_from_or_to_type::PB) {
 
@@ -1937,8 +1937,8 @@ t_vib_map build_vib_map(const RRGraphView& rr_graph,
     /* Second stages*/
     const std::vector<t_second_stage_mux_inf> second_stages = vib->get_second_stages();
     for (size_t i_second_stage = 0; i_second_stage < second_stages.size(); i_second_stage++) {
-        std::vector<t_from_or_to_inf> froms = second_stages[i_second_stage].froms;
-        std::vector<t_from_or_to_inf> tos = second_stages[i_second_stage].to;
+        const std::vector<t_from_or_to_inf>& from_infos = second_stages[i_second_stage].from_infos;
+        const std::vector<t_from_or_to_inf>& tos = second_stages[i_second_stage].to;
 
         std::vector<RRNodeId> to_nodes;
         for (auto to : tos) {
@@ -2023,7 +2023,7 @@ t_vib_map build_vib_map(const RRGraphView& rr_graph,
         }
 
         std::vector<RRNodeId> from_nodes;
-        for (auto from : froms) {
+        for (auto from : from_infos) {
             RRNodeId from_node;
             if (from.from_type == e_multistage_mux_from_or_to_type::PB) {
 

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_node_builder.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_node_builder.cpp
@@ -93,7 +93,7 @@ static size_t estimate_num_mux_rr_nodes(const DeviceGrid& grids,
             size_t count = 0;
             for (size_t i_first_stage = 0; i_first_stage < vib->get_first_stages().size(); i_first_stage++) {
                 auto first_stage = vib->get_first_stages()[i_first_stage];
-                if (first_stage.froms.size() == 0) {
+                if (first_stage.from_infos.size() == 0) {
                     VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
                                     "VIB first stage '%s' at (%d, %d) has no from!\n", first_stage.mux_name.c_str(), ix, iy);
                 }


### PR DESCRIPTION
Cleaned up the last necessary spelling mistakes in VPR so we can now add codespell to the CI. This will add spell-checking to the CI tests so when people merge code into VTR, we can ensure that there are no obvious spelling mistakes.

I have added a config file which contains which files should be ignored and what words can be ignored.