### PR TITLE
Exclude unused wire types from lookahead sampling point calculation

### DIFF
--- a/vpr/src/route/router_lookahead/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.cpp
@@ -545,7 +545,13 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
 
     int longest_seg_length = 0;
     for (const t_segment_inf& seg_inf : segment_inf_vec) {
-        longest_seg_length = std::max(longest_seg_length, seg_inf.length);
+        // longest_seg_length only cares about segments that exist in normal routing wires
+        // Exclude segment types with 0 frequency e.g. scatter gather segments and unused segments
+        // these wires can be long, and including them can move us too far from the edge of the die
+        // and lead to missing data for long distance connections in the lookahead.
+        if (seg_inf.frequency != 0) {
+            longest_seg_length = std::max(longest_seg_length, seg_inf.length);
+        }
     }
 
     // Profile each wire segment type


### PR DESCRIPTION
The router lookahead does flood fills from nodes located at (1,1), (2,2), (1 + longest_segment_length, 1 + longest_segment_length) and (1 + longest_segment_length + 1, 1 + longest_segment_length + 1). It would normally go through all segment types in the architecture file to find the longest ones, but this PR makes it take into account only segment types that have a non-zero frequency and are part of the normal routing wires.

Interposer architectures results (Koios benchmarks):

  |L17_Master | L17_Branch
-- | -- | --
vtr_flow_elapsed_time | 1 | 1.153
max_vpr_mem | 1 | 1.000
place_time | 1 | 1.145
routed_wirelength | 1 | 0.997
critical_path_delay | 1 | 1.025
crit_path_route_time | 1 | 0.944
total_heap_pops | 1 | 0.859
total_swap | 1 | 1.004
accepted_swap | 1 | 0.998
placed_CPD_est | 1 | 1.006

  | L37_Master | L37_Branch
-- | -- | --
vtr_flow_elapsed_time | 1 | 0.843
max_vpr_mem | 1 | 1.000
place_time | 1 | 1.061
routed_wirelength | 1 | 0.990
critical_path_delay | 1 | 0.992
crit_path_route_time | 1 | 0.577
total_heap_pops | 1 | 0.549
total_swap | 1 | 0.995
accepted_swap | 1 | 0.990
placed_CPD_est | 1 | 1.039

In general this makes the router scale a little bit better with interposer segment length:

  | Master | Branch
-- | -- | --
2D_heap_pops | 1 | 1
L17_heap_pops | 2.711990275 | 2.330621718
L37_heap_pops | 10.36698448 | 6.621974315



Running Koios on 7nm 2D architecture shows no change in quality:

  | Koios_7nm_Master | Koios_7nm_Branch
-- | -- | --
vtr_flow_elapsed_time | 1 | 0.995
max_vpr_mem | 1 | 1.000
place_time | 1 | 1.004
routed_wirelength | 1 | 1.000
critical_path_delay | 1 | 1.000
crit_path_route_time | 1 | 1.004
total_heap_pops | 1 | 1.000
total_swap | 1 | 1.000
accepted_swap | 1 | 1.000
placed_CPD_est | 1 | 1.000

