### PR TITLE
Use jemalloc where available for ~6% performance improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ option(VTR_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
 option(VTR_ENABLE_VERBOSE "Enable increased debug verbosity" OFF)
 option(SPEC_CPU "Enable SPEC CPU v8 support" OFF)
 
+option(VPR_USE_JEMALLOC "Use jemalloc for vpr instead of default glibc allocator when available" ON)
+
 #Allow the user to decide whether to compile the graphics library
 set(VPR_USE_EZGL "auto" CACHE STRING "Specify whether vpr uses the graphics library")
 set_property(CACHE VPR_USE_EZGL PROPERTY STRINGS auto off on)

--- a/install_apt_packages.sh
+++ b/install_apt_packages.sh
@@ -53,6 +53,11 @@ packages_to_install+=(
     zlib1g-dev
 )
 
+# Optional, but improves performance
+packages_to_install+=(
+    libjemalloc-dev
+)
+
 # Required for code formatting
 # NOTE: clang-format-18 may only be found on specific distributions. Only
 #       install it if the distribution has this version of clang format.

--- a/install_dnf_packages.sh
+++ b/install_dnf_packages.sh
@@ -49,3 +49,7 @@ sudo dnf install --refresh -y \
 # Required to run the analytical placement flow
 sudo dnf install --refresh -y \
     eigen3-devel
+
+# Optional, but improves performance
+sudo dnf install --refresh -y \
+    jemalloc-devel

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -175,6 +175,16 @@ add_executable(vpr ${EXEC_SOURCES})
 
 target_link_libraries(vpr libvpr)
 
+# Use jemalloc for ~5% better performance if enabled and we find it
+if(VPR_USE_JEMALLOC)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(JEMALLOC jemalloc)
+
+    if(JEMALLOC_FOUND)
+        target_link_libraries(vpr ${JEMALLOC_LIBRARIES})
+    endif()
+endif()
+
 
 #
 # Profile Guilded Optimization Configuration


### PR DESCRIPTION
#### Description
jemalloc is an alternative allocator that provides better performance than the default glibc malloc in most situations, especially for memory-heavy applications. This PR uses jemalloc by default when available and adds it to the default install lists.

#### Motivation and Context
vtr is slow. Anything that shaves a few seconds off each iteration is useful.

#### How Has This Been Tested?
I tested jemalloc locally on a 7800X3D along with tcmalloc and micalloc, two other popular allocator options. The following command was used:

```sh
/usr/bin/time -v vpr ../arch/titan/stratixiv_arch.timing.xml ./benchmarks/titan_blif/titan23/stratixiv/neuron_stratixiv_arch_timing.blif --sdc_file ./benchmarks/titan_blif/titan23/stratixiv/neuron_stratixiv_arch_timing.sdc --max_router_iterations 400     --router_lookahead map     --initial_pres_fac 1.0     --router_profiler_astar_fac 1.5     --seed 3     --route_chan_width 400 -j8
```

Here is a table of times and relative improvements.
  | malloc version | vpr time (s) |   | vpr max_rss (MiB) |   | user time (measured by `time`) |   | time rss (kbytes) |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
glibc malloc | 2.42 | 123.62 |   | 3160.3 |   | 158.05 |   | 3236160 |  
tcmalloc | 4.6.3 | 117.68 | -4.81% | 3072.8 | -2.77% | 149.14 | -5.64% | 3148120 | -2.72%
mimalloc | 2.1 | 118.06 | -4.50% | 3818.4 | 20.82% | 148.99 | -5.73% | 3910056 | 20.82%
jemalloc | 5.3.0 | 117.26 | -5.14% | 3042.9 | -3.71% | 148.32 | -6.16% | 3115924 | -3.72%

As you can see, jemalloc shaves about 6% off of total execution time and reduces peak memory usage by about 4%.

Please let me know if any documentation changes are required as a result of this change. Thanks :)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
