### PR TITLE
Remove -fPIC flag for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,10 @@ elseif(VTR_IPO_BUILD STREQUAL "auto")
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
     else()
         message(STATUS "Building with IPO: off (auto)")
-        set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fPIC")
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC")
+        if(NOT MSVC)
+            set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fPIC")
+            set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC")
+        endif()
     endif()
 else()
     message(STATUS "Building with IPO: off")
@@ -137,9 +139,10 @@ if(NOT MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g3")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-
+if(NOT MSVC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+endif()
 #
 # Warning flags
 #


### PR DESCRIPTION
MSVC does not support -fPIC (and the concept apparently doesn't really exist in Windows anyway) and the CI run was full of "cl : Command line warning D9002 : ignoring unknown option '-fPIC' ". This PR changes the Cmake config so that -fPIC is only added when the compiler is not MSVC.