### PR TITLE
[CI][HOTFIX] Fixed FASM Unit Test Failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         make -j${{ steps.cpu-cores.outputs.count}}
 
+    # Here we pack the build to store it as a build artifact. We exclude specific files
+    # to keep the build artifact reasonably low (to speed up file download times in the
+    # CI). Beyond the executables, some files need to be kept such as CTestTestFile.cmake
+    # files which are used by the unit tests CI run.
     - name: Pack Build
       shell: bash
       run: |
@@ -109,10 +113,11 @@ jobs:
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         make -j${{ steps.cpu-cores.outputs.count}}
 
+    # We pack the build similar to the default release build.
     - name: Pack Build
       shell: bash
       run: |
-        tar -czvf build.tar.gz --exclude='CMakeFiles' --exclude='*.a' --exclude='*.cmake' build/
+        tar -czvf build.tar.gz --exclude='CMakeFiles' --exclude='*.a' --exclude='cmake_install.cmake' build/
 
     - name: Store Build Artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Pack Build
       shell: bash
       run: |
-        tar -czvf build.tar.gz --exclude='CMakeFiles' --exclude='*.a' --exclude='*.cmake' build/
+        tar -czvf build.tar.gz --exclude='CMakeFiles' --exclude='*.a' --exclude='cmake_install.cmake' build/
 
     - name: Store Build Artifact
       uses: actions/upload-artifact@v7

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -247,6 +247,8 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
             "wire.eblif",
             "--route_chan_width",
             "100",
+            "--device",
+            "test",
         };
         vpr_init(sizeof(argv)/sizeof(argv[0]), argv,
                 &options, &vpr_setup, &arch);
@@ -312,6 +314,8 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
         "100",
         "--read_rr_graph",
         kRrGraphFile,
+        "--device",
+        "test",
     };
 
     vpr_init(sizeof(argv)/sizeof(argv[0]), argv,


### PR DESCRIPTION
The VTR unit tests were not running in CI due to missing CMAKE files in
the build folder. After fixing this, we found that the FASM tests were
failing. The fix was basic.
    
The issue is that --device must be provided when no `auto` device
exists. We need to discuss to see if this is expected and if so we
should provide a better error than just crashing.