### PR TITLE
Add APPack interposer gain multiplier

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1499,6 +1499,16 @@ Analytical Placement is generally split into three stages:
 
     **Default:** ``auto``
 
+.. option:: --appack_inter_die_gain_multiplier <float>
+
+   Multiplier applied to APPack candidate gains when the candidate's flat
+   placement location is on a different die than the current cluster location
+   in an interposer-based architecture. This option only applies when the
+   device grid has interposer cuts; it does not apply to candidates on a
+   different layer in a 3D architecture without interposer cuts.
+
+    **Default:** ``0.1``
+
 .. option:: --ap_high_fanout_threshold <int>
 
     Defines the threshold for high fanout nets within AP flow.

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2132,7 +2132,9 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .help(
             "Multiplier applied to APPack candidate gains when the candidate's "
             "flat placement location is on a different die than the current "
-            "cluster location.")
+            "cluster location in an interposer-based architecture. This does "
+            "not apply to candidates on a different layer in a 3D architecture "
+            "without interposer cuts.")
         .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2128,6 +2128,14 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value({"auto"})
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    ap_grp.add_argument(args.appack_inter_die_gain_multiplier, "--appack_inter_die_gain_multiplier")
+        .help(
+            "Multiplier applied to APPack candidate gains when the candidate's "
+            "flat placement location is on a different die than the current "
+            "cluster location.")
+        .default_value("0.1")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     ap_grp.add_argument<int>(args.ap_verbosity, "--ap_verbosity")
         .help(
             "Controls how verbose the AP flow's log messages will be. Higher "

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -108,6 +108,7 @@ struct t_options {
     argparse::ArgValue<std::vector<std::string>> ap_partial_legalizer_target_density;
     argparse::ArgValue<std::vector<std::string>> appack_max_dist_th;
     argparse::ArgValue<std::vector<std::string>> appack_unrelated_clustering_args;
+    argparse::ArgValue<float> appack_inter_die_gain_multiplier;
     argparse::ArgValue<int> ap_verbosity;
     argparse::ArgValue<float> ap_timing_tradeoff;
     argparse::ArgValue<int> ap_high_fanout_threshold;

--- a/vpr/src/base/setup_vpr.cpp
+++ b/vpr/src/base/setup_vpr.cpp
@@ -603,6 +603,7 @@ static void setup_ap_opts(const t_options& options,
     apOpts.ap_partial_legalizer_target_density = options.ap_partial_legalizer_target_density.value();
     apOpts.appack_max_dist_th = options.appack_max_dist_th.value();
     apOpts.appack_unrelated_clustering_args = options.appack_unrelated_clustering_args.value();
+    apOpts.appack_inter_die_gain_multiplier = options.appack_inter_die_gain_multiplier.value();
     apOpts.num_threads = options.num_workers.value();
     apOpts.log_verbosity = options.ap_verbosity.value();
     apOpts.generate_mass_report = options.ap_generate_mass_report.value();

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1178,6 +1178,9 @@ struct t_ap_opts {
     /// Array of strings passed by the user to configure the unrelated clustering parameters used by APPack
     std::vector<std::string> appack_unrelated_clustering_args;
 
+    /// Multiplier applied to APPack candidate gains when the candidate is on a different die than the cluster.
+    float appack_inter_die_gain_multiplier;
+
     /// The number of threads the AP flow can use.
     unsigned num_threads;
 

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1178,7 +1178,8 @@ struct t_ap_opts {
     /// Array of strings passed by the user to configure the unrelated clustering parameters used by APPack
     std::vector<std::string> appack_unrelated_clustering_args;
 
-    /// Multiplier applied to APPack candidate gains when the candidate is on a different die than the cluster.
+    /// Multiplier applied to APPack candidate gains when the candidate is on a
+    /// different die than the cluster in an interposer-based architecture.
     float appack_inter_die_gain_multiplier;
 
     /// The number of threads the AP flow can use.

--- a/vpr/src/pack/appack_context.h
+++ b/vpr/src/pack/appack_context.h
@@ -25,7 +25,9 @@
  */
 struct t_appack_options {
     // Constructor for the appack options.
-    t_appack_options(const FlatPlacementInfo& flat_placement_info) {
+    t_appack_options(const FlatPlacementInfo& flat_placement_info,
+                     const t_ap_opts& ap_opts)
+        : inter_die_gain_multiplier(ap_opts.appack_inter_die_gain_multiplier) {
         // If the flat placement info is valid, we want to use APPack.
         // TODO: Should probably check that all the information is valid here.
         use_appack = flat_placement_info.valid;
@@ -69,6 +71,10 @@ struct t_appack_options {
     // Squared scaling factor for the quadratic decay term.
     static constexpr float quad_fac_sqr = (1.0f - attenuation_th) / (dist_th * dist_th);
 
+    // Gain multiplier used when a candidate's flat placement location is on a
+    // different die than the cluster location.
+    float inter_die_gain_multiplier = 0.1f;
+
     // TODO: Investigate adding flat placement info to seed selection.
 };
 
@@ -86,7 +92,7 @@ struct APPackContext : public Context {
                   const t_ap_opts& ap_opts,
                   const std::vector<t_logical_block_type> logical_block_types,
                   const DeviceGrid& device_grid)
-        : appack_options(fplace_info)
+        : appack_options(fplace_info, ap_opts)
         , flat_placement_info(fplace_info) {
 
         // If the flat placement info has been provided, calculate max distance

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -1196,6 +1196,10 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
 
         // Update the gain.
         gain *= gain_mult;
+
+        if (!g_vpr_ctx.device().grid.are_locs_on_same_die({(int)target_loc.x, (int)target_loc.y, (int)target_loc.layer}, cluster_tile_loc)) {
+            gain *= appack_options.inter_die_gain_multiplier;
+        }
     }
 
     return gain;

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -1199,8 +1199,9 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
         // Update the gain.
         gain *= gain_mult;
 
-        // Multiply molecule gain by 'inter_die_gain_multiplier' if molecule is placed in a different location from the cluster
-        // With a default value of 0.1, this would penalize packing together molecules that are on different dice 
+        // Multiply molecule gain by 'inter_die_gain_multiplier' if the molecule is placed on
+        // a different interposer die from the cluster.
+        // With a default value of 0.1, this penalizes packing together molecules that are on different dice.
         if (grid.has_interposer_cuts()) {
             t_physical_tile_loc target_physical_loc = {(int)target_loc.x, (int)target_loc.y, (int)target_loc.layer};
             if (!grid.are_locs_on_same_die(target_physical_loc, cluster_tile_loc)) {

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include "PreClusterTimingManager.h"
 #include "appack_context.h"
+#include "device_grid.h"
 #include "flat_placement_types.h"
 #include "flat_placement_utils.h"
 #include "atom_netlist.h"
@@ -1109,6 +1110,7 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
                                const APPackContext& appack_ctx) {
     VTR_ASSERT(molecule_id.is_valid());
     const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
+    const DeviceGrid& grid = g_vpr_ctx.device().grid;
 
     float gain = 0;
     constexpr float attraction_group_penalty = 0.1;
@@ -1185,7 +1187,7 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
         // tile as the rest of the molecules in the cluster.
         float dist = get_manhattan_distance_to_tile(target_loc,
                                                     cluster_tile_loc,
-                                                    g_vpr_ctx.device().grid);
+                                                    grid);
         float gain_mult = 1.0f;
         if (dist < appack_options.dist_th) {
             gain_mult = 1.0f - (appack_options.quad_fac_sqr * dist * dist);
@@ -1197,8 +1199,13 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
         // Update the gain.
         gain *= gain_mult;
 
-        if (!g_vpr_ctx.device().grid.are_locs_on_same_die({(int)target_loc.x, (int)target_loc.y, (int)target_loc.layer}, cluster_tile_loc)) {
-            gain *= appack_options.inter_die_gain_multiplier;
+        // Multiply molecule gain by 'inter_die_gain_multiplier' if molecule is placed in a different location from the cluster
+        // With a default value of 0.1, this would penalize packing together molecules that are on different dice 
+        if (grid.has_interposer_cuts()) {
+            t_physical_tile_loc target_physical_loc = {(int)target_loc.x, (int)target_loc.y, (int)target_loc.layer};
+            if (!grid.are_locs_on_same_die(target_physical_loc, cluster_tile_loc)) {
+                gain *= appack_options.inter_die_gain_multiplier;
+            }
         }
     }
 


### PR DESCRIPTION
Adds a new option --appack_inter_die_gain_multiplier with a default value of 0.1 that penalizes packing together molecules that are placed on different dice.

inter-die gain multiplier | 1 | 0.75 | 0.5 | 0.25 | 0.1
-- | -- | -- | -- | -- | --
vtr_flow_elapsed_time | 1 | 1.003303723 | 0.9920243437 | 1.005093034 | 0.9985976003
max_vpr_mem | 1 | 0.9999967307 | 0.9999687007 | 1.000255661 | 1.000107037
place_time | 1 | 1.006803593 | 0.9923678069 | 1.006045928 | 0.9983451511
routed_wirelength | 1 | 0.9983856128 | 0.9970706835 | 0.9996980128 | 1.00021068
critical_path_delay | 1 | 1.022312659 | 1.007497817 | 0.9858393346 | 0.9789470556
crit_path_route_time | 1 | 0.990572735 | 1.002302073 | 1.007940993 | 1.007240622

Results (Koios) show CPD gains without any run-time cost.