### PR TITLE
[flow] Add -synthesis_params to replace YYY placeholder in parmys flow

### DIFF
--- a/doc/src/vtr/run_vtr_flow.rst
+++ b/doc/src/vtr/run_vtr_flow.rst
@@ -249,6 +249,13 @@ Detailed Command-line Options
     
     **Default:** default
 
+.. option:: -synthesis_params <SYNTHESIS_PARAMS>
+
+    Extra parameters passed to the ``parmys`` synthesis command in the Yosys script.
+    This replaces the ``YYY`` placeholder in ``synthesis.tcl``.
+
+    **Default:** "" (empty string)
+
 .. note::
 
     Yosys-Slang is a Yosys plugin that is built on top of the slang library to provide comprehensive SystemVerilog support.

--- a/doc/src/vtr/run_vtr_flow.rst
+++ b/doc/src/vtr/run_vtr_flow.rst
@@ -251,8 +251,8 @@ Detailed Command-line Options
 
 .. option:: -synthesis_params <SYNTHESIS_PARAMS>
 
-    Extra parameters passed to the ``parmys`` synthesis command in the Yosys script.
-    This replaces the ``YYY`` placeholder in ``synthesis.tcl``.
+    Specify additional synthesis parameters that are directly appended to the ``parmys`` command in the **default** synthesis flow. (e.g., ``-mults_ratio 0.5``, ``-exact_mults 0``).
+    For users using a **custom** Yosys script with ``-yosys_script``, this option acts as a dynamic substitute for the ``YYY`` placeholder (if present).
 
     **Default:** "" (empty string)
 

--- a/vtr_flow/misc/yosys/synthesis.tcl
+++ b/vtr_flow/misc/yosys/synthesis.tcl
@@ -22,7 +22,6 @@ if {$env(PARSER) == "slang" } {
 
 # arch file: QQQ
 # input files: [XXX]
-# other args: [YYY]
 # config file: CCC
 # output file: ZZZ
 
@@ -83,7 +82,7 @@ opt -full
 # Separate options for Parmys execution (Verilog or SystemVerilog)
 if {$env(PARSER) == "default" || $env(PARSER) == "slang"} {
     # For Verilog, use -nopass for a simpler, faster flow
-    parmys -a QQQ -nopass -c CCC YYY
+    parmys -a QQQ -nopass -c CCC
 } 
 
 opt -full

--- a/vtr_flow/misc/yosys/synthesis.tcl
+++ b/vtr_flow/misc/yosys/synthesis.tcl
@@ -22,6 +22,7 @@ if {$env(PARSER) == "slang" } {
 
 # arch file: QQQ
 # input files: [XXX]
+# other args: [YYY]
 # config file: CCC
 # output file: ZZZ
 
@@ -82,7 +83,7 @@ opt -full
 # Separate options for Parmys execution (Verilog or SystemVerilog)
 if {$env(PARSER) == "default" || $env(PARSER) == "slang"} {
     # For Verilog, use -nopass for a simpler, faster flow
-    parmys -a QQQ -nopass -c CCC
+    parmys -a QQQ -nopass -c CCC YYY
 } 
 
 opt -full

--- a/vtr_flow/scripts/python_libs/vtr/flow.py
+++ b/vtr_flow/scripts/python_libs/vtr/flow.py
@@ -215,6 +215,7 @@ def run(
     # RTL Elaboration & Synthesis (PARMYS)
     #
     elif should_run_stage(VtrStage.PARMYS, start_stage, end_stage):
+        synthesis_params = parmys_args.pop("synthesis_params", "") if parmys_args else ""
         vtr.parmys.run(
             architecture_copy,
             next_stage_netlist,
@@ -226,6 +227,7 @@ def run(
             yosys_script=yosys_script,
             min_hard_mult_size=min_hard_mult_size,
             min_hard_adder_size=min_hard_adder_size,
+            synthesis_params=synthesis_params,
         )
 
         next_stage_netlist = post_yosys_netlist

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -68,6 +68,7 @@ def init_script_file(
         {
             "XXX": "{}".format(" ".join(str(s) for s in circuit_list)),
             # "TTT": str(vtr.paths.yosys_tcl_path),
+            "YYY": "",
             "CCC": odin_config_full_path,
             "ZZZ": output_netlist,
             "QQQ": architecture_file_path,

--- a/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
+++ b/vtr_flow/scripts/python_libs/vtr/parmys/parmys.py
@@ -54,6 +54,7 @@ def init_script_file(
     output_netlist,
     architecture_file_path,
     odin_config_full_path,
+    synthesis_params="",
 ):
     """initializing the raw yosys script file"""
     # specify the input files type
@@ -68,7 +69,7 @@ def init_script_file(
         {
             "XXX": "{}".format(" ".join(str(s) for s in circuit_list)),
             # "TTT": str(vtr.paths.yosys_tcl_path),
-            "YYY": "",
+            "YYY": synthesis_params,
             "CCC": odin_config_full_path,
             "ZZZ": output_netlist,
             "QQQ": architecture_file_path,
@@ -137,6 +138,7 @@ def run(
     yosys_script=None,
     min_hard_mult_size=3,
     min_hard_adder_size=1,
+    synthesis_params="",
 ):
     """
     Runs Yosys on the specified architecture file and circuit
@@ -240,6 +242,7 @@ def run(
         output_netlist.name,
         architecture_file_path,
         odin_config_full_path,
+        synthesis_params=synthesis_params,
     )
 
     # Set the slang exe script path in the environment variable

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -373,7 +373,8 @@ def vtr_command_argparser(prog=None):
         "-synthesis_params",
         default=None,
         dest="synthesis_params",
-        help="Specify additional synthesis parameters directly appended to the parmys command in the default flow"
+        help="Specify additional synthesis parameters"
+        + " directly appended to the parmys command in the default flow"
         + " (e.g., -mults_ratio 0.5), or used to substitute the 'YYY' placeholder"
         + " in a custom Yosys script.",
     )

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -373,8 +373,9 @@ def vtr_command_argparser(prog=None):
         "-synthesis_params",
         default="",
         dest="synthesis_params",
-        help="Extra parameters passed to the parmys synthesis command "
-        + "(replaces YYY placeholder in synthesis.tcl).",
+        help="Specify additional synthesis parameters directly appended to the parmys command in the default flow"
+        + " (e.g., -mults_ratio 0.5), or used to substitute the 'YYY' placeholder"
+        + " in a custom Yosys script.",
     )
     #
     # VPR arguments

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -369,6 +369,13 @@ def vtr_command_argparser(prog=None):
         + "system-verilog]. The script used the Yosys conventional Verilog"
         + " parser if this argument is not specified.",
     )
+    parmys.add_argument(
+        "-synthesis_params",
+        default="",
+        dest="synthesis_params",
+        help="Extra parameters passed to the parmys synthesis command "
+        + "(replaces YYY placeholder in synthesis.tcl).",
+    )
     #
     # VPR arguments
     #
@@ -733,6 +740,7 @@ def process_parmys_args(args):
     """
     parmys_args = OrderedDict()
     parmys_args["parser"] = args.parser
+    parmys_args["synthesis_params"] = args.synthesis_params
 
     return parmys_args
 

--- a/vtr_flow/scripts/run_vtr_flow.py
+++ b/vtr_flow/scripts/run_vtr_flow.py
@@ -371,7 +371,7 @@ def vtr_command_argparser(prog=None):
     )
     parmys.add_argument(
         "-synthesis_params",
-        default="",
+        default=None,
         dest="synthesis_params",
         help="Specify additional synthesis parameters directly appended to the parmys command in the default flow"
         + " (e.g., -mults_ratio 0.5), or used to substitute the 'YYY' placeholder"
@@ -741,7 +741,7 @@ def process_parmys_args(args):
     """
     parmys_args = OrderedDict()
     parmys_args["parser"] = args.parser
-    parmys_args["synthesis_params"] = args.synthesis_params
+    parmys_args["synthesis_params"] = args.synthesis_params or ""
 
     return parmys_args
 


### PR DESCRIPTION
The `YYY` placeholder in parmys.py is never substituted during the VTR flow. It remains in the generated synthesis command and produces stray tokens in the yosys invocation.

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Remove the placeholder `YYY` in the template synthesis script

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3487

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accidentally found during debugging/writing my own script

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

