### PR TITLE
Make scatter-gather warnings more verbose

### DIFF
--- a/vpr/src/route/rr_graph_generation/build_scatter_gathers.cpp
+++ b/vpr/src/route/rr_graph_generation/build_scatter_gathers.cpp
@@ -327,6 +327,7 @@ std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const s
                                                                          const t_chan_width& nodes_per_chan,
                                                                          vtr::RngContainer& rng,
                                                                          vtr::NdMatrix<std::vector<t_bottleneck_link>, 2>& interdie_3d_links,
+                                                                         const int route_verbosity,
                                                                          bool device_model_warnings) {
     const DeviceGrid& grid = g_vpr_ctx.device().grid;
 
@@ -431,14 +432,14 @@ std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const s
 
                 if (fwd_bottleneck_fanin == 0 || fwd_bottleneck_fanout == 0) {
 
-                    VTR_LOGV_WARN(device_model_warnings && fwd_bottleneck_fanin == 0,
+                    VTR_LOGV_WARN(device_model_warnings && route_verbosity > 1 && fwd_bottleneck_fanin == 0,
                                   "Scatter-gather pattern '%s' with SG link '%s' at location (layer=%i, x=%i, y=%i) "
                                   "has zero gather fanin connections (candidates=%zu)\n",
                                   sg_pattern.name.c_str(), sg_link.name.c_str(),
                                   gather_loc.layer_num, gather_loc.x, gather_loc.y,
                                   fwd_gather_wire_candidates.size());
 
-                    VTR_LOGV_WARN(device_model_warnings && fwd_bottleneck_fanout == 0,
+                    VTR_LOGV_WARN(device_model_warnings && route_verbosity > 1 && fwd_bottleneck_fanout == 0,
                                   "Scatter-gather pattern '%s' with SG link '%s' at location (layer=%i, x=%i, y=%i) "
                                   "has zero scatter fanout connections (candidates=%zu)\n",
                                   sg_pattern.name.c_str(), sg_link.name.c_str(),

--- a/vpr/src/route/rr_graph_generation/build_scatter_gathers.h
+++ b/vpr/src/route/rr_graph_generation/build_scatter_gathers.h
@@ -57,7 +57,10 @@ struct t_bottleneck_link {
  * @param nodes_per_chan Channel width data.
  * @param rng Random number generator used to shuffle wire candidates.
  * @param interdie_3d_links Output: matrix storing inter-die (3D) bottleneck links.
- * @param route_verbosity Controls verbose routing diagnostics.
+ * @param route_verbosity Controls verbosity of scatter-gather warnings.
+ * If route_verbosity > 1, we warn when a sg instantiation does not have any fan-in
+ * or fan-out candidates. Since this is expected on device edges, we don't warn
+ * by default.
  * @return Vector of non-3d bottleneck links.
  */
 std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const std::vector<t_scatter_gather_pattern>& scatter_gather_patterns,

--- a/vpr/src/route/rr_graph_generation/build_scatter_gathers.h
+++ b/vpr/src/route/rr_graph_generation/build_scatter_gathers.h
@@ -57,6 +57,7 @@ struct t_bottleneck_link {
  * @param nodes_per_chan Channel width data.
  * @param rng Random number generator used to shuffle wire candidates.
  * @param interdie_3d_links Output: matrix storing inter-die (3D) bottleneck links.
+ * @param route_verbosity Controls verbose routing diagnostics.
  * @return Vector of non-3d bottleneck links.
  */
 std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const std::vector<t_scatter_gather_pattern>& scatter_gather_patterns,
@@ -69,6 +70,7 @@ std::vector<t_bottleneck_link> alloc_and_load_scatter_gather_connections(const s
                                                                          const t_chan_width& nodes_per_chan,
                                                                          vtr::RngContainer& rng,
                                                                          vtr::NdMatrix<std::vector<t_bottleneck_link>, 2>& interdie_3d_links,
+                                                                         const int route_verbosity,
                                                                          bool device_model_warnings);
 
 /**

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -837,6 +837,7 @@ static void build_rr_graph(e_graph_type graph_type,
                                                                                                       nodes_per_chan,
                                                                                                       switchpoint_rng,
                                                                                                       interdie_3d_links,
+                                                                                                      route_verbosity,
                                                                                                       device_model_warnings);
 
     // Check whether RR graph need to allocate new nodes for 3D connections.


### PR DESCRIPTION
The sg code prints warnings when there is no fan-in or fan-out candidates. We actually expect this to happen on device edges and we were printing a thousand of these warnings, so this PR makes them happen only on route_verbosity>1 (default is 1)