### PR TITLE
[Docs] Updated parse_vtr_flow docs

### DIFF
--- a/doc/src/vtr/parse_vtr_flow.rst
+++ b/doc/src/vtr/parse_vtr_flow.rst
@@ -26,7 +26,11 @@ where:
 
 Output
 ~~~~~~
-The script will produce no standard output.
-A single file named ``parse_results.txt`` will be produced in the ``<parse_path>`` folder.
-The file is tab delimited and contains two lines.
+The script prints its results to standard output.
+No output file is created.
+The output is tab-delimited and contains two lines.
 The first line is a list of field names that were searched for, and the second line contains the associated values.
+
+To save the output to a file, redirect stdout::
+
+    parse_vtr_flow.py <parse_path> <parse_config_file> > parse_results.txt


### PR DESCRIPTION
The parse_vtr_flow docs were incorrect regarding what the output of the script should be. I have updated the docs accordingly.

Resolves https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2478