### PR TITLE
[AP] Fixed Unrelated Clustering Bug

### DIFF
--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -1454,11 +1454,11 @@ PackMoleculeId GreedyCandidateSelector::get_unrelated_candidate_for_cluster_appa
         //       since they should be closer.
         if (node_loc.x >= 1)
             search_queue.push({node_loc.x - 1, node_loc.y, node_loc.layer_num});
-        if (node_loc.x <= (int)appack_unrelated_clustering_data_.dim_size(0) - 2)
+        if (node_loc.x <= (int)flat_grid_width - 2)
             search_queue.push({node_loc.x + 1, node_loc.y, node_loc.layer_num});
         if (node_loc.y >= 1)
             search_queue.push({node_loc.x, node_loc.y - 1, node_loc.layer_num});
-        if (node_loc.y <= (int)appack_unrelated_clustering_data_.dim_size(1) - 2)
+        if (node_loc.y <= (int)flat_grid_height - 2)
             search_queue.push({node_loc.x, node_loc.y + 1, node_loc.layer_num});
 
         // Pop the position off the queue.


### PR DESCRIPTION
I found a bug in the unrelated clustering code where the width and height of the device were confused with the number of layers.

Part of this code pre-dates bringing AP to 3D, so the 0th dim was width and the 1st dim was height. I noticed a strange access out of bounds and found that this was no longer the case (num layers is the 0th dim). I fixed the code.

This code path is a very rare fall-back, but this bug certainly made that path much worse.