### PR TITLE
[Spelling] Fixed Spelling Mistakes in VTR Flow

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -7,6 +7,10 @@ skip = ./build,
        *.log,
        *.vqm,
        *.blif,
+       *.xml,
+       *.pm,
+       # Special case: Pearl scripts are not being maintained.
+       *.pl,
        # External projects that do not belong to us.
        ./libs/EXTERNAL,
        ./parmys,
@@ -16,8 +20,11 @@ skip = ./build,
        ./ace2,
        ./blifexplorer,
        ./verilog_preprocessor,
-       # WIP spelling cleanups.
-       ./vtr_flow,
+       ./vtr_flow/scripts/perl_libs,
+       ./vtr_flow/scripts/benchtracker,
+       # Large testing directories.
+       ./vtr_flow/benchmarks,
+       ./vtr_flow/tasks,
        # Temporary as we wait for some PRs to merge.
        *_graph_uxsdcxx_capnp.h,
        ./vpr/src/route/rr_graph_generation/rr_graph.cpp,

--- a/vtr_flow/arch/titan/README.rst
+++ b/vtr_flow/arch/titan/README.rst
@@ -103,7 +103,7 @@ Adding Support for New Architectures
 Support can be added for additional Quartus II supported FPGA architectures 
 (Cyclone III, Stratix II etc), by defining models for the architecture's VQM
 primitives.  Good places to look for this information include:
-   * Altera's Quartus Univeristy Interface Program (QUIP) documentation
+   * Altera's Quartus University Interface Program (QUIP) documentation
    * The 'fv_lib' directory under a Quartus installation
 
 For more details see vqm_to_blif's README.txt

--- a/vtr_flow/arch/zeroasic/README.md
+++ b/vtr_flow/arch/zeroasic/README.md
@@ -2,7 +2,7 @@
 
 These are the VTR captures of the Zero ASIC architectures.
 
-The orginal Zero ASIC architectures can be found in logiklib here:
+The original Zero ASIC architectures can be found in logiklib here:
 https://github.com/siliconcompiler/logiklib
 
 These architectures have been slightly modified to work with VTR's CAD flow

--- a/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_fixed_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_fixed_chan_width.txt
@@ -11,6 +11,6 @@ crit_path_route_time;RangeAbs(0.10,10.0,2)
 
 #Peak memory
 #We set a 100MiB minimum threshold since the memory 
-#alloctor (e.g. TBB vs glibc) can cause a difference
+#allocator (e.g. TBB vs glibc) can cause a difference
 #particularly on small benchmarks
 max_vpr_mem;RangeAbs(0.8,1.35,102400)

--- a/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_fixed_chan_width_small.txt
+++ b/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_fixed_chan_width_small.txt
@@ -11,6 +11,6 @@ crit_path_route_time;RangeAbs(0.10,10.0,2)
 
 #Peak memory
 #We set a 100MiB minimum threshold since the memory 
-#alloctor (e.g. TBB vs glibc) can cause a difference
+#allocator (e.g. TBB vs glibc) can cause a difference
 #particularly on small benchmarks
 max_vpr_mem;RangeAbs(0.8,1.203,102400)

--- a/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_min_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_min_chan_width.txt
@@ -15,13 +15,13 @@ min_chan_width_route_time;RangeAbs(0.10,15.0,3)
 
 #Peak memory
 #We set a 100MiB minimum threshold since the memory 
-#alloctor (e.g. TBB vs glibc) can cause a difference
+#allocator (e.g. TBB vs glibc) can cause a difference
 #particularly on small benchmarks
 #
 #Note that due to different binary search path, peak memory
 #can differ significantly during binary search (e.g. a larger
 #or smaller channel width explored during the search can
 #significantly affect the size of the RR graph, and correspondingly
-#peak mememory usage in VPR. As a result we just a larger permissible
+#peak memory usage in VPR. As a result we just a larger permissible
 #range for peak memory usage.
 max_vpr_mem;RangeAbs(0.5,2.0,102400)

--- a/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_min_chan_width_small.txt
+++ b/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_min_chan_width_small.txt
@@ -16,13 +16,13 @@ min_chan_width_route_time;RangeAbs(0.05,15.0,4)
 
 #Peak memory
 #We set a 100MiB minimum threshold since the memory 
-#alloctor (e.g. TBB vs glibc) can cause a difference
+#allocator (e.g. TBB vs glibc) can cause a difference
 #particularly on small benchmarks
 #
 #Note that due to different binary search path, peak memory
 #can differ significantly during binary search (e.g. a larger
 #or smaller channel width explored during the search can
 #significantly affect the size of the RR graph, and correspondingly
-#peak mememory usage in VPR. As a result we just a larger permissible
+#peak memory usage in VPR. As a result we just a larger permissible
 #range for peak memory usage.
 max_vpr_mem;RangeAbs(0.5,2.0,102400)

--- a/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_relaxed_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/common/pass_requirements.vpr_route_relaxed_chan_width.txt
@@ -1,1 +1,1 @@
-#VPR metrix at relaxed (relative to minimum) channel width
+#VPR metrics at relaxed (relative to minimum) channel width

--- a/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_relaxed_chan_width.txt
+++ b/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_relaxed_chan_width.txt
@@ -1,4 +1,4 @@
-#VPR metrix at relaxed (relative to minimum) channel width with timing
+#VPR metrics at relaxed (relative to minimum) channel width with timing
 %include "../common/pass_requirements.vpr_route_relaxed_chan_width.txt"
 
 #Routing Metrics

--- a/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_relaxed_chan_width_small.txt
+++ b/vtr_flow/parse/pass_requirements/timing/pass_requirements.vpr_route_relaxed_chan_width_small.txt
@@ -1,4 +1,4 @@
-#VPR metrix at relaxed (relative to minimum) channel width with timing
+#VPR metrics at relaxed (relative to minimum) channel width with timing
 %include "../common/pass_requirements.vpr_route_relaxed_chan_width_small.txt"
 
 #Routing Metrics

--- a/vtr_flow/primitives.lib
+++ b/vtr_flow/primitives.lib
@@ -84,7 +84,7 @@ library (VTRPrimitives) {
      *
      *  INPUTS:
      *      datain
-     *  OUPUTS:
+     *  OUTPUTS:
      *      dataout
      */
     cell (fpga_interconnect) {
@@ -125,7 +125,7 @@ library (VTRPrimitives) {
      *          The LUT mask that defines the output of the LUT as a function
      *          of the input. mask[0] is the output if all the inputs are 0, and
      *          mask[2^k - 1] is the output if all the inputs are 1.
-     *  OUPUTS:
+     *  OUTPUTS:
      *      out
      */
     cell (LUT_4) {
@@ -171,7 +171,7 @@ library (VTRPrimitives) {
      *          The LUT mask that defines the output of the LUT as a function
      *          of the input. mask[0] is the output if all the inputs are 0, and
      *          mask[2^k - 1] is the output if all the inputs are 1.
-     *  OUPUTS:
+     *  OUTPUTS:
      *      out
      */
     cell (LUT_5) {
@@ -217,7 +217,7 @@ library (VTRPrimitives) {
      *          The LUT mask that defines the output of the LUT as a function
      *          of the input. mask[0] is the output if all the inputs are 0, and
      *          mask[2^k - 1] is the output if all the inputs are 1.
-     *  OUPUTS:
+     *  OUTPUTS:
      *      out
      */
     cell (LUT_6) {
@@ -262,7 +262,7 @@ library (VTRPrimitives) {
      *          edge.
      *      clock:
      *          The clock signal for the DFF.
-     *  OUPUTS:
+     *  OUTPUTS:
      *      Q:
      *          The current value stored in the latch.
      *      QN:

--- a/vtr_flow/primitives.v
+++ b/vtr_flow/primitives.v
@@ -7,13 +7,13 @@
 //If you wish to do back-annotated timing simulation you will need
 //to link with this file during simulation.
 //
-//To ensure currect result when performing back-annoatation with 
+//To ensure correct result when performing back-annoatation with 
 //Modelsim see the notes at the end of this comment.
 //
 //Specifying Timing Edges
 //=======================
 //To perform timing back-annotation the simulator must know the delay 
-//dependancies (timing edges) between the ports on each primitive.
+//dependencies (timing edges) between the ports on each primitive.
 //
 //During back-annotation the simulator will attempt to annotate SDF delay
 //values onto the timing edges.  It should give a warning if was unable
@@ -33,7 +33,7 @@
 //      (in[1] => out[1]) = "";
 //  endspecify
 //
-//This states that there are the following timing edges (dependancies):
+//This states that there are the following timing edges (dependencies):
 //  * from in[0] to out[0]
 //  * from in[1] to out[1]
 //
@@ -62,7 +62,7 @@
 //      (in *> out) = "";
 //  endspecify
 //
-//states that there are the following timing edges (dependancies):
+//states that there are the following timing edges (dependencies):
 //  * from in[0] to out[0]
 //  * from in[0] to out[1]
 //  * from in[0] to out[2]
@@ -91,11 +91,11 @@
 //This forces it to apply specify statements using multi-bit operands to
 //each bit of the operand (i.e. according to the Verilog standard).
 //
-//Confirming back-annotation is occuring correctly
+//Confirming back-annotation is occurring correctly
 //------------------------------------------------
 //
 //Another useful option is '+sdf_verbose' which produces extra output about
-//SDF annotation, which can be used to verify annotation occured correctly.
+//SDF annotation, which can be used to verify annotation occurred correctly.
 //
 //For example:
 //

--- a/vtr_flow/scripts/download_ispd.py
+++ b/vtr_flow/scripts/download_ispd.py
@@ -59,7 +59,7 @@ def parse_args():
         "--force",
         default=False,
         action="store_true",
-        help="Run extraction step even if directores etc. already exist",
+        help="Run extraction step even if directories etc. already exist",
     )
 
     parser.add_argument(
@@ -114,7 +114,7 @@ def main():
         print("File corrupt:", e)
         sys.exit(2)
     except ExtractionError as e:
-        print("Failed to extrac :", e)
+        print("Failed to extract :", e)
         sys.exit(3)
 
     sys.exit(0)

--- a/vtr_flow/scripts/download_noc_mlp.py
+++ b/vtr_flow/scripts/download_noc_mlp.py
@@ -20,7 +20,7 @@ import errno
 
 class ExtractionError(Exception):
     """
-    Raised when extracting the downlaoded file fails
+    Raised when extracting the downloaded file fails
     """
 
 
@@ -55,7 +55,7 @@ def parse_args():
         "--force",
         default=False,
         action="store_true",
-        help="Run extraction step even if directores etc. already exist",
+        help="Run extraction step even if directories etc. already exist",
     )
     parser.add_argument(
         "--full_archive",

--- a/vtr_flow/scripts/download_symbiflow.py
+++ b/vtr_flow/scripts/download_symbiflow.py
@@ -58,7 +58,7 @@ def parse_args():
         "--force",
         default=False,
         action="store_true",
-        help="Run extraction step even if directores etc. already exist",
+        help="Run extraction step even if directories etc. already exist",
     )
 
     parser.add_argument("--mirror", default="google", choices=["google"], help="Download mirror")

--- a/vtr_flow/scripts/download_titan.py
+++ b/vtr_flow/scripts/download_titan.py
@@ -59,7 +59,7 @@ def parse_args():
         "--force",
         default=False,
         action="store_true",
-        help="Run extraction step even if directores etc. already exist",
+        help="Run extraction step even if directories etc. already exist",
     )
     parser.add_argument(
         "--device_family",

--- a/vtr_flow/scripts/noc/noc_benchmark_test.py
+++ b/vtr_flow/scripts/noc/noc_benchmark_test.py
@@ -41,7 +41,7 @@ POST_ROUTED_WIRE_LENGTH_SEGMENTS = "Post Route WL (segments): "
 POST_ROUTED_FREQ = "Post Route Freq (MHz): "
 ROUTE_TIME = "Route Time (s): "
 
-# phrases to identify lines that contain palcement data
+# phrases to identify lines that contain placement data
 PLACEMENT_COST_PHRASE = "Placement cost:"
 NOC_PLACEMENT_COST_PHRASE = "NoC Placement Costs."
 PLACEMENT_TIME = "# Placement took"
@@ -87,8 +87,8 @@ def noc_test_command_line_parser(prog=None):
 
                 Run the NoC driven placement on a design located at
                 ./noc_test_circuits (design should be in .blif format).
-                Where we want to run 5 seeds (5 seperate runs)
-                using 3 threads (running 3 seperate runs of VPR in parallel).
+                Where we want to run 5 seeds (5 separate runs)
+                using 3 threads (running 3 separate runs of VPR in parallel).
                 For more information on all options run program with '-help'
                 parameter.
 
@@ -120,7 +120,7 @@ def noc_test_command_line_parser(prog=None):
         "-arch_file",
         default="",
         type=str,
-        help="The architecture file the NoC benchamrk designs are placed on",
+        help="The architecture file the NoC benchmark designs are placed on",
     )
 
     parser.add_argument("-vpr_executable", default="", type=str, help="The executable file of VPR")
@@ -250,7 +250,7 @@ def process_vpr_output(vpr_output_file):
 
     open_file = open(vpr_output_file)
 
-    # datastrcuture below stors the palcement data in a disctionary
+    # datastructure below stors the placement data in a dictionary
     placement_data = {}
 
     # process each line from the VPR output
@@ -291,7 +291,7 @@ def process_vpr_output(vpr_output_file):
 
 def process_placement_costs(placement_data, line_with_data):
     """
-    Given a string which contains palcement data. Extract the total
+    Given a string which contains placement data. Extract the total
     placement cost and wirelength cost.
     """
 
@@ -308,7 +308,7 @@ def process_placement_costs(placement_data, line_with_data):
     # 1st element is the overall placement cost, second element is the
     # placement bb cost and the third element is the placement td cost.
     #
-    # Covert them to floats and store them (we don't care about the td cost so # ignore it)
+    # Convert them to floats and store them (we don't care about the td cost so # ignore it)
     placement_data[PLACE_COST] = float(found_placement_metrics.group(1))
     placement_data[PLACE_BB_COST] = float(found_placement_metrics.group(2))
 
@@ -446,10 +446,10 @@ def check_for_constraints_file(design_file):
 
 def gen_vpr_run_command(design_file, design_flows_file, user_args):
     """
-    Generate a seperate VPR run commands each with a unique placement
+    Generate a separate VPR run commands each with a unique placement
     seed value. The number of commands generated is equal to the number
     of seeds the user requested to run.
-    For each run we generate seperate '.net' files. This was needed
+    For each run we generate separate '.net' files. This was needed
     since a single net file caused failures when multiple concurrent
     VPR runs tried accessing the file during placement.
     """
@@ -620,7 +620,7 @@ def process_vpr_runs(run_args, num_of_seeds, route):
         place_param: value / num_of_seeds for place_param, value in vpr_average_place_data.items()
     }
 
-    # need to divide the NoC latency cost by the weighting to conver it to
+    # need to divide the NoC latency cost by the weighting to convert it to
     # physical latency
     vpr_average_place_data[NOC_LATENCY_COST] = (
         vpr_average_place_data[NOC_LATENCY_COST] / latency_weight
@@ -638,7 +638,7 @@ def print_results(parsed_data, design_file, user_args):
     results_file_name = os.path.join(os.getcwd(), results_file_name + ".txt")
     results_file = open(results_file_name, "w+")
 
-    # write out placement info individually in seperate lines
+    # write out placement info individually in separate lines
     results_file.write("Design File: {0}\n".format(design_file))
     results_file.write("Flows File: {0}\n".format(user_args.flow_file))
 
@@ -664,7 +664,7 @@ def execute_vpr_and_process_output(vpr_command_list, num_of_seeds, num_of_thread
     for single_vpr_command in vpr_command_list:
 
         # generate VPR output file_name
-        # the constants represent the positions of the variabels in the command list
+        # the constants represent the positions of the variables in the command list
         design_file_name = single_vpr_command[2]
         seed_val = single_vpr_command[18]
         vpr_out_file = "{0}.{1}.vpr.out".format(design_file_name, seed_val)

--- a/vtr_flow/scripts/python_libs/vtr/abc/abc.py
+++ b/vtr_flow/scripts/python_libs/vtr/abc/abc.py
@@ -353,7 +353,7 @@ def run_lec(
             The reference netlist to be commpared to
 
         implementation_netlist :
-            The implemeted netlist to compare to the reference netlist
+            The implemented netlist to compare to the reference netlist
 
 
     Other Parameters
@@ -419,8 +419,8 @@ def run_lec(
 
 def check_abc_lec_status(output):
     """
-    Reads abc_lec output and determines if the files were equivelent and
-    if there were errors when preforming lec.
+    Reads abc_lec output and determines if the files were equivalent and
+    if there were errors when performing lec.
     """
     equivalent = None
     errored = False

--- a/vtr_flow/scripts/python_libs/vtr/log_parse.py
+++ b/vtr_flow/scripts/python_libs/vtr/log_parse.py
@@ -54,7 +54,7 @@ class PassRequirement(abc.ABC):
         self._type = type
 
     def metric(self):
-        """Return pass matric"""
+        """Return pass metric"""
         return self._metric
 
     @abc.abstractmethod
@@ -283,7 +283,7 @@ class ParseResults:
         self._metrics[(arch, circuit, script_param)] = parse_result
 
     def metrics(self, arch, circuit, script_param=None):
-        """Return individual metric based on the architechure, circuit and script"""
+        """Return individual metric based on the architecture, circuit and script"""
         script_param = load_script_param(script_param)
         if (arch, circuit, script_param) in self._metrics:
             return self._metrics[(arch, circuit, script_param)]
@@ -314,7 +314,7 @@ def load_parse_patterns(parse_config_filepath):
     """
     Loads the parse patterns from the desired file.
     These parse patterns are later used to load in the results file
-    The lines of this file should be formated in either of the following ways:
+    The lines of this file should be formatted in either of the following ways:
         name;path;regex;[default value]
         name;path;regex
     """
@@ -480,7 +480,7 @@ def determine_lut_size(architecture_file):
 
     lut_size = 0
     saw_blif_names = False
-    for elem in arch_xml.findall(".//pb_type"):  # Xpath recrusive search for 'pb_type'
+    for elem in arch_xml.findall(".//pb_type"):  # Xpath recursive search for 'pb_type'
         blif_model = elem.get("blif_model")
         if blif_model and blif_model == ".names":
             saw_blif_names = True
@@ -527,7 +527,7 @@ def determine_memory_addr_width(architecture_file):
 
 def determine_min_w(log_filename):
     """
-    determines the miniumum width.
+    determines the minimum width.
     """
     min_w_regex = re.compile(r"\s*Best routing used a channel width factor of (?P<min_w>\d+).")
     with open(log_filename) as file:

--- a/vtr_flow/scripts/python_libs/vtr/odin/odin.py
+++ b/vtr_flow/scripts/python_libs/vtr/odin/odin.py
@@ -54,7 +54,7 @@ def init_config_file(
     # specify the input files type
     file_extension = os.path.splitext(circuit_list[0])[-1]
     if file_extension not in FILE_TYPES:
-        raise vtr.VtrError("Inavlid input file type '{}'".format(file_extension))
+        raise vtr.VtrError("Invalid input file type '{}'".format(file_extension))
     input_file_type = FILE_TYPES[file_extension]
 
     # Check if the user specifically requested for the UHDM parser

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -60,7 +60,7 @@ def init_script_file(
     for circuit in circuit_list:
         file_extension = os.path.splitext(circuit)[-1]
         if file_extension not in FILE_TYPES:
-            raise vtr.VtrError("Inavlid input file type '{}'".format(file_extension))
+            raise vtr.VtrError("Invalid input file type '{}'".format(file_extension))
 
     # Update the config file
     vtr.file_replace(

--- a/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
+++ b/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
@@ -100,7 +100,7 @@ def vtr_command_argparser(prog=None):
         default=None,
         metavar="TEMP_DIR",
         dest="alt_tasks_dir",
-        help="Alternate directory to run the tasks in (will be created if non-existant)",
+        help="Alternate directory to run the tasks in (will be created if non-existent)",
     )
 
     parser.add_argument(
@@ -514,7 +514,7 @@ def summarize_qor(configs, alt_tasks_dir=None):
 
 
 def calc_geomean(args, configs):
-    """caclulate and ouput the geomean values to the geomean file"""
+    """calculate and output the geomean values to the geomean file"""
     first = False
     task_path = Path(find_task_dir(configs[0], args.alt_tasks_dir))
     if len(configs) > 1 or (task_path.parent / "task_list.txt").is_file():

--- a/vtr_flow/scripts/python_libs/vtr/task.py
+++ b/vtr_flow/scripts/python_libs/vtr/task.py
@@ -760,7 +760,7 @@ def create_job(
 
 def ret_expected_min_w(circuit, arch, golden_results, script_params=None):
     """
-    Retrive the expected minimum channel width from the golden results.
+    Retrieve the expected minimum channel width from the golden results.
     """
     script_params = load_script_param(script_params)
     golden_metrics = golden_results.metrics(arch, circuit, script_params)
@@ -771,7 +771,7 @@ def ret_expected_min_w(circuit, arch, golden_results, script_params=None):
 
 def ret_expected_vpr_status(arch, circuit, golden_results, script_params=None):
     """
-    Retrive the expected VPR status from the golden_results.
+    Retrieve the expected VPR status from the golden_results.
     """
     script_params = load_script_param(script_params)
     golden_metrics = golden_results.metrics(arch, circuit, script_params)
@@ -851,7 +851,7 @@ def find_task_config_file(task_name):
 
     base_dirs = []
     if PurePath(task_name).is_absolute():
-        # Only check the root path since the path is aboslute
+        # Only check the root path since the path is absolute
         base_dirs.append("/")
     else:
         # Not absolute path, so check from the current directory first

--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -114,7 +114,7 @@ class CommandRunner:
         Arguments
         =========
             cmd: list of tokens that form the command to be run
-            log_filename: the log fiel name for the command's output. Default: derived from command
+            log_filename: the log filename for the command's output. Default: derived from command
             temp_dir: The directory to run the command in. Default: None (uses object default).
             expected_return_code: The expected return code from the command.
             If the actula return code does not match, will generate an exception. Default: 0
@@ -283,7 +283,7 @@ def pretty_print_table(file, border=False):
 
 def write_tab_delimitted_csv(filepath, rows):
     """
-    Write out the data provied in a tab-delimited CSV format
+    Write out the data provided in a tab-delimited CSV format
 
     filepath: The filepath to write the data to
     rows: An iterable of dictionary-like elements; each element
@@ -320,7 +320,7 @@ def write_tab_delimitted_csv(filepath, rows):
 
 def load_tab_delimited_csv(filepath):
     """
-    loads a tab delimted csv as a list of ordered dictionaries
+    loads a tab delimited csv as a list of ordered dictionaries
     """
     data = []
     with open(filepath) as file:
@@ -404,7 +404,7 @@ def load_config_lines(filepath, allow_includes=True):
         @include "another_file.txt"
 
     will cause the specified file to be included in-line.
-    The @included filename is interpretted as relative to the directory
+    The @included filename is interpreted as relative to the directory
     containing filepath.
 
     Returns a list of lines

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -518,7 +518,7 @@ def get_memory_usage(logfile):
 
 def vtr_command_main(arg_list, prog=None):
     """
-    Running VTR with the specified arguemnts.
+    Running VTR with the specified arguments.
     """
     start = datetime.now()
     # Load the arguments

--- a/vtr_flow/scripts/run_vtr_task.py
+++ b/vtr_flow/scripts/run_vtr_task.py
@@ -103,7 +103,7 @@ def vtr_command_argparser(prog=None):
         default=None,
         metavar="TEMP_DIR",
         dest="alt_tasks_dir",
-        help="Alternate directory to run the tasks in (will be created if non-existant)",
+        help="Alternate directory to run the tasks in (will be created if non-existent)",
     )
 
     parser.add_argument(
@@ -427,7 +427,7 @@ def create_run_script(job, work_dir):
 
 
 def ret_expected_runtime(job, work_dir):
-    """Returns the expected run-time (in seconds) of the specified run, or -1 if unkown"""
+    """Returns the expected run-time (in seconds) of the specified run, or -1 if unknown"""
     seconds = -1
     golden_results = load_parse_results(
         str(Path(work_dir).parent.parent.parent.parent / "config/golden_results.txt")
@@ -443,7 +443,7 @@ def ret_expected_runtime(job, work_dir):
 
 
 def ret_expected_memory(job, work_dir):
-    """Returns the expected memory usage (in bytes) of the specified run, or -1 if unkown"""
+    """Returns the expected memory usage (in bytes) of the specified run, or -1 if unknown"""
     memory_kib = -1
     golden_results = load_parse_results(
         str(Path(work_dir).parent.parent.parent.parent / "config/golden_results.txt")

--- a/vtr_flow/scripts/slurm/submission_template.sh
+++ b/vtr_flow/scripts/slurm/submission_template.sh
@@ -18,7 +18,7 @@
 #SBATCH --error=error_%j.log                            # Determine the error log file
 #SBATCH --time=10:00:00                                 # The job time limit in hh:mm:ss
 
-#You can also overwrite the values of some of these paramters using environment variables
+#You can also overwrite the values of some of these parameters using environment variables
 #========================================================================================
 # - SBATCH_JOB_NAME instead of --job-name
 # - SBATCH_TIMELIMIT instead of --time

--- a/vtr_flow/scripts/tuning_runs/control_runs.py
+++ b/vtr_flow/scripts/tuning_runs/control_runs.py
@@ -125,7 +125,7 @@ def generate_xlsx(largest_run_path):
 
 
 def parse_script_params(script_params):
-    """Helper function to parse the script params values from earch row in
+    """Helper function to parse the script params values from each row in
     the parse_results.txt"""
 
     parsed_params = {key: "" for key in PARAMS_DICT}

--- a/vtr_flow/scripts/upgrade_arch.py
+++ b/vtr_flow/scripts/upgrade_arch.py
@@ -254,7 +254,7 @@ def add_model_timing(arch):
 
 def upgrade_fc_overrides(arch):
     """
-    Convets the legacy block <fc> pin and segment override specifications,
+    Converts the legacy block <fc> pin and segment override specifications,
     to the new unified format.
     """
     fc_tags = arch.findall(".//fc")
@@ -703,7 +703,7 @@ def upgrade_connection_block_input_switch(arch):
 
         # Comment the switch
         comment = ET.Comment(
-            "switch {} resistance set to yeild for 4x minimum drive strength buffer".format(
+            "switch {} resistance set to yield for 4x minimum drive strength buffer".format(
                 switch_name
             )
         )

--- a/vtr_flow/sdc/samples/F.sdc
+++ b/vtr_flow/sdc/samples/F.sdc
@@ -11,7 +11,7 @@ set_output_delay -clock output_clk -min 1 [get_ports{out*}]
 set_max_delay 17 -from [get_clocks{input_clk}] -to [get_clocks{output_clk}]
 set_min_delay 2 -from [get_clocks{input_clk}] -to [get_clocks{output_clk}]
 set_multicycle_path -setup -from [get_clocks{clk}] -to [get_clocks{clk2}] 3 
-#For multicycle_path, if setup is specified then hold is also implicity specified
+#For multicycle_path, if setup is specified then hold is also implicitly specified
 set_clock_uncertainty -from [get_clocks{clk}] -to [get_clocks{clk2}] 0.75 
 #For set_clock_uncertainty, if neither setup nor hold is unspecified then uncertainty is applied to both
 set_disable_timing -from [get_pins {FFA.Q\[0\]}] -to [get_pins {to_FFD.in\[0\]}]


### PR DESCRIPTION
Fixed the spelling mistakes in the VTR flow. We exclude the pearl libraries and benchtracker since these projects are not being maintained at this time.

We also ignore the benchmarks and tasks directories since these are mainly used for testing and contain a lot of false positives. We do not want to make it challenging to add more tests.

This should be the last major spelling fix-up, unless there is a directory that is currently not being checked that we actually want to be checked.