### PR TITLE
[Qt migration backport] Feature/draw graphics command wait for stage barrier

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -163,8 +163,16 @@ Graphics Options
          Sets the critical path delay drawing state.
          Bitmask: ``0`` = off,
          bit 0 (``1``) = flylines along the critical path,
-         bit 1 (``2``) = per-edge delay labels.
-         Common values: ``1`` = flylines, ``3`` = flylines + delays.
+         bit 1 (``2``) = per-edge delay labels,
+         bit 2 (``4``) = routed-wire highlight along the critical path.
+         Useful values: ``1`` = flylines, ``3`` = flylines + delays,
+         ``4`` = routing only, ``5`` = flylines + routing,
+         ``7`` = flylines + delays + routing.
+         Values ``2`` and ``6`` are degenerate (no-ops): delay labels are
+         drawn alongside flylines, so the delay bit on its own renders
+         nothing.
+         Bit 2 (routing) only renders at the routing stage; gate with
+         ``wait_for_stage routing_done``.
     * set_routing_util <int>
          Sets the routing utilization drawing state
     * set_clip_routing_util <int>
@@ -178,7 +186,9 @@ Graphics Options
     * set_draw_net_max_fanout <int>
          Sets the maximum fanout for nets to be drawn (if fanout is beyond this value the net will not be drawn)
     * set_congestion <int>
-         Sets the routing congestion drawing state
+         Sets the routing congestion drawing state.
+         ``0`` = off, ``1`` = congested nodes, ``2`` = congested nodes + nets.
+         Only renders when invoked at the routing stage.
     * wait_for_stage <stage>_<initial|done>
          Pauses script execution until VPR reaches the named stage at the
          requested checkpoint. Stages: ``placement``, ``routing``.

--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -155,9 +155,16 @@ Graphics Options
     * set_macros <int>
          Sets the placement macro drawing state
     * set_nets <int>
-         Sets the net drawing state
+         Sets the net drawing state.
+         ``0`` = nets off,
+         ``1`` = flylines (direct source-to-sink lines),
+         ``2`` = routed nets (actual routed wire paths).
     * set_cpd <int>
-         Sets the criticla path delay drawing state
+         Sets the critical path delay drawing state.
+         Bitmask: ``0`` = off,
+         bit 0 (``1``) = flylines along the critical path,
+         bit 1 (``2``) = per-edge delay labels.
+         Common values: ``1`` = flylines, ``3`` = flylines + delays.
     * set_routing_util <int>
          Sets the routing utilization drawing state
     * set_clip_routing_util <int>
@@ -172,6 +179,28 @@ Graphics Options
          Sets the maximum fanout for nets to be drawn (if fanout is beyond this value the net will not be drawn)
     * set_congestion <int>
          Sets the routing congestion drawing state
+    * wait_for_stage <stage>_<initial|done>
+         Pauses script execution until VPR reaches the named stage at the
+         requested checkpoint. Stages: ``placement``, ``routing``.
+
+         - ``<stage>_initial`` resumes on the *first* ``update_screen()``
+           call at that stage. Per-iteration state is mid-flight, but
+           anything that only needs already-settled inputs to that stage
+           (e.g. flylines based on netlist topology, route trees from the
+           first routing iteration) is available.
+         - ``<stage>_done`` resumes on the *post*-stage ``update_screen()``
+           checkpoint, where the underlying contexts (``place_ctx``,
+           ``route_ctx``) are fully settled. Required for any renderer that
+           depends on final per-stage output — e.g. ``set_congestion`` /
+           ``set_routing_util`` (need final occupancy data) or visual
+           regression goldens.
+
+         Commands placed after the barrier run on the matching checkpoint.
+         Examples::
+
+             wait_for_stage placement_done; save_graphics place.png;
+             wait_for_stage routing_initial; set_nets 2; save_graphics nets.png;
+             wait_for_stage routing_done; set_congestion 1; save_graphics cong.png;
     * exit <int>
          Exits VPR with specified exit code
 

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1129,7 +1129,11 @@ RouteStatus vpr_route_flow(const Netlist<>& net_list,
             print_switch_usage();
         }
 
-        // Update interactive graphics
+        // Update interactive graphics. Mark routing as complete first so that
+        // scripted graphics_commands using `wait_for_stage routing_done` will
+        // resume at this fully-settled checkpoint rather than per-iteration
+        // routing-stage updates where route_ctx is mid-flight.
+        notify_stage_complete(e_pic_type::ROUTING);
         update_screen(ScreenUpdatePriority::MAJOR, graphics_msg.c_str(), e_pic_type::ROUTING, timing_info);
     }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1216,6 +1216,25 @@ static void set_force_pause(GtkWidget* /*widget*/, gint /*response_id*/, gpointe
     draw_state->forced_pause = true;
 }
 
+enum e_set_nets_arg : int {
+    SET_NETS_OFF      = 0,
+    SET_NETS_FLYLINES = 1,
+    SET_NETS_ROUTED   = 2,
+};
+
+enum e_set_cpd_arg_bits : int {
+    SET_CPD_OFF      = 0,
+    SET_CPD_FLYLINES = 1 << 0,
+    SET_CPD_DELAYS   = 1 << 1,
+    SET_CPD_ROUTING  = 1 << 2,
+};
+
+enum e_set_congestion_arg : int {
+    SET_CONGESTION_OFF            = 0,
+    SET_CONGESTION_NODES          = 1,
+    SET_CONGESTION_NODES_AND_NETS = 2,
+};
+
 static void run_graphics_commands(const std::string& commands) {
     // A very simple command interpreter for scripting graphics.
     //
@@ -1323,11 +1342,12 @@ static void run_graphics_commands(const std::string& commands) {
             draw_state->show_placement_macros = (e_draw_placement_macros)vtr::atoi(cmd[1]);
             VTR_LOG("%d\n", (int)draw_state->show_placement_macros);
         } else if (cmd[0] == "set_nets") {
-            // 0 = off, 1 = flylines, 2 = routed nets.
             VTR_ASSERT_MSG(cmd.size() == 2,
                            "Expect net draw state (0=off, 1=flylines, 2=routed) after 'set_nets'");
             int state = vtr::atoi(cmd[1]);
-            if (state == 0) {
+            VTR_ASSERT_MSG(state >= SET_NETS_OFF && state <= SET_NETS_ROUTED,
+                           "set_nets expects a value in 0..2");
+            if (state == SET_NETS_OFF) {
                 draw_state->show_nets = false;
                 draw_state->draw_inter_cluster_nets = false;
                 draw_state->draw_intra_cluster_nets = false;
@@ -1337,23 +1357,27 @@ static void run_graphics_commands(const std::string& commands) {
                 draw_state->draw_inter_cluster_nets = true;
                 draw_state->draw_intra_cluster_nets = true;
                 draw_state->highlight_fan_in_fan_out = true;
-                draw_state->draw_nets = (state == 2) ? DRAW_ROUTED_NETS : DRAW_FLYLINES;
+                draw_state->draw_nets = (state == SET_NETS_ROUTED)
+                                            ? DRAW_ROUTED_NETS
+                                            : DRAW_FLYLINES;
             }
             VTR_LOG("%d\n", state);
         } else if (cmd[0] == "set_cpd") {
-            // Bitmask: 0=off, bit0(1)=flylines, bit1(2)=delay labels.
-            // Common values: 1=flylines, 3=flylines+delays.
             VTR_ASSERT_MSG(cmd.size() == 2,
-                           "Expect crit-path draw state (0=off, bitmask 1|2 = flylines|delays) after 'set_cpd'");
+                           "Expect crit-path draw state (0=off, bitmask 1|2|4 = flylines|delays|routing) after 'set_cpd'");
             int state = vtr::atoi(cmd[1]);
-            if (state == 0) {
+            VTR_ASSERT_MSG(state >= SET_CPD_OFF && state <= (SET_CPD_FLYLINES | SET_CPD_DELAYS | SET_CPD_ROUTING),
+                           "set_cpd expects a value in 0..7");
+            if (state == SET_CPD_OFF) {
                 draw_state->show_crit_path = false;
                 draw_state->show_crit_path_flylines = false;
                 draw_state->show_crit_path_delays = false;
+                draw_state->show_crit_path_routing = false;
             } else {
                 draw_state->show_crit_path = true;
-                draw_state->show_crit_path_flylines = (state & 1) != 0;
-                draw_state->show_crit_path_delays   = (state & 2) != 0;
+                draw_state->show_crit_path_flylines = (state & SET_CPD_FLYLINES) != 0;
+                draw_state->show_crit_path_delays   = (state & SET_CPD_DELAYS) != 0;
+                draw_state->show_crit_path_routing  = (state & SET_CPD_ROUTING) != 0;
             }
             VTR_LOG("%d\n", state);
         } else if (cmd[0] == "set_routing_util") {
@@ -1372,7 +1396,7 @@ static void run_graphics_commands(const std::string& commands) {
             VTR_ASSERT_MSG(cmd.size() == 2,
                            "Expect congestion draw state (0=off, 1=congested, 2=congested+nets) after 'set_congestion'");
             int state = vtr::atoi(cmd[1]);
-            VTR_ASSERT_MSG(state >= 0 && state <= 2,
+            VTR_ASSERT_MSG(state >= SET_CONGESTION_OFF && state <= SET_CONGESTION_NODES_AND_NETS,
                            "set_congestion expects a value in 0..2");
             draw_state->show_congestion = (e_draw_congestion)state;
             VTR_LOG("%d\n", state);

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -334,14 +334,12 @@ void update_screen(ScreenUpdatePriority priority,
 
         state_change = true;
 
-        // Compute initial_world unconditionally — it's used as the canvas's
-        // initial bounds (and as the reset target on stage change), so gating
-        // this on show_graphics produces a zero-sized rectangle under
-        // `--disp off` and silently breaks headless `save_graphics`.
-        if (pic_on_screen_val == e_pic_type::ANALYTICAL_PLACEMENT) {
-            set_initial_world_ap();
-        } else {
-            set_initial_world();
+        if (draw_state->show_graphics) {
+            if (pic_on_screen_val == e_pic_type::ANALYTICAL_PLACEMENT) {
+                set_initial_world_ap();
+            } else {
+                set_initial_world();
+            }
         }
 
         if (draw_state->pic_on_screen == e_pic_type::NO_PICTURE) {

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -334,12 +334,14 @@ void update_screen(ScreenUpdatePriority priority,
 
         state_change = true;
 
-        if (draw_state->show_graphics) {
-            if (pic_on_screen_val == e_pic_type::ANALYTICAL_PLACEMENT) {
-                set_initial_world_ap();
-            } else {
-                set_initial_world();
-            }
+        // Compute initial_world unconditionally — save_graphics derives the
+        // output image height from initial_world.width()/height(), so gating
+        // this on show_graphics produces a zero-sized rectangle under
+        // `--disp off` and silently breaks headless `save_graphics`
+        if (pic_on_screen_val == e_pic_type::ANALYTICAL_PLACEMENT) {
+            set_initial_world_ap();
+        } else {
+            set_initial_world();
         }
 
         if (draw_state->pic_on_screen == e_pic_type::NO_PICTURE) {

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cmath>
+#include <set>
 #include <vector>
 #include "draw.h"
 
@@ -140,6 +141,13 @@ ezgl::point2d point_1(0, 0);
 ezgl::rectangle initial_world;
 std::string rr_highlight_message;
 
+// Stages that have hit their first update_screen() (auto-recorded by
+// update_screen on pic_on_screen transitions) and stages that have been
+// marked complete via notify_stage_complete(). Consulted by the
+// `wait_for_stage <stage>_initial` / `<stage>_done` script barriers.
+std::set<e_pic_type> initial_stages;
+std::set<e_pic_type> completed_stages;
+
 #endif // NO_GRAPHICS
 
 /********************** Subroutine definitions ******************************/
@@ -174,6 +182,14 @@ void init_graphics_state(bool show_graphics_val,
     (void)graphics_commands;
     (void)is_flat;
 #endif // NO_GRAPHICS
+}
+
+void notify_stage_complete(e_pic_type stage) {
+#ifndef NO_GRAPHICS
+    completed_stages.insert(stage);
+#else
+    (void)stage;
+#endif
 }
 
 #ifndef NO_GRAPHICS
@@ -339,6 +355,9 @@ void update_screen(ScreenUpdatePriority priority,
 
         draw_state->setup_timing_info = setup_timing_info;
         draw_state->pic_on_screen = pic_on_screen_val;
+        // Record that we've now reached this stage at least once. Consumed
+        // by the `wait_for_stage <stage>_initial` script barrier.
+        initial_stages.insert(pic_on_screen_val);
     }
 
     bool should_pause = int(priority) >= draw_state->gr_automode;
@@ -1196,23 +1215,92 @@ static void set_force_pause(GtkWidget* /*widget*/, gint /*response_id*/, gpointe
 }
 
 static void run_graphics_commands(const std::string& commands) {
-    // A very simple command interpreter for scripting graphics
+    // A very simple command interpreter for scripting graphics.
+    //
+    // The parsed command list and the script cursor live on draw_state
+    // (parsed_graphics_cmds / graphics_cmd_cursor) so that `wait_for_stage`
+    // barriers can split a script across multiple update_screen() invocations
+    // (e.g. half at placement, half at routing). On each call, processing
+    // resumes at the cursor and stops either at a wait-barrier whose stage
+    // hasn't been reached yet, or at end-of-script.
     t_draw_state* draw_state = get_draw_state_vars();
+
+    // Parse once: `graphics_commands` is set at init and never mutated, so
+    // the empty-vector check doubles as a "first call" trigger.
+    if (draw_state->parsed_graphics_cmds.empty()) {
+        for (const std::string& raw_cmd : vtr::StringToken(commands).split(";")) {
+            draw_state->parsed_graphics_cmds.push_back(vtr::StringToken(raw_cmd).split(" \t\n"));
+        }
+    }
 
     t_draw_state backup_draw_state = *draw_state;
 
-    std::vector<std::vector<std::string>> cmds;
-    for (const std::string& raw_cmd : vtr::StringToken(commands).split(";")) {
-        cmds.push_back(vtr::StringToken(raw_cmd).split(" \t\n"));
-    }
-
-    for (auto& cmd : cmds) {
+    while (draw_state->graphics_cmd_cursor < draw_state->parsed_graphics_cmds.size()) {
+        auto& cmd = draw_state->parsed_graphics_cmds[draw_state->graphics_cmd_cursor];
         VTR_ASSERT_MSG(cmd.size() > 0, "Expect non-empty graphics commands");
 
         for (auto& item : cmd) {
             VTR_LOG("%s ", item.c_str());
         }
         VTR_LOG("\n");
+
+        if (cmd[0] == "wait_for_stage") {
+            // Argument form: <stage>_<initial|done>, e.g. routing_initial
+            // or placement_done. `_initial` resumes on the first
+            // update_screen() at that stage; `_done` resumes only after the
+            // stage has been marked complete by notify_stage_complete()
+            // (i.e. on the post-stage settled checkpoint).
+            VTR_ASSERT_MSG(cmd.size() == 2,
+                           "Expect <stage>_initial or <stage>_done after 'wait_for_stage' "
+                           "(stage = placement|routing)");
+            const std::string& arg = cmd[1];
+            e_pic_type want = e_pic_type::NO_PICTURE;
+            bool wait_for_done = false;
+            std::string stage_name;
+            const std::string done_suffix = "_done";
+            const std::string init_suffix = "_initial";
+            if (arg.size() > done_suffix.size()
+                && arg.compare(arg.size() - done_suffix.size(), done_suffix.size(), done_suffix) == 0) {
+                wait_for_done = true;
+                stage_name = arg.substr(0, arg.size() - done_suffix.size());
+            } else if (arg.size() > init_suffix.size()
+                && arg.compare(arg.size() - init_suffix.size(), init_suffix.size(), init_suffix) == 0) {
+                wait_for_done = false;
+                stage_name = arg.substr(0, arg.size() - init_suffix.size());
+            } else {
+                VPR_ERROR(VPR_ERROR_DRAW,
+                          vtr::string_fmt("Unknown wait_for_stage argument '%s' "
+                                          "(use <stage>_initial or <stage>_done)",
+                                          arg.c_str())
+                              .c_str());
+            }
+
+            if (stage_name == "placement") {
+                want = e_pic_type::PLACEMENT;
+            } else if (stage_name == "routing") {
+                want = e_pic_type::ROUTING;
+            } else {
+                VPR_ERROR(VPR_ERROR_DRAW,
+                          vtr::string_fmt("Unknown or unsupported stage '%s' in "
+                                          "wait_for_stage (use placement|routing)",
+                                          stage_name.c_str())
+                              .c_str());
+            }
+
+            const auto& flag_set = wait_for_done ? completed_stages : initial_stages;
+            if (draw_state->pic_on_screen != want
+                || flag_set.find(want) == flag_set.end()) {
+                // Revert any draw-state mutations made by commands earlier in
+                // this script run, but keep the script bookkeeping (cursor +
+                // parse cache) so the next update_screen() resumes here.
+                size_t saved_cursor = draw_state->graphics_cmd_cursor;
+                *draw_state = backup_draw_state;
+                draw_state->graphics_cmd_cursor = saved_cursor;
+                return;
+            }
+            ++draw_state->graphics_cmd_cursor;
+            continue;
+        }
 
         if (cmd[0] == "save_graphics") {
             VTR_ASSERT_MSG(cmd.size() == 2,
@@ -1233,17 +1321,39 @@ static void run_graphics_commands(const std::string& commands) {
             draw_state->show_placement_macros = (e_draw_placement_macros)vtr::atoi(cmd[1]);
             VTR_LOG("%d\n", (int)draw_state->show_placement_macros);
         } else if (cmd[0] == "set_nets") {
+            // 0 = off, 1 = flylines, 2 = routed nets.
             VTR_ASSERT_MSG(cmd.size() == 2,
-                           "Expect net draw state after 'set_nets'");
-            draw_state->draw_nets = (e_draw_nets)vtr::atoi(cmd[1]);
-            VTR_LOG("%d\n", (int)draw_state->draw_nets);
+                           "Expect net draw state (0=off, 1=flylines, 2=routed) after 'set_nets'");
+            int state = vtr::atoi(cmd[1]);
+            if (state == 0) {
+                draw_state->show_nets = false;
+                draw_state->draw_inter_cluster_nets = false;
+                draw_state->draw_intra_cluster_nets = false;
+                draw_state->highlight_fan_in_fan_out = false;
+            } else {
+                draw_state->show_nets = true;
+                draw_state->draw_inter_cluster_nets = true;
+                draw_state->draw_intra_cluster_nets = true;
+                draw_state->highlight_fan_in_fan_out = true;
+                draw_state->draw_nets = (state == 2) ? DRAW_ROUTED_NETS : DRAW_FLYLINES;
+            }
+            VTR_LOG("%d\n", state);
         } else if (cmd[0] == "set_cpd") {
+            // Bitmask: 0=off, bit0(1)=flylines, bit1(2)=delay labels.
+            // Common values: 1=flylines, 3=flylines+delays.
             VTR_ASSERT_MSG(cmd.size() == 2,
-                           "Expect show critical path delay (bool), show critical path flylines (bool), and show critical path routing (bool) after 'set_cpd'");
-            draw_state->show_crit_path = true;
-            draw_state->show_crit_path_flylines = true;
-            draw_state->show_crit_path_delays = (bool)vtr::atoi(cmd[1]);
-            VTR_LOG("%d\n", (int)draw_state->show_crit_path);
+                           "Expect crit-path draw state (0=off, bitmask 1|2 = flylines|delays) after 'set_cpd'");
+            int state = vtr::atoi(cmd[1]);
+            if (state == 0) {
+                draw_state->show_crit_path = false;
+                draw_state->show_crit_path_flylines = false;
+                draw_state->show_crit_path_delays = false;
+            } else {
+                draw_state->show_crit_path = true;
+                draw_state->show_crit_path_flylines = (state & 1) != 0;
+                draw_state->show_crit_path_delays   = (state & 2) != 0;
+            }
+            VTR_LOG("%d\n", state);
         } else if (cmd[0] == "set_routing_util") {
             VTR_ASSERT_MSG(cmd.size() == 2,
                            "Expect routing util draw state after 'set_routing_util'");
@@ -1256,10 +1366,14 @@ static void run_graphics_commands(const std::string& commands) {
             draw_state->clip_routing_util = (bool)vtr::atoi(cmd[1]);
             VTR_LOG("%d\n", (int)draw_state->clip_routing_util);
         } else if (cmd[0] == "set_congestion") {
+            // 0 = off, 1 = congested nodes, 2 = congested nodes + nets.
             VTR_ASSERT_MSG(cmd.size() == 2,
-                           "Expect congestion draw state after 'set_congestion'");
-            draw_state->show_congestion = (e_draw_congestion)vtr::atoi(cmd[1]);
-            VTR_LOG("%d\n", (int)draw_state->show_congestion);
+                           "Expect congestion draw state (0=off, 1=congested, 2=congested+nets) after 'set_congestion'");
+            int state = vtr::atoi(cmd[1]);
+            VTR_ASSERT_MSG(state >= 0 && state <= 2,
+                           "set_congestion expects a value in 0..2");
+            draw_state->show_congestion = (e_draw_congestion)state;
+            VTR_LOG("%d\n", state);
         } else if (cmd[0] == "set_draw_block_outlines") {
             VTR_ASSERT_MSG(cmd.size() == 2,
                            "Expect draw block outlines state after 'set_draw_block_outlines'");
@@ -1289,9 +1403,15 @@ static void run_graphics_commands(const std::string& commands) {
                                       cmd[0].c_str())
                           .c_str());
         }
+        ++draw_state->graphics_cmd_cursor;
     }
 
-    *draw_state = backup_draw_state; // Restore original draw state
+    // Restore user-controllable draw state, but keep the script cursor at
+    // end-of-script so subsequent update_screen() calls are no-ops rather
+    // than re-running the whole script.
+    size_t saved_cursor = draw_state->graphics_cmd_cursor;
+    *draw_state = backup_draw_state;
+    draw_state->graphics_cmd_cursor = saved_cursor;
 
     //Advance the sequence number
     ++draw_state->sequence_number;

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -334,10 +334,10 @@ void update_screen(ScreenUpdatePriority priority,
 
         state_change = true;
 
-        // Compute initial_world unconditionally — save_graphics derives the
-        // output image height from initial_world.width()/height(), so gating
+        // Compute initial_world unconditionally — it's used as the canvas's
+        // initial bounds (and as the reset target on stage change), so gating
         // this on show_graphics produces a zero-sized rectangle under
-        // `--disp off` and silently breaks headless `save_graphics`
+        // `--disp off` and silently breaks headless `save_graphics`.
         if (pic_on_screen_val == e_pic_type::ANALYTICAL_PLACEMENT) {
             set_initial_world_ap();
         } else {
@@ -569,6 +569,26 @@ void init_draw_coords(float clb_width, const BlkLocRegistry& blk_loc_registry) {
 
     // Load coordinates of sub-blocks inside the clbs
     draw_internal_init_blk();
+
+    // Tile coordinates are now fully populated — set initial_world so that
+    // save_graphics / graphics_commands can compute valid image dimensions
+    // even in headless mode (show_graphics = false).
+    const ezgl::rectangle prev_initial_world = initial_world;
+    set_initial_world();
+
+    // The router's binary search re-runs init_draw_coords() per channel-width
+    // trial, which can change tile_x/tile_y (and therefore initial_world)
+    // without a pic_on_screen state change — so update_screen()'s state-change
+    // branch will not refresh the camera. If the user is currently at "fit"
+    // (camera world == previous initial_world) push the new initial_world to
+    // the camera so the next render uses the correct world rect. If the user
+    // has pan/zoomed away from fit, leave their view alone.
+    if (initial_world != prev_initial_world) {
+        ezgl::canvas* canvas = application.get_canvas(application.get_main_canvas_id());
+        if (canvas != nullptr && canvas->get_camera().get_world() == prev_initial_world) {
+            canvas->get_camera().set_world(initial_world);
+        }
+    }
 
 #else
     (void)clb_width;

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1237,21 +1237,21 @@ static void set_force_pause(GtkWidget* /*widget*/, gint /*response_id*/, gpointe
 }
 
 enum e_set_nets_arg : int {
-    SET_NETS_OFF      = 0,
+    SET_NETS_OFF = 0,
     SET_NETS_FLYLINES = 1,
-    SET_NETS_ROUTED   = 2,
+    SET_NETS_ROUTED = 2,
 };
 
 enum e_set_cpd_arg_bits : int {
-    SET_CPD_OFF      = 0,
+    SET_CPD_OFF = 0,
     SET_CPD_FLYLINES = 1 << 0,
-    SET_CPD_DELAYS   = 1 << 1,
-    SET_CPD_ROUTING  = 1 << 2,
+    SET_CPD_DELAYS = 1 << 1,
+    SET_CPD_ROUTING = 1 << 2,
 };
 
 enum e_set_congestion_arg : int {
-    SET_CONGESTION_OFF            = 0,
-    SET_CONGESTION_NODES          = 1,
+    SET_CONGESTION_OFF = 0,
+    SET_CONGESTION_NODES = 1,
     SET_CONGESTION_NODES_AND_NETS = 2,
 };
 
@@ -1305,7 +1305,7 @@ static void run_graphics_commands(const std::string& commands) {
                 wait_for_done = true;
                 stage_name = arg.substr(0, arg.size() - done_suffix.size());
             } else if (arg.size() > init_suffix.size()
-                && arg.compare(arg.size() - init_suffix.size(), init_suffix.size(), init_suffix) == 0) {
+                       && arg.compare(arg.size() - init_suffix.size(), init_suffix.size(), init_suffix) == 0) {
                 wait_for_done = false;
                 stage_name = arg.substr(0, arg.size() - init_suffix.size());
             } else {
@@ -1396,8 +1396,8 @@ static void run_graphics_commands(const std::string& commands) {
             } else {
                 draw_state->show_crit_path = true;
                 draw_state->show_crit_path_flylines = (state & SET_CPD_FLYLINES) != 0;
-                draw_state->show_crit_path_delays   = (state & SET_CPD_DELAYS) != 0;
-                draw_state->show_crit_path_routing  = (state & SET_CPD_ROUTING) != 0;
+                draw_state->show_crit_path_delays = (state & SET_CPD_DELAYS) != 0;
+                draw_state->show_crit_path_routing = (state & SET_CPD_ROUTING) != 0;
             }
             VTR_LOG("%d\n", state);
         } else if (cmd[0] == "set_routing_util") {

--- a/vpr/src/draw/draw.h
+++ b/vpr/src/draw/draw.h
@@ -45,6 +45,21 @@ void update_screen(ScreenUpdatePriority priority,
                    e_pic_type pic_on_screen_val,
                    std::shared_ptr<const SetupTimingInfo> timing_info);
 
+/**
+ * @brief Mark a stage as fully complete.
+ *
+ * Records that the given stage (PLACEMENT, ROUTING, ANALYTICAL_PLACEMENT, …)
+ * has finished. The `wait_for_stage <stage>_done` graphics-command barrier
+ * advances only when both the current pic_on_screen matches the requested
+ * stage AND that stage has been marked complete here. This lets scripted
+ * commands defer past per-iteration update_screen() checkpoints and run
+ * only on the post-stage update_screen() where the underlying contexts
+ * (route_ctx, place_ctx, …) are fully settled.
+ *
+ * Call once per stage immediately before that stage's final update_screen.
+ */
+void notify_stage_complete(e_pic_type stage);
+
 //FIXME: Currently broken if no rr-graph is loaded
 /**
  * @brief Load the arrays containing the left and bottom coordinates of the clbs.

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -299,6 +299,17 @@ struct t_draw_state {
 
     std::string graphics_commands;
 
+    ///@brief Tokenized form of `graphics_commands` (one inner vector per
+    /// `;`-separated command). Built lazily by run_graphics_commands on the
+    /// first call (when this vector is still empty); `graphics_commands` is
+    /// set once at init and never mutated, so a single parse is sufficient.
+    std::vector<std::vector<std::string>> parsed_graphics_cmds;
+
+    ///@brief Cursor into `parsed_graphics_cmds`. Persists across
+    /// run_graphics_commands() invocations so that `wait_for_stage` barriers
+    /// can split a script across multiple update_screen() calls.
+    size_t graphics_cmd_cursor = 0;
+
     ///@brief If we should pause for user interaction (requested by user)
     bool forced_pause = false;
 

--- a/vpr/src/draw/save_graphics.cpp
+++ b/vpr/src/draw/save_graphics.cpp
@@ -6,8 +6,6 @@
 #include "save_graphics.h"
 #include "search_bar.h"
 
-extern ezgl::rectangle initial_world;
-
 void save_graphics_from_button(GtkWidget* /*widget*/, gint response_id, gpointer data) {
     auto dialog = static_cast<GtkWidget*>(data);
 
@@ -60,17 +58,28 @@ void save_graphics(std::string extension, std::string file_name) {
 
     auto canvas = application.get_canvas(application.get_main_canvas_id());
 
+    // Use the CURRENT camera's world rectangle for the output aspect ratio,
+    // not the initial-load world. This way the saved file shows what the
+    // user is currently looking at, with their tiles preserved at the
+    // correct world aspect (e.g., square tiles stay square). Using the
+    // initial-load world produces a distorted image whenever the user has
+    // zoomed or panned to a non-square sub-region.
+    const ezgl::rectangle current_world = canvas->get_camera().get_world();
+    const double aspect_w = current_world.width();
+    const double aspect_h = current_world.height();
+
     bool result = true;
 
     file_name = file_name + "." + extension;
     if (extension == "pdf") {
-        result = canvas->print_pdf(file_name.c_str(), initial_world.width(), initial_world.height());
+        result = canvas->print_pdf(file_name.c_str(), int(aspect_w), int(aspect_h));
     } else if (extension == "png") {
         constexpr int IMAGE_WIDTH_PIXELS = 2048;
-        int image_height_pixels = IMAGE_WIDTH_PIXELS * float(initial_world.height()) / initial_world.width();
+        const int image_height_pixels =
+            int(IMAGE_WIDTH_PIXELS * (aspect_h / aspect_w));
         result = canvas->print_png(file_name.c_str(), IMAGE_WIDTH_PIXELS, image_height_pixels);
     } else if (extension == "svg") {
-        result = canvas->print_svg(file_name.c_str(), initial_world.width(), initial_world.height());
+        result = canvas->print_svg(file_name.c_str(), int(aspect_w), int(aspect_h));
     } else {
         warning_dialog_box("Invalid file type");
     }

--- a/vpr/src/place/placement_log_printer.cpp
+++ b/vpr/src/place/placement_log_printer.cpp
@@ -270,6 +270,10 @@ void PlacementLogPrinter::print_post_placement_stats() const {
             placer_.costs_.cost, placer_.costs_.bb_cost, placer_.costs_.timing_cost, placer_.placer_opts_.place_chan_width);
     VTR_LOG("Placement cost: %g, bb_cost: %g, td_cost: %g, \n", placer_.costs_.cost,
             placer_.costs_.bb_cost, placer_.costs_.timing_cost);
+    // Mark placement as fully settled so `wait_for_stage placement_done`
+    // barriers in graphics_commands resume on this final checkpoint rather
+    // than the per-iteration placement update_screen() calls.
+    notify_stage_complete(e_pic_type::PLACEMENT);
     update_screen(ScreenUpdatePriority::MAJOR, msg_.data(), e_pic_type::PLACEMENT, placer_.timing_info_);
 
     // print the noc costs info


### PR DESCRIPTION
#### Description
This PR makes the existing `--graphics_commands` scripting layer usable as a headless renderer test driver. It covers three things:

1. **Headless `save_graphics` actually writes files.**
   - `initial_world` was only computed under `--disp on`. Under `--disp off` it stayed zero-sized, so `save_graphics` produced a cairo surface with `2048 × (2048 * 0 / 0)` dimensions, the write was silently skipped (no `openat()` in strace), and `canvas::print_png` returned `true` anyway. Fixed by computing `initial_world` unconditionally on each `update_screen()` state change *and* at the end of `init_draw_coords()` (the router's binary search re-runs `init_draw_coords()` per channel-width trial without a `pic_on_screen` change, so the camera also gets retargeted if the user is at "fit").
   - Saved images now use the **current camera world** for their aspect ratio rather than the initial-load world, so a saved file matches what the user is currently looking at (square tiles stay square after pan/zoom).

2. **New `wait_for_stage` barrier in `--graphics_commands`.** Pauses the script until VPR reaches a named checkpoint:
   - `wait_for_stage placement_done` / `routing_done` resume on the post-stage `update_screen()`, where `place_ctx` / `route_ctx` are fully settled. Required by renderers that depend on final per-stage output (`set_congestion`, `set_routing_util`, …).
   - `wait_for_stage placement_initial` / `routing_initial` resume on the *first* `update_screen()` at that stage (mid-flight state, but anything that only needs already-settled inputs — flylines from netlist topology, the first routing iteration's route trees — is available).
   The script's parsed command list and a cursor now live on `t_draw_state` so a script can be split across multiple `update_screen()` invocations.

3. **`set_nets` and `set_cpd` actually toggle every renderer they need to.** Previously `set_nets <n>` only assigned `e_draw_nets` and `set_cpd <bool>` only flipped `show_crit_path_delays`, leaving the other show-flags untouched — so the old commands didn't reliably show or hide what they advertised. Now:
   - `set_nets 0 / 1 / 2` → off / flylines / routed; toggles `show_nets`, `draw_inter_cluster_nets`, `draw_intra_cluster_nets`, `highlight_fan_in_fan_out`.
   - `set_cpd <bitmask>` → bit 0 = flylines, bit 1 = delay labels (e.g. `3` = flylines + delays); also flips `show_crit_path`.
   - `set_congestion <0..2>` gained an explicit range check.
   Magic numbers replaced with named constants (`SET_NETS_*`, `SET_CPD_*`).

Doc updates to [doc/src/vpr/command_line_usage.rst](doc/src/vpr/command_line_usage.rst) describe the new arg semantics and the `wait_for_stage` barrier with usage examples.

#### Related Issue
N/A — internal infrastructure for the Qt migration test layer.

#### Motivation and Context
These changes are required for the Qt-migration task. In our downstream branch a separate **automatic test layer** exercises the renderer by driving VPR with `--graphics_commands` scripts, saving PNGs at well-defined checkpoints, and comparing them against goldens. That layer relies on every piece in this PR:
- headless `save_graphics` that actually writes a non-empty file,
- a way to deterministically wait for `place_ctx` / `route_ctx` to settle before sampling,
- `set_nets` / `set_cpd` / `set_congestion` actually meaning what their docstrings claim (so a renderer regression is detected as a pixel diff rather than masked by an unrelated show-flag).

The automatic test layer itself is not yet upstreamable, so these primitives are landed first; the test layer will be contributed in a follow-up once the Qt migration is ready.

#### How Has This Been Tested?
Because the automatic test layer is not in upstream yet, the changes were validated **manually** using `r_32.sh`.

```
#!/usr/bin/env bash
#
# Sweep each graphics-state variable in isolation. Two VPR invocations:
#   pass 1: placement_done + routing_done sweeps for nets and cpd
#   pass 2: routing_initial sweep for set_congestion (early routing
#           checkpoint, mid-flight route_ctx)
#
#   set_nets:       0=off, 1=flylines (placement), 2=routed (routing)
#   set_cpd:        0=off, bitmask 1|2|4 = flylines|delays|routed-wires.
#                   Common: 1=flylines, 3=flylines+delays,
#                           5=flylines+routing, 7=flylines+delays+routing.
#                   Bit 2 (routing) only meaningful at routing stage.
#   set_congestion: 0=off, 1=congested nodes, 2=congested nodes + nets
#
# Outputs:
#   <script>_nets_<n>.png  for n in {0,1,2}
#   <script>_cpd_<c>.png   for c in {0,1,2,3,4,5,7}
#   <script>_cong_<g>.png  for g in {0,1,2}
# where <script> is this file's basename without the .sh extension.

set -euo pipefail

ROOT_DIR="$(pwd)"
VPR="./vpr"
ARCH="$ROOT_DIR/vtr_flow/arch/timing/EArch.xml"
BLIF="$ROOT_DIR/vtr_flow/benchmarks/blif/wiremap6/tseng.pre-vpr.blif"
SEED=1
COMMON_OPTS=(--disp off --pack --place --route --seed "$SEED")

# Prefix derived from this script's filename (no .sh) so renaming the script
# automatically renames its output files.
PREFIX="$(basename "${BASH_SOURCE[0]}" .sh)"

NETS_PLACEMENT=(0 1)        # render at placement
NETS_ROUTING=(2)             # routed nets; render at routing
CPD_PLACEMENT=(0 1 2 3)      # flylines/delays render at either stage
CPD_ROUTING=(4 5 7)          # bit 2 (routed-wire highlight) needs routing stage
                             #   4 = routing only
                             #   5 = flylines + routing
                             #   7 = flylines + delays + routing
                             # 6 (delays + routing without flylines) is
                             # degenerate — identical to 4.
CONG_VALUES=(0 1 2)          # routing-only

# -----------------------------------------------------------------------------
# Pass 1: nets + cpd sweeps. Placement saves at placement_done; routing saves
# at routing_done.
# -----------------------------------------------------------------------------
CMDS_NC="wait_for_stage placement_done; "
for n in "${NETS_PLACEMENT[@]}"; do
    CMDS_NC+="set_nets ${n}; save_graphics ${PREFIX}_nets_${n}.png; set_nets 0; "
done
for c in "${CPD_PLACEMENT[@]}"; do
    CMDS_NC+="set_cpd ${c}; save_graphics ${PREFIX}_cpd_${c}.png; set_cpd 0; "
done
CMDS_NC+="wait_for_stage routing_done; "
for n in "${NETS_ROUTING[@]}"; do
    CMDS_NC+="set_nets ${n}; save_graphics ${PREFIX}_nets_${n}.png; set_nets 0; "
done
for c in "${CPD_ROUTING[@]}"; do
    CMDS_NC+="set_cpd ${c}; save_graphics ${PREFIX}_cpd_${c}.png; set_cpd 0; "
done
CMDS_NC+="exit 0"

echo "=== Pass 1: nets + cpd ==="
{
cd "$ROOT_DIR/build/vpr"
"$VPR" "$ARCH" "$BLIF" "${COMMON_OPTS[@]}" \
    --graphics_commands "$CMDS_NC"
}

# -----------------------------------------------------------------------------
# Pass 2: congestion sweep at routing_initial (first routing-stage
# update_screen, mid-flight route_ctx). Run as a separate VPR invocation so
# the only graphics_commands in this run are the cong saves, isolating the
# initial-route checkpoint from the placement_done / routing_done barriers
# above.
# -----------------------------------------------------------------------------
CMDS_CONG="wait_for_stage routing_initial; "
for g in "${CONG_VALUES[@]}"; do
    CMDS_CONG+="set_congestion ${g}; save_graphics ${PREFIX}_cong_${g}.png; set_congestion 0; "
done
CMDS_CONG+="exit 0"

echo
echo "=== Pass 2: congestion at routing_initial ==="
{
cd "$ROOT_DIR/build/vpr"
"$VPR" "$ARCH" "$BLIF" "${COMMON_OPTS[@]}" \
    --graphics_commands "$CMDS_CONG"
}

echo
echo "Generated images:"
ls -l "${PREFIX}_nets_"*.png "${PREFIX}_cpd_"*.png "${PREFIX}_cong_"*.png
```

To run script:
- build vtr
- copy script into vtr working tree as r_32.sh script
- run it sh ./r_32.sh 
Note: no arguments are needed.
- observe generated images at build/vpr/*.png

What script does:

- Runs VPR on `tseng.pre-vpr.blif` with `EArch.xml`, `--disp off`, fixed seed.
- Pass 1 — at `placement_done` and `routing_done`, saves a PNG for each value of `set_nets` (0, 1, 2) and `set_cpd` (0, 1, 2, 3, 4, 5, 7), one combination per file.
- Pass 2 — at `routing_initial`, saves a PNG for each value of `set_congestion` (0, 1, 2).

Each flag combination ends up in its own image (`r_32_nets_*.png`, `r_32_cpd_*.png`, `r_32_cong_*.png`), so the renderer output can be eyeballed combination-by-combination.

Environment: ubuntu 20.04, GTK build, headless (`--disp off`), `VTR_ASSERT_LEVEL=2`, release build.

#### Types of changes
- [x] Bug fix (change which fixes an issue) — headless `save_graphics` silently produced no file
- [x] New feature (change which adds functionality) — `wait_for_stage` barrier, expanded `set_nets` / `set_cpd` semantics
- [ ] Breaking change

`set_nets` / `set_cpd` integer arguments are interpreted differently than before (they were under-specified previously and didn't reliably show/hide), but the command grammar is unchanged. Scripts that previously passed `0/1` to these commands continue to do something sensible; scripts that relied on the old partial-toggle behavior may need to be re-tuned.

#### Checklist:
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly ([command_line_usage.rst](doc/src/vpr/command_line_usage.rst))
- [ ] I have added tests to cover my changes — *the automatic renderer test layer that exercises these primitives lives in the downstream Qt-migration branch and is not yet ready to upstream; `r_32.sh` in the working tree serves as the manual verification harness in the meantime*
- [x] All new and existing tests passed (existing tests; no new ones added — see note above)