### PR TITLE
Directly construct NoOpLookahead in lookahead report

### DIFF
--- a/vpr/src/route/router_lookahead/router_lookahead_report.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_report.cpp
@@ -275,20 +275,14 @@ static void profile_lookahead_overestimation(std::ofstream& os,
 
     // Create a NOP router lookahead to be used during the all-destination dijkstra search.
     t_det_routing_arch temp_det_routing_arch;
-    std::unique_ptr<RouterLookahead> temp_router_lookahead = make_router_lookahead(temp_det_routing_arch, e_router_lookahead::NO_OP,
-                                                                                   /*write_lookahead=*/"", /*read_lookahead=*/"",
-                                                                                   /*segment_inf=*/{},
-                                                                                   false /*is_flat*/,
-                                                                                   1 /*route_verbosity*/,
-                                                                                   false /*device_model_warnings*/,
-                                                                                   0 /*router_lookahead_interposer_base_cut_multiplier*/);
+    NoOpLookahead temp_router_lookahead = NoOpLookahead();
 
     // Create the router to perform the all-destination dijkstra search,
     // TODO: The parallel connection router would be ideal for this use case.
     //       Should use it instead.
     SerialConnectionRouter<FourAryHeap> router(
         device_ctx.grid,
-        *temp_router_lookahead,
+        temp_router_lookahead,
         rr_graph.rr_nodes(),
         &rr_graph,
         device_ctx.rr_rc_data,


### PR DESCRIPTION
Very small change. The lookahead report should not be using the overly complicated factory method to construct the NoOpLookahead with a lot of unneeded arguments. This should make changing the lookahead API a bit simpler and less annoying.