### PR TITLE
Fix off by one error in drawing

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -535,14 +535,14 @@ void init_draw_coords(float clb_width, const BlkLocRegistry& blk_loc_registry) {
     size_t j = 0;
     for (size_t i = 0; i < grid.width() - 1; i++) {
         draw_coords->tile_x[i] = i * draw_coords->get_tile_width() + j;
-        j += max_chany_ptc_nums[i] + 1; // N wires need N+1 units of space
+        j += max_chany_ptc_nums[i] + 2; // N wires need N + 1 units of space, plus one more since max ptc_num of 0 means 1 wire in the channel
     }
     draw_coords->tile_x[grid.width() - 1] = (grid.width() - 1) * draw_coords->get_tile_width() + j;
 
     j = 0;
     for (size_t i = 0; i < grid.height() - 1; ++i) {
         draw_coords->tile_y[i] = i * draw_coords->get_tile_width() + j;
-        j += max_chanx_ptc_nums[i] + 1;
+        j += max_chanx_ptc_nums[i] + 2;
     }
     draw_coords->tile_y[grid.height() - 1] = (grid.height() - 1) * draw_coords->get_tile_width() + j;
 


### PR DESCRIPTION
Previously the draw code used channel width to calculate the space needed between tiles. A previous PR changed this to use the maximum ptc_num instead to make it work with all sorts of different architectures. This PR fixes an off by one error that was missed, as channel width starts from 1 and ptc_num starts from 0.