### PR TITLE
[Pack] Pack RAM clusters first and set candidate propose limit to RAM group size

### DIFF
--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -268,7 +268,8 @@ ClusterGainStats GreedyCandidateSelector::create_cluster_gain_stats(
         // Set the candidate propose limit to number of atoms in the physical RAM group.
         cluster_gain_stats.candidates_propose_limit = ram_mapper_.physical_ram_group(cluster_gain_stats.physical_ram_id).atoms.size();
         VTR_LOGV(log_verbosity_ > 2, "Cluster of seed atom %zu is a memory cluster in logical RAM group %zu, physical RAM group %zu.\n"
-                 "\tCandidate propose limit set to physical RAM group atom count: %u.\n", size_t(seed_atom), size_t(cluster_gain_stats.logical_ram_id),
+                                     "\tCandidate propose limit set to physical RAM group atom count: %u.\n",
+                 size_t(seed_atom), size_t(cluster_gain_stats.logical_ram_id),
                  size_t(cluster_gain_stats.physical_ram_id), cluster_gain_stats.candidates_propose_limit);
     }
 

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -267,8 +267,9 @@ ClusterGainStats GreedyCandidateSelector::create_cluster_gain_stats(
 
         // Set the candidate propose limit to number of atoms in the physical RAM group.
         cluster_gain_stats.candidates_propose_limit = ram_mapper_.physical_ram_group(cluster_gain_stats.physical_ram_id).atoms.size();
-        VTR_LOGV(log_verbosity_ > 2, "Cluster of seed atom %zu is a memory cluster in logical RAM group %zu, physical RAM group %zu.\n",
-                 size_t(seed_atom), size_t(cluster_gain_stats.logical_ram_id), size_t(cluster_gain_stats.physical_ram_id));
+        VTR_LOGV(log_verbosity_ > 2, "Cluster of seed atom %zu is a memory cluster in logical RAM group %zu, physical RAM group %zu.\n"
+                 "\tCandidate propose limit set to physical RAM group atom count: %u.\n", size_t(seed_atom), size_t(cluster_gain_stats.logical_ram_id),
+                 size_t(cluster_gain_stats.physical_ram_id), cluster_gain_stats.candidates_propose_limit);
     }
 
     // Return the cluster gain stats.

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -261,7 +261,7 @@ ClusterGainStats GreedyCandidateSelector::create_cluster_gain_stats(
     const auto seed_pb = cluster_legalizer.atom_pb_lookup().atom_pb(seed_atom);
     cluster_gain_stats.is_memory = seed_pb->pb_graph_node->pb_type->class_type == MEMORY_CLASS;
 
-    if (cluster_gain_stats.is_memory) {
+    if (has_ram_groups_ && cluster_gain_stats.is_memory) {
         cluster_gain_stats.logical_ram_id = ram_mapper_.group_id_of(seed_atom);
         cluster_gain_stats.physical_ram_id = ram_mapper_.physical_group_id_of(seed_atom);
 

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -264,6 +264,9 @@ ClusterGainStats GreedyCandidateSelector::create_cluster_gain_stats(
     if (cluster_gain_stats.is_memory) {
         cluster_gain_stats.logical_ram_id = ram_mapper_.group_id_of(seed_atom);
         cluster_gain_stats.physical_ram_id = ram_mapper_.physical_group_id_of(seed_atom);
+
+        // Set the candidate propose limit to number of atoms in the physical RAM group.
+        cluster_gain_stats.candidates_propose_limit = ram_mapper_.physical_ram_group(cluster_gain_stats.physical_ram_id).atoms.size();
         VTR_LOGV(log_verbosity_ > 2, "Cluster of seed atom %zu is a memory cluster in logical RAM group %zu, physical RAM group %zu.\n",
                  size_t(seed_atom), size_t(cluster_gain_stats.logical_ram_id), size_t(cluster_gain_stats.physical_ram_id));
     }
@@ -824,6 +827,8 @@ void GreedyCandidateSelector::add_ram_cluster_molecule_candidates(
         return;
     cluster_gain_stats.initial_search_for_feasible_blocks = false;
     const PhysicalRamGroup& phys_group = ram_mapper_.physical_ram_group(cluster_gain_stats.physical_ram_id);
+    VTR_ASSERT_DEBUG_MSG(cluster_gain_stats.candidates_propose_limit == phys_group.atoms.size(),
+                         "The limit of candidates to be proposed should be same as the number of atoms in the physical RAM group.");
     for (AtomBlockId atom_id : phys_group.atoms) {
         if (cluster_legalizer.is_atom_clustered(atom_id))
             continue;

--- a/vpr/src/pack/greedy_clusterer.cpp
+++ b/vpr/src/pack/greedy_clusterer.cpp
@@ -147,7 +147,8 @@ GreedyClusterer::do_clustering(ClusterLegalizer& cluster_legalizer,
                                      packer_opts_.cluster_seed_type,
                                      max_molecule_stats,
                                      arch_.models,
-                                     pre_cluster_timing_manager_);
+                                     pre_cluster_timing_manager_,
+                                     ram_mapper);
 
     // Pick the first seed molecule.
     PackMoleculeId seed_mol_id = seed_selector.get_next_seed(cluster_legalizer);

--- a/vpr/src/pack/greedy_seed_selector.cpp
+++ b/vpr/src/pack/greedy_seed_selector.cpp
@@ -234,10 +234,9 @@ GreedySeedSelector::GreedySeedSelector(const AtomNetlist& atom_netlist,
     std::stable_sort(seed_mols_.begin(), seed_mols_.end(), by_descending_gain);
 
     // If there are RAM groups, move RAM seeds to the front so that RAM clusters
-    // are formed before non-RAM clusters. This ensures that the dedicated RAM
-    // candidate path (which offers only atoms from the same physical RAM group)
-    // has full freedom to pack RAM atoms together without non-RAM clusters
-    // having already claimed some of them.
+    // are formed first. Since the RAM mapper has full information about which
+    // atoms belong together, packing RAM clusters early gives non-RAM clusters
+    // transitive connectivity information and makes ordering more intuitive.
     if (ram_mapper.num_groups() > 0) {
         std::stable_partition(seed_mols_.begin(), seed_mols_.end(),
                               [&](PackMoleculeId mol_id) {

--- a/vpr/src/pack/greedy_seed_selector.cpp
+++ b/vpr/src/pack/greedy_seed_selector.cpp
@@ -17,6 +17,7 @@
 #include "echo_files.h"
 #include "greedy_clusterer.h"
 #include "logic_types.h"
+#include "logical_ram_infer.h"
 #include "prepack.h"
 #include "vpr_error.h"
 #include "vpr_types.h"
@@ -176,7 +177,8 @@ GreedySeedSelector::GreedySeedSelector(const AtomNetlist& atom_netlist,
                                        const e_cluster_seed seed_type,
                                        const t_molecule_stats& max_molecule_stats,
                                        const LogicalModels& models,
-                                       const PreClusterTimingManager& pre_cluster_timing_manager)
+                                       const PreClusterTimingManager& pre_cluster_timing_manager,
+                                       const RamMapper& ram_mapper)
     : seed_mols_(prepacker.molecules().begin(), prepacker.molecules().end()) {
     // Seed molecule list is initialized with all molecule in the netlist.
 
@@ -230,6 +232,20 @@ GreedySeedSelector::GreedySeedSelector(const AtomNetlist& atom_netlist,
         return molecule_gains[lhs] > molecule_gains[rhs];
     };
     std::stable_sort(seed_mols_.begin(), seed_mols_.end(), by_descending_gain);
+
+    // If there are RAM groups, move RAM seeds to the front so that RAM clusters
+    // are formed before non-RAM clusters. This ensures that the dedicated RAM
+    // candidate path (which offers only atoms from the same physical RAM group)
+    // has full freedom to pack RAM atoms together without non-RAM clusters
+    // having already claimed some of them.
+    if (ram_mapper.num_groups() > 0) {
+        std::stable_partition(seed_mols_.begin(), seed_mols_.end(),
+                              [&](PackMoleculeId mol_id) {
+                                  const t_pack_molecule& mol = prepacker.get_molecule(mol_id);
+                                  AtomBlockId root = mol.atom_block_ids[mol.root];
+                                  return ram_mapper.group_id_of(root).is_valid();
+                              });
+    }
 
     // Print the seed gains if requested.
     if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_CLUSTERING_BLOCK_CRITICALITIES)) {

--- a/vpr/src/pack/greedy_seed_selector.h
+++ b/vpr/src/pack/greedy_seed_selector.h
@@ -15,6 +15,7 @@ class AtomNetlist;
 class ClusterLegalizer;
 class LogicalModels;
 class PreClusterTimingManager;
+class RamMapper;
 struct t_molecule_stats;
 
 /**
@@ -48,13 +49,18 @@ class GreedySeedSelector {
      *  @param pre_cluster_timing_manager
      *              Timing manager class for the primitive netlist. Used to
      *              compute the criticalities of seeds.
+     *  @param ram_mapper
+     *              The RAM mapper which contains the pre-assigned RAM groups.
+     *              If there are any RAM groups, RAM seeds are moved to the
+     *              front of the seed list so that RAM clusters are formed first.
      */
     GreedySeedSelector(const AtomNetlist& atom_netlist,
                        const Prepacker& prepacker,
                        const e_cluster_seed seed_type,
                        const t_molecule_stats& max_molecule_stats,
                        const LogicalModels& models,
-                       const PreClusterTimingManager& pre_cluster_timing_manager);
+                       const PreClusterTimingManager& pre_cluster_timing_manager,
+                       const RamMapper& ram_mapper);
 
     /**
      * @brief Propose a new seed molecule to start a new cluster with. If no


### PR DESCRIPTION
For RAM clusters, we are only offering candidates from the physical RAM groups (as of #3492). Since we know what to be packed in these clusters, it makes sense to move seeds of type memory to front if we have RAM groups. That way types can have the transitive connectivity information while they are being packed. 

We also set the candidate propose limit to the number of atoms in the RAM group of that seed since we know the exact number of atoms to be packed in RAM clusters. Both changes makes the RAM packing more intuitive. The change in results is nearly noise to me.


Titan results normalized to master

| Metric        | PR/Master |
| ------------- | --------- |
| Routed WL     | 1.0048    |
| Final CPD     | 0.9989    |
| Avg. Disp.    | 0.9944    |
| GP Runtime    | 1.0157    |
| FL Runtime    | 1.0001    |
| DP Runtime    | 1.0254    |
| Route Runtime | 1.0489    |
| Total Runtime | 1.0137    |
| LAB Count     | 0.9988    |
| M9K Count     | 1.0000    |
| M144 Count    | 1.0000    |





