### PR TITLE
Change floating RR Node warning to verbose mode

### DIFF
--- a/libs/librrgraph/src/io/rr_graph_reader.cpp
+++ b/libs/librrgraph/src/io/rr_graph_reader.cpp
@@ -127,6 +127,7 @@ void load_rr_file(RRGraphBuilder* rr_graph_builder,
         &arch->strings,
         schema_file_id,
         is_flat,
+        route_verbosity,
         device_model_warnings);
 
     if (vtr::check_file_name_extension(read_rr_graph_name, ".xml")) {

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -294,6 +294,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         vtr::string_internment* strings,
         unsigned long schema_file_id,
         bool is_flat,
+        int route_verbosity,
         bool device_model_warnings)
         : chan_width_(chan_width)
         , rr_nodes_(rr_nodes)
@@ -321,6 +322,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
         , report_error_(nullptr)
         , schema_file_id_(schema_file_id)
         , is_flat_(is_flat)
+        , route_verbosity_(route_verbosity)
         , device_model_warnings_(device_model_warnings) {
         // Initialize internal data
         init_side_map();
@@ -1829,6 +1831,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
             base_cost_type_,
             echo_enabled_,
             echo_file_name_,
+            route_verbosity_,
             device_model_warnings_);
 
         VTR_ASSERT(rr_indexed_data_->size() == seg_index_.size());
@@ -2212,6 +2215,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
     const std::function<void(const char*)>* report_error_;
     unsigned long schema_file_id_;
     bool is_flat_;
+    int route_verbosity_;
     bool device_model_warnings_;
 
     // Temporary data to check grid block types

--- a/libs/librrgraph/src/io/rr_graph_writer.cpp
+++ b/libs/librrgraph/src/io/rr_graph_writer.cpp
@@ -81,6 +81,7 @@ void write_rr_graph(RRGraphBuilder* rr_graph_builder,
         &arch->strings,
         schema_file_id,
         is_flat,
+        route_verbosity,
         device_model_warnings);
 
     if (vtr::check_file_name_extension(file_name, ".xml")) {

--- a/libs/librrgraph/src/utils/alloc_and_load_rr_indexed_data.cpp
+++ b/libs/librrgraph/src/utils/alloc_and_load_rr_indexed_data.cpp
@@ -32,6 +32,7 @@ static float get_delay_normalization_fac(const vtr::vector<RRIndexedDataId, t_rr
 
 static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
                                           vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
+                                          int route_verbosity,
                                           bool device_model_warnings);
 
 /**
@@ -91,6 +92,7 @@ void alloc_and_load_rr_indexed_data(const RRGraphView& rr_graph,
                                     e_base_cost_type base_cost_type,
                                     const bool echo_enabled,
                                     const char* echo_file_name,
+                                    int route_verbosity,
                                     bool device_model_warnings) {
     const size_t total_num_segment = segment_inf_x.size() + segment_inf_y.size() + segment_inf_z.size();
 
@@ -159,7 +161,7 @@ void alloc_and_load_rr_indexed_data(const RRGraphView& rr_graph,
         rr_indexed_data[index].seg_index = seg_ptr->seg_index;
     }
 
-    load_rr_indexed_data_T_values(rr_graph, rr_indexed_data, device_model_warnings);
+    load_rr_indexed_data_T_values(rr_graph, rr_indexed_data, route_verbosity, device_model_warnings);
 
     fixup_rr_indexed_data_T_values(rr_indexed_data, total_num_segment);
 
@@ -517,6 +519,7 @@ static float get_delay_normalization_fac(const vtr::vector<RRIndexedDataId, t_rr
  */
 static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
                                           vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
+                                          int route_verbosity,
                                           bool device_model_warnings) {
     vtr::vector<RRNodeId, std::vector<RREdgeId>> fan_in_list = get_fan_in_list(rr_graph);
 
@@ -537,6 +540,7 @@ static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
 
     size_t ipin_switch_count = 0;
     float ipin_switch_T_total = 0.;
+    size_t num_nodes_without_outgoing_switches = 0;
 
     // Walk through the RR graph and collect all R and C values of all the nodes,
     // as well as their fan-in switches R, T_del, and Cinternal values.
@@ -578,8 +582,9 @@ static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
 
         if (num_switches == 0) {
             if (num_shorts == 0) {
+                num_nodes_without_outgoing_switches++;
                 std::string node_cords = rr_graph.node_coordinate_to_string(RRNodeId(rr_id));
-                VTR_LOGV_WARN(device_model_warnings, "Node: %d with RR_type: %s  at Location:%s, had no out-going switches\n", rr_id,
+                VTR_LOGV_WARN(device_model_warnings && route_verbosity > 1, "Node: %d with RR_type: %s  at Location:%s, had no out-going switches\n", rr_id,
                               rr_graph.node_type_string(rr_id), node_cords.c_str());
             }
             continue;
@@ -674,6 +679,9 @@ static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
     VTR_LOGV_WARN(device_model_warnings && num_occurences_of_no_instances_with_cost_index > 0,
                   "Found %u cost indices where no instances of RR nodes could be found\n",
                   num_occurences_of_no_instances_with_cost_index);
+    VTR_LOGV_WARN(device_model_warnings && route_verbosity <= 1 && num_nodes_without_outgoing_switches > 0,
+                  "Found %zu nodes with no out-going switches. Run VTR with route_verbosity > 1 to see details.\n",
+                  num_nodes_without_outgoing_switches);
 }
 
 static void calculate_average_switch(const RRGraphView& rr_graph,

--- a/libs/librrgraph/src/utils/alloc_and_load_rr_indexed_data.h
+++ b/libs/librrgraph/src/utils/alloc_and_load_rr_indexed_data.h
@@ -15,6 +15,7 @@ void alloc_and_load_rr_indexed_data(const RRGraphView& rr_graph,
                                     e_base_cost_type base_cost_type,
                                     const bool echo_enabled,
                                     const char* echo_file_name,
+                                    int route_verbosity,
                                     bool device_model_warnings);
 
 std::vector<int> find_ortho_cost_index(const RRGraphView& rr_graph,

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -1000,7 +1000,7 @@ static void build_rr_graph(e_graph_type graph_type,
     // Save the channel widths for the newly constructed graph
     device_ctx.chan_width = nodes_per_chan;
 
-    rr_graph_externals(segment_inf, segment_inf_x, segment_inf_y, segment_inf_z, base_cost_type, device_model_warnings);
+    rr_graph_externals(segment_inf, segment_inf_x, segment_inf_y, segment_inf_z, base_cost_type, route_verbosity, device_model_warnings);
 
     const VibDeviceGrid vib_grid;
     check_rr_graph(device_ctx.rr_graph,
@@ -1211,6 +1211,7 @@ void rr_graph_externals(const std::vector<t_segment_inf>& segment_inf,
                         const std::vector<t_segment_inf>& segment_inf_y,
                         const std::vector<t_segment_inf>& segment_inf_z,
                         e_base_cost_type base_cost_type,
+                        int route_verbosity,
                         bool device_model_warnings) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const RRGraphView& rr_graph = device_ctx.rr_graph;
@@ -1221,7 +1222,7 @@ void rr_graph_externals(const std::vector<t_segment_inf>& segment_inf,
     const char* echo_file_name = getEchoFileName(E_ECHO_RR_GRAPH_INDEXED_DATA);
     add_rr_graph_C_from_switches();
     alloc_and_load_rr_indexed_data(rr_graph, grid, segment_inf, segment_inf_x, segment_inf_y, segment_inf_z,
-                                   rr_indexed_data, base_cost_type, echo_enabled, echo_file_name, device_model_warnings);
+                                   rr_indexed_data, base_cost_type, echo_enabled, echo_file_name, route_verbosity, device_model_warnings);
     //load_rr_index_segments(segment_inf.size());
 }
 

--- a/vpr/src/route/rr_graph_generation/rr_graph.h
+++ b/vpr/src/route/rr_graph_generation/rr_graph.h
@@ -49,6 +49,7 @@ void rr_graph_externals(const std::vector<t_segment_inf>& segment_inf,
                         const std::vector<t_segment_inf>& segment_inf_y,
                         const std::vector<t_segment_inf>& segment_inf_z,
                         e_base_cost_type base_cost_type,
+                        int route_verbosity,
                         bool device_model_warnings);
 
 std::vector<vtr::Matrix<int>> alloc_and_load_actual_fc(const std::vector<t_physical_tile_type>& types,

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_builder.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_builder.cpp
@@ -317,7 +317,7 @@ void build_tileable_unidir_rr_graph(const std::vector<t_physical_tile_type>& typ
     // Allocate external data structures
     //  a. cost_index
     //  b. RC tree
-    rr_graph_externals(segment_inf, segment_inf_x, segment_inf_y, segment_inf_z, base_cost_type, device_model_warnings);
+    rr_graph_externals(segment_inf, segment_inf_x, segment_inf_y, segment_inf_z, base_cost_type, route_verbosity, device_model_warnings);
 
     // Sanitizer for the rr_graph, check connectivities of rr_nodes
     // Essential check for rr_graph, build look-up and


### PR DESCRIPTION
This PR changes the RR Graph warnings regarding floating RR Nodes (nodes with no out-going edges) to happen in detail only in verbose mode. With default route_verbosity, we now only print the number of floating RR Nodes and not every single one.

I believe floating wires are expected in device edges and we have a lot of them in interposer-based architectures. Here's how the warnings look like for an interposer architecture now:

> Warning 1433: Found 11654 nodes with no out-going switches. Run VTR with route_verbosity > 1 to see details.