### PR TITLE
Fix a text drawing issue related to the deferred and rhi renderer

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1679,7 +1679,7 @@ void highlight_moved_block_and_its_terminals(
     clear_colored_locations();
     set_draw_loc_color(blocks_affected.moved_blocks[0].old_loc,
                        OLD_BLK_LOC_COLOR);
-    set_draw_loc_color(blocks_affected.moved_blocks[0].old_loc,
+    set_draw_loc_color(blocks_affected.moved_blocks[0].new_loc,
                        NEW_BLK_LOC_COLOR);
 }
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -156,7 +156,7 @@ void draw_place(ezgl::renderer* g) {
 
                     g->set_font_size(14);
                     if (draw_state->draw_block_text) {
-                        // The function draw_internal_draw_subblk() in intra_logic_block.cpp is called after this function during every redraw, and it 
+                        // The function draw_internal_draw_subblk() in intra_logic_block.cpp is called after this function during every redraw, and it
                         // draws cluster blocks (which overlap with the ones drawn in this function), their child blocks and their block types when
                         // "show block internals" is toggled. In this case, we should no longer draw the block types here again, because in the deferred renderer
                         // or rhi renderer mode, all texts are queued and unleashed together after geometries are drawn, meaning that cluster blocks drawn in draw_internal_draw_subblk()

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -168,7 +168,7 @@ void draw_place(ezgl::renderer* g) {
                             g->draw_text(center, block_type_loc, abs_clb_bbox.width(), abs_clb_bbox.height());
                         }
 
-                        // Draw the cluster block name if "show block internal" is not toggled and the block is not empty.
+                        // Draw the cluster block name if "show block internals" is not toggled and the block is not empty.
                         if (!draw_state->show_blk_internal && bnum) {
                             const std::string name = cluster_ctx.clb_nlist.block_name(bnum) + vtr::string_fmt(" (#%zu)", size_t(bnum));
                             // The drawing position is offset from the block center to avoid being overlapped with the block type name.

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -127,7 +127,6 @@ void draw_place(ezgl::renderer* g) {
                 for (int k = 0; k < num_sub_tiles; ++k) {
                     // Look at the tile at start of large block
                     ClusterBlockId bnum = grid_blocks.block_at_location({i, j, k, layer_num});
-                    // Fill background for the clb. Do not fill if "show_blk_internal" is toggled.
 
                     // Determine the block color and logical type
                     ezgl::color block_color;
@@ -155,21 +154,27 @@ void draw_place(ezgl::renderer* g) {
                         g->draw_rectangle(abs_clb_bbox);
                     }
 
-                    g->set_font_size(16);
+                    g->set_font_size(14);
                     if (draw_state->draw_block_text) {
-                        // Draw text if the space has parts of the netlist
-                        if (bnum) {
+                        // The function draw_internal_draw_subblk() in intra_logic_block.cpp is called after this function during every redraw, and it 
+                        // draws cluster blocks (which overlap with the ones drawn in this function), their child blocks and their block types when
+                        // "show block internals" is toggled. In this case, we should no longer draw the block types here again, because in the deferred renderer
+                        // or rhi renderer mode, all texts are queued and unleashed together after geometries are drawn, meaning that cluster blocks drawn in draw_internal_draw_subblk()
+                        // cannot effectively hide the block types drawn in this function. However, draw_internal_draw_subblk() skips drawing empty cluster blocks (i.e. !bnum),
+                        // and therefore we should still draw their block types here.
+                        if (!draw_state->show_blk_internal || !bnum) {
+                            std::string block_type_loc = type->name;
+                            block_type_loc += vtr::string_fmt(" (%d,%d)", i, j);
+                            g->draw_text(center, block_type_loc, abs_clb_bbox.width(), abs_clb_bbox.height());
+                        }
+
+                        // Draw the cluster block name if "show block internal" is not toggled and the block is not empty.
+                        if (!draw_state->show_blk_internal && bnum) {
                             const std::string name = cluster_ctx.clb_nlist.block_name(bnum) + vtr::string_fmt(" (#%zu)", size_t(bnum));
-                            // The drawing position is offset from the block center to avoid being overlapped with
-                            // another text drawn inside the same block (see below).
+                            // The drawing position is offset from the block center to avoid being overlapped with the block type name.
                             g->draw_text(center - ezgl::point2d(0, abs_clb_bbox.height() / 4),
                                          name, abs_clb_bbox.width(), abs_clb_bbox.height());
                         }
-
-                        // Draw text for block type so that user knows what block
-                        std::string block_type_loc = type->name;
-                        block_type_loc += vtr::string_fmt(" (%d,%d)", i, j);
-                        g->draw_text(center, block_type_loc, abs_clb_bbox.width(), abs_clb_bbox.height());
                     }
                 }
             }

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -399,16 +399,16 @@ static void draw_connections_from_atom_netlist(AtomPinId atom_sink_pin, ezgl::co
 
     t_draw_state* draw_state = get_draw_state_vars();
 
+    // A src net pin is always 0.
     std::vector<RRNodeId> routed_rr_nodes = trace_routed_connection_rr_nodes(atom_net_id, 0, sink_net_pin_index);
 
-    // Mark all the nodes highlighted
-
+    // Mark all the nodes highlighted.
     for (RRNodeId inode : routed_rr_nodes) {
         draw_state->draw_rr_node[inode].color = color;
         draw_state->draw_rr_node[inode].node_highlighted = true;
     }
 
-    // draw_partial_route() takes care of layer visibility and cross-layer settings
+    // draw_partial_route() takes care of layer visibility and cross-layer settings.
     draw_partial_route(routed_rr_nodes, g);
 }
 

--- a/vpr/src/draw/intra_logic_block.cpp
+++ b/vpr/src/draw/intra_logic_block.cpp
@@ -520,12 +520,13 @@ static bool draw_internal_pb(const ClusterBlockId clb_index, t_pb* pb, const ezg
     std::string pb_type_name(pb_type->name);
 
     // This is a special case: blocks that correspond to pb_type->depth == 0 are essentially the top-level clustered blocks,
-    // and in each drawing cycle they are drawn already in draw_place() in draw_basic.cpp. The reason for that is,
-    // draw_internal_pb() is not called anymore when we zoom out too much. This said, the naming convention for clustered blocks
-    // has been historically different between the two functions, and when level of detail is on (the children of clustered blocks
-    // are drawn), we want to use the naming convention specified under the else if statement below. And when level of detail
-    // is off (!at_least_one_child_pb_drawn), we still want to use the naming convention from draw_place()
-    // to ensure consistency. This one is specified under the if statement just below.
+    // and draw_place() already draws them in draw_basic.cpp. This duplicate drawing exists because
+    // draw_internal_pb() is no longer called when we zoom out too far, yet we still want the clustered blocks to be drawn.
+    // At other zoom levels, clustered blocks drawn in draw_internal_pb() are overlaid onto the same blocks drawn in draw_place().
+    // However, the two functions have historically used different naming conventions for clustered blocks (both have their own merits)
+    // and it can feel abrupt when the block names suddenly change from draw_place() style to draw_internal_pb() style due to the overlay,
+    // while the block drawing itself remains the same. Therefore, we keep using draw_place() style at this transition level.
+    // When the block drawing does differ (draw_internal_pb() starts drawing children blocks inside the clusters), we switch to draw_internal_pb() style.
     if (pb_type->depth == 0 && !at_least_one_child_pb_drawn) {
         const t_pl_loc& loc = block_locs[clb_index].loc;
         // loc.x and loc.y are the x and y coordinates of the containing subtile.

--- a/vpr/src/draw/intra_logic_block.cpp
+++ b/vpr/src/draw/intra_logic_block.cpp
@@ -520,13 +520,13 @@ static bool draw_internal_pb(const ClusterBlockId clb_index, t_pb* pb, const ezg
     std::string pb_type_name(pb_type->name);
 
     // This is a special case: blocks that correspond to pb_type->depth == 0 are essentially the top-level clustered blocks,
-    // and draw_place() already draws them in draw_basic.cpp. This duplicate drawing exists because
-    // draw_internal_pb() is no longer called when we zoom out too far, yet we still want the clustered blocks to be drawn.
-    // At other zoom levels, clustered blocks drawn in draw_internal_pb() are overlaid onto the same blocks drawn in draw_place().
-    // However, the two functions have historically used different naming conventions for clustered blocks (both have their own merits)
-    // and it can feel abrupt when the block names suddenly change from draw_place() style to draw_internal_pb() style due to the overlay,
-    // while the block drawing itself remains the same. Therefore, we keep using draw_place() style at this transition level.
-    // When the block drawing does differ (draw_internal_pb() starts drawing children blocks inside the clusters), we switch to draw_internal_pb() style.
+    // and draw_place() already draws them in draw_basic.cpp. This duplicate drawing exists because draw_internal_pb()
+    // is not called when "show block internals" is not toggled. At other times, clustered blocks drawn in this function
+    // are overlaid onto the same blocks drawn in draw_place(). However, the two functions have historically used different
+    // naming conventions for clustered blocks (both have their own merits), and it can feel abrupt when the block names suddenly
+    // change from draw_place() style to draw_internal_pb() style when we toggle "show block internals" at a zoom level where
+    // the block drawing remains the same (child blocks not drawn yet). Therefore, we keep using draw_place() style at this transition level.
+    // When draw_internal_pb() starts drawing child blocks inside the clusters, we switch to draw_internal_pb() style because things have meaningfully changed.
     if (pb_type->depth == 0 && !at_least_one_child_pb_drawn) {
         const t_pl_loc& loc = block_locs[clb_index].loc;
         // loc.x and loc.y are the x and y coordinates of the containing subtile.

--- a/vpr/src/draw/intra_logic_block.cpp
+++ b/vpr/src/draw/intra_logic_block.cpp
@@ -216,12 +216,12 @@ void draw_internal_draw_subblk(ezgl::renderer* g) {
     const auto& grid_blocks = draw_state->get_graphics_blk_loc_registry_ref().grid_blocks();
 
     int total_layer_num = device_ctx.grid.get_num_layers();
-
+    g->set_line_width(0);
     for (int layer_num = 0; layer_num < total_layer_num; layer_num++) {
         if (draw_state->draw_layer_display[layer_num].visible) {
             for (int i = 0; i < (int)device_ctx.grid.width(); i++) {
                 for (int j = 0; j < (int)device_ctx.grid.height(); j++) {
-                    /* Only the first block of a group should control drawing */
+                    // Only the first block of a group should control drawing.
                     const auto& type = device_ctx.grid.get_physical_type({i, j, layer_num});
                     int width_offset = device_ctx.grid.get_width_offset({i, j, layer_num});
                     int height_offset = device_ctx.grid.get_height_offset({i, j, layer_num});
@@ -229,20 +229,20 @@ void draw_internal_draw_subblk(ezgl::renderer* g) {
                     if (width_offset > 0 || height_offset > 0)
                         continue;
 
-                    /* Don't draw if tile is empty. This includes corners. */
+                    // Don't draw if tile is empty. This includes corners.
                     if (is_empty_type(type))
                         continue;
 
                     int num_sub_tiles = type->capacity;
                     for (int k = 0; k < num_sub_tiles; ++k) {
-                        /* Don't draw if block is empty. */
+                        // Don't draw if block is empty.
                         if (!grid_blocks.block_at_location({i, j, k, layer_num})) {
                             continue;
                         }
 
-                        /* Get block ID */
+                        // Get block ID.
                         ClusterBlockId bnum = grid_blocks.block_at_location({i, j, k, layer_num});
-                        /* Safety check, that physical blocks exists in the CLB */
+                        // Safety check, that physical blocks exists in the CLB.
                         if (cluster_ctx.clb_nlist.block_pb(bnum) == nullptr) {
                             continue;
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Currently, there are two functions that draw blocks, draw_place() and draw_internal_draw_subblk().
draw_place() is called first during every redraw, and it draws empty and non-empty clustered blocks.
draw_internal_draw_subblk() draws only non-empty clustered blocks and their child blocks, and these clustered blocks overlap with the previous ones.

Previously, draw_place() always draws texts inside the clustered blocks, because the same clustered blocks in draw_internal_draw_subblk() can effectively hide them, and texts drawn in draw_internal_draw_subblk() are the only visible ones.

But this is no longer valid after the Qt upgrade, because in the deferred and rhi renderer, all texts are queued and unleashed together after geometries are drawn (the idea of overlay), meaning that the texts mentioned before cannot be hidden anymore, causing the scene below:
<img width="623" height="382" alt="2026-07-06 111724" src="https://github.com/user-attachments/assets/4e098c0a-1b09-47e2-a998-00fdd8d62f17" />

I added a few condition checks inside draw_place() so that texts are drawn only when needed.

Note: the change only stays in the VPR drawing code, and nothing in ezgl was touched.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this on a few regression tests, and all worked well except the 3d test. This is expected, because when multiple layers are shown together, clustered blocks that share the same 2d location can have overlapped text because of the same overlay reason. If only one layer is shown, there is no issue.

I personally want to fix this in the next PR.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
