### PR TITLE
Remove legacy memory management code

### DIFF
--- a/libs/librrgraph/src/base/rr_graph_storage.h
+++ b/libs/librrgraph/src/base/rr_graph_storage.h
@@ -1005,7 +1005,7 @@ class t_rr_graph_storage {
      * storage_ stores the core RR node data used by the router and is **very**
      * hot.
      */
-    vtr::vector<RRNodeId, t_rr_node_data, vtr::aligned_allocator<t_rr_node_data>> node_storage_;
+    vtr::vector<RRNodeId, t_rr_node_data> node_storage_;
 
     /** @brief
      * The PTC data is cold data, and is generally not used during the inner

--- a/libs/libvtrutil/src/vtr_memory.cpp
+++ b/libs/libvtrutil/src/vtr_memory.cpp
@@ -35,11 +35,10 @@ void* free(void* some) {
 }
 
 void* calloc(size_t nelem, size_t size) {
-    void* ret;
     if (nelem == 0) {
         return nullptr;
     }
-    ret = std::calloc(nelem, size);
+    void* ret = std::calloc(nelem, size);
     if (ret == nullptr) {
         throw VtrError("Unable to calloc memory.", __FILE__, __LINE__);
     }

--- a/libs/libvtrutil/src/vtr_memory.cpp
+++ b/libs/libvtrutil/src/vtr_memory.cpp
@@ -39,139 +39,32 @@ void* calloc(size_t nelem, size_t size) {
     if (nelem == 0) {
         return nullptr;
     }
-
-    if ((ret = std::calloc(nelem, size)) == nullptr) {
+    ret = std::calloc(nelem, size);
+    if (ret == nullptr) {
         throw VtrError("Unable to calloc memory.", __FILE__, __LINE__);
     }
     return ret;
 }
 
 void* malloc(size_t size) {
-    void* ret;
     if (size == 0) {
         return nullptr;
     }
-
-    if ((ret = std::malloc(size)) == nullptr && size != 0) {
+    void* ret = std::malloc(size);
+    if (ret == nullptr && size != 0) {
         throw VtrError("Unable to malloc memory.", __FILE__, __LINE__);
     }
     return ret;
 }
 
 void* realloc(void* ptr, size_t size) {
-    void* ret;
 
-    ret = std::realloc(ptr, size);
+    void* ret = std::realloc(ptr, size);
     if (nullptr == ret && size != 0) {
         throw VtrError(string_fmt("Unable to realloc memory (ptr=%p, size=%d).", ptr, size),
                        __FILE__, __LINE__);
     }
     return ret;
-}
-
-void* chunk_malloc(size_t size, t_chunk* chunk_info) {
-    /* This routine should be used for allocating fairly small data             *
-     * structures where memory-efficiency is crucial.  This routine allocates   *
-     * large "chunks" of data, and parcels them out as requested.  Whenever     *
-     * it mallocs a new chunk it adds it to the linked list pointed to by       *
-     * chunk_info->chunk_ptr_head.  This list can be used to free the	    *
-     * chunked memory.							    *
-     * Information about the currently open "chunk" must be stored by the       *
-     * user program.  chunk_info->mem_avail_ptr points to an int storing	    *
-     * how many bytes are left in the current chunk, while			    *
-     * chunk_info->next_mem_loc_ptr is the address of a pointer to the	    *
-     * next free bytes in the chunk.  To start a new chunk, simply set	    *
-     * chunk_info->mem_avail_ptr = 0.  Each independent set of data		    *
-     * structures should use a new chunk.                                       */
-
-    /* To make sure the memory passed back is properly aligned, I must *
-     * only send back chunks in multiples of the worst-case alignment  *
-     * restriction of the machine.  On most machines this should be    *
-     * a long, but on 64-bit machines it might be a long long or a     *
-     * double.  Change the typedef below if this is the case.          */
-
-    typedef size_t Align;
-
-    constexpr int CHUNK_SIZE = 32768;
-    constexpr int FRAGMENT_THRESHOLD = 100;
-
-    char* tmp_ptr;
-    int aligned_size;
-
-    VTR_ASSERT(chunk_info->mem_avail >= 0);
-
-    if ((size_t)(chunk_info->mem_avail) < size) { /* Need to malloc more memory. */
-        if (size > CHUNK_SIZE) {                  /* Too big, use standard routine. */
-                                                  /* Want to allocate a block of memory the size of size.
-                                                   * i.e. malloc(size) */
-            tmp_ptr = new char[size];
-
-            /* When debugging, uncomment the code below to see if memory allocation size */
-            /* makes sense */
-            //#ifdef DEBUG
-            // vtr_printf("NB: my_chunk_malloc got a request for %d bytes.\n", size);
-            // vtr_printf("You should consider using vtr::malloc for such big requests.\n");
-            // #endif
-
-            VTR_ASSERT(chunk_info != nullptr);
-            chunk_info->chunk_ptr_head = insert_in_vptr_list(chunk_info->chunk_ptr_head, tmp_ptr);
-            return tmp_ptr;
-        }
-
-        if (chunk_info->mem_avail < FRAGMENT_THRESHOLD) { /* Only a small scrap left. */
-            chunk_info->next_mem_loc_ptr = new char[CHUNK_SIZE];
-            chunk_info->mem_avail = CHUNK_SIZE;
-            VTR_ASSERT(chunk_info != nullptr);
-            chunk_info->chunk_ptr_head = insert_in_vptr_list(chunk_info->chunk_ptr_head, chunk_info->next_mem_loc_ptr);
-        }
-
-        /* Execute else clause only when the chunk we want is pretty big,  *
-         * and would leave too big an unused fragment.  Then we use malloc *
-         * to allocate normally.                                           */
-
-        else {
-            tmp_ptr = new char[size];
-            VTR_ASSERT(chunk_info != nullptr);
-            chunk_info->chunk_ptr_head = insert_in_vptr_list(chunk_info->chunk_ptr_head, tmp_ptr);
-
-            return tmp_ptr;
-        }
-    }
-
-    /* Find the smallest distance to advance the memory pointer and keep *
-     * everything aligned.                                               */
-
-    if (size % sizeof(Align) == 0) {
-        aligned_size = size;
-    } else {
-        aligned_size = size + sizeof(Align) - size % sizeof(Align);
-    }
-
-    tmp_ptr = chunk_info->next_mem_loc_ptr;
-    chunk_info->next_mem_loc_ptr += aligned_size;
-    chunk_info->mem_avail -= aligned_size;
-    return tmp_ptr;
-}
-
-void free_chunk_memory(t_chunk* chunk_info) {
-    /* Frees the memory allocated by a sequence of calls to my_chunk_malloc. */
-
-    t_linked_vptr *curr_ptr, *prev_ptr;
-
-    curr_ptr = chunk_info->chunk_ptr_head;
-
-    while (curr_ptr != nullptr) {
-        /* Must cast pointers to type char*, since the're of type void*, which delete can't
-         * be called on.*/
-        delete[] ((char*)curr_ptr->data_vptr); /* Free memory "chunk". */
-        prev_ptr = curr_ptr;
-        curr_ptr = curr_ptr->next;
-        delete (t_linked_vptr*)prev_ptr; /* Free memory used to track "chunk". */
-    }
-
-    chunk_info->chunk_ptr_head = nullptr;
-    chunk_info->mem_avail = 0;
-    chunk_info->next_mem_loc_ptr = nullptr;
 }
 
 } // namespace vtr

--- a/libs/libvtrutil/src/vtr_memory.h
+++ b/libs/libvtrutil/src/vtr_memory.h
@@ -33,49 +33,10 @@ void release_memory(Container& container) {
     Container().swap(container);
 }
 
-struct t_linked_vptr; //Forward declaration
-
-/**
- * This structure keeps track to chenks of memory
- *
- * This structure is to keep track of chunks of memory that is being	
- * allocated to save overhead when allocating very small memory pieces. 
- * For a complete description, please see the comment in chunk_malloc
- */
-struct t_chunk {
-    t_linked_vptr* chunk_ptr_head = nullptr;
-
-    //chunk_ptr_head->data_vptr: head of the entire linked
-    //list of allocated "chunk" memory;
-    //chunk_ptr_head->next: pointer to the next chunk on the linked list
-    int mem_avail = 0;                ///< number of bytes left in the current chunk
-    char* next_mem_loc_ptr = nullptr; ///< pointer to the first available (free) byte in the current chunk
-};
-
 void* free(void* some);
 void* calloc(size_t nelem, size_t size);
 void* malloc(size_t size);
 void* realloc(void* ptr, size_t size);
-
-void* chunk_malloc(size_t size, t_chunk* chunk_info);
-void free_chunk_memory(t_chunk* chunk_info);
-
-///@brief Like chunk_malloc, but with proper C++ object initialization
-template<typename T>
-T* chunk_new(t_chunk* chunk_info) {
-    void* block = chunk_malloc(sizeof(T), chunk_info);
-
-    return new (block) T(); //Placement new
-}
-
-///@brief Call the destructor of an obj which must have been allocated in the specified chunk
-template<typename T>
-void chunk_delete(T* obj, t_chunk* /*chunk_info*/) {
-    if (obj) {
-        obj->~T(); // Manually call destructor
-        // Currently we don't mark the unused memory as free
-    }
-}
 
 /**
  * @brief Cross platform wrapper around GNU's malloc_trim()
@@ -83,20 +44,6 @@ void chunk_delete(T* obj, t_chunk* /*chunk_info*/) {
  * TODO: This is only used in one place within VPR, consider removing it
  */
 int malloc_trim(size_t pad);
-
-inline int memalign(void** ptr_out, size_t align, size_t size) {
-#ifdef _WIN32
-    void* temp_ptr = _aligned_malloc(size, align);
-    if (temp_ptr != NULL) {
-        *ptr_out = temp_ptr;
-        return 0;
-    } else {
-        return errno;
-    }
-#else
-    return posix_memalign(ptr_out, align, size);
-#endif
-}
 
 /**
  * @brief A macro generates a prefetch instruction on all architectures that include it.
@@ -107,51 +54,5 @@ inline int memalign(void** ptr_out, size_t align, size_t size) {
  * not just constexpr.
  */
 #define VTR_PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
-
-/**
- * @brief aligned_allocator is a STL allocator that allocates memory in an aligned fashion
- *
- * works if supported by the platform
- * 
- * It is worth noting the C++20 std::allocator does aligned allocations, but
- * C++20 has poor support.
- */
-template<class T>
-struct aligned_allocator {
-    using value_type = T;
-    using pointer = T*;
-    using const_pointer = const T*;
-    using reference = T&;
-    using const_reference = const T&;
-    using size_type = std::size_t;
-    using difference_type = std::ptrdiff_t;
-
-    pointer allocate(size_type n, const void* /*hint*/ = 0) {
-        void* data;
-        int ret = vtr::memalign(&data, alignof(T), sizeof(T) * n);
-        if (ret != 0) {
-            throw std::bad_alloc();
-        }
-        return static_cast<pointer>(data);
-    }
-
-    void deallocate(T* p, size_type /*n*/) {
-#ifdef _WIN32
-        _aligned_free(p);
-#else
-        vtr::free(p);
-#endif
-    }
-};
-
-/**
- * @brief compare two aligned_allocators.
- *
- * Since the allocator doesn't have any internal state, all allocators for a given type are the same.
- */
-template<typename T>
-bool operator==(const aligned_allocator<T>&, const aligned_allocator<T>&) {
-    return true;
-}
 
 } // namespace vtr


### PR DESCRIPTION
There were some unused/mostly unused memory management code in vtr_memory.h. In this PR I removed the unused things and removed vtr::aligned_allocator which was used in RR Graph storage for performance critical stuff. This is not needed anymore in modern C++ and the default allocator respects alingas(). To be sure, I ran the Titan benchmarks:

  | Master | Branch
-- | -- | --
vtr_flow_elapsed_time | 1 | 1.004046651
max_vpr_mem | 1 | 0.9999824426
pack_time | 1 | 1.013110634
place_time | 1 | 0.9995324822
crit_path_route_time | 1 | 0.9919467308
routed_wirelength | 1 | 1
critical_path_delay | 1 | 1
total_heap_pops | 1 | 1
total_swap | 1 | 1
accepted_swap | 1 | 1
placed_CPD_est | 1 | 1

We can see that QoR is completely unaffected. Runtime is not changed beyond noise and machine load. The allocator was actually the source of some problems in #3526. Removing that and unused code would make the code base simpler.