### PR TITLE
Fix router bounding box heuristic for interposer architectures

### DIFF
--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -282,6 +282,10 @@ struct DeviceContext : public Context {
      * Indexed as `[layer][cut_idx]`, where `cut_idx` refers to the entry in
      * `DeviceGrid::get_horizontal_interposer_cuts()[layer]`.
      * The pair stores `{min_y, max_y}` of all `CHANY` rr_nodes that cross the cut.
+     * i.e. the smallest y of any rr_node that crosses a cut, and the largest y of
+     * any rr node that crosses the cut. These values will normally come from different wires;
+     * e.g. with length 10 interposer wires you'd expect to get min_y to be 9 below the cut
+     * and max_y to be 9 avove the cut.
      */
     vtr::NdMatrix<std::pair<int, int>, 2> horz_interposer_cut_bounds_;
 
@@ -291,6 +295,7 @@ struct DeviceContext : public Context {
      * Indexed as `[layer][cut_idx]`, where `cut_idx` refers to the entry in
      * `DeviceGrid::get_vertical_interposer_cuts()[layer]`.
      * The pair stores `{min_x, max_x}` of all `CHANX` rr_nodes that cross the cut.
+     * This is similar to horz_interposer_cut_bounds_, but for vertical interposer cuts and wires.
      */
     vtr::NdMatrix<std::pair<int, int>, 2> vert_interposer_cut_bounds_;
 

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -285,7 +285,7 @@ struct DeviceContext : public Context {
      * i.e. the smallest y of any rr_node that crosses a cut, and the largest y of
      * any rr node that crosses the cut. These values will normally come from different wires;
      * e.g. with length 10 interposer wires you'd expect to get min_y to be 9 below the cut
-     * and max_y to be 9 avove the cut.
+     * and max_y to be 9 above the cut.
      */
     vtr::NdMatrix<std::pair<int, int>, 2> horz_interposer_cut_bounds_;
 

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include <mutex>
+#include <utility>
 
 #include "flat_placement_types.h"
 #include "physical_types.h"
@@ -274,6 +275,24 @@ struct DeviceContext : public Context {
      * Values are accumulated from the capacities of `CHANX` rr_nodes which cross the cut.
      */
     vtr::NdMatrix<int, 3> vert_interposer_capacity_;
+
+    /**
+     * @brief Min/max x coordinate of routing wires that cross each horizontal interposer cut.
+     *
+     * Indexed as `[layer][cut_idx]`, where `cut_idx` refers to the entry in
+     * `DeviceGrid::get_horizontal_interposer_cuts()[layer]`.
+     * The pair stores `{min_x, max_x}` of `CHANY` rr_nodes crossing the cut.
+     */
+    vtr::NdMatrix<std::pair<int, int>, 2> horz_interposer_cut_bounds_;
+
+    /**
+     * @brief Min/max y coordinate of routing wires that cross each vertical interposer cut.
+     *
+     * Indexed as `[layer][cut_idx]`, where `cut_idx` refers to the entry in
+     * `DeviceGrid::get_vertical_interposer_cuts()[layer]`.
+     * The pair stores `{min_y, max_y}` of `CHANX` rr_nodes crossing the cut.
+     */
+    vtr::NdMatrix<std::pair<int, int>, 2> vert_interposer_cut_bounds_;
 
     /// Stores the maximum channel segment width in each horizontal/vertical channel
     ChannelMetric<std::vector<int>> rr_chan_width;

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -277,20 +277,20 @@ struct DeviceContext : public Context {
     vtr::NdMatrix<int, 3> vert_interposer_capacity_;
 
     /**
-     * @brief Min/max x coordinate of routing wires that cross each horizontal interposer cut.
+     * @brief Min/max y coordinate of all routing wires that cross each horizontal interposer cut.
      *
      * Indexed as `[layer][cut_idx]`, where `cut_idx` refers to the entry in
      * `DeviceGrid::get_horizontal_interposer_cuts()[layer]`.
-     * The pair stores `{min_x, max_x}` of `CHANY` rr_nodes crossing the cut.
+     * The pair stores `{min_y, max_y}` of all `CHANY` rr_nodes that cross the cut.
      */
     vtr::NdMatrix<std::pair<int, int>, 2> horz_interposer_cut_bounds_;
 
     /**
-     * @brief Min/max y coordinate of routing wires that cross each vertical interposer cut.
+     * @brief Min/max x coordinate of all routing wires that cross each vertical interposer cut.
      *
      * Indexed as `[layer][cut_idx]`, where `cut_idx` refers to the entry in
      * `DeviceGrid::get_vertical_interposer_cuts()[layer]`.
-     * The pair stores `{min_y, max_y}` of `CHANX` rr_nodes crossing the cut.
+     * The pair stores `{min_x, max_x}` of all `CHANX` rr_nodes that cross the cut.
      */
     vtr::NdMatrix<std::pair<int, int>, 2> vert_interposer_cut_bounds_;
 

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -80,8 +80,10 @@ static vtr::vector<ParentNetId, uint8_t> load_is_clock_net(const Netlist<>& net_
 static bool classes_in_same_block(ParentBlockId blk_id, int first_class_ptc_num, int second_class_ptc_num, bool is_flat);
 
 /**
- * @brief Expand a net route bounding box so any crossed interposer cut includes
- *        all rr_node coordinates that can legally cross that cut.
+ * @brief If a bounding box crosses an interposer cut, expand it to
+ * at minimum span the bounds defined in device_ctx.[horz/vert]_interposer_cut_bounds_.
+ * Doing this ensures that die crossing nets can be succcesfully routed in the
+ * bounding box (in valid architectures).
  */
 static void expand_route_bb_to_interposer_cut_bounds(const DeviceContext& device_ctx,
                                                      t_bb& bb);
@@ -711,14 +713,15 @@ static void expand_route_bb_to_interposer_cut_bounds(const DeviceContext& device
     const vtr::NdMatrix<std::pair<int, int>, 2>& horizontal_cut_bounds = device_ctx.horz_interposer_cut_bounds_;
     const vtr::NdMatrix<std::pair<int, int>, 2>& vertical_cut_bounds = device_ctx.vert_interposer_cut_bounds_;
 
-    VTR_ASSERT(horizontal_cut_bounds.dim_size(0) == horizontal_cuts.size());
-    VTR_ASSERT(vertical_cut_bounds.dim_size(0) == vertical_cuts.size());
+    VTR_ASSERT_SAFE(horizontal_cut_bounds.dim_size(0) == horizontal_cuts.size());
+    VTR_ASSERT_SAFE(vertical_cut_bounds.dim_size(0) == vertical_cuts.size());
 
     const t_bb original_bb = bb;
     for (int layer = original_bb.layer_min; layer <= original_bb.layer_max; layer++) {
         VTR_ASSERT(horizontal_cut_bounds.dim_size(1) >= horizontal_cuts[layer].size());
         for (size_t cut_idx = 0; cut_idx < horizontal_cuts[layer].size(); cut_idx++) {
             int cut_y = horizontal_cuts[layer][cut_idx];
+            // bounding box crosses horizontal_cuts[layer][cut_idx] at y = cut_y
             if (cut_y >= original_bb.ymin && cut_y < original_bb.ymax) {
                 const std::pair<int, int>& cut_bounds = horizontal_cut_bounds[layer][cut_idx];
                 bb.ymin = std::min(bb.ymin, cut_bounds.first);
@@ -729,6 +732,7 @@ static void expand_route_bb_to_interposer_cut_bounds(const DeviceContext& device
         VTR_ASSERT(vertical_cut_bounds.dim_size(1) >= vertical_cuts[layer].size());
         for (size_t cut_idx = 0; cut_idx < vertical_cuts[layer].size(); cut_idx++) {
             int cut_x = vertical_cuts[layer][cut_idx];
+            // bounding box crosses vertical_cuts[layer][cut_idx] at x = cut_x
             if (cut_x >= original_bb.xmin && cut_x < original_bb.xmax) {
                 const std::pair<int, int>& cut_bounds = vertical_cut_bounds[layer][cut_idx];
                 bb.xmin = std::min(bb.xmin, cut_bounds.first);

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -16,6 +16,7 @@
 #include "vtr_vector.h"
 
 #include <ranges>
+#include <utility>
 
 #if defined(VPR_USE_TBB)
 #include <tbb/parallel_for_each.h>
@@ -77,6 +78,13 @@ static vtr::vector<ParentNetId, uint8_t> load_is_clock_net(const Netlist<>& net_
                                                            bool is_flat);
 
 static bool classes_in_same_block(ParentBlockId blk_id, int first_class_ptc_num, int second_class_ptc_num, bool is_flat);
+
+/**
+ * @brief Expand a net route bounding box so any crossed interposer cut includes
+ *        all rr_node coordinates that can legally cross that cut.
+ */
+static void expand_route_bb_to_interposer_cut_bounds(const DeviceContext& device_ctx,
+                                                     t_bb& bb);
 
 /**
  * @brief Computes the initial `acc_cost` for the given RR node by checking
@@ -691,6 +699,45 @@ static bool classes_in_same_block(ParentBlockId blk_id, int first_class_ptc_num,
     return classes_in_same_block(physical_tile, first_class_ptc_num, second_class_ptc_num, is_flat);
 }
 
+static void expand_route_bb_to_interposer_cut_bounds(const DeviceContext& device_ctx,
+                                                     t_bb& bb) {
+    const DeviceGrid& grid = device_ctx.grid;
+    if (!grid.has_interposer_cuts()) {
+        return;
+    }
+
+    const std::vector<std::vector<int>>& horizontal_cuts = grid.get_horizontal_interposer_cuts();
+    const std::vector<std::vector<int>>& vertical_cuts = grid.get_vertical_interposer_cuts();
+    const vtr::NdMatrix<std::pair<int, int>, 2>& horizontal_cut_bounds = device_ctx.horz_interposer_cut_bounds_;
+    const vtr::NdMatrix<std::pair<int, int>, 2>& vertical_cut_bounds = device_ctx.vert_interposer_cut_bounds_;
+
+    VTR_ASSERT(horizontal_cut_bounds.dim_size(0) == horizontal_cuts.size());
+    VTR_ASSERT(vertical_cut_bounds.dim_size(0) == vertical_cuts.size());
+
+    const t_bb original_bb = bb;
+    for (int layer = original_bb.layer_min; layer <= original_bb.layer_max; layer++) {
+        VTR_ASSERT(horizontal_cut_bounds.dim_size(1) >= horizontal_cuts[layer].size());
+        for (size_t cut_idx = 0; cut_idx < horizontal_cuts[layer].size(); cut_idx++) {
+            int cut_y = horizontal_cuts[layer][cut_idx];
+            if (cut_y >= original_bb.ymin && cut_y < original_bb.ymax) {
+                const std::pair<int, int>& cut_bounds = horizontal_cut_bounds[layer][cut_idx];
+                bb.ymin = std::min(bb.ymin, cut_bounds.first);
+                bb.ymax = std::max(bb.ymax, cut_bounds.second);
+            }
+        }
+
+        VTR_ASSERT(vertical_cut_bounds.dim_size(1) >= vertical_cuts[layer].size());
+        for (size_t cut_idx = 0; cut_idx < vertical_cuts[layer].size(); cut_idx++) {
+            int cut_x = vertical_cuts[layer][cut_idx];
+            if (cut_x >= original_bb.xmin && cut_x < original_bb.xmax) {
+                const std::pair<int, int>& cut_bounds = vertical_cut_bounds[layer][cut_idx];
+                bb.xmin = std::min(bb.xmin, cut_bounds.first);
+                bb.xmax = std::max(bb.xmax, cut_bounds.second);
+            }
+        }
+    }
+}
+
 vtr::vector<ParentNetId, t_bb> load_route_bb(const Netlist<>& net_list,
                                              int bb_factor) {
     vtr::vector<ParentNetId, t_bb> route_bb;
@@ -806,16 +853,21 @@ t_bb load_net_route_bb(const Netlist<>& net_list,
     xmin -= 1;
     ymin -= 1;
 
-    // Expand the net bounding box by bb_factor, then clip to the physical chip area.
-
     t_bb bb;
-
-    bb.xmin = std::max<int>(xmin - bb_factor, 0);
-    bb.xmax = std::min<int>(xmax + bb_factor, device_ctx.grid.width() - 1);
-    bb.ymin = std::max<int>(ymin - bb_factor, 0);
-    bb.ymax = std::min<int>(ymax + bb_factor, device_ctx.grid.height() - 1);
+    bb.xmin = xmin;
+    bb.xmax = xmax;
+    bb.ymin = ymin;
+    bb.ymax = ymax;
     bb.layer_min = layer_min;
     bb.layer_max = layer_max;
+
+    expand_route_bb_to_interposer_cut_bounds(device_ctx, bb);
+
+    // Expand the net bounding box by bb_factor, then clip to the physical chip area.
+    bb.xmin = std::max<int>(bb.xmin - bb_factor, 0);
+    bb.xmax = std::min<int>(bb.xmax + bb_factor, device_ctx.grid.width() - 1);
+    bb.ymin = std::max<int>(bb.ymin - bb_factor, 0);
+    bb.ymax = std::min<int>(bb.ymax + bb_factor, device_ctx.grid.height() - 1);
 
     return bb;
 }

--- a/vpr/src/route/route_common.cpp
+++ b/vpr/src/route/route_common.cpp
@@ -823,12 +823,14 @@ t_bb load_net_route_bb(const Netlist<>& net_list,
     VTR_ASSERT(rr_graph.node_xlow(driver_rr) <= rr_graph.node_xhigh(driver_rr));
     VTR_ASSERT(rr_graph.node_ylow(driver_rr) <= rr_graph.node_yhigh(driver_rr));
 
-    int xmin = rr_graph.node_xlow(driver_rr);
-    int ymin = rr_graph.node_ylow(driver_rr);
-    int xmax = rr_graph.node_xhigh(driver_rr);
-    int ymax = rr_graph.node_yhigh(driver_rr);
-    int layer_min = rr_graph.node_layer_low(driver_rr);
-    int layer_max = rr_graph.node_layer_high(driver_rr);
+    t_bb bb;
+
+    bb.xmin = rr_graph.node_xlow(driver_rr);
+    bb.ymin = rr_graph.node_ylow(driver_rr);
+    bb.xmax = rr_graph.node_xhigh(driver_rr);
+    bb.ymax = rr_graph.node_yhigh(driver_rr);
+    bb.layer_min = rr_graph.node_layer_low(driver_rr);
+    bb.layer_max = rr_graph.node_layer_high(driver_rr);
 
     auto net_sinks = net_list.net_sinks(net_id);
     for (size_t ipin = 1; ipin < net_sinks.size() + 1; ++ipin) { //Start at 1 since looping through sinks
@@ -845,25 +847,17 @@ t_bb load_net_route_bb(const Netlist<>& net_list,
                                                               rr_graph.node_ylow(sink_rr),
                                                               rr_graph.node_layer_low(sink_rr)});
 
-        xmin = std::min<int>(xmin, tile_bb.xmin());
-        xmax = std::max<int>(xmax, tile_bb.xmax());
-        ymin = std::min<int>(ymin, tile_bb.ymin());
-        ymax = std::max<int>(ymax, tile_bb.ymax());
-        layer_min = std::min<int>(layer_min, rr_graph.node_layer_low(sink_rr));
-        layer_max = std::max<int>(layer_max, rr_graph.node_layer_high(sink_rr));
+        bb.xmin = std::min<int>(bb.xmin, tile_bb.xmin());
+        bb.xmax = std::max<int>(bb.xmax, tile_bb.xmax());
+        bb.ymin = std::min<int>(bb.ymin, tile_bb.ymin());
+        bb.ymax = std::max<int>(bb.ymax, tile_bb.ymax());
+        bb.layer_min = std::min<int>(bb.layer_min, rr_graph.node_layer_low(sink_rr));
+        bb.layer_max = std::max<int>(bb.layer_max, rr_graph.node_layer_high(sink_rr));
     }
 
     // Want the channels on all 4 sides to be usable, even if bb_factor = 0.
-    xmin -= 1;
-    ymin -= 1;
-
-    t_bb bb;
-    bb.xmin = xmin;
-    bb.xmax = xmax;
-    bb.ymin = ymin;
-    bb.ymax = ymax;
-    bb.layer_min = layer_min;
-    bb.layer_max = layer_max;
+    bb.xmin -= 1;
+    bb.ymin -= 1;
 
     expand_route_bb_to_interposer_cut_bounds(device_ctx, bb);
 

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -294,19 +294,23 @@ static int get_delayless_switch_id(const t_det_routing_arch& det_routing_arch,
                                    bool load_rr_graph);
 
 /**
- * @brief Build per-cut interposer crossing-capacity tables from the RR graph.
+ * @brief Build per-cut interposer-related tables from the RR graph.
  *
  * Architectures with interposer cut lines need a fast way to know how much routing capacity
  * crosses each cut at every coordinate along the cut. Placement and interposer congestion
  * estimation consume these tables; computing them here (once, next to channel-width init)
  * keeps that logic out of the hot path.
  *
+ * In addition, the router needs to know the bounds of interposer wires that cross each
+ * cut in order to correctly set up the router's bounding box. That information is also
+ * computed in this function.
+ *
  * @param device_ctx Writable device context; fills horz_interposer_capacity_,
  *                   vert_interposer_capacity_, horz_interposer_cut_bounds_, and
  *                   vert_interposer_cut_bounds_ when the grid defines interposer cuts.
- * @param rr_graph   RR graph whose CHANX/CHANY segment capacities are summed per cut.
+ * @param rr_graph   Input RR graph to be analyzed.
  */
-static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
+static void init_interposer_per_cut_tables_from_rr_graph(DeviceContext& device_ctx,
                                                    const RRGraphView& rr_graph);
 
 /**
@@ -1039,7 +1043,7 @@ static int get_delayless_switch_id(const t_det_routing_arch& det_routing_arch,
     return delayless_switch;
 }
 
-static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
+static void init_interposer_per_cut_tables_from_rr_graph(DeviceContext& device_ctx,
                                                    const RRGraphView& rr_graph) {
     const DeviceGrid& grid = device_ctx.grid;
     // No interposer cuts on this device; nothing to populate.
@@ -1170,7 +1174,7 @@ static void alloc_and_init_channel_width() {
         chan_width_list.y[loc.x] = std::max(chan_width.y[loc.layer_num][loc.x][loc.y], chan_width_list.y[loc.x]);
     }
 
-    init_interposer_capacity_from_rr_graph(mutable_device_ctx, rr_graph);
+    init_interposer_per_cut_tables_from_rr_graph(mutable_device_ctx, rr_graph);
 }
 
 void build_tile_rr_graph(RRGraphBuilder& rr_graph_builder,

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -311,7 +311,7 @@ static int get_delayless_switch_id(const t_det_routing_arch& det_routing_arch,
  * @param rr_graph   Input RR graph to be analyzed.
  */
 static void init_interposer_per_cut_tables_from_rr_graph(DeviceContext& device_ctx,
-                                                   const RRGraphView& rr_graph);
+                                                         const RRGraphView& rr_graph);
 
 /**
  * @brief Calculates the routing channel width at each grid location.
@@ -1044,7 +1044,7 @@ static int get_delayless_switch_id(const t_det_routing_arch& det_routing_arch,
 }
 
 static void init_interposer_per_cut_tables_from_rr_graph(DeviceContext& device_ctx,
-                                                   const RRGraphView& rr_graph) {
+                                                         const RRGraphView& rr_graph) {
     const DeviceGrid& grid = device_ctx.grid;
     // No interposer cuts on this device; nothing to populate.
     if (!grid.has_interposer_cuts()) {

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <cmath>
 #include <algorithm>
+#include <limits>
 #include <utility>
 #include <vector>
 #include <ranges>
@@ -300,8 +301,9 @@ static int get_delayless_switch_id(const t_det_routing_arch& det_routing_arch,
  * estimation consume these tables; computing them here (once, next to channel-width init)
  * keeps that logic out of the hot path.
  *
- * @param device_ctx Writable device context; fills horz_interposer_capacity_ and
- *                   vert_interposer_capacity_ when the grid defines interposer cuts.
+ * @param device_ctx Writable device context; fills horz_interposer_capacity_,
+ *                   vert_interposer_capacity_, horz_interposer_cut_bounds_, and
+ *                   vert_interposer_cut_bounds_ when the grid defines interposer cuts.
  * @param rr_graph   RR graph whose CHANX/CHANY segment capacities are summed per cut.
  */
 static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
@@ -1058,6 +1060,8 @@ static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
 
     vtr::NdMatrix<int, 3>& horz_interposer_capacity = device_ctx.horz_interposer_capacity_;
     vtr::NdMatrix<int, 3>& vert_interposer_capacity = device_ctx.vert_interposer_capacity_;
+    vtr::NdMatrix<std::pair<int, int>, 2>& horz_interposer_cut_bounds = device_ctx.horz_interposer_cut_bounds_;
+    vtr::NdMatrix<std::pair<int, int>, 2>& vert_interposer_cut_bounds = device_ctx.vert_interposer_cut_bounds_;
 
     // Matrices are sized to the maximum cut count across layers.
     // Layers with fewer cuts will leave the extra [cut_idx] planes at zero.
@@ -1065,6 +1069,10 @@ static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
     vert_interposer_capacity.resize({num_layers, max_v_cuts, grid.height()});
     horz_interposer_capacity.fill(0);
     vert_interposer_capacity.fill(0);
+
+    const std::pair<int, int> default_bounds = {std::numeric_limits<int>::max(), std::numeric_limits<int>::min()};
+    horz_interposer_cut_bounds.resize({num_layers, max_h_cuts}, default_bounds);
+    vert_interposer_cut_bounds.resize({num_layers, max_v_cuts}, default_bounds);
 
     for (RRNodeId node_id : rr_graph.nodes()) {
         e_rr_type rr_type = rr_graph.node_type(node_id);
@@ -1081,6 +1089,10 @@ static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
                 // This CHANY node crosses the horizontal cut at y = cut_y.
                 if (ylow <= cut_y && cut_y < yhigh) {
                     horz_interposer_capacity[layer][cut_idx][x] += cap;
+
+                    std::pair<int, int>& cut_bounds = horz_interposer_cut_bounds[layer][cut_idx];
+                    cut_bounds.first = std::min(cut_bounds.first, ylow);
+                    cut_bounds.second = std::max(cut_bounds.second, yhigh);
                 }
             }
         } else if (rr_type == e_rr_type::CHANX) {
@@ -1093,6 +1105,10 @@ static void init_interposer_capacity_from_rr_graph(DeviceContext& device_ctx,
                 // This CHANX node crosses the vertical cut at x = cut_x.
                 if (xlow <= cut_x && cut_x < xhigh) {
                     vert_interposer_capacity[layer][cut_idx][y] += cap;
+
+                    std::pair<int, int>& cut_bounds = vert_interposer_cut_bounds[layer][cut_idx];
+                    cut_bounds.first = std::min(cut_bounds.first, xlow);
+                    cut_bounds.second = std::max(cut_bounds.second, xhigh);
                 }
             }
         }


### PR DESCRIPTION
Interposer wires are not compatible with the router's bounding box heuristic. This would make routing bonding boxes to be at least as big as the area of the device that has interposer wires. Doing this avoids situations where the routing bounding box is smaller than the interposer wire that must be crossed, resulting in first iteration routing failures.

QoR changes for 2.5D arch:

  | Master | Feature
-- | -- | --
routed_wirelength | 1 | 0.999660872
critical_path_delay | 1 | 1.001979415
crit_path_route_time | 1 | 0.8099027725
total_heap_pops | 1 | 0.7089621547
total_swap | 1 | 1
accepted_swap | 1 | 1
placed_CPD_est | 1 | 1

Free 30% reduction of heap pops.