### PR TITLE
Change interposer placement cost to non-zero defaults

### DIFF
--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2687,20 +2687,20 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
 
     place_grp.add_argument(args.place_interposer_cost_factor, "--place_interposer_cost_factor")
         .help("Factor to scale the interposer cost when calculating the total cost.")
-        .default_value("0.0")
+        .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.place_interposer_cong_cost_factor, "--place_interposer_cong_cost_factor")
         .help("Weighting factor for interposer congestion cost during placement. "
               "Higher values prioritize avoiding interposer congestion over other placement costs. "
               "When set to zero, interposer congestion modeling and optimization is disabled in the placement stage.")
-        .default_value("0.0")
+        .default_value("0.1")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.place_interposer_cong_threshold, "--place_interposer_cong_threshold")
         .help("Penalizes placements whose average interposer congestion exceeds this threshold. "
               "Higher values reduce the likelihood of a penalty; very large values effectively disable threshold-based penalization.")
-        .default_value("0.0")
+        .default_value("0.9")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     place_grp.add_argument(args.place_congestion_factor, "--congestion_factor")


### PR DESCRIPTION
In previous versions of the interposer cost code, setting the cost weights to non-zero values would change 2D results. This is not the case anymore. This PR sets these weights to sensible defaults.

QoR is unchanged in VtR benchmarks.

  | Master | New Default Costs
-- | -- | --
vtr_flow_elapsed_time | 36.6081588 | 36.34155769
max_vpr_mem | 202975.3122 | 203029.9634
place_time | 3.557239802 | 3.47517484
routed_wirelength | 38050.19813 | 38050.19813
critical_path_delay | 10.07061446 | 10.07061446
crit_path_route_time | 0.8927628693 | 0.869372556
crit_path_total_heap_pops | 323341.3615 | 323341.3615
total_swap | 358690.3624 | 358690.3624
accepted_swap | 141949.0111 | 141949.0111
placed_CPD_est | 9.672265563 | 9.672265563