### PR TITLE
[Scripts] Fixed Timeout Issue

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -214,7 +214,13 @@ class CommandRunner:
                     # Abort if over time limit
                     elapsed_time = time.time() - start_time
                     if self._timeout_sec and elapsed_time > self._timeout_sec:
+                        # Send SIGTERM command to all processes in the process
+                        # group. We need to do this since Popen may create a
+                        # process which has children. We want all of them to
+                        # receive this signal.
                         os.killpg(proc.pid, signal.SIGTERM)
+                        # Wait 5 seconds for the process to gracefully terminate.
+                        # If it still has not terminated, send SIGKILL.
                         try:
                             proc.wait(timeout=5)
                         except subprocess.TimeoutExpired:


### PR DESCRIPTION
The timeout argument for run_vtr_flow was not working correctly. If a test ran longer than the timeout, the Python script will not terminate the process. The run will continue until it is finished and then get the proper timeout error. This defeats the whole purpose of having a timeout.

Tracked the problem down to a utility script which was trying to kill the process and was unable to do so.