### PR TITLE
[Python][Lint] Fixed Linting Error in CI

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -335,8 +335,7 @@ def pretty_print_table(file, border=False):
                 row = row[:-1]
             if first:
                 table.field_names = list(row)
-                for head in list(row):
-                    table.align[head] = "l"
+                table.align = "l"
                 first = False
             else:
                 table.add_row(row)


### PR DESCRIPTION
It looks like the version of prettytable was updated on Pip and our code was not quite version agnostic, leading to an error in CI. Updated the prettytable printer to use a simpler method to avoid the lint error.