### PR TITLE
router_opt_choke_points rst doc

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -1589,6 +1589,13 @@ VPR uses a negotiated congestion algorithm (based on Pathfinder) to perform rout
 
     **Default:** ``off``
 
+.. option:: --router_opt_choke_points {on | off}
+
+    Some FPGA architectures with limited fan-out options within a cluster (e.g. fracturable LUTs with shared pins) do not converge well in routing unless fan-out choke points are discovered and optimized for during net routing.
+    Enabling this option improves router convergence for such architectures.
+
+    **Default:** ``on``
+
 .. option:: --max_router_iterations <int>
 
     The number of iterations of a Pathfinder-based router that will be executed before a circuit is declared unrouteable (if it hasn’t routed successfully yet) at a given channel width.

--- a/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/vtr_reg_qor_large_depop_run_flat/config/config.txt
+++ b/vtr_flow/tasks/regression_tests/vtr_reg_nightly_test7/vtr_reg_qor_large_depop_run_flat/config/config.txt
@@ -29,4 +29,4 @@ qor_parse_file=qor_standard.txt
 pass_requirements_file=pass_requirements.txt
 
 #Script parameters
-script_params=-track_memory_usage --max_router_iterations 300 --flat_routing on --router_opt_choke_points true
+script_params=-track_memory_usage --max_router_iterations 300 --flat_routing on --router_opt_choke_points on


### PR DESCRIPTION
Add documentation for `router_opt_choke_points` in the RST file and fix the choking point test.