### PR TITLE
[VQM] Fixed Unmatched Rule Warning

### DIFF
--- a/libs/libvqm/vqm_parser.l
+++ b/libs/libvqm/vqm_parser.l
@@ -43,7 +43,6 @@
 ^[ \t]*\(\*[^\n\r]*\*\)                     /* skip synthesis attributes and directives */
 [ \t\n\r]+                                      /* skip white spaces */
 !				    /* skip the logical operator ! applied on the input ports of the lut - this results in lut mask not being valid anoymore */
-(\n|\r\n)                                   /* skip empty lines */
 module                                      return TOKEN_MODULE;
 endmodule                                   return TOKEN_ENDMODULE;
 defparam                                    return TOKEN_DEFPARAM;


### PR DESCRIPTION
The VQM parser had a rule which was redundant, since a rule already exists for matching all white-space.

Removed the unused rule.

I came across this while looking through the build logs. This must have been missed from my cleaning of the warnings a long time ago.
<img width="1134" height="135" alt="Screenshot from 2026-05-01 16-31-47" src="https://github.com/user-attachments/assets/eee41729-b3ee-4d19-b3cb-9347f0758981" />

The redundant rule conflicts with the rule on line 44 which matches all white spaces.