### PR TITLE
Create virtual python environment in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ ENV WORKSPACE=/workspace
 RUN mkdir -p ${WORKSPACE}
 WORKDIR ${WORKSPACE}
 COPY . ${WORKSPACE}
-# Required to bypass Python's protection on system-wide package installations in Ubuntu 23.04+.
-# This allows pip to install packages globally without using a virtual environment.
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV VIRTUAL_ENV=${WORKSPACE}/.venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 # Install and cleanup is done in one command to minimize the build cache size
 RUN apt-get update -qq \
 # Extract package names from install_apt_packages.sh
@@ -19,10 +18,14 @@ RUN apt-get update -qq \
     wget \
     ninja-build \
     python3-pip \
+    python3-venv \
     time \
     verilator \
 # Install python packages
+    && python3 -m venv ${VIRTUAL_ENV} \
     && pip install -r requirements.txt \
+    && echo "[ -f ${VIRTUAL_ENV}/bin/activate ] && . ${VIRTUAL_ENV}/bin/activate" > /etc/profile.d/vtr-venv.sh \
+    && echo "[ -f ${VIRTUAL_ENV}/bin/activate ] && . ${VIRTUAL_ENV}/bin/activate" >> /etc/bash.bashrc \
 # Cleanup
     && apt-get autoclean && apt-get clean && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The current docker image tries to install python packages system wide. Currently this is resulting in a CI error. This PR changes the dockerfile to create a venv, install the packages in the venv and add the venv activation command to interactive shell startup.