### PR TITLE
Add clang tidy bugprone

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,7 +30,7 @@ Checks: >
   #-readability-redundant-inline-specifier,
   #-readability-isolate-declaration,
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 ExcludeHeaderFilterRegex: '.*/libs/EXTERNAL/.*'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+---
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-branch-clone,
+  -bugprone-signed-char-misuse,
+  -bugprone-sizeof-expression,
+  -bugprone-lambda-function-name,
+  -bugprone-throwing-static-initialization,
+  -bugprone-random-generator-seed,
+  -bugprone-nondeterministic-pointer-iteration-order,
+  -bugprone-unchecked-optional-access,
+  -bugprone-suspicious-stringview-data-usage,
+  -bugprone-return-const-ref-from-parameter,
+  -bugprone-unchecked-string-to-number-conversion,
+  # performance-*,
+  # readability-*,
+  #-readability-function-cognitive-complexity,
+  #-readability-identifier-length,
+  #-readability-simplify-boolean-expr,
+  #-readability-redundant-access-specifiers,
+  #-readability-avoid-const-params-in-decls,
+  #-readability-else-after-return,
+  #-readability-uppercase-literal-suffix,
+  #-readability-use-anyofallof,
+  #-readability-redundant-inline-specifier,
+  #-readability-isolate-declaration,
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+ExcludeHeaderFilterRegex: '.*/libs/EXTERNAL/.*'
+FormatStyle: file

--- a/dev/run_linter.py
+++ b/dev/run_linter.py
@@ -2,7 +2,7 @@
 """
 Small wrapper around LLVM's run-clang-tidy script.
 
-Run using './run_linter.py vpr' to run the linter for vpr.
+Run using './dev/run_linter.py vpr' to run the linter for vpr.
 This script was generated using LLMs. While we have reviewed it and
 tested the output for some use cases, you should not blindly trust its
 output.
@@ -28,7 +28,7 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument(
         "paths",
         nargs="*",
-        help="Files or directories to lint. Example: ./run_linter.py vpr",
+        help="Files or directories to lint. Example: ./dev/run_linter.py vpr",
     )
     parser.add_argument(
         "-p",
@@ -39,7 +39,7 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument(
         "-j",
         "--jobs",
-        default=str(os.cpu_count() or 1),
+        default=str(1),
         help="Number of clang-tidy instances to run in parallel.",
     )
     parser.add_argument(
@@ -88,7 +88,7 @@ def has_forwarded_option(args: list[str], option: str) -> bool:
 def main() -> int:
     """Run the linter wrapper and return run-clang-tidy's exit code."""
     args, forwarded_args = parse_args()
-    repo_root = Path(__file__).resolve().parent
+    repo_root = Path(__file__).resolve().parent.parent
     runner = shutil.which(args.run_clang_tidy)
 
     if runner is None:
@@ -111,8 +111,6 @@ def main() -> int:
         command.extend(["-clang-tidy-binary", args.clang_tidy])
     if args.fix:
         command.append("-fix")
-    if not has_forwarded_option(forwarded_args, "-warnings-as-errors"):
-        command.extend(["-warnings-as-errors", "*"])
 
     filter_regex = path_regex(args.paths, repo_root)
     if filter_regex is not None:

--- a/run_linter.py
+++ b/run_linter.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """
-Small project wrapper around LLVM's run-clang-tidy script. Run using './run_linter.py vpr' to run linter for vpr.
-This script was generated using LLMs. While we have reviewed it and tested the output for some usecases, you should
-not be blindly trusting its output.
+Small wrapper around LLVM's run-clang-tidy script.
+
+Run using './run_linter.py vpr' to run the linter for vpr.
+This script was generated using LLMs. While we have reviewed it and
+tested the output for some use cases, you should not blindly trust its
+output.
 """
 
 from __future__ import annotations
@@ -17,6 +20,7 @@ import sys
 
 
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    """Parse wrapper arguments and preserve unknown args for run-clang-tidy."""
     parser = argparse.ArgumentParser(
         description="Run clang-tidy through LLVM's run-clang-tidy wrapper.",
         epilog="Extra arguments are forwarded to run-clang-tidy.",
@@ -57,6 +61,7 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
 
 
 def path_regex(paths: list[str], repo_root: Path) -> str | None:
+    """Build a run-clang-tidy file matching regex from user paths."""
     if not paths:
         return None
 
@@ -76,10 +81,12 @@ def path_regex(paths: list[str], repo_root: Path) -> str | None:
 
 
 def has_forwarded_option(args: list[str], option: str) -> bool:
+    """Return whether an option was already passed through by the user."""
     return any(arg == option or arg.startswith(f"{option}=") for arg in args)
 
 
 def main() -> int:
+    """Run the linter wrapper and return run-clang-tidy's exit code."""
     args, forwarded_args = parse_args()
     repo_root = Path(__file__).resolve().parent
     runner = shutil.which(args.run_clang_tidy)

--- a/run_linter.py
+++ b/run_linter.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Small project wrapper around LLVM's run-clang-tidy script. Run using './run_linter.py vpr' to run linter for vpr.
+This script was generated using LLMs. While we have reviewed it and tested the output for some usecases, you should
+not be blindly trusting its output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(
+        description="Run clang-tidy through LLVM's run-clang-tidy wrapper.",
+        epilog="Extra arguments are forwarded to run-clang-tidy.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files or directories to lint. Example: ./run_linter.py vpr",
+    )
+    parser.add_argument(
+        "-p",
+        "--build-dir",
+        default="build",
+        help="Directory containing compile_commands.json.",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        default=str(os.cpu_count() or 1),
+        help="Number of clang-tidy instances to run in parallel.",
+    )
+    parser.add_argument(
+        "--run-clang-tidy",
+        default=os.environ.get("RUN_CLANG_TIDY", "run-clang-tidy"),
+        help="LLVM run-clang-tidy executable to use.",
+    )
+    parser.add_argument(
+        "--clang-tidy",
+        default=os.environ.get("CLANG_TIDY"),
+        help="clang-tidy executable to pass to run-clang-tidy.",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Forward -fix to run-clang-tidy.",
+    )
+    return parser.parse_known_args()
+
+
+def path_regex(paths: list[str], repo_root: Path) -> str | None:
+    if not paths:
+        return None
+
+    patterns = []
+    for path in paths:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = repo_root / candidate
+        candidate = candidate.resolve()
+
+        if candidate.is_dir():
+            patterns.append(f"{re.escape(candidate.as_posix())}(/|$)")
+        else:
+            patterns.append(re.escape(candidate.as_posix()))
+
+    return f"^({'|'.join(patterns)})"
+
+
+def has_forwarded_option(args: list[str], option: str) -> bool:
+    return any(arg == option or arg.startswith(f"{option}=") for arg in args)
+
+
+def main() -> int:
+    args, forwarded_args = parse_args()
+    repo_root = Path(__file__).resolve().parent
+    runner = shutil.which(args.run_clang_tidy)
+
+    if runner is None:
+        print(
+            f"error: run-clang-tidy executable not found: {args.run_clang_tidy}",
+            file=sys.stderr,
+        )
+        return 2
+
+    command = [
+        runner,
+        "-p",
+        str((repo_root / args.build_dir).resolve()),
+        "-j",
+        str(args.jobs),
+        "-quiet",
+    ]
+
+    if args.clang_tidy:
+        command.extend(["-clang-tidy-binary", args.clang_tidy])
+    if args.fix:
+        command.append("-fix")
+    if not has_forwarded_option(forwarded_args, "-warnings-as-errors"):
+        command.extend(["-warnings-as-errors", "*"])
+
+    filter_regex = path_regex(args.paths, repo_root)
+    if filter_regex is not None:
+        if not has_forwarded_option(forwarded_args, "-header-filter"):
+            command.extend(["-header-filter", filter_regex])
+        command.append(filter_regex)
+
+    command.extend(forwarded_args)
+    return subprocess.call(command, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vpr/src/analytical_place/flat_placement_density_manager.cpp
+++ b/vpr/src/analytical_place/flat_placement_density_manager.cpp
@@ -177,7 +177,7 @@ FlatPlacementDensityManager::FlatPlacementDensityManager(const APNetlist& ap_net
                 // tile type..
                 float target_density = phy_ty_target_densities[tile_type->index];
                 bin_target_density_.push_back(target_density);
-                VTR_ASSERT(bin_target_density_[new_bin_id] = target_density);
+                VTR_ASSERT(bin_target_density_[new_bin_id] == target_density);
             }
         }
     }

--- a/vpr/src/analytical_place/partial_legalizer.cpp
+++ b/vpr/src/analytical_place/partial_legalizer.cpp
@@ -1614,9 +1614,9 @@ PartitionedWindow BiPartitioningPartialLegalizer::partition_window(
     }
 
     // Next, try all of the vertical partitions.
-    double min_pivot_x = std::floor(window.region.xmin()) + 1.0;
-    double max_pivot_x = std::ceil(window.region.xmax()) - 1.0;
-    for (double pivot_x = min_pivot_x; pivot_x <= max_pivot_x; pivot_x++) {
+    int min_pivot_x = std::floor(window.region.xmin()) + 1.0;
+    int max_pivot_x = std::ceil(window.region.xmax()) - 1.0;
+    for (int pivot_x = min_pivot_x; pivot_x <= max_pivot_x; pivot_x++) {
         // Cut the region at this cut line.
         auto lower_region = vtr::Rect<double>(vtr::Point<double>(window.region.xmin(),
                                                                  window.region.ymin()),
@@ -1664,9 +1664,9 @@ PartitionedWindow BiPartitioningPartialLegalizer::partition_window(
     }
 
     // Next, try all of the horizontal partitions.
-    double min_pivot_y = std::floor(window.region.ymin()) + 1.0;
-    double max_pivot_y = std::ceil(window.region.ymax()) - 1.0;
-    for (double pivot_y = min_pivot_y; pivot_y <= max_pivot_y; pivot_y++) {
+    int min_pivot_y = std::floor(window.region.ymin()) + 1.0;
+    int max_pivot_y = std::ceil(window.region.ymax()) - 1.0;
+    for (int pivot_y = min_pivot_y; pivot_y <= max_pivot_y; pivot_y++) {
         // Cut the region at this cut line.
         auto lower_region = vtr::Rect<double>(vtr::Point<double>(window.region.xmin(),
                                                                  window.region.ymin()),

--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -2634,8 +2634,6 @@ class MergedNetlistWriterVisitor : public NetlistWriterVisitor {
     void print_primary_io(int depth) override {
         //Primary Inputs
         for (auto iter = inputs_.begin(); iter != inputs_.end(); ++iter) {
-            //verilog_os_ << indent(depth + 1) << "input " << escape_verilog_identifier(*iter);
-            std::string range;
             if (portmap[*iter] > 0)
                 verilog_os_ << indent(depth + 1) << "input [" << portmap[*iter] << ":0] " << *iter;
             else
@@ -2648,7 +2646,6 @@ class MergedNetlistWriterVisitor : public NetlistWriterVisitor {
 
         //Primary Outputs
         for (auto iter = outputs_.begin(); iter != outputs_.end(); ++iter) {
-            std::string range;
             if (portmap[*iter] > 0)
                 verilog_os_ << indent(depth + 1) << "output [" << portmap[*iter] << ":0] " << *iter;
             else

--- a/vpr/src/base/place_and_route.h
+++ b/vpr/src/base/place_and_route.h
@@ -1,21 +1,8 @@
 #pragma once
 
-#define INFINITE -1
-
-#define WNEED 1
-#define WL 2
-
 #include "vpr_types.h"
 #include "timing_info.h"
 #include "RoutingDelayCalculator.h"
-
-struct t_fmap_cell {
-    int fs;         ///<at this fs
-    int fc;         ///<at this fc
-    int wneed;      ///<need wneed to route
-    int wirelength; ///<corresponding wirelength of successful routing at wneed
-    t_fmap_cell* next;
-};
 
 int binary_search_place_and_route(const Netlist<>& placement_net_list,
                                   const Netlist<>& router_net_list,

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -80,7 +80,6 @@ struct BlifAllocCallback : public blifparse::Callback {
         VTR_ASSERT_MSG(blk_model.outputs->size == 1, "Inpad model has non-single-bit output port");
         VTR_ASSERT_MSG(!blk_model.outputs->next, "Inpad model has multiple output ports");
 
-        std::string pin_name = blk_model.outputs->name;
         for (const auto& input : input_names) {
             AtomBlockId blk_id = curr_model().create_block(input, blk_model_id);
             AtomPortId port_id = curr_model().create_port(blk_id, blk_model.outputs);
@@ -99,7 +98,6 @@ struct BlifAllocCallback : public blifparse::Callback {
         VTR_ASSERT_MSG(blk_model.inputs->size == 1, "Outpad model has non-single-bit input port");
         VTR_ASSERT_MSG(!blk_model.inputs->next, "Outpad model has multiple input ports");
 
-        std::string pin_name = blk_model.inputs->name;
         for (const auto& output : output_names) {
             //Since we name blocks based on their drivers we need to uniquify outpad names,
             //which we do with a prefix

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -245,7 +245,7 @@ static void process_route(const Netlist<>& net_list,
         } else if (tokens[0][0] == '#') {
             continue; //Skip commented lines
         } else if (tokens[0] == "Net") {
-            ClusterNetId inet(atoi(tokens[1].c_str()));
+            ClusterNetId inet(std::stoi(tokens[1]));
             process_nets(net_list,
                          fp,
                          inet,
@@ -329,8 +329,8 @@ static void process_nodes(const Netlist<>& net_list,
 
     /*remember the position of the last line in order to go back*/
     std::streampos oldpos = fp.tellg();
-    int inode, layer_num, x, y, layer_num2, x2, y2, ptc, switch_id, net_pin_index, offset;
-    std::string prev_type;
+    short switch_id;
+    int inode, layer_num, x, y, layer_num2, x2, y2, ptc, net_pin_index, offset;
     int node_count = 0;
     std::string input;
     std::vector<std::string> tokens;
@@ -360,7 +360,7 @@ static void process_nodes(const Netlist<>& net_list,
             break;
         } else if (tokens[0] == "Node:") {
             /*An actual line, go through each node and add it to the route tree*/
-            inode = atoi(tokens[1].c_str());
+            inode = std::stoi(tokens[1]);
 
             /*First node needs to be source. It is isolated to correctly set heap head.*/
             if (node_count == 0 && tokens[2] != "SOURCE") {
@@ -420,7 +420,7 @@ static void process_nodes(const Netlist<>& net_list,
                 }
             }
 
-            ptc = atoi(tokens[5 + offset].c_str());
+            ptc = std::stoi(tokens[5 + offset]);
             if (rr_graph.node_ptc_num(RRNodeId(inode)) != ptc) {
                 vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                           "The ptc num of node %d does not match the rr graph, Running without flat routing; "
@@ -466,9 +466,10 @@ static void process_nodes(const Netlist<>& net_list,
                     vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                               "%d node does not have correct pins", inode);
                 }
-                switch_id = atoi(tokens[8 + offset].c_str());
+
+                switch_id = static_cast<short>(std::stoi(tokens[8 + offset]));
             } else {
-                switch_id = atoi(tokens[7 + offset].c_str());
+                switch_id = static_cast<short>(std::stoi(tokens[7 + offset]));
             }
 
             /* Process net pin index for sinks                                   *
@@ -477,7 +478,7 @@ static void process_nodes(const Netlist<>& net_list,
              * information for sinks. If not, plrase re-generate the routing.    */
             if (tokens[2] == "SINK") {
                 if (tokens[8 + offset] == "Net_pin_index:") {
-                    net_pin_index = atoi(tokens[9 + offset].c_str());
+                    net_pin_index = std::stoi(tokens[9 + offset]);
                 } else {
                     vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                               "%d (sink) node does not have net pin index. If you are using an old .route file without this information, please re-generate the routing.", inode);
@@ -543,7 +544,7 @@ static void process_global_blocks(const Netlist<>& net_list, std::ifstream& fp, 
             bnum_str = format_name(tokens[2]);
             /*remove #*/
             bnum_str.erase(bnum_str.begin());
-            ParentBlockId bnum(atoi(bnum_str.c_str()));
+            ParentBlockId bnum(std::stoi(bnum_str));
 
             /*Check for name, coordinate, and pins*/
             if (0 != net_list.block_name(bnum).compare(tokens[1])) {
@@ -562,10 +563,10 @@ static void process_global_blocks(const Netlist<>& net_list, std::ifstream& fp, 
             }
 
             auto pin_class = get_class_range_for_block(bnum, is_flat);
-            if (pin_class.low > atoi(tokens[7].c_str()) || pin_class.high < atoi(tokens[7].c_str())) {
+            if (pin_class.low > std::stoi(tokens[7]) || pin_class.high < std::stoi(tokens[7])) {
                 vpr_throw(VPR_ERROR_ROUTE, filename, lineno,
                           "The pin class %d of %lu net does not match given ",
-                          atoi(tokens[7].c_str()), size_t(inet));
+                          std::stoi(tokens[7]), size_t(inet));
             }
         }
         oldpos = fp.tellg();

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1224,7 +1224,7 @@ static void run_graphics_commands(const std::string& commands) {
             std::string name = vtr::replace_all(name_ext[0], "{i}",
                                                 std::to_string(draw_state->sequence_number));
 
-            save_graphics(/*extension=*/name_ext[1], /*filename=*/name);
+            save_graphics(/*extension=*/name_ext[1], /*file_name=*/name);
             VTR_LOG("Saving to %s\n", std::string(name + name_ext[1]).c_str());
 
         } else if (cmd[0] == "set_macros") {

--- a/vpr/src/draw/draw_debug.cpp
+++ b/vpr/src/draw/draw_debug.cpp
@@ -452,7 +452,7 @@ void set_moves_button_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     GtkWidget* entry = gtk_grid_get_child_at(GTK_GRID(grid), 1, 1);
 
     //check for input validity
-    int moves = atoi(gtk_entry_get_text((GtkEntry*)entry));
+    int moves = std::stoi(gtk_entry_get_text((GtkEntry*)entry));
     if (moves >= 1 && strchr(gtk_entry_get_text((GtkEntry*)entry), '.') == NULL) {
         draw_state->list_of_breakpoints.push_back(Breakpoint(BT_MOVE_NUM, moves));
         std::string bpDescription = "Breakpoint at move_num += " + std::to_string(moves);
@@ -467,7 +467,7 @@ void set_temp_button_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     GtkWidget* entry = gtk_grid_get_child_at((GtkGrid*)grid, 1, 2);
 
     //input validity
-    int temps = atoi(gtk_entry_get_text((GtkEntry*)entry));
+    int temps = std::stoi(gtk_entry_get_text((GtkEntry*)entry));
     if (temps >= 1 && strchr(gtk_entry_get_text((GtkEntry*)entry), '.') == NULL) {
         draw_state->list_of_breakpoints.push_back(Breakpoint(BT_TEMP_NUM, temps));
         std::string bpDescription = "Breakpoint at temp_count += " + std::to_string(temps);
@@ -481,7 +481,7 @@ void set_block_button_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     t_draw_state* draw_state = get_draw_state_vars();
     GtkWidget* entry = gtk_grid_get_child_at((GtkGrid*)grid, 1, 3);
 
-    draw_state->list_of_breakpoints.push_back(Breakpoint(BT_FROM_BLOCK, atoi(gtk_entry_get_text((GtkEntry*)entry))));
+    draw_state->list_of_breakpoints.push_back(Breakpoint(BT_FROM_BLOCK, std::stoi(gtk_entry_get_text((GtkEntry*)entry))));
     std::string s(gtk_entry_get_text((GtkEntry*)entry));
     std::string bpDescription = "Breakpoint from_block == " + s;
     add_to_bpList(bpDescription);
@@ -493,7 +493,7 @@ void set_router_iter_button_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     GtkWidget* entry = gtk_grid_get_child_at(GTK_GRID(grid), 1, 5);
 
     //check for input validity
-    int iters = atoi(gtk_entry_get_text((GtkEntry*)entry));
+    int iters = std::stoi(gtk_entry_get_text((GtkEntry*)entry));
     if (iters >= 1 && strchr(gtk_entry_get_text((GtkEntry*)entry), '.') == NULL) {
         draw_state->list_of_breakpoints.push_back(Breakpoint(BT_ROUTER_ITER, iters));
         std::string bpDescription = "Breakpoint at router_iter == " + std::to_string(iters);
@@ -507,7 +507,7 @@ void set_net_id_button_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     t_draw_state* draw_state = get_draw_state_vars();
     GtkWidget* entry = gtk_grid_get_child_at((GtkGrid*)grid, 1, 6);
 
-    draw_state->list_of_breakpoints.push_back(Breakpoint(BT_ROUTE_NET_ID, atoi(gtk_entry_get_text((GtkEntry*)entry))));
+    draw_state->list_of_breakpoints.push_back(Breakpoint(BT_ROUTE_NET_ID, std::stoi(gtk_entry_get_text((GtkEntry*)entry))));
     std::string s(gtk_entry_get_text((GtkEntry*)entry));
     std::string bpDescription = "Breakpoint route_net_id == " + s;
     add_to_bpList(bpDescription);

--- a/vpr/src/draw/manual_moves.cpp
+++ b/vpr/src/draw/manual_moves.cpp
@@ -105,7 +105,7 @@ void calculate_cost_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     std::string block_id_string = gtk_entry_get_text((GtkEntry*)block_entry);
 
     if (string_is_a_number(block_id_string)) { //for block ID
-        block_id = std::atoi(block_id_string.c_str());
+        block_id = std::stoi(block_id_string);
     } else { //for block name
         block_id = size_t(cluster_ctx.clb_nlist.find_block(gtk_entry_get_text((GtkEntry*)block_entry)));
     }
@@ -115,10 +115,10 @@ void calculate_cost_callback(GtkWidget* /*widget*/, GtkWidget* grid) {
     GtkWidget* layer_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 3);
     GtkWidget* subtile_position_entry = gtk_grid_get_child_at((GtkGrid*)grid, 2, 4);
 
-    int x_location = std::atoi(gtk_entry_get_text((GtkEntry*)x_position_entry));
-    int y_location = std::atoi(gtk_entry_get_text((GtkEntry*)y_position_entry));
-    int layer_location = std::atoi(gtk_entry_get_text((GtkEntry*)layer_position_entry));
-    int subtile_location = std::atoi(gtk_entry_get_text((GtkEntry*)subtile_position_entry));
+    int x_location = std::stoi(gtk_entry_get_text((GtkEntry*)x_position_entry));
+    int y_location = std::stoi(gtk_entry_get_text((GtkEntry*)y_position_entry));
+    int layer_location = std::stoi(gtk_entry_get_text((GtkEntry*)layer_position_entry));
+    int subtile_location = std::stoi(gtk_entry_get_text((GtkEntry*)subtile_position_entry));
 
     if (std::string(gtk_entry_get_text((GtkEntry*)block_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)x_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)y_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)layer_position_entry)).empty() || std::string(gtk_entry_get_text((GtkEntry*)subtile_position_entry)).empty()) {
         invalid_breakpoint_entry_window("Not all fields are complete");

--- a/vpr/src/noc/read_xml_noc_traffic_flows_file.cpp
+++ b/vpr/src/noc/read_xml_noc_traffic_flows_file.cpp
@@ -139,7 +139,7 @@ double get_traffic_flow_bandwidth(pugi::xml_node single_flow_tag, const pugiutil
     std::string traffic_flow_bandwidth_intermediate_val = pugiutil::get_attribute(single_flow_tag, "bandwidth", loc_data, pugiutil::REQUIRED).as_string();
 
     // now convert the value to double
-    traffic_flow_bandwidth = std::atof(traffic_flow_bandwidth_intermediate_val.c_str());
+    traffic_flow_bandwidth = std::stof(traffic_flow_bandwidth_intermediate_val);
 
     return traffic_flow_bandwidth;
 }
@@ -160,7 +160,7 @@ double get_max_traffic_flow_latency(pugi::xml_node single_flow_tag, const pugiut
         max_traffic_flow_latency_intermediate_val = max_traffic_flow_latency_attribute.as_string();
 
         // now convert the value to double
-        max_traffic_flow_latency = std::atof(max_traffic_flow_latency_intermediate_val.c_str());
+        max_traffic_flow_latency = std::stof(max_traffic_flow_latency_intermediate_val);
     }
 
     return max_traffic_flow_latency;

--- a/vpr/src/pack/cluster_util.cpp
+++ b/vpr/src/pack/cluster_util.cpp
@@ -211,7 +211,6 @@ size_t update_pb_type_count(const t_pb* pb, std::map<t_pb_type*, int>& pb_type_c
     t_pb_graph_node* pb_graph_node = pb->pb_graph_node;
     t_pb_type* pb_type = pb_graph_node->pb_type;
     t_mode* mode = &pb_type->modes[pb->mode];
-    std::string pb_type_name(pb_type->name);
 
     pb_type_count[pb_type]++;
 

--- a/vpr/src/pack/pack_report.cpp
+++ b/vpr/src/pack/pack_report.cpp
@@ -31,8 +31,8 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
     for (auto blk : cluster_ctx.clb_nlist.blocks()) {
         t_logical_block_type_ptr type = cluster_ctx.clb_nlist.block_type(blk);
 
-        inputs_used[type].push_back(cluster_ctx.clb_nlist.block_input_pins(blk).size() + cluster_ctx.clb_nlist.block_clock_pins(blk).size());
-        outputs_used[type].push_back(cluster_ctx.clb_nlist.block_output_pins(blk).size());
+        inputs_used[type].push_back(static_cast<float>(cluster_ctx.clb_nlist.block_input_pins(blk).size() + cluster_ctx.clb_nlist.block_clock_pins(blk).size()));
+        outputs_used[type].push_back(static_cast<float>(cluster_ctx.clb_nlist.block_output_pins(blk).size()));
     }
 
     vtr::OsFormatGuard os_guard(os);
@@ -44,27 +44,27 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
         if (is_empty_type(type)) continue;
         if (!inputs_used.count(type)) continue;
 
-        float max_inputs = *std::max_element(inputs_used[type].begin(), inputs_used[type].end());
-        float min_inputs = *std::min_element(inputs_used[type].begin(), inputs_used[type].end());
-        float avg_inputs = std::accumulate(inputs_used[type].begin(), inputs_used[type].end(), 0) / float(inputs_used[type].size());
+        float max_inputs = static_cast<float>(*std::max_element(inputs_used[type].begin(), inputs_used[type].end()));
+        float min_inputs = static_cast<float>(*std::min_element(inputs_used[type].begin(), inputs_used[type].end()));
+        float avg_inputs = static_cast<float>(std::accumulate(inputs_used[type].begin(), inputs_used[type].end(), 0.f)) / static_cast<float>(inputs_used[type].size());
 
         float max_outputs = *std::max_element(outputs_used[type].begin(), outputs_used[type].end());
         float min_outputs = *std::min_element(outputs_used[type].begin(), outputs_used[type].end());
-        float avg_outputs = std::accumulate(outputs_used[type].begin(), outputs_used[type].end(), 0) / float(outputs_used[type].size());
+        float avg_outputs = std::accumulate(outputs_used[type].begin(), outputs_used[type].end(), 0.f) / static_cast<float>(outputs_used[type].size());
 
         os << "Type: " << type->name << "\n";
 
         os << "\tInput Pin Usage:\n";
-        os << "\t\tMax: " << max_inputs << " (" << max_inputs / float(total_input_pins[type]) << ")"
+        os << "\t\tMax: " << max_inputs << " (" << max_inputs / static_cast<float>(total_input_pins[type]) << ")"
            << "\n";
-        os << "\t\tAvg: " << avg_inputs << " (" << avg_inputs / float(total_input_pins[type]) << ")"
+        os << "\t\tAvg: " << avg_inputs << " (" << avg_inputs / static_cast<float>(total_input_pins[type]) << ")"
            << "\n";
-        os << "\t\tMin: " << min_inputs << " (" << min_inputs / float(total_input_pins[type]) << ")"
+        os << "\t\tMin: " << min_inputs << " (" << min_inputs / static_cast<float>(total_input_pins[type]) << ")"
            << "\n";
 
         if (total_input_pins[type] != 0) {
             os << "\t\tHistogram:\n";
-            auto input_histogram = build_histogram(inputs_used[type], 10, 0, total_input_pins[type]);
+            auto input_histogram = build_histogram(inputs_used[type], 10, 0, static_cast<float>(total_input_pins[type]));
             for (const std::string& line : format_histogram(input_histogram)) {
                 os << "\t\t" << line << "\n";
             }
@@ -81,7 +81,7 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
         if (total_output_pins[type] != 0) {
             os << "\t\tHistogram:\n";
 
-            auto output_histogram = build_histogram(outputs_used[type], 10, 0, total_output_pins[type]);
+            auto output_histogram = build_histogram(outputs_used[type], 10, 0, static_cast<float>(total_output_pins[type]));
             for (auto line : format_histogram(output_histogram)) {
                 os << "\t\t" << line << "\n";
             }

--- a/vpr/src/place/annealer.cpp
+++ b/vpr/src/place/annealer.cpp
@@ -251,7 +251,7 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
     VTR_LOG("Moves per temperature: %d\n", first_move_lim);
 
     if (placer_opts.inner_loop_recompute_divider != 0) {
-        inner_recompute_limit_ = static_cast<int>(0.5 + (float)first_move_lim / (float)placer_opts.inner_loop_recompute_divider);
+        inner_recompute_limit_ = std::lround((float)first_move_lim / (float)placer_opts.inner_loop_recompute_divider);
     } else {
         // don't do an inner recompute
         inner_recompute_limit_ = first_move_lim + 1;
@@ -260,7 +260,7 @@ PlacementAnnealer::PlacementAnnealer(const t_placer_opts& placer_opts,
     /* calculate the number of moves in the quench that we should recompute timing after based on the value of *
      * the commandline option quench_recompute_divider                                                         */
     if (placer_opts.quench_recompute_divider != 0) {
-        quench_recompute_limit_ = static_cast<int>(0.5 + (float)move_lim / (float)placer_opts.quench_recompute_divider);
+        quench_recompute_limit_ = std::lround((float)move_lim / (float)placer_opts.quench_recompute_divider);
     } else {
         // don't do an quench recompute
         quench_recompute_limit_ = first_move_lim + 1;

--- a/vpr/src/power/power_util.cpp
+++ b/vpr/src/power/power_util.cpp
@@ -412,8 +412,7 @@ static void alloc_and_load_mux_graph_recursive(t_mux_node* node,
     int child_idx;
     int pin_idx = starting_pin_idx;
 
-    node->num_inputs = (int)(pow(num_primary_inputs, 1 / ((float)level + 1))
-                             + 0.5);
+    node->num_inputs = std::lround(pow(num_primary_inputs, 1 / ((float)level + 1)));
     node->level = level;
     node->starting_pin_idx = starting_pin_idx;
 

--- a/vpr/src/route/route_budgets.h
+++ b/vpr/src/route/route_budgets.h
@@ -20,7 +20,7 @@ enum slack_allocated_type {
     BOTH
 };
 
-#define UNINITIALIZED_PATH_DELAY -2.
+#define UNINITIALIZED_PATH_DELAY (-2)
 class route_budgets {
   public:
     route_budgets(const Netlist<>& net_list, bool is_flat);

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/crr_generator/crr_edge_builder.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/crr_generator/crr_edge_builder.cpp
@@ -56,7 +56,7 @@ std::unordered_map<int, RRSwitchId> pre_create_crr_switches(const int min_delay_
         return delay_to_switch_id;
     }
 
-    delay_to_switch_id.reserve(static_cast<size_t>(max_delay_ps - min_delay_ps + 1));
+    delay_to_switch_id.reserve(max_delay_ps - min_delay_ps + 1);
     for (int delay_ps = min_delay_ps; delay_ps <= max_delay_ps; ++delay_ps) {
         int sw_id = static_cast<int>(all_sw_inf.size());
         all_sw_inf.emplace(sw_id, create_crr_switch(delay_ps));

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/crr_generator/crr_pattern_matcher.h
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/crr_generator/crr_pattern_matcher.h
@@ -96,7 +96,6 @@ class CRRPatternMatcher {
                 // Find the matching closing bracket
                 size_t close_bracket = pattern.find(']', i);
                 if (close_bracket != std::string::npos) {
-                    std::string range = pattern.substr(i, close_bracket - i + 1);
                     regex_pattern += "([0-9]+)"; // Capture the number, validate range later
                     i = close_bracket;           // Skip to after the closing bracket
                 } else {

--- a/vpr/src/server/telegrambuffer.cpp
+++ b/vpr/src/server/telegrambuffer.cpp
@@ -51,8 +51,6 @@ void TelegramBuffer::take_telegram_frames(std::vector<comm::TelegramFramePtr>& r
                     TelegramFramePtr telegram_frame_ptr = std::make_shared<TelegramFrame>();
                     telegram_frame_ptr->header = header;
                     telegram_frame_ptr->body = std::move(body);
-                    body.clear(); // post std::move safety step
-
                     result.push_back(telegram_frame_ptr);
                 } else {
                     m_errors.push_back("wrong checkSums " + std::to_string(actual_check_sum) + " for " + header.info() + " , drop this chunk");

--- a/vpr/src/server/telegramheader.cpp
+++ b/vpr/src/server/telegramheader.cpp
@@ -35,7 +35,7 @@ TelegramHeader::TelegramHeader(const ByteArray& buffer) {
 
     if (buffer.size() >= TelegramHeader::size()) {
         // Check the signature to ensure that this is a valid header
-        if (std::memcmp(buffer.data(), TelegramHeader::SIGNATURE, TelegramHeader::SIGNATURE_SIZE)) {
+        if (std::memcmp(buffer.data(), TelegramHeader::SIGNATURE, TelegramHeader::SIGNATURE_SIZE) != 0) {
             has_error = true;
         }
 
@@ -67,7 +67,7 @@ std::string TelegramHeader::info() const {
        << "l=" << get_pretty_size_str_from_bytes_num(m_body_bytes_num)
        << "/s=" << m_body_check_sum;
     if (m_compressor_id) {
-        ss << "/c=" << m_compressor_id;
+        ss << "/c=" << static_cast<int>(m_compressor_id);
     }
     ss << "]";
     return ss.str();

--- a/vpr/test/test_compressed_grid.cpp
+++ b/vpr/test/test_compressed_grid.cpp
@@ -40,8 +40,6 @@ void set_tile_type_at_loc(const int x_anchor, const int y_anchor, vtr::NdMatrix<
 }
 
 TEST_CASE("test_compressed_grid", "[vpr_compressed_grid]") {
-    // test device grid name
-    std::string device_grid_name = "test";
 
     // creating a reference for the empty tile name and router name
     char empty_tile_name[] = "empty";

--- a/vpr/test/test_noc_place_utils.cpp
+++ b/vpr/test/test_noc_place_utils.cpp
@@ -41,7 +41,7 @@ TEST_CASE("test_initial_noc_placement", "[noc_place_utils]") {
     // set NoC link bandwidth
     // dist_2 is used to generate traffic flow bandwidths.
     // Setting the NoC link bandwidth to max() / 5 makes link congestion more likely to happen
-    const double noc_link_bandwidth = dist_2.max() / 5;
+    const double noc_link_bandwidth = dist_2.max() / 5.0;
     constexpr double noc_link_latency = 1.0;
     constexpr double noc_router_latency = 1.0;
     noc_ctx.noc_model.set_noc_link_bandwidth(noc_link_bandwidth);

--- a/vpr/test/test_setup_noc.cpp
+++ b/vpr/test/test_setup_noc.cpp
@@ -132,7 +132,7 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
         t_grid_def grid_def;
         grid_def.name = device_grid_name;
         grid_def.layers.resize(1);
-        DeviceGrid test_device = DeviceGrid(grid_def, std::move(test_grid));
+        DeviceGrid test_device = DeviceGrid(grid_def, test_grid);
 
         // call the test function
         list_of_routers = identify_and_store_noc_router_tile_positions(test_device, router_tile_name);
@@ -252,7 +252,7 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
         t_grid_def grid_def;
         grid_def.name = device_grid_name;
         grid_def.layers.resize(1);
-        DeviceGrid test_device = DeviceGrid(grid_def, std::move(test_grid));
+        DeviceGrid test_device = DeviceGrid(grid_def, test_grid);
 
         // call the test function
         list_of_routers = identify_and_store_noc_router_tile_positions(test_device, router_tile_name);
@@ -372,7 +372,7 @@ TEST_CASE("test_identify_and_store_noc_router_tile_positions", "[vpr_setup_noc]"
         t_grid_def grid_def;
         grid_def.name = device_grid_name;
         grid_def.layers.resize(1);
-        DeviceGrid test_device = DeviceGrid(grid_def, std::move(test_grid));
+        DeviceGrid test_device = DeviceGrid(grid_def, test_grid);
 
         // call the test function
         list_of_routers = identify_and_store_noc_router_tile_positions(test_device, router_tile_name);
@@ -538,8 +538,6 @@ TEST_CASE("test_create_noc_routers", "[vpr_setup_noc]") {
         // this is similar to the user provided a config file
         temp_router = new t_router;
 
-        NocRouterId noc_router_id;
-
         for (int router_id = 1; router_id < 9; router_id++) {
             // we will have 6 logical routers that will take up the bottom and middle physical routers of the mesh
             temp_router->device_x_position = list_of_routers[router_id - 1].tile_centroid_x;
@@ -566,8 +564,6 @@ TEST_CASE("test_create_noc_routers", "[vpr_setup_noc]") {
         // start by creating all the logical routers
         // this is similar to the user provided a config file
         temp_router = new t_router;
-
-        NocRouterId noc_router_id;
 
         for (int router_id = 1; router_id < 9; router_id++) {
             // we will have 6 logical routers that will take up the bottom and middle physical routers of the mesh
@@ -941,7 +937,7 @@ TEST_CASE("test_setup_noc", "[vpr_setup_noc]") {
         t_grid_def grid_def;
         grid_def.name = device_grid_name;
         grid_def.layers.resize(1);
-        device_ctx.grid = DeviceGrid(grid_def, std::move(test_grid));
+        device_ctx.grid = DeviceGrid(grid_def, test_grid);
 
         REQUIRE_THROWS_WITH(setup_noc(arch), "The Provided NoC topology information in the architecture file has more number of routers than what is available in the FPGA device.");
     }
@@ -995,7 +991,7 @@ TEST_CASE("test_setup_noc", "[vpr_setup_noc]") {
         t_grid_def grid_def;
         grid_def.name = device_grid_name;
         grid_def.layers.resize(1);
-        device_ctx.grid = DeviceGrid(grid_def, std::move(test_grid));
+        device_ctx.grid = DeviceGrid(grid_def, test_grid);
 
         REQUIRE_THROWS_WITH(setup_noc(arch), "No physical NoC routers were found on the FPGA device. Either the provided name for the physical router tile was incorrect or the FPGA device has no routers.");
     }
@@ -1233,7 +1229,7 @@ TEST_CASE("test_setup_noc", "[vpr_setup_noc]") {
         t_grid_def grid_def;
         grid_def.name = device_grid_name;
         grid_def.layers.resize(1);
-        device_ctx.grid = DeviceGrid(grid_def, std::move(test_grid));
+        device_ctx.grid = DeviceGrid(grid_def, test_grid);
 
         REQUIRE_NOTHROW(setup_noc(arch));
 


### PR DESCRIPTION
This PR adds a helper script to run clang-tidy, along with a config with some sensible checks enabled. There's also fixes for all the stuff that were flagged by clang-tidy. I don't want to add this to CI yet, but it would be nice at some point.

Here's some of the issues flagged by clang-tidy and fixed in this PR:

>VTR_ASSERT(bin_target_density_[new_bin_id] = target_density);

Assignment instead of comparision

> for (double pivot_x = min_pivot_x; pivot_x <= max_pivot_x; pivot_x++)

Floating point loop index

> block_id = std::atoi(block_id_string.c_str());
 
could simply use std::stoi instead. We had lots of this.

> static_cast<int>(0.5 + (float)first_move_lim / (float)placer_opts.inner_loop_recompute_divider);

Wrong way to round a float. For example static_cast<int>(0.5 + 0.499999975) results in 1 instead of zero.

> ss << "/c=" << m_compressor_id;

Because m_compressor_id is char, this actually prints a character instead the numerical id.

> const double noc_link_bandwidth = dist_2.max() / 5;

integer division into a float.

__________________

And a lot of use after moves. I overall think this is a good addition to our CI. Note that I think some of the static_cast changes are not needed anymore since I decided to exclude narrowing cast warnings. If you think they're excessive, I can remove them.