### PR TITLE
Fixed a memory corruption in rr_graph_view_util.cpp on std::find() the same vector

### DIFF
--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/rr_graph_view_util.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/rr_graph_view_util.cpp
@@ -116,8 +116,10 @@ std::vector<RRNodeId> find_rr_graph_grid_nodes(const RRGraphView& rr_graph,
     for (int pin = 0; pin < device_grid.get_physical_type(tile_loc)->num_pins; ++pin) {
         /* Skip those pins have been ignored during rr_graph build-up */
         if (true == device_grid.get_physical_type(tile_loc)->is_ignored_pin[pin]) {
+            // Cache the vector to avoid memory corruption in the std::find()
+            std::vector<int> clk_pins = device_grid.get_physical_type(tile_loc)->get_clock_pins_indices();
             /* If specified, force to include all the clock pins */
-            if (!include_clock || std::find(device_grid.get_physical_type(tile_loc)->get_clock_pins_indices().begin(), device_grid.get_physical_type(tile_loc)->get_clock_pins_indices().end(), pin) == device_grid.get_physical_type(tile_loc)->get_clock_pins_indices().end()) {
+            if (!include_clock || std::find(clk_pins.begin(), clk_pins.end(), pin) == clk_pins.end()) {
                 continue;
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Fixed a memory corruption in rr_graph_view_util.cpp on std::find() where different vectors may be returned each time through a method.
Code change is very straightforward. See details in motivation.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The std::find() may cause memory corruption when used improperly.

https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/351274472b7b758dfc064a051752a21105bf52bd/vpr/src/route/rr_graph_generation/tileable_rr_graph/rr_graph_view_util.cpp#L120-L122

Each time the ``get_clock_pins_indices()`` may return a different address to a vector.

This causes memory corruption (detected by valgrind).

```
==3201043== Memcheck, a memory error detector
==3201043== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3201043== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==3201043== Command: /home/xifan/github/OpenFPGA/build/openfpga/openfpga -f rst_cond_run.openfpga
==3201043== Parent PID: 2734201
==3201043== 
==3201043== Invalid read of size 4
==3201043==    at 0x7F71AC: bool __gnu_cxx::__ops::_Iter_equals_val<int const>::operator()<__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > > >(__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >) (predefined_ops.h:270)
==3201043==    by 0x7F7234: __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > > std::__find_if<__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__ops::_Iter_equals_val<int const> >(__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__ops::_Iter_equals_val<int const>, std::random_access_iterator_tag) (stl_algobase.h:2073)
==3201043==    by 0x7F5CAE: __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > > std::__find_if<__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__ops::_Iter_equals_val<int const> >(__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__ops::_Iter_equals_val<int const>) (stl_algobase.h:2114)
==3201043==    by 0x7F3E01: __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > > std::find<__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, int>(__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >, int const&) (stl_algo.h:3884)
==3201043==    by 0xBB4091: find_rr_graph_grid_nodes(RRGraphView const&, DeviceGrid const&, unsigned long const&, int const&, int const&, e_rr_type const&, e_side const&, bool) (rr_graph_view_util.cpp:120)
```

A detailed valgrind log is attached.
[vg.log](https://github.com/user-attachments/files/29450271/vg.log)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In VTR, the include_clock is never enabled. therefore the memory corruption is not seen in regression tests.

[```
std::find(get_vector().begin(). 
```](https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/351274472b7b758dfc064a051752a21105bf52bd/vpr/src/route/rr_graph_generation/tileable_rr_graph/rr_graph_view_util.cpp#L120-L122)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
