### PR TITLE
[Scripts] Fixed Missing sys.exit in run_vtr_task

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "readline",
     "openssl",
     "pkgconf",
-    "capnproto"
+    "capnproto",
+    "eigen3"
   ]
 }

--- a/vtr_flow/scripts/run_vtr_task.py
+++ b/vtr_flow/scripts/run_vtr_task.py
@@ -286,8 +286,6 @@ def vtr_command_main(arg_list, prog=None) -> int:
             print("\tfile: ", exception.filename)
     except VtrError as exception:
         print("Error:", exception.msg)
-    if __name__ == "main":
-        sys.exit(num_failed)
     return num_failed
 
 
@@ -507,4 +505,4 @@ def run_vtr_flow_process(queue, run_dirs, job, script) -> None:
 
 
 if __name__ == "__main__":
-    vtr_command_main(sys.argv[1:])
+    sys.exit(vtr_command_main(sys.argv[1:], prog=sys.argv[0]))


### PR DESCRIPTION
run_vtr_task.py had a malformed if statement in its main function where it was supposed to exit the program with an exit code if the script was executed directly, but it was never doing so. Resolved it by rewriting it to match run_vtr_flow.py

Resolves #3598 