### PR TITLE
[CI] Update External Actions

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: 🛰️ Push container image
         if: github.event_name != 'pull_request'
-        uses: pyTooling/Actions/with-post-step@r0
+        uses: pyTooling/Actions/with-post-step@v7.10.1
         with:
           main: |
             echo '${{ github.token }}' | docker login ghcr.io -u GitHub-Actions --password-stdin

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/labeler@master
+    - uses: actions/labeler@v6.1.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/nightly_test_manual.yml
+++ b/.github/workflows/nightly_test_manual.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Install dependencies
       run: ./install_apt_packages.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1178,7 +1178,7 @@ jobs:
           echo "CURL_PATH=$curlPath" >> $env:GITHUB_ENV
 
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1.13.0
       
       - name: Check MSVC Version
         run: cl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: ./install_apt_packages.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}
 
@@ -104,7 +104,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install qtbase5-dev
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}
 
@@ -278,7 +278,7 @@ jobs:
     - name: Install GUI test dependencies
       run: ./dev/install_gui_test_deps.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}
 
@@ -377,7 +377,7 @@ jobs:
     - name: Install GUI test dependencies
       run: ./dev/install_gui_test_deps.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}
 
@@ -475,7 +475,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: 'ccache'
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}
 
@@ -792,7 +792,7 @@ jobs:
       run: |
         pip install -r requirements.txt
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}-${{ matrix.suite }}
 
@@ -962,7 +962,7 @@ jobs:
     - name: Install dependencies
       run: ./install_apt_packages.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}-${{ matrix.CC }}
 
@@ -993,7 +993,7 @@ jobs:
     - name: Install Dependencies
       run: ./install_apt_packages.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}-gcc-11
 
@@ -1024,7 +1024,7 @@ jobs:
     - name: Install Dependencies
       run: ./install_apt_packages.sh
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ github.job }}-gcc-15
 
@@ -1108,7 +1108,7 @@ jobs:
           ls /${{ matrix.config.prefix }}/lib/gcc/x86_64-w64-mingw32/*/adalib/libgnat.a
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}-msys2-${{ github.job }}-${{ hashFiles('**/CMakeLists.txt', '**/Makefile') }}
           restore-keys: |
@@ -1184,7 +1184,7 @@ jobs:
         run: cl
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}-msvc-${{ github.sha }}
           restore-keys: ${{ runner.os }}-msvc-


### PR DESCRIPTION
I always assumed that GitHub actions followed NPM-style semver matching such that when you select version 1.2, for example, you would implicitly be getting version 1.2.23 (or whatever the latest is). We are currently receiving warnings from the ccache action since we are on the release titled 1.2, but we want to be on 1.2.23 which is the latest.

Due to this, Dependabot was not updating these releases correctly. I went through our external actions and ensured that they were all locked to versions which Dependabot can see and maintain. This should prevent issues like this from coming in the future.