### PR TITLE
[CI] Locked Tight Floorplanning to Traditional Flow

### DIFF
--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan/config/config.txt
@@ -24,7 +24,7 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements_fixed_chan_width.txt
 
 # Script parameters
-script_params_common =-starting_stage vpr --route_chan_width 300 --max_router_iterations 400 --router_lookahead map --initial_pres_fac 1.0 --router_profiler_astar_fac 1.5 --seed 3 --device neuron 
+script_params_common =-starting_stage vpr --pack --place --route --analysis --route_chan_width 300 --max_router_iterations 400 --router_lookahead map --initial_pres_fac 1.0 --router_profiler_astar_fac 1.5 --seed 3 --device neuron 
 script_params_list_add = -sdc_file sdc/samples/neuron_stratixiv_arch_timing.sdc -read_vpr_constraints tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan/sixteenth.xml
 script_params_list_add = -sdc_file sdc/samples/neuron_stratixiv_arch_timing.sdc -read_vpr_constraints tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan/half_blocks_half.xml
 script_params_list_add = -sdc_file sdc/samples/neuron_stratixiv_arch_timing.sdc -read_vpr_constraints tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan/one_big_partition.xml

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan_3d/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan_3d/config/config.txt
@@ -24,7 +24,7 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements_fixed_chan_width.txt
 
 # Script parameters
-script_params_common =-starting_stage vpr --route_chan_width 300 --max_router_iterations 400 --router_lookahead map --initial_pres_fac 1.0 --router_profiler_astar_fac 1.5 --seed 3 --device neuron3d
+script_params_common =-starting_stage vpr --pack --place --route --analysis --route_chan_width 300 --max_router_iterations 400 --router_lookahead map --initial_pres_fac 1.0 --router_profiler_astar_fac 1.5 --seed 3 --device neuron3d
 script_params_list_add = -sdc_file sdc/samples/neuron_stratixiv_arch_timing.sdc -read_vpr_constraints tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan_3d/one_big_partition.xml
 script_params_list_add = -sdc_file sdc/samples/neuron_stratixiv_arch_timing.sdc -read_vpr_constraints tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan_3d/half_blocks_right_left.xml
 script_params_list_add = -sdc_file sdc/samples/neuron_stratixiv_arch_timing.sdc -read_vpr_constraints tasks/regression_tests/vtr_reg_nightly_test5/vpr_tight_floorplan_3d/half_blocks_up_down.xml


### PR DESCRIPTION
The original tight floorplanning testcases were designed based off the original pack, place, and route flow; they were built to just barely be able to legalize with the original packing algorithm.

The analytical placement flow is struggling to find the exact solution that the original flow found due to issues in how the region constraints are handled. I locked these tests to the traditional flow while I investigate improved handling of region constraints for AP.