### PR TITLE
[WIP] Add clang-tidy checks to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,18 +17,6 @@ Checks: >
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-return-const-ref-from-parameter,
   -bugprone-unchecked-string-to-number-conversion,
-  # performance-*,
-  # readability-*,
-  #-readability-function-cognitive-complexity,
-  #-readability-identifier-length,
-  #-readability-simplify-boolean-expr,
-  #-readability-redundant-access-specifiers,
-  #-readability-avoid-const-params-in-decls,
-  #-readability-else-after-return,
-  #-readability-uppercase-literal-suffix,
-  #-readability-use-anyofallof,
-  #-readability-redundant-inline-specifier,
-  #-readability-isolate-declaration,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,9 @@ jobs:
     name: C/C++ Lint
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    env:
+      CLANG_TIDY: clang-tidy-19
+      RUN_CLANG_TIDY: run-clang-tidy-19
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,3 +43,35 @@ jobs:
 
       - name: Lint Python Files Using Pylint
         run: ./dev/pylint_check.py
+
+  CppLint:
+    name: C/C++ Lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
+
+      - name: Install Requirements
+        run: |
+          ./install_apt_packages.sh
+          sudo apt-get install -y clang-tidy clang-tools
+
+      - name: Configure Build Database
+        run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Lint VPR C/C++ Files Using Clang-Tidy
+        run: ./dev/run_linter.py -j${{ steps.cpu-cores.outputs.count }} vpr
+
+      - name: Lint librrgraph C/C++ Files Using Clang-Tidy
+        run: ./dev/run_linter.py -j${{ steps.cpu-cores.outputs.count }} libs/librrgraph
+
+      - name: Lint libarchfpga C/C++ Files Using Clang-Tidy
+        run: ./dev/run_linter.py -j${{ steps.cpu-cores.outputs.count }} libs/libarchfpga

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Requirements
         run: |
           ./install_apt_packages.sh
-          sudo apt-get install -y clang-tidy clang-tools
+          sudo apt-get install -y clang-tidy-19
 
       - name: Configure Build Database
         run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON


### PR DESCRIPTION
Adds automatic linter runs for vpr, libarchfpga and librrgraph to CI. Should wait until #3551 and #3552 are merger before this.