### PR TITLE
[CI] Made the MSVC build parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -935,4 +935,4 @@ jobs:
           mkdir build
           cd build
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S .. -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_PARMYS=OFF -DSLANG_SYSTEMVERILOG=OFF -DVTR_IPO_BUILD=OFF -DWITH_ABC=OFF -DWGET="${{ env.CURL_PATH }}" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build .
+          cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}


### PR DESCRIPTION
I found that the MSVC build was running serially which is just a waste on the GitHub runners. We may as well use the extra cores.

This should speed up both the cached and uncached MSVC builds.