### PR TITLE
[WIP][FlatRouting] Fixed Memory Corruption in Sync Netlist

### DIFF
--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -318,6 +318,8 @@ static void sync_clustered_netlist_to_routing(void) {
      * Add the associated net and port too if they don't exist */
     for (auto parent_net_id : atom_ctx.netlist().nets()) {
         auto& tree = route_ctx.route_trees[parent_net_id];
+        if (!tree)
+            continue;
         AtomNetId atom_net_id = convert_to_atom_net_id(parent_net_id);
 
         ClusterNetId clb_net_id;
@@ -376,8 +378,7 @@ static void sync_clustered_netlist_to_routing(void) {
                              clb_netlist.block_name(clb).c_str());
                 continue;
             }
-            ClusterPinId new_pin = clb_netlist.create_pin(port_id, pb_graph_pin->pin_number, clb_net_id, pin_type, pb_graph_pin->pin_count_in_cluster);
-            clb_netlist.set_pin_net(new_pin, pin_type, clb_net_id);
+            clb_netlist.create_pin(port_id, pb_graph_pin->pin_number, clb_net_id, pin_type, pb_graph_pin->pin_count_in_cluster);
         }
     }
     /* 4. Rebuild internal cluster netlist lookups */


### PR DESCRIPTION
Currently, several tests are crashing during deallocation of the major datastructures. This often means memory corruption. From looking at Valgrind, I traced the issue down to the sync_netlists_to_routing_flat method. I believe the issue is that we walk the routing data structure, but we are not checking if the tree exists. It is possible for trees to not exist when the net is global for example (i.e. clocks are not routed). Fixed this by adding a safety check.

Resolves #3667 