### PR TITLE
[CI] Added No Assert Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,6 +278,18 @@ jobs:
         make -j${{ steps.cpu-cores.outputs.count}}
         ./run_reg_test.py vtr_reg_basic -show_failures -j${{ steps.cpu-cores.outputs.count}}
 
+    - name: 'Test with VTR_ASSERT_LEVEL 0'
+      timeout-minutes: 120
+      if: success() || failure()
+      env:
+        CMAKE_PARAMS: "${{ env.COMMON_CMAKE_PARAMS }} -DVTR_ASSERT_LEVEL=0"
+        NUM_PROC: ${{ steps.cpu-cores.outputs.count }}
+      run: |
+        rm -f build/CMakeCache.txt
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        make -j${{ steps.cpu-cores.outputs.count}}
+        ./run_reg_test.py vtr_reg_basic -show_failures -j${{ steps.cpu-cores.outputs.count}}
+
     - name: 'Test with NO_GRAPHICS'
       timeout-minutes: 60
       if: success() || failure()

--- a/libs/libarchfpga/src/read_fpga_interchange_arch.cpp
+++ b/libs/libarchfpga/src/read_fpga_interchange_arch.cpp
@@ -380,7 +380,7 @@ struct ArchReader {
         for (auto bel : site.getBels())
             if (str(bel.getName()) == bel_name)
                 return bel;
-        VTR_ASSERT_MSG(0, "Could not find the BEL reader!\n");
+        archfpga_throw(__FILE__, __LINE__, "Could not find the BEL reader!\n");
     }
 
     /** @brief Get the BEL pin reader given its name, site and corresponding BEL */
@@ -392,7 +392,7 @@ struct ArchReader {
             if (str(pin_reader.getName()) == pin_name)
                 return pin_reader;
         }
-        VTR_ASSERT_MSG(0, "Could not find the BEL pin reader!\n");
+        archfpga_throw(__FILE__, __LINE__, "Could not find the BEL pin reader!\n");
     }
 
     /** @brief Get the BEL name, with an optional deduplication suffix in case its name collides with the site name */

--- a/utils/fasm/src/fasm.cpp
+++ b/utils/fasm/src/fasm.cpp
@@ -332,8 +332,8 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
       // Get the input pin of the LUT that feeds the wire. There should be one
       // and only one.
       const t_pb_graph_pin* wire_input_pin = get_wire_input_pin(pb_routes, pb_graph_node);
-      VTR_ASSERT_MSG(wire_input_pin != nullptr,
-                     "Wire found with no used input pins");
+      if (wire_input_pin == nullptr)
+          VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Wire found with no used input pins.");
 
       // Get the route going into this pin.
       const auto& route = pb_routes.at(wire_input_pin->pin_count_in_cluster);
@@ -341,6 +341,8 @@ void FasmWriterVisitor::visit_all_impl(const t_pb_routes &pb_routes, const t_pb*
       // Find the lut definition for the parent of this wire.
       const int num_inputs = *route.pb_graph_pin->parent_node->num_input_pins;
       const auto *lut_definition = find_lut(route.pb_graph_pin->parent_node);
+      if (lut_definition == nullptr)
+          VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Could not find LUT definition for wire's parent node.");
       VTR_ASSERT(lut_definition->num_inputs == num_inputs);
 
       // Create a wire implementation for the LUT.
@@ -506,7 +508,8 @@ const t_metadata_dict *FasmWriterVisitor::get_fasm_type(const t_pb_graph_node* p
 
   if(meta != nullptr) {
     auto* value = meta->one(fasm_type);
-    VTR_ASSERT(value != nullptr);
+    if (value == nullptr)
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "Expected a metadata value for fasm_type but got none.");
     if(value->as_string().get(strings_) == target_type) {
       return meta;
     }

--- a/vpr/src/base/old_traceback.cpp
+++ b/vpr/src/base/old_traceback.cpp
@@ -109,6 +109,9 @@ t_trace* TracebackCompat::traceback_from_route_tree(const RouteTree& tree) {
 
     std::tie(head, tail) = traceback_from_route_tree_recurr(nullptr, nullptr, tree.root());
 
+    // Intentionally inside VTR_ASSERT: this is a pure validation check with no
+    // side effects, and it is expensive enough to matter on hot paths. Stripping
+    // it at lower assert levels is acceptable.
     VTR_ASSERT(validate_and_update_traceback(head));
 
     return head;

--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -510,7 +510,9 @@ static void process_nodes(const Netlist<>& net_list,
         oldpos = fp.tellg();
     }
 
-    VTR_ASSERT(validate_and_update_traceback(head_ptr, verify_route_file_switch_id));
+    if (!validate_and_update_traceback(head_ptr, verify_route_file_switch_id)) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Traceback validation failed after reading route file.");
+    }
 
     /* Convert to route_tree after reading */
     route_ctx.route_trees[inet] = TracebackCompat::traceback_to_route_tree(head_ptr);

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -214,6 +214,8 @@ void draw_analytical_place(ezgl::renderer* g) {
     const PartialPlacement* ap_pp = draw_state->get_ap_partial_placement_ref();
     // The reference should be set in the beginning of analytial placement.
     VTR_ASSERT(ap_pp != nullptr);
+    if (ap_pp == nullptr)
+        return;
     for (const auto& [blk_id, x] : ap_pp->block_x_locs.pairs()) {
         double y = ap_pp->block_y_locs[blk_id];
 

--- a/vpr/src/draw/draw_interposer.cpp
+++ b/vpr/src/draw/draw_interposer.cpp
@@ -36,7 +36,7 @@ void draw_interposer_cuts(ezgl::renderer* g) {
         }
 
         for (int cut_y : horizontal_cuts[layer]) {
-            float y;
+            float y = 0.0;
             if (draw_state->pic_on_screen == e_pic_type::PLACEMENT) {
                 // Draw the interposer line exactly in the middle of routing channel.
                 y = (draw_coords->tile_y[cut_y + 1] + draw_coords->tile_y[cut_y] + draw_coords->get_tile_height()) / 2.0f;
@@ -53,7 +53,7 @@ void draw_interposer_cuts(ezgl::renderer* g) {
         }
 
         for (int cut_x : vertical_cuts[layer]) {
-            float x;
+            float x = 0.0;
             if (draw_state->pic_on_screen == e_pic_type::PLACEMENT) {
                 // Draw the interposer line exactly in the middle of routing channel.
                 x = (draw_coords->tile_x[cut_x + 1] + draw_coords->tile_x[cut_x] + draw_coords->get_tile_width()) / 2.0f;

--- a/vpr/src/noc/noc_storage.cpp
+++ b/vpr/src/noc/noc_storage.cpp
@@ -94,7 +94,8 @@ NocRouterId NocStorage::get_router_at_grid_location(const t_pl_loc& hard_router_
     // get the hard router block id at the given grid location
     auto hard_router_block = grid_location_to_router_id.find(router_key);
     // verify whether a router hard block exists at this location
-    VTR_ASSERT(hard_router_block != grid_location_to_router_id.end());
+    if (hard_router_block == grid_location_to_router_id.end())
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER, "No router hard block found at the given grid location.");
 
     return hard_router_block->second;
 }

--- a/vpr/src/pack/post_routing_pb_pin_fixup.cpp
+++ b/vpr/src/pack/post_routing_pb_pin_fixup.cpp
@@ -556,7 +556,8 @@ static const t_pb_graph_pin* find_mapped_equivalent_pb_pin_by_net(t_pb* pb,
         }
     }
 
-    VTR_ASSERT(1 == cnt);
+    if (cnt != 1)
+        VPR_FATAL_ERROR(VPR_ERROR_PACK, "Expected exactly 1 pb_graph_pin mapped to the atom net, found %d.", cnt);
 
     return found_pb_pin;
 }
@@ -769,7 +770,8 @@ static void update_cluster_regular_routing_traces_with_post_routing_results(Atom
                     const t_pb* sink_pb = pb->find_pb(new_sink_pb_pin_to_add->parent_node);
                     VTR_ASSERT(sink_pb);
                     t_pb_graph_pin* next_sink_pb_pin_to_add = find_used_sink_pb_pin(new_sink_pb_pin_to_add, sink_pb->mode);
-                    VTR_ASSERT(next_sink_pb_pin_to_add);
+                    if (next_sink_pb_pin_to_add == nullptr)
+                        VPR_FATAL_ERROR(VPR_ERROR_PACK, "Could not find a unique sink pb_graph_pin from the driver pb_graph_pin.");
 
                     /* Assign sinks */
                     new_pb_routes[new_sink_pb_route_id].sink_pb_pin_ids.push_back(next_sink_pb_pin_to_add->pin_count_in_cluster);
@@ -824,7 +826,8 @@ static void update_cluster_regular_routing_traces_with_post_routing_results(Atom
                             const t_pb* next_pb = pb->find_pb(next_pb_pin->parent_node);
                             VTR_ASSERT(next_pb);
                             next_pb_pin = find_used_sink_pb_pin(next_pb_pin, next_pb->mode);
-                            VTR_ASSERT(next_pb_pin);
+                            if (next_pb_pin == nullptr)
+                                VPR_FATAL_ERROR(VPR_ERROR_PACK, "Could not find a unique sink pb_graph_pin from the driver pb_graph_pin.");
                             new_pb_routes[next_pb_pin->pin_count_in_cluster].atom_net_id = remapped_net;
                         }
 

--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -362,7 +362,7 @@ static void sync_clustered_netlist_to_routing(void) {
                 else if (pb_graph_pin->port->type == OUT_PORT)
                     port_type = PortType::OUTPUT;
                 else
-                    VTR_ASSERT_MSG(false, "Unsupported port type");
+                    VPR_FATAL_ERROR(VPR_ERROR_PACK, "Unsupported port type.");
                 port_id = clb_netlist.create_port(clb, pb_graph_pin->port->name, pb_graph_pin->port->num_pins, port_type);
             }
             PinType pin_type = node_type == e_rr_type::OPIN ? PinType::DRIVER : PinType::SINK;

--- a/vpr/src/power/power_cmos_tech.cpp
+++ b/vpr/src/power/power_cmos_tech.cpp
@@ -379,7 +379,7 @@ bool power_find_transistor_info(t_transistor_size_inf** lower,
     } else if (type == PMOS) {
         trans_info = &power_ctx.tech->PMOS_inf;
     } else {
-        VTR_ASSERT(0);
+        VPR_FATAL_ERROR(VPR_ERROR_POWER, "Unsupported transistor type.");
     }
 
     /* No transistor data exists */

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -913,7 +913,12 @@ void reserve_locally_used_opins(HeapInterface* heap, float pres_fac, float acc_f
             for (ipin = 0; ipin < num_local_opin; ipin++) {
                 //Pop the nodes off the heap. We get them from the heap so we
                 //reserve those pins with lowest congestion cost first.
-                VTR_ASSERT(heap->try_pop(heap_head_node));
+                if (!heap->try_pop(heap_head_node)) {
+                    VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
+                                    "Ran out of OPINs when reserving locally used pins "
+                                    "for block %d, class %d (needed %d, exhausted after %d).",
+                                    (int)blk_id, iclass, num_local_opin, ipin);
+                }
                 const RRNodeId& inode = heap_head_node.node;
 
                 VTR_ASSERT(rr_graph.node_type(inode) == e_rr_type::OPIN);

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
@@ -392,7 +392,7 @@ inline int chan_type_to_index(e_rr_type chan_type) {
             chan_index = 2;
             break;
         default:
-            VTR_ASSERT(false);
+            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Unsupported channel type.");
     }
 
     return chan_index;

--- a/vpr/src/route/rr_graph_generation/rr_graph_intra_cluster.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph_intra_cluster.cpp
@@ -222,7 +222,8 @@ static std::vector<int> get_cluster_block_pins(t_physical_tile_type_ptr physical
         }
     }
 
-    VTR_ASSERT(found_sub_tile);
+    if (!found_sub_tile)
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Could not find the sub-tile instance that the cluster block is mapped to.");
     std::vector<int> pin_num_vec(cluster_sub_tile_inst_num_pins);
     // Pin numbers are assigned such that each instance’s tile-level pins
     // occupy a continuous range equal to the total number of tile-level pins for that instance.

--- a/vpr/src/route/rr_graph_generation/rr_graph_opin_chan_edges.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph_opin_chan_edges.cpp
@@ -534,7 +534,8 @@ static int get_opin_direct_connections(RRGraphBuilder& rr_graph_builder,
                                 break;
                             }
                         }
-                        VTR_ASSERT(target_sub_tile != nullptr);
+                        if (target_sub_tile == nullptr)
+                            VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Could not find the sub-tile instance for the target capacity.");
                         if (relative_ipin >= target_sub_tile->num_phy_pins) continue;
 
                         // If this block has capacity > 1 then the pins of z position > 0 are offset

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/crr_generator/crr_edge_builder.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/crr_generator/crr_edge_builder.cpp
@@ -98,8 +98,8 @@ void build_crr_gsb_edges(RRGraphBuilder& rr_graph_builder,
             rr_switch_id = rr_node_driver_switches[connection.sink_node()];
         } else {
             auto it = delay_to_switch_id.find(delay_ps);
-            VTR_ASSERT_MSG(it != delay_to_switch_id.end(),
-                           "CRR connection delay was not pre-created in delay_to_switch_id map");
+            if (it == delay_to_switch_id.end())
+                VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "CRR connection delay was not pre-created in delay_to_switch_id map.");
             rr_switch_id = it->second;
         }
         VTR_ASSERT(rr_switch_id != RRSwitchId::INVALID());

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_gsb.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_gsb.cpp
@@ -1760,7 +1760,8 @@ void build_direct_connections_for_one_gsb(const RRGraphView& rr_graph,
                             break;
                         }
                     }
-                    VTR_ASSERT(to_sub_tile != nullptr);
+                    if (to_sub_tile == nullptr)
+                        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Could not find the sub-tile instance for the target capacity.");
                     // Check if the to port is the one from the subtile, if not, pass as this is not the destination
                     bool port_match = false;
                     for (auto to_sub_tile_port : to_sub_tile->ports) {

--- a/vpr/src/timing/net_delay.cpp
+++ b/vpr/src/timing/net_delay.cpp
@@ -81,7 +81,8 @@ static void load_one_net_delay(const Netlist<>& net_list,
 
     for (unsigned int ipin = 1; ipin < net_list.net_pins(net_id).size(); ipin++) {
         auto itr = ipin_to_Tdel_map.find(ipin);
-        VTR_ASSERT(itr != ipin_to_Tdel_map.end());
+        if (itr == ipin_to_Tdel_map.end())
+            VPR_FATAL_ERROR(VPR_ERROR_TIMING, "Could not find ipin in ipin_to_Tdel_map.");
 
         net_delay[net_id][ipin] = itr->second; // search for the value of Tdel in the ipin map and load into net_delay
     }

--- a/vpr/src/timing/read_sdc.cpp
+++ b/vpr/src/timing/read_sdc.cpp
@@ -1389,7 +1389,8 @@ class SdcParseCallback : public sdcparse::Callback {
         }
 
         auto it = object_to_net_id_.find(net_object_id);
-        VTR_ASSERT(it != object_to_net_id_.end());
+        if (it == object_to_net_id_.end())
+            VPR_FATAL_ERROR(VPR_ERROR_SDC, "Could not find net object in object_to_net_id_ map.");
         return it->second;
     }
 
@@ -1420,7 +1421,8 @@ class SdcParseCallback : public sdcparse::Callback {
         }
 
         auto it = object_to_clock_id_.find(clock_object_id);
-        VTR_ASSERT(it != object_to_clock_id_.end());
+        if (it == object_to_clock_id_.end())
+            VPR_FATAL_ERROR(VPR_ERROR_SDC, "Could not find clock object in object_to_clock_id_ map.");
         return it->second;
     }
 


### PR DESCRIPTION
I have been finding some bad anti-patterns in the code where people are using asserts to throw an error from a function. This is always a bad idea and will cause undefined behavior in release builds where assert levels are turned down.

The default VTR assert level is 2, which is hiding a lot of this behavior, but it does concern me since I sometimes run at assert level 1 to collect results.

Added this CI test to at least keep an eye on this. The warnings are actually quite good at catching this. We should decide if we should make this test error on warning or not.