### PR TITLE
[CI] Locked sub-tile directs to pack,place,route flow

### DIFF
--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_subtile/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_subtile/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_subtile_neg_z_offset/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_subtile_neg_z_offset/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_super_subtile/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_super_subtile/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_super_subtile_neg_z_offset/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_direct_super_subtile_neg_z_offset/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_subtile/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_subtile/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_subtile_neg_z_offset/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_subtile_neg_z_offset/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_subtile_neg_z_offset2/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_subtile_neg_z_offset2/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_super_subtile/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_super_subtile/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage

--- a/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_super_subtile_neg_z_offset/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_strong/strong_tileable_rr_graph_direct_super_subtile_neg_z_offset/config/config.txt
@@ -24,4 +24,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 # Script parameters
-script_params=-starting_stage vpr -track_memory_usage
+script_params=-starting_stage vpr --pack --place --route --analysis -track_memory_usage


### PR DESCRIPTION
The way inter-sub-tile directs were implemented made them hard-coded to the traditional pack-place-route flows in such a way that they cannot be replicated currently on other flows. The reason is because the current implementation relies on the initial placer to order the blocks correctly and the annealer to not mess it up (which it normally does not do). Other flows, like analytical placement, cannot replicate this behavior consistently and cause these testcases to crash.

I locked these testcases to that flow so that they can be investigated in another issue while AP transistions to becoming the default flow.

This is related to this issue: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/3528

The problem is that inter-sub-tile directs are not forming macros. The current implementation is likely not stable because of this. Once macros are formed, the AP flow handles this situation just fine.

This issue is not just with the AP flow, any changes to the order of the initial placer could potentially cause this to fail. This should be resolved.