### PR TITLE
Strict check on children of an interconnect(complete, direct, mux)  tag

### DIFF
--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1849,6 +1849,7 @@ static void process_interconnect(vtr::string_internment& strings,
 
         while (cur != nullptr) {
             expect_only_attributes(cur, {"name", "input", "output"}, loc_data);
+            expect_only_children(cur, {"delay_constant", "delay_matrix", "C_constant", "C_matrix", "pack_pattern", "metadata"}, loc_data);
 
             if (0 == strcmp(cur.name(), "complete")) {
                 mode->interconnect[interconnect_idx].type = COMPLETE_INTERC;


### PR DESCRIPTION
Due to a error producing an architecture xml, `direct<> `tags had `T_clock_to_Q<>` delays as children. This was not caught by the VPR parser (but was caught by [this](https://github.com/AlexandreSinger/rust-fpga-arch-visualizer) project!).
This change checks that:
`<complete | direct |mux >` contain only `<delay_constant | delay_matrix | C_constant | C_matrix | pack_pattern |metadata>` tags.
Happy to contribute a test arch file or run additional regression tests.