### PR TITLE
[VTR][Geometry] Updated Rect Contains Syntax

### DIFF
--- a/libs/libvtrutil/src/vtr_geometry.h
+++ b/libs/libvtrutil/src/vtr_geometry.h
@@ -166,14 +166,23 @@ class Rect {
     ///@brief Return the rectangle height
     T height() const;
 
-    ///@brief Returns true if the point is fully contained within the rectangle (excluding the top-right edges)
+    /// @brief Returns true if the point is within the rectangle using half-open bounds:
+    ///        xmin <= x < xmax  AND  ymin <= y < ymax  (top and right edges are excluded).
+    ///
+    /// Use this when the rectangle represents an index range where xmax/ymax is one past
+    /// the last valid value (e.g., Rect(0, 0, width, height) for a width x height matrix).
     bool contains(Point<T> point) const;
 
-    ///@brief Returns true if the point is strictly contained within the region (excluding all edges)
+    /// @brief Returns true if the point is strictly inside the rectangle (all edges excluded):
+    ///        xmin < x < xmax  AND  ymin < y < ymax
     bool strictly_contains(Point<T> point) const;
 
-    ///@brief Returns true if the point is coincident with the rectangle (including the top-right edges)
-    bool coincident(Point<T> point) const;
+    /// @brief Returns true if the point is within the rectangle using fully-closed bounds:
+    ///        xmin <= x <= xmax  AND  ymin <= y <= ymax  (all edges are included).
+    ///
+    /// Use this when the rectangle stores the actual last valid value as xmax/ymax,
+    /// such as inclusive tile coordinate ranges in placement constraint regions.
+    bool contains_inclusive(Point<T> point) const;
 
     ///@brief Returns true if other is contained within the rectangle (including all edges)
     bool contains(const Rect<T>& other) const;
@@ -304,14 +313,16 @@ class RectUnion {
     ///@brief Returns the bounding box of all rectangles in the union
     Rect<T> bounding_box() const;
 
-    ///@brief Returns true if the point is fully contained within the region (excluding top-right edges)
+    /// @brief Returns true if the point is within the union using half-open bounds
+    ///        (xmin <= x < xmax, ymin <= y < ymax for each constituent rectangle).
     bool contains(Point<T> point) const;
 
-    ///@brief Returns true if the point is strictly contained within the region (excluding all edges)
+    /// @brief Returns true if the point is strictly inside the union (all edges excluded for each rectangle).
     bool strictly_contains(Point<T> point) const;
 
-    ///@brief Returns true if the point is coincident with the region (including the top-right edges)
-    bool coincident(Point<T> point) const;
+    /// @brief Returns true if the point is within the union using fully-closed bounds
+    ///        (xmin <= x <= xmax, ymin <= y <= ymax for each constituent rectangle).
+    bool contains_inclusive(Point<T> point) const;
 
     ///@brief Returns a range of all constituent rectangles
     rect_range rects() const;

--- a/libs/libvtrutil/src/vtr_geometry.tpp
+++ b/libs/libvtrutil/src/vtr_geometry.tpp
@@ -178,7 +178,7 @@ bool Rect<T>::strictly_contains(Point<T> point) const {
 }
 
 template<class T>
-bool Rect<T>::coincident(Point<T> point) const {
+bool Rect<T>::contains_inclusive(Point<T> point) const {
     //Including right or top edges
     return point.x() >= xmin() && point.x() <= xmax()
            && point.y() >= ymin() && point.y() <= ymax();
@@ -361,9 +361,9 @@ bool RectUnion<T>::strictly_contains(Point<T> point) const {
 }
 
 template<class T>
-bool RectUnion<T>::coincident(Point<T> point) const {
+bool RectUnion<T>::contains_inclusive(Point<T> point) const {
     for (const auto& rect : rects()) {
-        if (rect.coincident(point)) {
+        if (rect.contains_inclusive(point)) {
             return true;
         }
     }

--- a/libs/libvtrutil/test/test_geometry.cpp
+++ b/libs/libvtrutil/test/test_geometry.cpp
@@ -74,11 +74,11 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
             REQUIRE_FALSE(r2.strictly_contains(pi_2));
         }
 
-        SECTION("coincident_int") {
-            REQUIRE(r2.coincident(pi_1));
-            REQUIRE(r2.coincident({6, 4}));
-            REQUIRE_FALSE(r2.coincident({100, 4}));
-            REQUIRE(r2.coincident(pi_2));
+        SECTION("contains_inclusive_int") {
+            REQUIRE(r2.contains_inclusive(pi_1));
+            REQUIRE(r2.contains_inclusive({6, 4}));
+            REQUIRE_FALSE(r2.contains_inclusive({100, 4}));
+            REQUIRE(r2.contains_inclusive(pi_2));
         }
 
         SECTION("bounds_int") {
@@ -149,11 +149,11 @@ TEST_CASE("Rect", "[vtr_geometry/Rect]") {
             REQUIRE_FALSE(r4.strictly_contains(pf_2));
         }
 
-        SECTION("coincident_float") {
-            REQUIRE(r4.coincident(pf_1));
-            REQUIRE(r4.coincident({6, 4}));
-            REQUIRE_FALSE(r4.coincident({100, 4}));
-            REQUIRE(r4.coincident(pf_2));
+        SECTION("contains_inclusive_float") {
+            REQUIRE(r4.contains_inclusive(pf_1));
+            REQUIRE(r4.contains_inclusive({6, 4}));
+            REQUIRE_FALSE(r4.contains_inclusive({100, 4}));
+            REQUIRE(r4.contains_inclusive(pf_2));
         }
 
         SECTION("bounds_float") {
@@ -236,10 +236,10 @@ TEST_CASE("RectUnion", "[vtr_geometry/RectUnion]") {
         REQUIRE_FALSE(rect_union.strictly_contains({3, 3}));
     }
 
-    SECTION("coincident") {
-        REQUIRE(rect_union.coincident({0, 0}));
-        REQUIRE(rect_union.coincident({1, 1}));
-        REQUIRE(rect_union.coincident({2, 2}));
-        REQUIRE(rect_union.coincident({3, 3}));
+    SECTION("contains_inclusive") {
+        REQUIRE(rect_union.contains_inclusive({0, 0}));
+        REQUIRE(rect_union.contains_inclusive({1, 1}));
+        REQUIRE(rect_union.contains_inclusive({2, 2}));
+        REQUIRE(rect_union.contains_inclusive({3, 3}));
     }
 }

--- a/vpr/src/base/region.cpp
+++ b/vpr/src/base/region.cpp
@@ -58,8 +58,9 @@ bool Region::is_loc_in_reg(t_pl_loc loc) const {
 
     const vtr::Point<int> loc_coord(loc.x, loc.y);
 
-    //check that loc x and y coordinates are within region bounds
-    bool in_rectangle = rect_.coincident(loc_coord);
+    // Region tile bounds are fully inclusive on all edges, so use contains_inclusive
+    // ([xmin,xmax] x [ymin,ymax]) rather than contains ([xmin,xmax) x [ymin,ymax)).
+    bool in_rectangle = rect_.contains_inclusive(loc_coord);
 
     //if a subtile is specified for the region, the location subtile should match
     if (in_rectangle && sub_tile_ == loc.sub_tile) {

--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -354,7 +354,9 @@ static bool is_loc_legal(const t_pl_loc& loc,
             continue;
         }
 
-        if (reg_rect.coincident({loc.x, loc.y})) {
+        // Region tile bounds are fully inclusive on all edges, so use contains_inclusive
+        // ([xmin,xmax] x [ymin,ymax]) rather than contains ([xmin,xmax) x [ymin,ymax)).
+        if (reg_rect.contains_inclusive({loc.x, loc.y})) {
             //check if the location is compatible with the block type
             const auto& type = grid.get_physical_type({loc.x, loc.y, loc.layer});
             int height_offset = grid.get_height_offset({loc.x, loc.y, loc.layer});

--- a/vpr/src/route/router_lookahead/router_lookahead_cost_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_cost_map.cpp
@@ -121,6 +121,8 @@ util::Cost_Entry CostMap::find_cost(int from_seg_index, int delta_x, int delta_y
     // Delta coordinate with the offset adjusted to fit the segment bounding box
     vtr::Point<int> coord(delta_x - offset_[0][from_seg_index].first,
                           delta_y - offset_[0][from_seg_index].second);
+    // bounds uses half-open convention: xmax/ymax = dim_size (one past the last valid index),
+    // matching the matrix's [0, dim_size) index range. Use contains() (not contains_inclusive()) below.
     vtr::Rect<int> bounds(0, 0, cost_map.dim_size(0), cost_map.dim_size(1));
 
     // Get the closest point in the bounding box:
@@ -173,6 +175,7 @@ void CostMap::fill_holes(vtr::NdMatrix<util::Cost_Entry, 2>& matrix, int seg_ind
     // find missing cost entries and fill them in by copying a nearby cost entry
     std::vector<std::tuple<unsigned, unsigned, util::Cost_Entry>> missing;
     bool couldnt_fill = false;
+    // shifted_bounds uses half-open convention: xmax/ymax = dimension size (one past the last valid index).
     auto shifted_bounds = vtr::Rect<int>(0, 0, bounding_box_width, bounding_box_height);
     int max_fill = 0;
     for (unsigned ix = 0; ix < matrix.dim_size(0); ix++) {
@@ -375,7 +378,8 @@ std::pair<util::Cost_Entry, int> CostMap::get_nearby_cost_entry(const vtr::NdMat
                                                                 int cx,
                                                                 int cy,
                                                                 const vtr::Rect<int>& bounds) {
-    // spiral around (cx, cy) looking for a nearby entry
+    // spiral around (cx, cy) looking for a nearby entry.
+    // bounds is half-open ([xmin,xmax) x [ymin,ymax)), so contains() is correct for index validation.
     bool in_bounds = bounds.contains(vtr::Point<int>(cx, cy));
     if (!in_bounds) {
         return std::make_pair(util::Cost_Entry(), 0);


### PR DESCRIPTION
I found the difference between contains and coincident confusing and found an example of a bug where this confusion can cause issues.

I updated the documentation and function names in vtr::Rect to try and alleviate confusion. I also documented the uses of these methods in the code to verify that the correct method was used in each case.

Resolves https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/2868