### PR TITLE
[Pack] Fixed Molecule Tracking Bug

### DIFF
--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -123,6 +123,17 @@ class DeviceGrid {
     inline int get_height_offset(const t_physical_tile_loc& tile_loc) const {
         return grid_[tile_loc.layer_num][tile_loc.x][tile_loc.y].height_offset;
     }
+
+    ///@brief Returns true if the given location is within the bounds of the device grid (valid layer, x, and y).
+    inline bool is_valid_tile_loc(const t_physical_tile_loc& tile_loc) const {
+        return tile_loc.layer_num >= 0
+               && tile_loc.layer_num < (int)get_num_layers()
+               && tile_loc.x >= 0
+               && tile_loc.x < (int)width()
+               && tile_loc.y >= 0
+               && tile_loc.y < (int)height();
+    }
+
     ///@brief Returns true if the given location is the root location (bottom left corner) of a tile.
     inline bool is_root_location(const t_physical_tile_loc& tile_loc) const {
         return get_width_offset(tile_loc) == 0 && get_height_offset(tile_loc) == 0;

--- a/vpr/src/base/flat_placement_utils.h
+++ b/vpr/src/base/flat_placement_utils.h
@@ -11,6 +11,7 @@
 #include "device_grid.h"
 #include "flat_placement_types.h"
 #include "physical_types.h"
+#include "vtr_assert.h"
 
 /**
  * @brief Returns the manhattan distance (L1 distance) between two flat
@@ -28,6 +29,9 @@ inline float get_manhattan_distance(const t_flat_pl_loc& loc_a,
 inline float get_manhattan_distance_to_tile(const t_flat_pl_loc& src_flat_loc,
                                             const t_physical_tile_loc& tile_loc,
                                             const DeviceGrid& device_grid) {
+    VTR_ASSERT_SAFE_MSG(device_grid.is_valid_tile_loc(tile_loc),
+                        "tile_loc is not a valid location on the device grid");
+
     // Get the bounds of the tile.
     // Note: The get_tile_bb function will not work in this case since it
     //       subtracts 1 from the width and height.

--- a/vpr/src/pack/cluster_legalizer.cpp
+++ b/vpr/src/pack/cluster_legalizer.cpp
@@ -1288,23 +1288,24 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
                                                          mutable_atom_pb_lookup());
         }
 
-        // If we're using the pin feasibility filter, we need to add the candidate molecule to
-        // cluster.molecules. We use this flag to control the cleanup in case of failure.
+        // This flag controls the pop_back cleanup of cluster.molecules in case of subsequent failure.
         bool candidate_molecule_added_to_cluster = false;
 
-        if (enable_pin_feasibility_filter_ && block_pack_status == e_block_pack_status::BLK_PASSED) {
-            // try_update_lookahead_pins_used needs the candidate molecule to be in cluster.molecules.
+        if (block_pack_status == e_block_pack_status::BLK_PASSED) {
             cluster.molecules.push_back(molecule_id);
             candidate_molecule_added_to_cluster = true;
 
-            // Check if pin usage is feasible for the current packing assignment
-            reset_lookahead_pins_used(cluster.pb);
-            try_update_lookahead_pins_used(cluster, prepacker_, atom_cluster_, atom_pb_lookup());
-            if (!check_lookahead_pins_used(cluster.pb, max_external_pin_util)) {
-                VTR_LOGV(log_verbosity_ > 4, "\t\t\tFAILED Pin Feasibility Filter\n");
-                block_pack_status = e_block_pack_status::BLK_FAILED_FEASIBLE;
-            } else {
-                VTR_LOGV(log_verbosity_ > 3, "\t\t\tPin Feasibility: Passed pin feasibility filter\n");
+            if (enable_pin_feasibility_filter_) {
+                // try_update_lookahead_pins_used requires the candidate molecule to
+                // already be in cluster.molecules, which is satisfied by the push above.
+                reset_lookahead_pins_used(cluster.pb);
+                try_update_lookahead_pins_used(cluster, prepacker_, atom_cluster_, atom_pb_lookup());
+                if (!check_lookahead_pins_used(cluster.pb, max_external_pin_util)) {
+                    VTR_LOGV(log_verbosity_ > 4, "\t\t\tFAILED Pin Feasibility Filter\n");
+                    block_pack_status = e_block_pack_status::BLK_FAILED_FEASIBLE;
+                } else {
+                    VTR_LOGV(log_verbosity_ > 3, "\t\t\tPin Feasibility: Passed pin feasibility filter\n");
+                }
             }
         }
 


### PR DESCRIPTION
When the pin_feasibility filter was disabled, the molecules were not being tracked as being part of the cluster. This is not intuitive and was causing division by zero in the AP flow.

Resolved the tracking issue in the packer.