### PR TITLE
[Qt migration backport] fix/draw_doubled_render_calls_draw

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -182,10 +182,6 @@ static void draw_main_canvas(ezgl::renderer* g) {
 
     g->set_font_size(14);
     if (draw_state->pic_on_screen != e_pic_type::ANALYTICAL_PLACEMENT) {
-        draw_block_pin_util();
-        draw_place(g);
-        draw_internal_draw_subblk(g);
-
         draw_interposer_cuts(g);
 
         draw_block_pin_util();


### PR DESCRIPTION
#### Description
`draw_main_canvas()` invoked `draw_block_pin_util()`, `draw_place()`, and
`draw_internal_draw_subblk()` twice on every frame for non-AP stages: once
before `draw_interposer_cuts()` and again immediately after. This drops the
pre-cuts copy and keeps the post-cuts ordering, so each function runs exactly
once per frame and interposer cuts remain visually beneath the block/sub-block
overlays.

Before (`vpr/src/draw/draw.cpp`, master):

```cpp
if (draw_state->pic_on_screen != e_pic_type::ANALYTICAL_PLACEMENT) {
    draw_block_pin_util();
    draw_place(g);
    draw_internal_draw_subblk(g);

    draw_interposer_cuts(g);

    draw_block_pin_util();        // duplicate
    draw_place(g);                // duplicate
    draw_internal_draw_subblk(g); // duplicate
    ...
```

After: only the post-`draw_interposer_cuts` trio remains.

#### Related Issue
None filed — found while porting the draw path to Qt-based renderers (see *Motivation* below).

#### Motivation and Context
The duplication was discovered while prototyping a Qt-backed graphics path during an ezgl → Qt migration experiment. Two renderer modes there — **deferred** and **RHI** — preserve and replay draw commands as a recorded list, so the duplicate trio is *visible*: pin-utilisation rectangles, block fills, and sub-block decorations all appear twice, and the second pass re-issues the block draws *after* `draw_interposer_cuts`, so the interposer cuts end up occluded by the second copy of the placement overlay.

These renderers are not yet in upstream VTR, which is why the bug has gone unnoticed: the upstream GTK/ezgl path uses an **immediate** renderer, where the second invocation of each function simply paints the same pixels on top of the first with identical state — overdraw absorbs the duplication and the result is visually indistinguishable from drawing once. The duplication still costs ~2× the CPU for the affected primitives per frame even under the immediate renderer, but it produces no visible artifact, which is presumably why the duplicate was introduced and left in place when interposer-cut drawing was added.

Removing the pre-cuts trio:
- eliminates the wasted work under all renderers,
- makes layer ordering well-defined (cuts beneath placement overlay) independent of which renderer is active,
- unblocks the Qt deferred/RHI renderers from rendering interposer architectures correctly without per-renderer workarounds.

#### How Has This Been Tested?
manual check of basic example run
```
#!/usr/bin/env bash

ROOT_DIR="$(pwd)"

"$ROOT_DIR/build/vpr/vpr" \
"$ROOT_DIR/vpr/test/test_post_verilog_arch.xml" \
"$ROOT_DIR/vpr/test/unconnected.eblif" \
--route_chan_width 100 \
--gen_post_synthesis_netlist on \
--post_synth_netlist_unconn_inputs unconnected \
--post_synth_netlist_unconn_outputs unconnected \
--disp on \
"$@"
```

#### Types of changes
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed