### PR TITLE
Fix system Qt discovery in Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ if (NOT VPR_USE_EZGL STREQUAL "off")
                 break()
             endif()
         endforeach()
-        find_package(Qt6 ${VTR_QT_MIN_VERSION} QUIET COMPONENTS Core Gui Widgets)
+        find_package(Qt6 ${VTR_QT_MIN_VERSION} REQUIRED QUIET COMPONENTS Core Gui Widgets)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ if (NOT VPR_USE_EZGL STREQUAL "off")
                 break()
             endif()
         endforeach()
-        find_package(Qt6 ${VTR_QT_MIN_VERSION} REQUIRED QUIET COMPONENTS Core Gui Widgets)
+        find_package(Qt6 ${VTR_QT_MIN_VERSION} QUIET COMPONENTS Core Gui Widgets)
     endif()
 endif()
 

--- a/install_dnf_packages.sh
+++ b/install_dnf_packages.sh
@@ -29,9 +29,12 @@ sudo dnf install --refresh -y \
     swig
 
 # Required for graphics
-# GL/EGL/xkb runtime that the Qt6 GUI links against; the Qt6 SDK itself is
-# provisioned separately by dev/ensure_qt6_sdk.sh.
 sudo dnf install --refresh -y \
+    qt6-qtbase-devel \
+    qt6-qtsvg-devel \
+    qt6-qtbase-private-devel \
+    qt6-qtshadertools \
+    qt6-qtshadertools-devel \
     libxkbcommon-devel \
     mesa-libGL-devel \
     mesa-libEGL-devel \

--- a/vpr/test/gui/test_save_graphics.cpp
+++ b/vpr/test/gui/test_save_graphics.cpp
@@ -54,6 +54,8 @@
 #include <filesystem>
 #include <string>
 
+#include "vtr_util.h"
+
 #include <QApplication>
 #include <QComboBox>
 #include <QDialog>
@@ -114,7 +116,7 @@ class TmpDir {
     TmpDir() {
         static std::atomic<unsigned> seq{0};
         path_ = fs::temp_directory_path()
-                / ("vpr_gui_t003_" + std::to_string(::getpid()) + "_"
+                / ("vpr_gui_t003_" + std::to_string(vtr::get_pid()) + "_"
                    + std::to_string(seq.fetch_add(1)));
         fs::create_directories(path_);
     }


### PR DESCRIPTION
Adds Qt packages to dnf install script and some other minor fixes. Should only be merged after https://github.com/verilog-to-routing/ezgl/pull/31 is merged.