### PR TITLE
[AP][Timing] Generate Timing Report After GP

### DIFF
--- a/vpr/src/analytical_place/analytical_placement_flow.cpp
+++ b/vpr/src/analytical_place/analytical_placement_flow.cpp
@@ -310,6 +310,13 @@ void run_analytical_placement_flow(t_vpr_setup& vpr_setup) {
                                   device_height,
                                   device_ctx.grid.get_num_layers()));
 
+    // Generate the pre-cluster timing report now that global placement has
+    // updated the timing arc delays to reflect the flat placement.
+    pre_cluster_timing_manager.generate_setup_timing_report(atom_nlist,
+                                                            g_vpr_ctx.atom().lookup(),
+                                                            *device_ctx.arch,
+                                                            vpr_setup.AnalysisOpts);
+
     // Run the Full Legalizer.
     std::unique_ptr<FullLegalizer> full_legalizer = make_full_legalizer(ap_opts.full_legalizer_type,
                                                                         ap_netlist,

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -744,6 +744,10 @@ bool vpr_pack(t_vpr_setup& vpr_setup, const t_arch& arch) {
                                                        vpr_setup.RoutingArch,
                                                        vpr_setup.PackerOpts.device_layout,
                                                        vpr_setup.AnalysisOpts);
+    pre_cluster_timing_manager.generate_setup_timing_report(g_vpr_ctx.atom().netlist(),
+                                                            g_vpr_ctx.atom().lookup(),
+                                                            arch,
+                                                            vpr_setup.AnalysisOpts);
 
     // Estimate the device size before packing and build the RR graph if necessary.
     // When auto-sizing is used, this sets the device grid to the estimated size so

--- a/vpr/src/timing/PreClusterTimingManager.cpp
+++ b/vpr/src/timing/PreClusterTimingManager.cpp
@@ -103,25 +103,6 @@ PreClusterTimingManager::PreClusterTimingManager(bool timing_driven,
         write_setup_timing_graph_dot(getEchoFileName(E_ECHO_PRE_PACKING_TIMING_GRAPH) + std::string(".dot"),
                                      *timing_info_, debug_tnode);
     }
-
-    // Write a timing report.
-    {
-        auto& timing_ctx = g_vpr_ctx.timing();
-        PreClusterTimingGraphResolver resolver(atom_netlist,
-                                               atom_lookup,
-                                               arch.models,
-                                               *timing_ctx.graph,
-                                               *clustering_delay_calc_);
-        resolver.set_detail_level(analysis_opts.timing_report_detail);
-
-        tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph,
-                                              *timing_ctx.constraints);
-
-        timing_reporter.report_timing_setup(
-            "pre_pack.report_timing.setup.rpt",
-            *timing_info_->setup_analyzer(),
-            analysis_opts.timing_report_npaths);
-    }
 }
 
 static float approximate_inter_cluster_delay(const t_arch& arch,
@@ -269,6 +250,30 @@ static void get_intercluster_switch_fanin_estimates(const t_arch& arch,
         VPR_FATAL_ERROR(VPR_ERROR_PACK, "Unrecognized directionality: %d\n",
                         (int)routing_arch.directionality);
     }
+}
+
+void PreClusterTimingManager::generate_setup_timing_report(const AtomNetlist& atom_netlist,
+                                                           const AtomLookup& atom_lookup,
+                                                           const t_arch& arch,
+                                                           const t_analysis_opts& analysis_opts) const {
+    if (!is_valid_)
+        return;
+
+    auto& timing_ctx = g_vpr_ctx.timing();
+    PreClusterTimingGraphResolver resolver(atom_netlist,
+                                           atom_lookup,
+                                           arch.models,
+                                           *timing_ctx.graph,
+                                           *clustering_delay_calc_);
+    resolver.set_detail_level(analysis_opts.timing_report_detail);
+
+    tatum::TimingReporter timing_reporter(resolver, *timing_ctx.graph,
+                                          *timing_ctx.constraints);
+
+    timing_reporter.report_timing_setup(
+        "pre_pack.report_timing.setup.rpt",
+        *timing_info_->setup_analyzer(),
+        analysis_opts.timing_report_npaths);
 }
 
 float PreClusterTimingManager::calc_atom_setup_criticality(AtomBlockId blk_id,

--- a/vpr/src/timing/PreClusterTimingManager.h
+++ b/vpr/src/timing/PreClusterTimingManager.h
@@ -70,6 +70,30 @@ class PreClusterTimingManager {
                             const t_analysis_opts& analysis_opts);
 
     /**
+     * @brief Generates a setup timing report for the pre-clustered netlist and
+     *        writes it to "pre_pack.report_timing.setup.rpt".
+     *
+     * This is separated from the constructor so callers can choose when to
+     * generate the report. In the standard packing flow the report is generated
+     * immediately after construction, but in the analytical placement flow the
+     * timing graph is modified by global placement before the report should be
+     * written.
+     *
+     *  @param atom_netlist
+     *          The primitive netlist.
+     *  @param atom_lookup
+     *          Primitive-to-timing-node lookup.
+     *  @param arch
+     *          The architecture.
+     *  @param analysis_opts
+     *          Timing analysis options.
+     */
+    void generate_setup_timing_report(const AtomNetlist& atom_netlist,
+                                      const AtomLookup& atom_lookup,
+                                      const t_arch& arch,
+                                      const t_analysis_opts& analysis_opts) const;
+
+    /**
      * @brief Calculates the setup criticality of the given primitive block.
      *
      * Currently defined as the maximum criticality over the block inputs.


### PR DESCRIPTION
I found that the pre-cluster timing report was being generated before global placement. This was using a delay model where all delays between primitives was estimated as a somewhat large constant delay (representing the inter-tile delay).

AP improves on this by updating the timing graph using the current flat placement. It is much more useful for users of AP to see the timing graph after global placement, so I moved the generation of the pre-pack timing report to after global placement and before full legalization.

Trying this on a basic testcase, the values look reasonable (much more reasonable than the prior timing report); however the delay of staying within a tile still appears quite large. Something to investigate.