### PR TITLE
[CI] Fix Windows Build Caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -857,8 +857,8 @@ jobs:
       - name: Build
         shell: msys2 {0}
         env:
-          CMAKE_PARAMS: "-DWITH_ABC=OFF -DWITH_PARMYS=OFF -DSLANG_SYSTEMVERILOG=OFF"
+          CMAKE_PARAMS: "-DWITH_ABC=OFF -DWITH_PARMYS=OFF -DSLANG_SYSTEMVERILOG=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           BUILD_TYPE: release # Note: Found that release build caches way better than debug build for this test.
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: |
           make -j${{ steps.cpu-cores.outputs.count}}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -857,7 +857,7 @@ jobs:
       - name: Build
         shell: msys2 {0}
         env:
-          CMAKE_PARAMS: "-DWITH_ABC=OFF -DWITH_PARMYS=OFF -DSLANG_SYSTEMVERILOG=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          CMAKE_PARAMS: "-DWITH_ABC=OFF -DWITH_PARMYS=OFF -DSLANG_SYSTEMVERILOG=OFF -DVTR_IPO_BUILD=off -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           BUILD_TYPE: release # Note: Found that release build caches way better than debug build for this test.
           CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: |


### PR DESCRIPTION
Currently the windows build is not using ccache. Looking at the build script, I beleive it is caused by CMAKE not using the ccache by default.

Normally we set ccache using the PATH variable on linux, but I am not sure if Windows can do the same. Instead we can set ccache in CMAKE by declaring it as our compiler launcher.