### PR TITLE
[Dependabot] Cleaned Up Pip Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,23 +19,12 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Pip dependency updates. Directories are listed explicitly to prevent
-  # vtr_flow/parse/pass_requirements/ (a VTR-internal config folder whose
-  # files happen to match the requirements*.txt pattern) from being
-  # misidentified as pip manifests.
+  # Pip dependency updates. vtr_flow/parse/ is excluded because its
+  # pass_requirements*.txt files are a VTR-internal config format that
+  # Dependabot would otherwise misidentify as pip manifests.
   - package-ecosystem: pip
     directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: pip
-    directory: "/dev"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: pip
-    directory: "/doc"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: pip
-    directory: "/parmys"
+    exclude-paths:
+      - "vtr_flow/parse/**"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I found that my last PR did not fix the problem. I am trying just completely ignoring the parse repository. Eventually, we need to consider changing the parse files to potentially having a different extension. I hate pip...