### PR TITLE
[Interposer] Router Sink Order

### DIFF
--- a/libs/libarchfpga/src/device_grid.cpp
+++ b/libs/libarchfpga/src/device_grid.cpp
@@ -162,6 +162,28 @@ bool DeviceGrid::are_locs_on_same_die(t_physical_tile_loc loc_a, t_physical_tile
     return first_id == second_id;
 }
 
+bool DeviceGrid::do_locs_cross_vertical_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const {
+    // Dice are guaranteed to be axis-aligned rectangles, so checking the die at loc_a's row
+    // is sufficient to tell whether a vertical cut separates the two locations' x coordinates;
+    // this is well-defined even when loc_a.y != loc_b.y.
+    int y = loc_a.y;
+    const DeviceDieId first_id = die_id_matrix_[loc_a.layer_num][loc_a.x][y];
+    const DeviceDieId second_id = die_id_matrix_[loc_b.layer_num][loc_b.x][y];
+
+    return first_id != second_id;
+}
+
+bool DeviceGrid::do_locs_cross_horizontal_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const {
+    // Dice are guaranteed to be axis-aligned rectangles, so checking the die at loc_a's column
+    // is sufficient to tell whether a horizontal cut separates the two locations' y coordinates;
+    // this is well-defined even when loc_a.x != loc_b.x.
+    int x = loc_a.x;
+    const DeviceDieId first_id = die_id_matrix_[loc_a.layer_num][x][loc_a.y];
+    const DeviceDieId second_id = die_id_matrix_[loc_b.layer_num][x][loc_b.y];
+
+    return first_id != second_id;
+}
+
 DeviceDieId DeviceGrid::get_loc_die_id(t_physical_tile_loc loc) const {
     return die_id_matrix_[loc.layer_num][loc.x][loc.y];
 }

--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -326,6 +326,16 @@ class DeviceGrid {
     bool are_locs_on_same_die(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const;
 
     /**
+     * @brief Returns true if the straight line between loc_a and loc_b crosses a vertical interposer cut.
+     */
+    bool do_locs_cross_vertical_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const;
+
+    /**
+     * @brief Returns true if the straight line between loc_a and loc_b crosses a horizontal interposer cut.
+     */
+    bool do_locs_cross_horizontal_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const;
+
+    /**
      * @brief Get the die identifier of a location. In 2.5D and 3D architectures each die has its own unique identifier.
      * 
      * @param loc (x, y, layer) position that you want the id of.

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -3379,6 +3379,24 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("2")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument<float>(args.router_interposer_die_crossing_bonus, "--router_interposer_die_crossing_bonus")
+        .help(
+            "Sort-priority bonus given to a sink that is on the other side of an interposer die "
+            "crossing from the net's driver. Used to route die-crossing sinks earlier so their "
+            "route can be reused by other sinks on the same die. Only has effect on interposer-based "
+            "architectures.")
+        .default_value("1.0")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
+    route_timing_grp.add_argument<float>(args.router_interposer_inline_alignment_bonus, "--router_interposer_inline_alignment_bonus")
+        .help(
+            "Additional sort-priority bonus (on top of --router_interposer_die_crossing_bonus) given "
+            "to a die-crossing sink that is inline with the driver along the crossed cut. The bonus is "
+            "scaled down to 0 as the perpendicular offset (relative to the net's bounding box) grows. "
+            "Only has effect on interposer-based architectures.")
+        .default_value("1.0")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.router_max_convergence_count, "--router_max_convergence_count")
         .help(
             "Controls how many times the router is allowed to converge to a legal routing before halting."

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -3386,7 +3386,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
             "3D stacked architectures), to influence the order in which a net's sinks are routed. "
             "Used to route die-crossing sinks earlier so their route can be reused by other sinks "
             "on the same die. Only has effect on interposer-based or multi-layer (3D) architectures.")
-        .default_value("1.0")
+        .default_value("0.0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_timing_grp.add_argument<float>(args.router_sink_order_die_alignment_multiplier, "--router_sink_order_die_alignment_multiplier")
@@ -3396,7 +3396,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
             "to influence the order in which a net's sinks are routed. Scaled down to 0 as the offset "
             "perpendicular to that boundary (relative to the net's bounding box) grows. Only has effect "
             "on interposer-based or multi-layer (3D) architectures.")
-        .default_value("1.0")
+        .default_value("0.5")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
     route_timing_grp.add_argument(args.router_max_convergence_count, "--router_max_convergence_count")

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -3379,21 +3379,23 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .default_value("2")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    route_timing_grp.add_argument<float>(args.router_interposer_die_crossing_bonus, "--router_interposer_die_crossing_bonus")
+    route_timing_grp.add_argument<float>(args.router_sink_order_die_crossing_multiplier, "--router_sink_order_die_crossing_multiplier")
         .help(
-            "Sort-priority bonus given to a sink that is on the other side of an interposer die "
-            "crossing from the net's driver. Used to route die-crossing sinks earlier so their "
-            "route can be reused by other sinks on the same die. Only has effect on interposer-based "
-            "architectures.")
+            "Sort-priority term added for a sink that is on the other side of a die boundary "
+            "from the net's driver (an interposer cut in the x/y plane, or a layer boundary for "
+            "3D stacked architectures), to influence the order in which a net's sinks are routed. "
+            "Used to route die-crossing sinks earlier so their route can be reused by other sinks "
+            "on the same die. Only has effect on interposer-based or multi-layer (3D) architectures.")
         .default_value("1.0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
-    route_timing_grp.add_argument<float>(args.router_interposer_inline_alignment_bonus, "--router_interposer_inline_alignment_bonus")
+    route_timing_grp.add_argument<float>(args.router_sink_order_die_alignment_multiplier, "--router_sink_order_die_alignment_multiplier")
         .help(
-            "Additional sort-priority bonus (on top of --router_interposer_die_crossing_bonus) given "
-            "to a die-crossing sink that is inline with the driver along the crossed cut. The bonus is "
-            "scaled down to 0 as the perpendicular offset (relative to the net's bounding box) grows. "
-            "Only has effect on interposer-based architectures.")
+            "Additional sort-priority term (on top of --router_sink_order_die_crossing_multiplier) "
+            "added for a die-crossing sink that is inline with the driver across the crossed boundary, "
+            "to influence the order in which a net's sinks are routed. Scaled down to 0 as the offset "
+            "perpendicular to that boundary (relative to the net's bounding box) grows. Only has effect "
+            "on interposer-based or multi-layer (3D) architectures.")
         .default_value("1.0")
         .show_in(argparse::ShowIn::HELP_ONLY);
 

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -285,6 +285,8 @@ struct t_options {
     argparse::ArgValue<double> router_initial_acc_cost_chan_congestion_threshold;
     argparse::ArgValue<double> router_initial_acc_cost_chan_congestion_weight;
     argparse::ArgValue<float> router_lookahead_interposer_base_cut_multiplier;
+    argparse::ArgValue<float> router_interposer_die_crossing_bonus;
+    argparse::ArgValue<float> router_interposer_inline_alignment_bonus;
     argparse::ArgValue<int> router_max_convergence_count;
     argparse::ArgValue<float> router_reconvergence_cpd_threshold;
     argparse::ArgValue<bool> router_update_lower_bound_delays;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -285,8 +285,8 @@ struct t_options {
     argparse::ArgValue<double> router_initial_acc_cost_chan_congestion_threshold;
     argparse::ArgValue<double> router_initial_acc_cost_chan_congestion_weight;
     argparse::ArgValue<float> router_lookahead_interposer_base_cut_multiplier;
-    argparse::ArgValue<float> router_interposer_die_crossing_bonus;
-    argparse::ArgValue<float> router_interposer_inline_alignment_bonus;
+    argparse::ArgValue<float> router_sink_order_die_crossing_multiplier;
+    argparse::ArgValue<float> router_sink_order_die_alignment_multiplier;
     argparse::ArgValue<int> router_max_convergence_count;
     argparse::ArgValue<float> router_reconvergence_cpd_threshold;
     argparse::ArgValue<bool> router_update_lower_bound_delays;

--- a/vpr/src/base/setup_vpr.cpp
+++ b/vpr/src/base/setup_vpr.cpp
@@ -535,8 +535,8 @@ static void setup_router_opts(const t_options& Options, t_router_opts* RouterOpt
     RouterOpts->initial_acc_cost_chan_congestion_threshold = Options.router_initial_acc_cost_chan_congestion_threshold;
     RouterOpts->initial_acc_cost_chan_congestion_weight = Options.router_initial_acc_cost_chan_congestion_weight;
     RouterOpts->router_lookahead_interposer_base_cut_multiplier = Options.router_lookahead_interposer_base_cut_multiplier;
-    RouterOpts->router_interposer_die_crossing_bonus = Options.router_interposer_die_crossing_bonus;
-    RouterOpts->router_interposer_inline_alignment_bonus = Options.router_interposer_inline_alignment_bonus;
+    RouterOpts->router_sink_order_die_crossing_multiplier = Options.router_sink_order_die_crossing_multiplier;
+    RouterOpts->router_sink_order_die_alignment_multiplier = Options.router_sink_order_die_alignment_multiplier;
 
     RouterOpts->max_convergence_count = Options.router_max_convergence_count;
     RouterOpts->reconvergence_cpd_threshold = Options.router_reconvergence_cpd_threshold;

--- a/vpr/src/base/setup_vpr.cpp
+++ b/vpr/src/base/setup_vpr.cpp
@@ -535,6 +535,8 @@ static void setup_router_opts(const t_options& Options, t_router_opts* RouterOpt
     RouterOpts->initial_acc_cost_chan_congestion_threshold = Options.router_initial_acc_cost_chan_congestion_threshold;
     RouterOpts->initial_acc_cost_chan_congestion_weight = Options.router_initial_acc_cost_chan_congestion_weight;
     RouterOpts->router_lookahead_interposer_base_cut_multiplier = Options.router_lookahead_interposer_base_cut_multiplier;
+    RouterOpts->router_interposer_die_crossing_bonus = Options.router_interposer_die_crossing_bonus;
+    RouterOpts->router_interposer_inline_alignment_bonus = Options.router_interposer_inline_alignment_bonus;
 
     RouterOpts->max_convergence_count = Options.router_max_convergence_count;
     RouterOpts->reconvergence_cpd_threshold = Options.router_reconvergence_cpd_threshold;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1378,6 +1378,13 @@ struct t_router_opts {
     double initial_acc_cost_chan_congestion_threshold;
     double initial_acc_cost_chan_congestion_weight;
     float router_lookahead_interposer_base_cut_multiplier; ///< Multiplier to apply for base cost of interposer wires in the router lookahead
+    /// Sort-priority bonus given to a sink that is on the other side of an interposer die
+    /// crossing from the net's driver, used to influence the order sinks are routed in.
+    float router_interposer_die_crossing_bonus;
+    /// Additional sort-priority bonus (on top of router_interposer_die_crossing_bonus) given to a
+    /// die-crossing sink that is inline with the driver along the crossed cut; scaled down to 0 as
+    /// the perpendicular offset within the net's bounding box grows.
+    float router_interposer_inline_alignment_bonus;
     int max_convergence_count;
     int route_verbosity;
     float reconvergence_cpd_threshold;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1378,13 +1378,14 @@ struct t_router_opts {
     double initial_acc_cost_chan_congestion_threshold;
     double initial_acc_cost_chan_congestion_weight;
     float router_lookahead_interposer_base_cut_multiplier; ///< Multiplier to apply for base cost of interposer wires in the router lookahead
-    /// Sort-priority bonus given to a sink that is on the other side of an interposer die
-    /// crossing from the net's driver, used to influence the order sinks are routed in.
-    float router_interposer_die_crossing_bonus;
-    /// Additional sort-priority bonus (on top of router_interposer_die_crossing_bonus) given to a
-    /// die-crossing sink that is inline with the driver along the crossed cut; scaled down to 0 as
-    /// the perpendicular offset within the net's bounding box grows.
-    float router_interposer_inline_alignment_bonus;
+    /// Sort-priority term added for a sink that is on the other side of a die boundary from the
+    /// net's driver (an interposer cut in the x/y plane, or a layer boundary for 3D stacked
+    /// architectures), used to influence the order sinks are routed in.
+    float router_sink_order_die_crossing_multiplier;
+    /// Additional sort-priority term (on top of router_sink_order_die_crossing_multiplier) added for a
+    /// die-crossing sink that is inline with the driver across the crossed boundary; scaled down
+    /// to 0 as the offset perpendicular to that boundary within the net's bounding box grows.
+    float router_sink_order_die_alignment_multiplier;
     int max_convergence_count;
     int route_verbosity;
     float reconvergence_cpd_threshold;

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -142,11 +142,11 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
     const DeviceGrid& device_grid = device_ctx.grid;
     if (device_grid.has_interposer_cuts()) {
         // Sort-priority bonuses for sinks that cross an interposer die boundary.
-        // kDieCrossingBonus rewards any die crossing; kInlineAlignmentBonus additionally
+        // die_crossing_bonus rewards any die crossing; inline_alignment_bonus additionally
         // rewards being inline with the driver along the crossed cut (scaled down to 0
         // as the perpendicular offset grows, see dx/dy below).
-        constexpr float kDieCrossingBonus = 1.0f;
-        constexpr float kInlineAlignmentBonus = 1.0f;
+        float die_crossing_bonus = router_opts.router_interposer_die_crossing_bonus;
+        float inline_alignment_bonus = router_opts.router_interposer_inline_alignment_bonus;
 
         RRNodeId driver_rr = route_ctx.net_rr_terminals[net_id][0];
         t_physical_tile_loc driver_loc(rr_graph.node_xlow(driver_rr),
@@ -169,15 +169,15 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
             bool crosses_horizontal = device_grid.do_locs_cross_horizontal_cut(driver_loc, sink_loc);
 
             if (crosses_vertical || crosses_horizontal) {
-                pin_sort_priority[ipin] += kDieCrossingBonus;
+                pin_sort_priority[ipin] += die_crossing_bonus;
 
                 if (crosses_vertical) {
                     int dy = std::abs(driver_loc.y - sink_loc.y);
-                    pin_sort_priority[ipin] += (bb_height > 0) ? kInlineAlignmentBonus * (1.0f - float(dy) / bb_height) : kInlineAlignmentBonus;
+                    pin_sort_priority[ipin] += (bb_height > 0) ? inline_alignment_bonus * (1.0f - float(dy) / bb_height) : inline_alignment_bonus;
                 }
                 if (crosses_horizontal) {
                     int dx = std::abs(driver_loc.x - sink_loc.x);
-                    pin_sort_priority[ipin] += (bb_width > 0) ? kInlineAlignmentBonus * (1.0f - float(dx) / bb_width) : kInlineAlignmentBonus;
+                    pin_sort_priority[ipin] += (bb_width > 0) ? inline_alignment_bonus * (1.0f - float(dx) / bb_width) : inline_alignment_bonus;
                 }
             }
         }

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -141,7 +141,12 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
 
     const DeviceGrid& device_grid = device_ctx.grid;
     bool has_interposer_cuts = device_grid.has_interposer_cuts();
-    bool has_multiple_layers = device_grid.get_num_layers() > 1;
+
+    // FIXME: 3D FPGAs were not shown to work well with this sink-order stuff yet.
+    //        Force them off for now.
+    // bool has_multiple_layers = device_grid.get_num_layers() > 1;
+    bool has_multiple_layers = false;
+
     if (has_interposer_cuts || has_multiple_layers) {
         // Sort-priority terms for sinks that cross a die boundary (an interposer cut in
         // the x/y plane, or a layer boundary in the z direction for 3D stacked devices).

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -2,6 +2,8 @@
 
 /** @file Header implementations for templated net routing fns. */
 
+#include "device_grid.h"
+#include "physical_types.h"
 #include "route_net.h"
 
 #include <tuple>
@@ -130,9 +132,60 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
                                                         is_flat);
     }
 
-    // compare the criticality of different sink nodes
+    // Determines the order remaining_targets is routed in. Starts as a copy of
+    // pin_criticality, but may be further adjusted (e.g. for interposer die crossings
+    // below) to influence routing order without disturbing pin_criticality itself,
+    // which is also used downstream (e.g. cost_params.criticality) to drive the
+    // router's cost function.
+    std::vector<float> pin_sort_priority = pin_criticality;
+
+    const DeviceGrid& device_grid = device_ctx.grid;
+    if (device_grid.has_interposer_cuts()) {
+        // Sort-priority bonuses for sinks that cross an interposer die boundary.
+        // kDieCrossingBonus rewards any die crossing; kInlineAlignmentBonus additionally
+        // rewards being inline with the driver along the crossed cut (scaled down to 0
+        // as the perpendicular offset grows, see dx/dy below).
+        constexpr float kDieCrossingBonus = 1.0f;
+        constexpr float kInlineAlignmentBonus = 1.0f;
+
+        RRNodeId driver_rr = route_ctx.net_rr_terminals[net_id][0];
+        t_physical_tile_loc driver_loc(rr_graph.node_xlow(driver_rr),
+                                       rr_graph.node_ylow(driver_rr),
+                                       rr_graph.node_layer_low(driver_rr));
+
+        // net_bb is used to normalize the inline-alignment bonus below. Note it is slightly
+        // larger than the net's true pin bounding box, since it is expanded by bb_factor
+        // for routing search purposes.
+        int bb_width = net_bb.xmax - net_bb.xmin;
+        int bb_height = net_bb.ymax - net_bb.ymin;
+
+        for (int ipin : remaining_targets) {
+            RRNodeId sink_rr = route_ctx.net_rr_terminals[net_id][ipin];
+            t_physical_tile_loc sink_loc(rr_graph.node_xlow(sink_rr),
+                                         rr_graph.node_ylow(sink_rr),
+                                         rr_graph.node_layer_low(sink_rr));
+
+            bool crosses_vertical = device_grid.do_locs_cross_vertical_cut(driver_loc, sink_loc);
+            bool crosses_horizontal = device_grid.do_locs_cross_horizontal_cut(driver_loc, sink_loc);
+
+            if (crosses_vertical || crosses_horizontal) {
+                pin_sort_priority[ipin] += kDieCrossingBonus;
+
+                if (crosses_vertical) {
+                    int dy = std::abs(driver_loc.y - sink_loc.y);
+                    pin_sort_priority[ipin] += (bb_height > 0) ? kInlineAlignmentBonus * (1.0f - float(dy) / bb_height) : kInlineAlignmentBonus;
+                }
+                if (crosses_horizontal) {
+                    int dx = std::abs(driver_loc.x - sink_loc.x);
+                    pin_sort_priority[ipin] += (bb_width > 0) ? kInlineAlignmentBonus * (1.0f - float(dx) / bb_width) : kInlineAlignmentBonus;
+                }
+            }
+        }
+    }
+
+    // compare the sort priority of different sink nodes
     std::stable_sort(begin(remaining_targets), end(remaining_targets), [&](int a, int b) {
-        return pin_criticality[a] > pin_criticality[b];
+        return pin_sort_priority[a] > pin_sort_priority[b];
     });
 
     /* Update base costs according to fanout and criticality rules */

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -140,24 +140,28 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
     std::vector<float> pin_sort_priority = pin_criticality;
 
     const DeviceGrid& device_grid = device_ctx.grid;
-    if (device_grid.has_interposer_cuts()) {
-        // Sort-priority bonuses for sinks that cross an interposer die boundary.
-        // die_crossing_bonus rewards any die crossing; inline_alignment_bonus additionally
-        // rewards being inline with the driver along the crossed cut (scaled down to 0
-        // as the perpendicular offset grows, see dx/dy below).
-        float die_crossing_bonus = router_opts.router_interposer_die_crossing_bonus;
-        float inline_alignment_bonus = router_opts.router_interposer_inline_alignment_bonus;
+    bool has_interposer_cuts = device_grid.has_interposer_cuts();
+    bool has_multiple_layers = device_grid.get_num_layers() > 1;
+    if (has_interposer_cuts || has_multiple_layers) {
+        // Sort-priority terms for sinks that cross a die boundary (an interposer cut in
+        // the x/y plane, or a layer boundary in the z direction for 3D stacked devices).
+        // die_crossing_multiplier rewards any die crossing; die_alignment_multiplier additionally
+        // rewards being inline with the driver across the crossed boundary (scaled down to
+        // 0 as the offset perpendicular to that boundary grows, see dx/dy below).
+        float die_crossing_multiplier = router_opts.router_sink_order_die_crossing_multiplier;
+        float die_alignment_multiplier = router_opts.router_sink_order_die_alignment_multiplier;
 
         RRNodeId driver_rr = route_ctx.net_rr_terminals[net_id][0];
         t_physical_tile_loc driver_loc(rr_graph.node_xlow(driver_rr),
                                        rr_graph.node_ylow(driver_rr),
                                        rr_graph.node_layer_low(driver_rr));
 
-        // net_bb is used to normalize the inline-alignment bonus below. Note it is slightly
+        // net_bb is used to normalize the die-alignment term below. Note it is slightly
         // larger than the net's true pin bounding box, since it is expanded by bb_factor
         // for routing search purposes.
         int bb_width = net_bb.xmax - net_bb.xmin;
         int bb_height = net_bb.ymax - net_bb.ymin;
+        int bb_planar = bb_width + bb_height;
 
         for (int ipin : remaining_targets) {
             RRNodeId sink_rr = route_ctx.net_rr_terminals[net_id][ipin];
@@ -165,19 +169,31 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
                                          rr_graph.node_ylow(sink_rr),
                                          rr_graph.node_layer_low(sink_rr));
 
-            bool crosses_vertical = device_grid.do_locs_cross_vertical_cut(driver_loc, sink_loc);
-            bool crosses_horizontal = device_grid.do_locs_cross_horizontal_cut(driver_loc, sink_loc);
+            bool crosses_vertical = has_interposer_cuts && device_grid.do_locs_cross_vertical_cut(driver_loc, sink_loc);
+            bool crosses_horizontal = has_interposer_cuts && device_grid.do_locs_cross_horizontal_cut(driver_loc, sink_loc);
+            bool crosses_planar = has_multiple_layers && (driver_loc.layer_num != sink_loc.layer_num);
 
-            if (crosses_vertical || crosses_horizontal) {
-                pin_sort_priority[ipin] += die_crossing_bonus;
+            if (crosses_vertical || crosses_horizontal || crosses_planar) {
+                pin_sort_priority[ipin] += die_crossing_multiplier;
 
+                int dx = std::abs(driver_loc.x - sink_loc.x);
+                int dy = std::abs(driver_loc.y - sink_loc.y);
+
+                // NOTE: this assumes interposer cuts and layer boundaries never both apply to the
+                // same driver/sink pair (i.e. interposer architectures are not also 3D), so the
+                // vertical/horizontal terms below only normalize against their own boundary's
+                // offset (dy or dx), unlike the planar term which already folds in both.
+                // TODO: once a 3D interposer architecture exists to validate against, the vertical
+                // and horizontal terms should also fold in a dz/bb_depth component, matching how
+                // the planar term already folds in dx and dy.
                 if (crosses_vertical) {
-                    int dy = std::abs(driver_loc.y - sink_loc.y);
-                    pin_sort_priority[ipin] += (bb_height > 0) ? inline_alignment_bonus * (1.0f - float(dy) / bb_height) : inline_alignment_bonus;
+                    pin_sort_priority[ipin] += (bb_height > 0) ? die_alignment_multiplier * (1.0f - float(dy) / bb_height) : die_alignment_multiplier;
                 }
                 if (crosses_horizontal) {
-                    int dx = std::abs(driver_loc.x - sink_loc.x);
-                    pin_sort_priority[ipin] += (bb_width > 0) ? inline_alignment_bonus * (1.0f - float(dx) / bb_width) : inline_alignment_bonus;
+                    pin_sort_priority[ipin] += (bb_width > 0) ? die_alignment_multiplier * (1.0f - float(dx) / bb_width) : die_alignment_multiplier;
+                }
+                if (crosses_planar) {
+                    pin_sort_priority[ipin] += (bb_planar > 0) ? die_alignment_multiplier * (1.0f - float(dx + dy) / bb_planar) : die_alignment_multiplier;
                 }
             }
         }


### PR DESCRIPTION
When routing across the interposer boundary, the order in which we route
the sinks can matter. If we route the sinks that cross the interposer
boundary last, we may use more inter-die resources than we need.

Added a sorting cost term which routes sinks that cross the interposer
boundary and are most in-lined with the driver.