### PR TITLE
[AP][Interposer] Reduced the Default Density of the AP flow

### DIFF
--- a/vpr/src/pack/appack_context.h
+++ b/vpr/src/pack/appack_context.h
@@ -104,7 +104,8 @@ struct APPackContext : public Context {
                                                 device_grid);
 
             unrelated_clustering_manager.init(ap_opts.appack_unrelated_clustering_args,
-                                              logical_block_types);
+                                              logical_block_types,
+                                              device_grid);
         }
     }
 

--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -44,7 +44,7 @@ class APPackMaxDistThManager {
 
     // Logic blocks (such as CLBs and LABs) tend to have more resources on the
     // device, thus they have tighter thresholds. This was found to work well.
-    static constexpr float logic_block_max_dist_th_scale_ = 0.02f;
+    static constexpr float logic_block_max_dist_th_scale_ = 0.08f;
     static constexpr float logic_block_max_dist_th_offset_ = 10.0f;
 
     // Memory blocks (i.e. blocks that contain pb_types of the memory class)

--- a/vpr/src/pack/appack_unrelated_clustering_manager.cpp
+++ b/vpr/src/pack/appack_unrelated_clustering_manager.cpp
@@ -8,38 +8,17 @@
 #include "appack_unrelated_clustering_manager.h"
 #include "ap_argparse_utils.h"
 #include "arch_util.h"
+#include "device_grid.h"
 #include "vpr_error.h"
+#include "vpr_utils.h"
 
 void APPackUnrelatedClusteringManager::init(
     const std::vector<std::string>& unrelated_clustering_args,
-    const std::vector<t_logical_block_type>& logical_block_types) {
+    const std::vector<t_logical_block_type>& logical_block_types,
+    const DeviceGrid& device_grid) {
 
-    // Set the max unrelated tile distances for all logical block types.
-    // By default, we set this to a low value to only allow unrelated molecules
-    // that are very close to the cluster being created.
-    // NOTE: Molecules within the same tile as the centroid are considered to have
-    //       0 distance. The distance is computed relative to the bounds of the
-    //       tile containing the centroid.
-    max_unrelated_tile_distance_.resize(logical_block_types.size(),
-                                        default_max_unrelated_tile_distance_);
-    max_unrelated_clustering_attempts_.resize(logical_block_types.size(),
-                                              default_max_unrelated_clustering_attempts_);
-
-    // For memories (such as BRAMs and MLABs), we do not perform unrelated clustering.
-    for (const t_logical_block_type& lb_ty : logical_block_types) {
-        // Skip the empty logical block type. This should not have any blocks.
-        if (lb_ty.is_empty())
-            continue;
-
-        // If the logical block type contains a pb_type which is a memory class,
-        // it is assumed to be a BRAM or an MLAB.
-        bool has_memory = pb_type_contains_memory_pbs(lb_ty.pb_type);
-        if (!has_memory)
-            continue;
-
-        // Do not do unrelated clustering on memories. It is not worth it.
-        max_unrelated_clustering_attempts_[lb_ty.index] = 0;
-    }
+    // Automatically set the unrelated clustering parameters.
+    auto_set_unrelated_clustering_params(logical_block_types, device_grid);
 
     // At this point, the data structures have been initialized properly.
     is_initialized_ = true;
@@ -79,5 +58,47 @@ void APPackUnrelatedClusteringManager::init(
         int lb_ty_index = lb_type_name_to_index[lb_name];
         max_unrelated_tile_distance_[lb_ty_index] = logical_block_max_unrel_dist;
         max_unrelated_clustering_attempts_[lb_ty_index] = logical_block_max_unrel_attempts;
+    }
+}
+
+void APPackUnrelatedClusteringManager::auto_set_unrelated_clustering_params(
+    const std::vector<t_logical_block_type>& logical_block_types,
+    const DeviceGrid& device_grid) {
+
+    // Set the max unrelated tile distances for all logical block types.
+    // By default, we set this to a low value to only allow unrelated molecules
+    // that are very close to the cluster being created.
+    // NOTE: Molecules within the same tile as the centroid are considered to have
+    //       0 distance. The distance is computed relative to the bounds of the
+    //       tile containing the centroid.
+    max_unrelated_tile_distance_.resize(logical_block_types.size(),
+                                        default_max_unrelated_tile_distance_);
+    max_unrelated_clustering_attempts_.resize(logical_block_types.size(),
+                                              default_max_unrelated_clustering_attempts_);
+
+    // Find which (if any) of the logical block types most looks like a CLB block.
+    t_logical_block_type_ptr logic_block_type = infer_logic_block_type(device_grid);
+
+    for (const t_logical_block_type& lb_ty : logical_block_types) {
+        // Skip the empty logical block type. This should not have any blocks.
+        if (lb_ty.is_empty())
+            continue;
+
+        // If the logical block type contains a pb_type which is a memory class,
+        // it is assumed to be a BRAM or an MLAB.
+        bool has_memory = pb_type_contains_memory_pbs(lb_ty.pb_type);
+        if (!has_memory)
+            continue;
+
+        // Do not do unrelated clustering on memories. It is not worth it.
+        max_unrelated_clustering_attempts_[lb_ty.index] = 0;
+
+        // Logic blocks (such as CLBs and LABs) were found to benefit from
+        // different unrelated clustering parameters than the default.
+        bool is_logic_block_type = (lb_ty.index == logic_block_type->index);
+        if (is_logic_block_type) {
+            max_unrelated_tile_distance_[lb_ty.index] = logic_block_max_unrelated_tile_distance_;
+            max_unrelated_clustering_attempts_[lb_ty.index] = logic_block_max_unrelated_clustering_attempts_;
+        }
     }
 }

--- a/vpr/src/pack/appack_unrelated_clustering_manager.h
+++ b/vpr/src/pack/appack_unrelated_clustering_manager.h
@@ -12,6 +12,9 @@
 #include "physical_types.h"
 #include "vtr_assert.h"
 
+// Forward declarations.
+class DeviceGrid;
+
 /**
  * @brief Manager class for unrelated clustering in APPack.
  *
@@ -55,6 +58,12 @@ class APPackUnrelatedClusteringManager {
      */
     static constexpr int default_max_unrelated_clustering_attempts_ = 1;
 
+    // Logic blocks (such as CLBs and LABs) were found to benefit from a larger
+    // search distance and number of attempts than the default. These numbers
+    // were found empirically to work well.
+    static constexpr float logic_block_max_unrelated_tile_distance_ = 2.0f;
+    static constexpr int logic_block_max_unrelated_clustering_attempts_ = 1;
+
   public:
     /**
      * @brief When the packing is particularly difficult, and it has failed enough
@@ -77,9 +86,11 @@ class APPackUnrelatedClusteringManager {
      *      behavior.
      *  @param logical_block_types
      *      A vector of all logical block types in the architecture.
+     *  @param device_grid
      */
     void init(const std::vector<std::string>& unrelated_clustering_args,
-              const std::vector<t_logical_block_type>& logical_block_types);
+              const std::vector<t_logical_block_type>& logical_block_types,
+              const DeviceGrid& device_grid);
 
     /**
      * @brief Get the max search distance for the given logical block type.
@@ -137,6 +148,14 @@ class APPackUnrelatedClusteringManager {
     }
 
   private:
+    /**
+     * @brief Helper method that initializes the unrelated clustering parameters
+     *        of all logical block types to reasonable numbers based on the
+     *        characteristics of the logical block type.
+     */
+    void auto_set_unrelated_clustering_params(const std::vector<t_logical_block_type>& logical_block_types,
+                                              const DeviceGrid& device_grid);
+
     /// @brief A flag which shows if the data within this class has been initialized
     ///        or not.
     bool is_initialized_ = false;

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -334,6 +334,16 @@ bool try_pack(const t_packer_opts& packer_opts,
                              device_ctx.logical_block_types,
                              device_ctx.grid);
 
+    // For APPack, we do a low-effort unrelated clustering.
+    // We found that this can increase density in a way that
+    // better matches how a traditional flow may pack; but with
+    // improved spatial awareness.
+    if (appack_ctx.appack_options.use_appack) {
+        if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
+            allow_unrelated_clustering = true;
+        }
+    }
+
     // Initialize the greedy clusterer.
     GreedyClusterer clusterer(packer_opts,
                               analysis_opts,


### PR DESCRIPTION
The default values for the AP flow on Koios were far too relaxed and were causing massive regressions when the device size is fixed to tight devices. Updated the default values.

Two major updates were done:

- We now do a low-effort unrelated clustering in the first packing iteration. For DSPs, this tries to find candidates in the exact same tile; for CLBs, we search in a radius of 3.
- I increased the max distance threshold for CLBs from 0.02 to 0.08.

The current results are shown below:
  | total runtime | pack_time | CPD | routed wirelength | interposer_nets_crossing | total_heap_pops
-- | -- | -- | -- | -- | -- | --
Traditional | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000
Default AP | 1.558 | 1.728 | 1.068 | 0.925 | 0.841 | 0.890
NEW| 1.226 | 1.306 | 1.026 | 0.921 | 0.791 | 0.897

There are still 4 circuits that are hitting the fallback path:

circuit | Repacked | Overused resource | Overusage | CPD | WL | interposer_nets_crossing
-- | -- | -- | -- | -- | -- | --
attention_layer.blif |   |   |   | 1.03 | 0.93 | 0.37
bnn.blif |   |   |   | 0.91 | 0.96 | 1.29
bwave_like.fixed.large.blif | TRUE | dsp | 1.02 | 1.13 | 0.94 | 0.77
clstm_like.large.blif | TRUE | clb | 1.03 | 1.07 | 1.02 | 1.38
clstm_like.medium.blif | TRUE | clb | 1.05 | 1.17 | 1.01 | 1.22
clstm_like.small.blif | TRUE | clb | 1 | 1.06 | 0.97 | 1.02
conv_layer_hls.blif |   |   |   | 0.99 | 0.95 | 0.54
dla_like.medium.blif |   |   |   | 0.96 | 0.86 | 0.82
dla_like.small.blif |   |   |   | 1.01 | 0.88 | 0.52
dnnweaver.blif |   |   |   | 1.02 | 0.90 | 0.94
gemm_layer.blif |   |   |   | 0.89 | 0.84 | 0.40
lstm.blif |   |   |   | 1.00 | 0.87 | 0.48
proxy.5.blif |   |   |   | 1.04 | 0.95 | 1.33
proxy.7.blif |   |   |   | 1.10 | 0.92 | 0.79
tdarknet_like.large.blif |   |   |   | 1.08 | 0.94 | 0.81
tdarknet_like.small.blif |   |   |   | 1.04 | 1.00 | 2.04
tpu_like.large.os.blif |   |   |   | 0.92 | 0.91 | 1.08
tpu_like.large.ws.blif |   |   |   | 1.15 | 0.84 | 0.53

NOTE: tdarknet_like.small.blif is an outlier. It is severely RAM limited; so AP is not making as big of a difference on the architecture. Since it is creating denser CLBs though it seems to be having a harder time optimizing CPD. One idea is to detect if the utilization will be very low for CLBs and reducing the defaults to try and create less dense CLBs.

I am working locally to resolve these last 4 circuits. I wanted to bring this in now since it improves the interposer nets crossing by over 5%, and cut the increase in CPD in half.

@vaughnbetz FYI.