### PR TITLE
Fix parse_vtr_task crash when parse file is not defined

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
+++ b/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
@@ -217,20 +217,20 @@ def parse_task(config, config_jobs, flow_metrics_basename=FIRST_PARSE_FILE, alt_
     max_circuit_len = len("circuit")
     for job in config_jobs:
         work_dir = job.work_dir(get_active_run_dir(find_task_dir(config, alt_tasks_dir)))
-        job.parse_command()[0] = work_dir
-        # job.second_parse_command()[0] = work_dir
-        job.qor_parse_command()[0] = work_dir
         if job.parse_command():
+            job.parse_command()[0] = work_dir
             parse_filepath = str(PurePath(work_dir) / flow_metrics_basename)
             with open(parse_filepath, "w+", encoding="utf-8") as parse_file:
                 with redirect_stdout(parse_file):
                     parse_vtr_flow(job.parse_command())
         if job.second_parse_command():
+            job.second_parse_command()[0] = work_dir
             parse_filepath = str(PurePath(work_dir) / SECOND_PARSE_FILE)
             with open(parse_filepath, "w+", encoding="utf-8") as parse_file:
                 with redirect_stdout(parse_file):
                     parse_vtr_flow(job.second_parse_command())
         if job.qor_parse_command():
+            job.qor_parse_command()[0] = work_dir
             parse_filepath = str(PurePath(work_dir) / QOR_PARSE_FILE)
             with open(parse_filepath, "w+", encoding="utf-8") as parse_file:
                 with redirect_stdout(parse_file):


### PR DESCRIPTION
parse_vtr_task assigned something to both parse_command and qor_parse_command without actually checking if a 'parse_file' or 'qor_parse_file' was actually defined in the task parsing file, resulting in #3389 with some of the tasks being unable to run. This PR fixes that by assigning that variable only if it actually exists.

One thing to think about is, do we want to error out and give an error message if they haven't defined a parse file? Before this PR it always crashed if 'parse_file' and 'qor_parse_file' weren't defined, but now the script just continues. I personally think it's fine to run a vtr task without parsing the output, but maybe the intended behaviour is different.