### PR TITLE
Changed the type of t_model::name from char* to std::string

### DIFF
--- a/libs/libarchfpga/src/arch_check.cpp
+++ b/libs/libarchfpga/src/arch_check.cpp
@@ -24,7 +24,7 @@ bool check_model_clocks(const t_model& model, const char* file, uint32_t line) {
             if (!port->clock.empty() && !clocks.count(port->clock)) {
                 archfpga_throw(file, line,
                                "No matching clock port '%s' on model '%s', required for port '%s'",
-                               port->clock.c_str(), model.name, port->name);
+                               port->clock.c_str(), model.name.c_str(), port->name);
             }
         }
     }
@@ -37,7 +37,7 @@ bool check_model_combinational_sinks(const t_model& model, const char* file, uin
         if (!port->combinational_sink_ports.empty()) {
             archfpga_throw(file, line,
                            "Model '%s' output port '%s' can not have combinational sink ports",
-                           model.name, port->name);
+                           model.name.c_str(), port->name);
         }
     }
 
@@ -53,7 +53,7 @@ bool check_model_combinational_sinks(const t_model& model, const char* file, uin
             if (!output_ports.count(sink_port_name)) {
                 archfpga_throw(file, line,
                                "Model '%s' input port '%s' can not be combinationally connected to '%s' (not an output port of the model)",
-                               model.name, port->name, sink_port_name.c_str());
+                               model.name.c_str(), port->name, sink_port_name.c_str());
             }
 
             //Check that any output combinational sinks are not clocks
@@ -63,7 +63,7 @@ bool check_model_combinational_sinks(const t_model& model, const char* file, uin
                 archfpga_throw(file, line,
                                "Model '%s' output port '%s' can not be both: a clock source (is_clock=\"%d\"),"
                                " and combinationally connected to input port '%s' (acting as a clock buffer).",
-                               model.name, sink_port->name, sink_port->is_clock, port->name);
+                               model.name.c_str(), sink_port->name, sink_port->is_clock, port->name);
             }
         }
     }
@@ -81,7 +81,7 @@ void warn_model_missing_timing(const t_model& model, const char* file, uint32_t 
         ) {
             if (device_model_warnings) {
                 VTR_LOGF_WARN(file, line,
-                              "Model '%s' input port '%s' has no timing specification (no clock specified to create a sequential input port, not combinationally connected to any outputs, not a clock input)\n", model.name, port->name);
+                              "Model '%s' input port '%s' has no timing specification (no clock specified to create a sequential input port, not combinationally connected to any outputs, not a clock input)\n", model.name.c_str(), port->name);
             }
         }
 
@@ -95,7 +95,7 @@ void warn_model_missing_timing(const t_model& model, const char* file, uint32_t 
         ) {
             if (device_model_warnings) {
                 VTR_LOGF_WARN(file, line,
-                              "Model '%s' output port '%s' has no timing specification (no clock specified to create a sequential output port, not combinationally connected to any inputs, not a clock output)\n", model.name, port->name);
+                              "Model '%s' output port '%s' has no timing specification (no clock specified to create a sequential output port, not combinationally connected to any inputs, not a clock output)\n", model.name.c_str(), port->name);
             }
         }
     }
@@ -200,13 +200,13 @@ bool check_leaf_pb_model_timing_consistency(const t_pb_type* pb_type, const t_ar
                             archfpga_throw(get_arch_file_name(), annotation.line_num,
                                            "<pb_type> timing-annotation/<model> mismatch on port '%s' of model '%s', model specifies"
                                            " no clock but timing annotation specifies '%s'",
-                                           annot_port.port_name().c_str(), model.name, annot_clock.port_name().c_str());
+                                           annot_port.port_name().c_str(), model.name.c_str(), annot_clock.port_name().c_str());
                         }
                         if (model_port->clock != annot_clock.port_name()) {
                             archfpga_throw(get_arch_file_name(), annotation.line_num,
                                            "<pb_type> timing-annotation/<model> mismatch on port '%s' of model '%s', model specifies"
                                            " clock as '%s' but timing annotation specifies '%s'",
-                                           annot_port.port_name().c_str(), model.name, model_clock.c_str(), annot_clock.port_name().c_str());
+                                           annot_port.port_name().c_str(), model.name.c_str(), model_clock.c_str(), annot_clock.port_name().c_str());
                         }
                     }
                 }
@@ -242,7 +242,7 @@ bool check_leaf_pb_model_timing_consistency(const t_pb_type* pb_type, const t_ar
                             archfpga_throw(get_arch_file_name(), annotation.line_num,
                                            "<pb_type> timing-annotation/<model> mismatch on port '%s' of model '%s', timing annotation"
                                            " specifies combinational connection to port '%s' but the connection does not exist in the model",
-                                           model_port->name, model.name, annot_out.port_name().c_str());
+                                           model_port->name, model.name.c_str(), annot_out.port_name().c_str());
                         }
                     }
                 }
@@ -391,7 +391,7 @@ void check_models(t_arch* arch) {
         const t_model& model = arch->models.get_model(model_id);
         if (model.pb_types.empty()) {
             archfpga_throw(get_arch_file_name(), 0,
-                           "No pb_type found for model %s\n", model.name);
+                           "No pb_type found for model %s\n", model.name.c_str());
         }
 
         int clk_count, input_count, output_count;
@@ -408,7 +408,7 @@ void check_models(t_arch* arch) {
                         break;
                     default:
                         archfpga_throw(get_arch_file_name(), 0,
-                                       "Port %s of model %s, has an unrecognized type %s\n", port->name, model.name);
+                                       "Port %s of model %s, has an unrecognized type %s\n", port->name, model.name.c_str());
                 }
 
                 port->index = index;

--- a/libs/libarchfpga/src/echo_arch.cpp
+++ b/libs/libarchfpga/src/echo_arch.cpp
@@ -336,7 +336,7 @@ void PrintArchInfo(FILE* Echo, const t_arch* arch) {
 }
 
 static void print_model(FILE* echo, const t_model& model) {
-    fprintf(echo, "Model: \"%s\"\n", model.name);
+    fprintf(echo, "Model: \"%s\"\n", model.name.c_str());
     t_model_ports* input_model_port = model.inputs;
     while (input_model_port) {
         fprintf(echo, "\tInput Ports: \"%s\" \"%d\" min_size=\"%d\"\n",

--- a/libs/libarchfpga/src/logic_types.cpp
+++ b/libs/libarchfpga/src/logic_types.cpp
@@ -148,7 +148,6 @@ void LogicalModels::free_model_data(t_model& model) {
 
     if (model.instances)
         vtr::free(model.instances);
-    vtr::free(model.name);
 }
 
 static void free_arch_model_ports(t_model_ports* model_ports) {

--- a/libs/libarchfpga/src/logic_types.h
+++ b/libs/libarchfpga/src/logic_types.h
@@ -70,7 +70,7 @@ struct t_model_ports {
  *        LogicalModels storage class below.
  */
 struct t_model {
-    char* name = nullptr;             ///< name of this logic model
+    std::string name;             ///< name of this logic model
     t_model_ports* inputs = nullptr;  ///< linked list of input/clock ports
     t_model_ports* outputs = nullptr; ///< linked list of output ports
     void* instances = nullptr;        ///< TODO: Remove this. This is only used in the Parmys plugin and should be moved into there.
@@ -203,7 +203,7 @@ class LogicalModels {
                        "A model with the given name already exists");
         // Create the new model.
         t_model new_model;
-        new_model.name = vtr::strdup(model_name.c_str());
+        new_model.name = model_name;
 
         // Create the new model's ID
         LogicalModelId new_model_id = LogicalModelId(logical_model_ids_.size());

--- a/libs/libarchfpga/src/logic_types.h
+++ b/libs/libarchfpga/src/logic_types.h
@@ -70,7 +70,7 @@ struct t_model_ports {
  *        LogicalModels storage class below.
  */
 struct t_model {
-    std::string name;             ///< name of this logic model
+    std::string name;                 ///< name of this logic model
     t_model_ports* inputs = nullptr;  ///< linked list of input/clock ports
     t_model_ports* outputs = nullptr; ///< linked list of output ports
     void* instances = nullptr;        ///< TODO: Remove this. This is only used in the Parmys plugin and should be moved into there.

--- a/libs/libarchfpga/src/write_models_bb.cpp
+++ b/libs/libarchfpga/src/write_models_bb.cpp
@@ -93,7 +93,7 @@ void WriteModels_bb(const char* ArchFile,
  */
 void DeclareModel_bb(FILE* Echo, const t_model& model) {
     // module
-    fprintf(Echo, "module %s(\n", model.name);
+    fprintf(Echo, "module %s(\n", model.name.c_str());
 
     // input/output ports
     t_model_ports* input_port = model.inputs;

--- a/odin_ii/src/core/adders.cpp
+++ b/odin_ii/src/core/adders.cpp
@@ -115,7 +115,7 @@ void find_hard_adders() {
     hard_adders = NULL;
     for (LogicalModelId model_id : Arch.models.user_models()) {
         hard_adders = &Arch.models.get_model(model_id);
-        if (strcmp(hard_adders->name, "adder") == 0) {
+        if (hard_adders->name == "adder") {
             init_add_distribution();
             return;
         } else {

--- a/odin_ii/src/core/hard_blocks.cpp
+++ b/odin_ii/src/core/hard_blocks.cpp
@@ -59,7 +59,7 @@ void cache_hard_block_names() {
     hard_block_names = sc_new_string_cache();
     for (LogicalModelId model_id : Arch.models.user_models()) {
         t_model* hard_blocks = &Arch.models.get_model(model_id);
-        int sc_spot = sc_add_string(hard_block_names, hard_blocks->name);
+        int sc_spot = sc_add_string(hard_block_names, hard_blocks->name.c_str());
         hard_block_names->data[sc_spot] = (void*)hard_blocks;
     }
 }
@@ -211,11 +211,11 @@ void output_hard_blocks(FILE* out) {
         if (hard_blocks->used == 1) /* Hard Block is utilized */
         {
             //IF the hard_blocks is an adder or a multiplier, we ignore it.(Already print out in add_the_blackbox_for_adds and add_the_blackbox_for_mults)
-            if (strcmp(hard_blocks->name, "adder") == 0 || strcmp(hard_blocks->name, "multiply") == 0) {
+            if (hard_blocks->name == "adder" || hard_blocks->name == "multiply") {
                 break;
             }
 
-            fprintf(out, "\n.model %s\n", hard_blocks->name);
+            fprintf(out, "\n.model %s\n", hard_blocks->name.c_str());
             count = fprintf(out, ".inputs");
             hb_ports = hard_blocks->inputs;
             while (hb_ports != NULL) {
@@ -287,7 +287,7 @@ int hard_block_port_size(t_model* hb, char* pname) {
      *  depending on the instance of the hard block. May want to extend
      *  this list of blocks in the future.
      */
-    if ((strcmp(hb->name, SINGLE_PORT_RAM_string) == 0) || (strcmp(hb->name, DUAL_PORT_RAM_string) == 0)) {
+    if ((strcmp(hb->name.c_str(), SINGLE_PORT_RAM_string) == 0) || (strcmp(hb->name.c_str(), DUAL_PORT_RAM_string) == 0)) {
         return -1;
     }
 

--- a/odin_ii/src/core/multipliers.cpp
+++ b/odin_ii/src/core/multipliers.cpp
@@ -302,7 +302,7 @@ void find_hard_multipliers() {
     min_mult = configuration.min_hard_multiplier;
     for (LogicalModelId model_id : Arch.models.user_models()) {
         hard_multipliers = &Arch.models.get_model(model_id);
-        if (strcmp(hard_multipliers->name, "multiply") == 0) {
+        if (hard_multipliers->name == "multiply") {
             init_mult_distribution();
             return;
         } else {

--- a/odin_ii/src/netlist/netlist_create_from_ast.cpp
+++ b/odin_ii/src/netlist/netlist_create_from_ast.cpp
@@ -1586,7 +1586,7 @@ void connect_hard_block_and_alias(ast_node_t* hb_instance, char* instance_name_p
             oassert(port_size != 0);
             port_size = outport_size;
 
-            if (strcmp(hb_model->name, "adder") == 0) {
+            if (hb_model->name == "adder") {
                 if (strcmp(hb_var_node->types.identifier, "cout") == 0 && flag == 0)
                     port_size = 1;
                 else if (strcmp(hb_var_node->types.identifier, "sumout") == 0 && flag == 0)
@@ -5156,9 +5156,9 @@ signal_list_t* create_hard_block(ast_node_t* block, char* instance_name_prefix, 
     }
 
     /* memory's are a special case due to splitting */
-    if (strcmp(hb_model->name, "multiply") == 0) {
+    if (hb_model->name == "multiply") {
         is_mult = 1;
-    } else if (strcmp(hb_model->name, "adder") == 0) {
+    } else if (hb_model->name == "adder") {
         is_adder = 1;
     }
 

--- a/parmys/parmys-plugin/core/adder.cc
+++ b/parmys/parmys-plugin/core/adder.cc
@@ -104,7 +104,7 @@ void find_hard_adders()
     hard_adders = NULL;
     for (LogicalModelId model_id : Arch.models.user_models()) {
         hard_adders = &Arch.models.get_model(model_id);
-        if (strcmp(hard_adders->name, "adder") == 0) {
+        if (hard_adders->name == "adder") {
             init_add_distribution();
             return;
         } else {

--- a/parmys/parmys-plugin/core/hard_block.cc
+++ b/parmys/parmys-plugin/core/hard_block.cc
@@ -64,7 +64,7 @@ void cache_hard_block_names()
     std::reverse(user_models.begin(), user_models.end());
     for (LogicalModelId model_id : user_models) {
         t_model* hard_blocks = &Arch.models.get_model(model_id);
-        int sc_spot = sc_add_string(hard_block_names, hard_blocks->name);
+        int sc_spot = sc_add_string(hard_block_names, hard_blocks->name.c_str());
         hard_block_names->data[sc_spot] = (void *)hard_blocks;
     }
 }
@@ -214,7 +214,7 @@ void output_hard_blocks_yosys(Yosys::Design *design)
         {
             // IF the hard_blocks is an adder or a multiplier, we ignore it.(Already print out in add_the_blackbox_for_adds and
             // add_the_blackbox_for_mults)
-            if (strcmp(hard_blocks->name, "adder") == 0 || strcmp(hard_blocks->name, "multiply") == 0) {
+            if (hard_blocks->name == "adder" || hard_blocks->name == "multiply") {
                 break;
             }
 

--- a/parmys/parmys-plugin/core/multiplier.cc
+++ b/parmys/parmys-plugin/core/multiplier.cc
@@ -549,7 +549,7 @@ void find_hard_multipliers()
     min_mult = configuration.min_hard_multiplier;
     for (LogicalModelId model_id : Arch.models.user_models()) {
         hard_multipliers = &Arch.models.get_model(model_id);
-        if (strcmp(hard_multipliers->name, "multiply") == 0) {
+        if (hard_multipliers->name == "multiply") {
             init_mult_distribution();
             return;
         } else {

--- a/parmys/parmys-plugin/parmys_arch.cc
+++ b/parmys/parmys-plugin/parmys_arch.cc
@@ -128,10 +128,10 @@ struct ParmysArchPass : public Pass {
             std::reverse(user_models.begin(), user_models.end());
             for (LogicalModelId model_id : user_models) {
                 t_model* hb = &arch.models.get_model(model_id);
-                if (strcmp(hb->name, SINGLE_PORT_RAM_string) && strcmp(hb->name, DUAL_PORT_RAM_string) && strcmp(hb->name, "multiply") &&
-                    strcmp(hb->name, "adder")) {
+                if (strcmp(hb->name.c_str(), SINGLE_PORT_RAM_string) && strcmp(hb->name.c_str(), DUAL_PORT_RAM_string) && strcmp(hb->name.c_str(), "multiply") &&
+                    strcmp(hb->name.c_str(), "adder")) {
                     add_hb_to_design(hb, design);
-                    log("Hard block added to the Design ---> `%s`\n", hb->name);
+                    log("Hard block added to the Design ---> `%s`\n", hb->name.c_str());
                 }
             }
 

--- a/vpr/src/base/atom_netlist_utils.cpp
+++ b/vpr/src/base/atom_netlist_utils.cpp
@@ -315,7 +315,7 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist, const LogicalMod
         }
 
         fprintf(f, "# Subckt %zu: %s\n", size_t(blk_id), netlist.block_name(blk_id).c_str());
-        fprintf(f, ".subckt %s \\\n", model.name);
+        fprintf(f, ".subckt %s \\\n", model.name.c_str());
         for (size_t i = 0; i < ports.size(); i++) {
             auto width = netlist.port_width(ports[i]);
             for (size_t j = 0; j < width; ++j) {
@@ -370,7 +370,7 @@ void print_netlist_as_blif(FILE* f, const AtomNetlist& netlist, const LogicalMod
     //The subckt models
     for (LogicalModelId model_id : subckt_models) {
         const t_model& model = models.get_model(model_id);
-        fprintf(f, ".model %s\n", model.name);
+        fprintf(f, ".model %s\n", model.name.c_str());
 
         fprintf(f, ".inputs");
         const t_model_ports* port = model.inputs;

--- a/vpr/src/base/atom_netlist_utils.cpp
+++ b/vpr/src/base/atom_netlist_utils.cpp
@@ -630,7 +630,7 @@ int infer_and_mark_block_sequential_outputs_constant(AtomNetlist& netlist, AtomB
             VTR_LOGV(verbosity > 1, "Marking sequential pin '%s' as constant since all inputs to block '%s' (%s) are constant\n",
                      netlist.pin_name(output_pin).c_str(),
                      netlist.block_name(blk).c_str(),
-                     models.get_model(netlist.block_model(blk)).name);
+                     models.get_model(netlist.block_model(blk)).name.c_str());
             netlist.set_pin_is_constant(output_pin, true);
             ++num_pins_marked_constant;
         }

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -268,7 +268,7 @@ struct BlifAllocCallback : public blifparse::Callback {
             //Since this is unusual, warn the user
             VTR_LOGF_WARN(filename_.c_str(), lineno_,
                           "Subckt of type '%s' at %s:%d has no output pins, and has been named '%s'\n",
-                          blk_model.name, filename_.c_str(), lineno_, subckt_name.c_str());
+                          blk_model.name.c_str(), filename_.c_str(), lineno_, subckt_name.c_str());
         }
 
         //The name for every block should be unique, check that there is no name conflict
@@ -277,7 +277,7 @@ struct BlifAllocCallback : public blifparse::Callback {
             vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_,
                       "Duplicate blocks named '%s' found in netlist."
                       " Existing block of type '%s' conflicts with subckt of type '%s'.",
-                      subckt_name.c_str(), models_.get_model(conflicting_model).name, subckt_model.c_str());
+                      subckt_name.c_str(), models_.get_model(conflicting_model).name.c_str(), subckt_model.c_str());
         }
 
         //Create the block
@@ -478,7 +478,7 @@ struct BlifAllocCallback : public blifparse::Callback {
                         //Out of range
                         vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_,
                                   "Port '%s' on architecture model '%s' exceeds port width (%d bits)\n",
-                                  port_name.c_str(), blk_model.name, curr_port->size);
+                                  port_name.c_str(), blk_model.name.c_str(), curr_port->size);
                     }
                 }
                 curr_port = curr_port->next;
@@ -488,7 +488,7 @@ struct BlifAllocCallback : public blifparse::Callback {
         //No match
         vpr_throw(VPR_ERROR_BLIF_F, filename_.c_str(), lineno_,
                   "Found no matching port '%s' on architecture model '%s'\n",
-                  port_name.c_str(), blk_model.name);
+                  port_name.c_str(), blk_model.name.c_str());
         return nullptr;
     }
 

--- a/vpr/src/base/read_interchange_netlist.cpp
+++ b/vpr/src/base/read_interchange_netlist.cpp
@@ -380,7 +380,7 @@ struct NetlistReader {
                 vpr_throw(VPR_ERROR_IC_NETLIST_F, netlist_file_, -1,
                           "Duplicate blocks named '%s' found in netlist."
                           " Existing block of type '%s' conflicts with subckt of type '%s'.",
-                          inst_name.c_str(), models_.get_model(conflicting_model).name, blk_model.name);
+                          inst_name.c_str(), models_.get_model(conflicting_model).name.c_str(), blk_model.name.c_str());
             }
 
             auto port_net_map = port_net_maps_.at(inst_idx);
@@ -470,7 +470,7 @@ struct NetlistReader {
         //No match
         vpr_throw(VPR_ERROR_IC_NETLIST_F, netlist_file_, -1,
                   "Found no matching port '%s' on architecture model '%s'\n",
-                  name.c_str(), blk_model.name);
+                  name.c_str(), blk_model.name.c_str());
         return nullptr;
     }
 

--- a/vpr/src/pack/greedy_clusterer.cpp
+++ b/vpr/src/pack/greedy_clusterer.cpp
@@ -448,7 +448,7 @@ LegalizationClusterId GreedyClusterer::start_new_cluster(
         prioritize_pre_assigned_ram_type(root_atom, prepacker, ram_mapper, atom_netlist_, candidate_types);
 
     if (log_verbosity_ > 2) {
-        VTR_LOG("\tSeed: '%s' (%s)", root_atom_name.c_str(), arch_.models.get_model(root_model_id).name);
+        VTR_LOG("\tSeed: '%s' (%s)", root_atom_name.c_str(), arch_.models.get_model(root_model_id).name.c_str());
         VTR_LOGV(seed_mol.pack_pattern, " molecule_type %s molecule_size %zu",
                  seed_mol.pack_pattern->name, seed_mol.atom_block_ids.size());
         VTR_LOG("\n");

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -911,7 +911,7 @@ void Prepacker::alloc_and_load_pack_molecules(std::multimap<AtomBlockId, PackMol
         t_pb_graph_node* best = get_expected_lowest_cost_primitive_for_atom_block(blk_id, logical_block_types);
         if (!best) {
             VPR_FATAL_ERROR(VPR_ERROR_PACK, "Failed to find any location to pack primitive of type '%s' in architecture",
-                            models.get_model(atom_nlist.block_model(blk_id)).name);
+                            models.get_model(atom_nlist.block_model(blk_id)).name.c_str());
         }
 
         VTR_ASSERT_SAFE(nullptr != best);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Changed the type of t_model::name from char* to std::string, and made non-logical changes to affected files. NOTE: this PR is a substitution to an earlier one I submitted, where I also changed t_model_port::name to std::string. Something dramatic with Odin II happened at the end and I wasn't able to resolve it, and hence I had to revert everything. Full details can be seen on my Wiki page.
#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The old C style string is inconsistent with other parts of VTR where std::string is mainly used, and it is hard to maintain. This commit brings the t_model struct closer to the modern C++ fashion.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I had a successful build (one with Odin II and one without) and run three strong regression tests named "strong_timing", "strong_fpu_hard_block_arch" and "strong_soft_multipliers". No issues were found.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
