### PR TITLE
[CI] Added Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
 
     # Update all submodules
     directory: /
+
+  # This will create a PR if there are any updates to the actions used in the CI.
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Our CI uses external GitHub Actions for different things such as checking out the repo. This updates Dependabot to check for updates to these actions and raise a PR whenever there is an update.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependency management configuration to enable weekly update checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->