### PR TITLE
Separable router lookahead

### DIFF
--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1219,6 +1219,8 @@ struct ParseRouterLookahead {
             conv_value.set_value(e_router_lookahead::EXTENDED_MAP);
         else if (str == "simple")
             conv_value.set_value(e_router_lookahead::SIMPLE);
+        else if (str == "separable")
+            conv_value.set_value(e_router_lookahead::SEPARABLE);
         else {
             std::stringstream msg;
             msg << "Invalid conversion from '"
@@ -1240,6 +1242,8 @@ struct ParseRouterLookahead {
             conv_value.set_value("compressed_map");
         } else if (val == e_router_lookahead::SIMPLE) {
             conv_value.set_value("simple");
+        } else if (val == e_router_lookahead::SEPARABLE) {
+            conv_value.set_value("separable");
         } else {
             VTR_ASSERT(val == e_router_lookahead::EXTENDED_MAP);
             conv_value.set_value("extended_map");
@@ -1248,7 +1252,7 @@ struct ParseRouterLookahead {
     }
 
     std::vector<std::string> default_choices() {
-        return {"classic", "map", "compressed_map", "extended_map", "simple"};
+        return {"classic", "map", "compressed_map", "extended_map", "simple", "separable"};
     }
 };
 
@@ -3342,6 +3346,8 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
             " * extended_map: A more advanced and extended lookahead which accounts for a more\n"
             "                 exhaustive node sampling method\n"
             " * simple: A purely distance-based lookahead loaded from an external file\n"
+            " * separable: A lookahead which treats the x and y components of a route\n"
+            "              as separable (not yet implemented)\n"
             "\n"
             " The extended map differs from the map lookahead in the lookahead computation.\n"
             " It is better suited for architectures that have specialized routing for specific\n"

--- a/vpr/src/base/show_setup.cpp
+++ b/vpr/src/base/show_setup.cpp
@@ -433,6 +433,9 @@ static void show_router_opts(const t_router_opts& router_opts) {
             case e_router_lookahead::SIMPLE:
                 VTR_LOG("SIMPLE\n");
                 break;
+            case e_router_lookahead::SEPARABLE:
+                VTR_LOG("SEPARABLE\n");
+                break;
             case e_router_lookahead::NO_OP:
                 VTR_LOG("NO_OP\n");
                 break;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -109,6 +109,8 @@ enum class e_router_lookahead {
     EXTENDED_MAP,
     ///@brief Simple distance-based lookahead
     SIMPLE,
+    ///@brief Lookahead which treats the x and y components of a route as separable
+    SEPARABLE,
     ///@brief A no-operation lookahead which always returns zero
     NO_OP
 };

--- a/vpr/src/route/router_lookahead/router_lookahead.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead.cpp
@@ -5,6 +5,7 @@
 #include "router_lookahead_compressed_map.h"
 #include "router_lookahead_extended_map.h"
 #include "router_lookahead_simple.h"
+#include "router_lookahead_separable.h"
 #include "vpr_error.h"
 #include "globals.h"
 
@@ -36,6 +37,8 @@ static std::unique_ptr<RouterLookahead> make_router_lookahead_object(const t_det
         return std::make_unique<ExtendedMapLookahead>(is_flat, route_verbosity, device_model_warnings);
     } else if (router_lookahead_type == e_router_lookahead::SIMPLE) {
         return std::make_unique<SimpleLookahead>();
+    } else if (router_lookahead_type == e_router_lookahead::SEPARABLE) {
+        return std::make_unique<SeparableLookahead>(det_routing_arch, is_flat, route_verbosity, device_model_warnings, interposer_base_cut_multiplier);
     } else if (router_lookahead_type == e_router_lookahead::NO_OP) {
         return std::make_unique<NoOpLookahead>();
     }

--- a/vpr/src/route/router_lookahead/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.cpp
@@ -419,6 +419,76 @@ std::pair<float, float> MapLookahead::get_expected_delay_and_cong(RRNodeId from_
     return std::make_pair(expected_delay_cost, expected_cong_cost);
 }
 
+std::pair<float, float> MapLookahead::get_expected_delay_and_cong_from_deltas(RRNodeId from_node, int delta_x, int delta_y, const t_conn_cost_params& params) const {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+
+    int from_layer_num = rr_graph.node_layer_low(from_node);
+    // Since there is no actual target node, we don't know its layer; assume it is
+    // on the same layer as from_node.
+    int to_layer_num = from_layer_num;
+
+    delta_x = abs(delta_x);
+    delta_y = abs(delta_y);
+
+    float expected_delay_cost = std::numeric_limits<float>::infinity();
+    float expected_cong_cost = std::numeric_limits<float>::infinity();
+
+    e_rr_type from_type = rr_graph.node_type(from_node);
+    if (from_type == e_rr_type::SOURCE || from_type == e_rr_type::OPIN) {
+        t_physical_tile_type_ptr from_tile_type = device_ctx.grid.get_physical_type({rr_graph.node_xlow(from_node),
+                                                                                     rr_graph.node_ylow(from_node),
+                                                                                     from_layer_num});
+
+        auto from_tile_index = std::distance(&device_ctx.physical_tile_types[0], from_tile_type);
+        int from_ptc = rr_graph.node_ptc_num(from_node);
+
+        for (size_t layer_num = 0; layer_num < device_ctx.grid.get_num_layers(); layer_num++) {
+            const auto [this_delay_cost, this_cong_cost] = util::get_cost_from_src_opin(src_opin_delays[from_layer_num][from_tile_index][from_ptc][layer_num],
+                                                                                        delta_x,
+                                                                                        delta_y,
+                                                                                        to_layer_num,
+                                                                                        get_wire_cost_entry);
+            expected_delay_cost = std::min(expected_delay_cost, this_delay_cost);
+            expected_cong_cost = std::min(expected_cong_cost, this_cong_cost);
+        }
+    } else if (from_type == e_rr_type::CHANX || from_type == e_rr_type::CHANY || from_type == e_rr_type::CHANZ) {
+        if (from_type == e_rr_type::CHANZ) {
+            Direction chanz_node_dir = rr_graph.node_direction(from_node);
+            if (chanz_node_dir == Direction::INC) {
+                from_layer_num = rr_graph.node_layer_high(from_node);
+                to_layer_num = from_layer_num;
+            }
+            // For BIDIR CHANZ nodes we would normally pick the target's layer; since there is
+            // no actual target node here, we just leave from_layer_num/to_layer_num as-is.
+        }
+
+        RRIndexedDataId from_cost_index = rr_graph.node_cost_index(from_node);
+        int from_seg_index = device_ctx.rr_indexed_data[from_cost_index].seg_index;
+
+        VTR_ASSERT(from_seg_index >= 0);
+
+        util::Cost_Entry cost_entry = get_wire_cost_entry(from_type,
+                                                          from_seg_index,
+                                                          from_layer_num,
+                                                          delta_x,
+                                                          delta_y,
+                                                          to_layer_num);
+
+        expected_delay_cost = cost_entry.delay;
+        expected_cong_cost = cost_entry.congestion;
+    } else if (from_type == e_rr_type::IPIN) { // Change if you're allowing route-throughs
+        return std::make_pair(0., device_ctx.rr_indexed_data[RRIndexedDataId(SINK_COST_INDEX)].base_cost);
+    } else { // Change this if you want to investigate route-throughs
+        return std::make_pair(0., 0.);
+    }
+
+    expected_delay_cost *= params.criticality;
+    expected_cong_cost *= (1.0f - params.criticality);
+
+    return std::make_pair(expected_delay_cost, expected_cong_cost);
+}
+
 void MapLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
     vtr::ScopedStartFinishTimer timer("Computing router lookahead map");
 

--- a/vpr/src/route/router_lookahead/router_lookahead_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.h
@@ -14,6 +14,21 @@ class MapLookahead : public RouterLookahead {
   public:
     explicit MapLookahead(const t_det_routing_arch& det_routing_arch, bool is_flat, int route_verbosity, bool device_model_warnings, float interposer_base_cost_multiplier);
 
+    /**
+     * @brief Get the delay and congestion cost estimated by the lookahead map for a node that
+     *        is (delta_x, delta_y) away from from_node, without reference to an actual target node.
+     * @attention This does not account for effects that depend on an actual target node (e.g. the
+     *            interposer lookahead, or the target's layer when it differs from from_node's layer).
+     *            It is intended for profiling/reporting purposes (e.g. checking how separable the
+     *            lookahead's delay estimate is in x and y), not for use during routing.
+     * @param from_node The source node from which the cost is estimated.
+     * @param delta_x Horizontal distance (in tiles) to the (hypothetical) target node.
+     * @param delta_y Vertical distance (in tiles) to the (hypothetical) target node.
+     * @param params Contains the router parameters such as connection criticality, etc.
+     * @return A pair of (delay cost, congestion cost).
+     */
+    std::pair<float, float> get_expected_delay_and_cong_from_deltas(RRNodeId from_node, int delta_x, int delta_y, const t_conn_cost_params& params) const;
+
   private:
     float get_expected_cost_flat_router(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const;
     //Look-up table from SOURCE/OPIN to CHANX/CHANY of various types

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
@@ -593,6 +593,38 @@ RRNodeId get_chanxy_start_node(int layer, int start_x, int start_y, int target_x
     return result;
 }
 
+RRNodeId get_chanxy_start_node(int layer, int start_x, int start_y, Direction direction, e_rr_type rr_type, int seg_index, int track_offset) {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+    const auto& node_lookup = rr_graph.node_lookup();
+
+    VTR_ASSERT(rr_type == e_rr_type::CHANX || rr_type == e_rr_type::CHANY);
+
+    RRNodeId result = RRNodeId::INVALID();
+
+    // Find first node in channel that has specified segment index and goes in the desired direction.
+    // Unlike get_chanxy_start_node(int, int, int, int, int, e_rr_type, int, int), this only matches nodes
+    // whose direction is exactly the requested one (a BIDIR node is not treated as a match for INC/DEC).
+    for (const RRNodeId node_id : node_lookup.find_channel_nodes(layer, start_x, start_y, rr_type)) {
+        VTR_ASSERT(rr_graph.node_type(node_id) == rr_type);
+
+        Direction node_direction = rr_graph.node_direction(node_id);
+        RRIndexedDataId node_cost_ind = rr_graph.node_cost_index(node_id);
+        int node_seg_ind = device_ctx.rr_indexed_data[node_cost_ind].seg_index;
+
+        if (node_direction == direction && node_seg_ind == seg_index) {
+            // Found first track that has the specified segment index and goes in the desired direction
+            result = node_id;
+            if (track_offset == 0) {
+                break;
+            }
+            track_offset -= 2;
+        }
+    }
+
+    return result;
+}
+
 RRNodeId get_chanz_start_node(int start_x, int start_y, int seg_index, int track_offset, Direction dir) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
@@ -56,13 +56,15 @@ static void run_dijkstra(RRNodeId start_node,
                          util::t_routing_cost_map& routing_cost_map,
                          util::t_dijkstra_data& data,
                          const std::unordered_map<int, std::unordered_set<int>>& sample_locs,
-                         bool sample_all_locs);
+                         bool sample_all_locs,
+                         const t_bb& bb);
 
 /* iterates over the children of the specified node and selectively pushes them onto the priority queue */
 static void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
                                        vtr::vector<RRNodeId, float>& node_visited_costs,
                                        vtr::vector<RRNodeId, bool>& node_expanded,
                                        std::priority_queue<util::PQ_Entry>& pq,
+                                       const t_bb& bb,
                                        bool has_interposer_cuts = false);
 
 /**
@@ -732,10 +734,14 @@ t_routing_cost_map get_routing_cost_map(int longest_seg_length,
                                         const std::unordered_map<int, std::unordered_set<int>>& sample_locs,
                                         bool sample_all_locs,
                                         int route_verbosity,
-                                        bool device_model_warnings) {
+                                        bool device_model_warnings,
+                                        const t_bb* bb) {
     const auto& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
     const auto& grid = device_ctx.grid;
+
+    t_bb full_device_bb(0, grid.width() - 1, 0, grid.height() - 1, 0, grid.get_num_layers() - 1);
+    const t_bb& search_bb = bb ? *bb : full_device_bb;
 
     // Start sampling at the lower left non-corner
     int ref_x = 1;
@@ -850,7 +856,8 @@ t_routing_cost_map get_routing_cost_map(int longest_seg_length,
                          routing_cost_map,
                          dijkstra_data,
                          sample_locs,
-                         sample_all_locs);
+                         sample_all_locs,
+                         search_bb);
         }
     }
 
@@ -1334,7 +1341,8 @@ static void run_dijkstra(RRNodeId start_node,
                          util::t_routing_cost_map& routing_cost_map,
                          util::t_dijkstra_data& data,
                          const std::unordered_map<int, std::unordered_set<int>>& sample_locs,
-                         bool sample_all_locs) {
+                         bool sample_all_locs,
+                         const t_bb& bb) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
@@ -1405,7 +1413,7 @@ static void run_dijkstra(RRNodeId start_node,
             }
         }
 
-        expand_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq, has_interposer_cuts);
+        expand_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq, bb, has_interposer_cuts);
         node_expanded[curr_node] = true;
     }
 }
@@ -1414,6 +1422,7 @@ static void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
                                        vtr::vector<RRNodeId, float>& node_visited_costs,
                                        vtr::vector<RRNodeId, bool>& node_expanded,
                                        std::priority_queue<util::PQ_Entry>& pq,
+                                       const t_bb& bb,
                                        bool has_interposer_cuts /*=false*/) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
@@ -1427,6 +1436,13 @@ static void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
         if (!is_inter_cluster_node(rr_graph, child_node)) {
             continue;
         }
+
+        // Don't expand nodes whose adjusted position falls outside of the bounding box.
+        auto [child_x, child_y] = util::get_adjusted_rr_position(child_node);
+        if (child_x < bb.xmin || child_x > bb.xmax || child_y < bb.ymin || child_y > bb.ymax) {
+            continue;
+        }
+
         int switch_ind = size_t(rr_graph.edge_switch(parent, edge));
 
         if (rr_graph.node_type(child_node) == e_rr_type::SINK) return;

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
@@ -23,6 +23,8 @@
 #include "rr_graph_view.h"
 #include "router_lookahead_constants.h"
 
+struct t_bb;
+
 namespace util {
 
 class Cost_Entry;
@@ -349,6 +351,13 @@ std::pair<int, int> get_xy_deltas(RRNodeId from_node, RRNodeId to_node);
  */
 std::pair<int, int> get_adjusted_rr_position(const RRNodeId rr);
 
+/**
+ * @brief Computes the routing cost map for a given wire segment/channel type by running a Dijkstra flood
+ * from a set of representative sample locations.
+ * @param bb Optional bounding box restricting the Dijkstra expansion: nodes whose adjusted position
+ * (see get_adjusted_rr_position()) falls outside this box are not expanded. If nullptr, the bounding
+ * box spans the whole device (0..grid.width()-1, 0..grid.height()-1).
+ */
 t_routing_cost_map get_routing_cost_map(int longest_seg_length,
                                         unsigned from_layer_num,
                                         const e_rr_type chan_type,
@@ -356,7 +365,8 @@ t_routing_cost_map get_routing_cost_map(int longest_seg_length,
                                         const std::unordered_map<int, std::unordered_set<int>>& sample_locs,
                                         bool sample_all_locs,
                                         int route_verbosity,
-                                        bool device_model_warnings);
+                                        bool device_model_warnings,
+                                        const t_bb* bb = nullptr);
 
 /**
  * @brief Iterate over all of the wire segments accessible from the SOURCE/OPIN (stored in src_opin_delay_map) and return the minimum cost (congestion and delay) across them to the sink

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.h
@@ -325,6 +325,14 @@ t_ipin_primitive_sink_delays compute_intra_tile_dijkstra(const RRGraphView& rr_g
 
 /* returns index of a node from which to start routing */
 RRNodeId get_chanxy_start_node(int layer, int start_x, int start_y, int target_x, int target_y, e_rr_type rr_type, int seg_index, int track_offset);
+
+/**
+ * @brief Same as get_chanxy_start_node(), but takes the desired wire direction directly instead of
+ * inferring it by comparing start/target coordinates. Unlike get_chanxy_start_node(), this only matches
+ * nodes whose direction is exactly @p direction (i.e. BIDIR nodes are not treated as a match for INC/DEC).
+ */
+RRNodeId get_chanxy_start_node(int layer, int start_x, int start_y, Direction direction, e_rr_type rr_type, int seg_index, int track_offset);
+
 RRNodeId get_chanz_start_node(int start_x, int start_y, int seg_index, int track_offset, Direction dir);
 
 /**

--- a/vpr/src/route/router_lookahead/router_lookahead_report.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_report.cpp
@@ -18,6 +18,7 @@
 #include "serial_connection_router.h"
 #include "vpr_context.h"
 #include "vpr_types.h"
+#include "vtr_log.h"
 #include "vtr_random.h"
 #include "vtr_time.h"
 #include "vtr_util.h"
@@ -137,7 +138,6 @@ static void profile_sample_routes(std::ofstream& os,
     // estimated for traveling delta_x in x only and delta_y in y only. This
     // helps gauge how separable (in x and y) the lookahead's delay estimate is.
     const MapLookahead* map_lookahead = dynamic_cast<const MapLookahead*>(router_lookahead);
-
     // Get all the path delays from this sample node.
     RouteTree tree(sample_rr_node);
     e_rr_type sample_rr_node_type = rr_graph.node_type(sample_rr_node);
@@ -148,7 +148,6 @@ static void profile_sample_routes(std::ofstream& os,
                                                                                                                         bounding_box,
                                                                                                                         router_stats,
                                                                                                                         conn_params);
-
     // Get the max difference between the heuristic delay and the actual delay
     // for each possible sink node on the device.
     size_t num_targets = 0;
@@ -164,7 +163,6 @@ static void profile_sample_routes(std::ofstream& os,
     for (RRNodeId rr_node_id : sink_rr_nodes) {
         VTR_ASSERT_SAFE(rr_graph.node_type(rr_node_id) == e_rr_type::SINK);
         VTR_ASSERT_SAFE(rr_node_id != sample_rr_node);
-
         // Get the delay of this path. The delay of the path is just equal
         // to the backward path cost at the target node.
         float path_delay = route_ctx.rr_node_route_inf[rr_node_id].backward_path_cost;
@@ -178,7 +176,6 @@ static void profile_sample_routes(std::ofstream& os,
                                                                     rr_node_id,
                                                                     cost_params,
                                                                     0);
-
         // If the lookahead being profiled is the MapLookahead, also compute the
         // "separable" estimate of the cost: the cost of traveling delta_x (with
         // delta_y = 0) plus the cost of traveling delta_y (with delta_x = 0).

--- a/vpr/src/route/router_lookahead/router_lookahead_report.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_report.cpp
@@ -12,6 +12,8 @@
 #include "d_ary_heap.h"
 #include "globals.h"
 #include "router_lookahead.h"
+#include "router_lookahead_map.h"
+#include "router_lookahead_map_utils.h"
 #include "rr_graph_view.h"
 #include "serial_connection_router.h"
 #include "vpr_context.h"
@@ -82,6 +84,12 @@ struct t_overestimation_info {
  *      The current trial number this is. This is used for writing status logs.
  *  @param max_overestimation_per_type
  *      Information on the maximum overestimation per RR node type.
+ *  @param sep_squared_error_sum
+ *      Accumulator (across all trials) for the sum of squared errors between the
+ *      separable delay estimate and the actual path delay.
+ *  @param num_sep_targets
+ *      Accumulator (across all trials) for the number of targets used to compute
+ *      sep_squared_error_sum.
  */
 static void profile_sample_routes(std::ofstream& os,
                                   RRNodeId sample_rr_node,
@@ -91,7 +99,9 @@ static void profile_sample_routes(std::ofstream& os,
                                   const t_router_opts& router_opts,
                                   float& max_difference,
                                   size_t num_trials,
-                                  vtr::array<e_rr_type, t_overestimation_info, (size_t)e_rr_type::NUM_RR_TYPES>& max_overestimation_per_type) {
+                                  vtr::array<e_rr_type, t_overestimation_info, (size_t)e_rr_type::NUM_RR_TYPES>& max_overestimation_per_type,
+                                  double& sep_squared_error_sum,
+                                  size_t& num_sep_targets) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const RRGraphView& rr_graph = device_ctx.rr_graph;
     RoutingContext& route_ctx = g_vpr_ctx.mutable_routing();
@@ -122,6 +132,12 @@ static void profile_sample_routes(std::ofstream& os,
     cost_params.post_target_prune_offset = router_opts.post_target_prune_offset;
     cost_params.bend_cost = router_opts.bend_cost;
 
+    // If the router lookahead being profiled is the MapLookahead, we can also
+    // compare its estimate against a "separable" estimate: the sum of the cost
+    // estimated for traveling delta_x in x only and delta_y in y only. This
+    // helps gauge how separable (in x and y) the lookahead's delay estimate is.
+    const MapLookahead* map_lookahead = dynamic_cast<const MapLookahead*>(router_lookahead);
+
     // Get all the path delays from this sample node.
     RouteTree tree(sample_rr_node);
     e_rr_type sample_rr_node_type = rr_graph.node_type(sample_rr_node);
@@ -142,6 +158,9 @@ static void profile_sample_routes(std::ofstream& os,
     float total_heur_cost = 0.0f;
     float max_overestimation_this_iter = 0.0f;
     double squared_error_sum = 0.0;
+    double sep_squared_error_sum_this_iter = 0.0;
+    float total_sep_cost = 0.0f;
+    size_t num_sep_targets_this_iter = 0;
     for (RRNodeId rr_node_id : sink_rr_nodes) {
         VTR_ASSERT_SAFE(rr_graph.node_type(rr_node_id) == e_rr_type::SINK);
         VTR_ASSERT_SAFE(rr_node_id != sample_rr_node);
@@ -159,6 +178,25 @@ static void profile_sample_routes(std::ofstream& os,
                                                                     rr_node_id,
                                                                     cost_params,
                                                                     0);
+
+        // If the lookahead being profiled is the MapLookahead, also compute the
+        // "separable" estimate of the cost: the cost of traveling delta_x (with
+        // delta_y = 0) plus the cost of traveling delta_y (with delta_x = 0).
+        // Comparing this against the actual delay estimates how separable (in x
+        // and y) the lookahead's cost function is.
+        if (map_lookahead != nullptr) {
+            auto [delta_x, delta_y] = util::get_xy_deltas(sample_rr_node, rr_node_id);
+
+            auto [delay_x, cong_x] = map_lookahead->get_expected_delay_and_cong_from_deltas(sample_rr_node, delta_x, 0, cost_params);
+            auto [delay_y, cong_y] = map_lookahead->get_expected_delay_and_cong_from_deltas(sample_rr_node, 0, delta_y, cost_params);
+            float separable_delay = (delay_x + cong_x) + (delay_y + cong_y);
+
+            double sep_error = separable_delay - path_delay;
+            sep_squared_error_sum_this_iter += (sep_error * sep_error);
+            total_sep_cost += separable_delay;
+            num_sep_targets_this_iter++;
+        }
+
         // If the heuristic estimate of the path cost is higher than the actual
         // path cost, this means that the router lookahead overestimated on this
         // path.
@@ -191,6 +229,11 @@ static void profile_sample_routes(std::ofstream& os,
         num_targets++;
     }
 
+    // Fold this trial's separable delay statistics into the running totals
+    // across all trials.
+    sep_squared_error_sum += sep_squared_error_sum_this_iter;
+    num_sep_targets += num_sep_targets_this_iter;
+
     // Reset the global path costs to prepare for the next route.
     router.reset_path_costs();
     router.clear_modified_rr_node_info();
@@ -210,7 +253,13 @@ static void profile_sample_routes(std::ofstream& os,
         average_heur_cost = total_heur_cost / (float)num_targets;
         mean_squared_error = squared_error_sum / (double)num_targets;
     }
-    os << vtr::string_fmt("%10zu  %20.3g  %11s  %12zu  %14.3g  %15.3g  %12.3g  %18zu  %14.3g  %14.3g\n",
+    float average_sep_cost = 0.0f;
+    double sep_mean_squared_error = 0.0f;
+    if (num_sep_targets_this_iter > 0) {
+        average_sep_cost = total_sep_cost / (float)num_sep_targets_this_iter;
+        sep_mean_squared_error = sep_squared_error_sum_this_iter / (double)num_sep_targets_this_iter;
+    }
+    os << vtr::string_fmt("%10zu  %20.3g  %11s  %12zu  %14.3g  %15.3g  %12.3g  %18zu  %14.3g  %14.3g  %15.3g  %16.3g\n",
                           num_trials,
                           max_difference,
                           source_node_type.c_str(),
@@ -220,7 +269,9 @@ static void profile_sample_routes(std::ofstream& os,
                           mean_squared_error,
                           num_overestimations,
                           average_overestimation,
-                          max_overestimation_this_iter);
+                          max_overestimation_this_iter,
+                          average_sep_cost,
+                          sep_mean_squared_error);
 }
 
 /**
@@ -266,6 +317,15 @@ static void profile_lookahead_overestimation(std::ofstream& os,
     os << "be aware that these results entirely focus on the delay component of the\n";
     os << "costs of the paths.\n";
     os << "\n";
+    os << "If the router lookahead being profiled is the MapLookahead, this report also\n";
+    os << "computes a \'separable\' cost estimate for each path: the cost of covering\n";
+    os << "delta_x (with delta_y = 0) plus the cost of covering delta_y (with delta_x = 0),\n";
+    os << "as estimated by the lookahead. Comparing this separable estimate against the\n";
+    os << "actual path cost (via its own MSE) indicates how separable the lookahead's\n";
+    os << "cost function is in x and y; a high separable MSE relative to the heuristic's\n";
+    os << "MSE suggests the lookahead's cost is not well-approximated as the sum of an\n";
+    os << "independent x-cost and y-cost.\n";
+    os << "\n";
 
     // Variables for the profiling.
     //  The target number of random source (sample) nodes to use.
@@ -303,10 +363,10 @@ static void profile_lookahead_overestimation(std::ofstream& os,
     vtr::array<e_rr_type, t_overestimation_info, (size_t)e_rr_type::NUM_RR_TYPES> max_overestimation_per_type;
 
     // Print some header information on what each column of the status bar means.
-    os << "----------  --------------------  -----------  ------------  --------------  ---------------  ------------  ------------------  --------------  --------------\n";
-    os << "Trial Num.  Worst Overestimation  Source Node  Num. Targets  Avg. Path Cost  Avg. Heur. Cost  Mean Squared  Num. Overestimated  Avg.            Max           \n";
-    os << "            So Far                Type         Found                                          Error         Paths               Overestimation  Overestimation\n";
-    os << "----------  --------------------  -----------  ------------  --------------  ---------------  ------------  ------------------  --------------  --------------\n";
+    os << "----------  --------------------  -----------  ------------  --------------  ---------------  ------------  ------------------  --------------  --------------  ---------------  ----------------\n";
+    os << "Trial Num.  Worst Overestimation  Source Node  Num. Targets  Avg. Path Cost  Avg. Heur. Cost  Mean Squared  Num. Overestimated  Avg.            Max             Avg. Separable  Separable Mean  \n";
+    os << "            So Far                Type         Found                                          Error         Paths               Overestimation  Overestimation  Cost            Squared Error   \n";
+    os << "----------  --------------------  -----------  ------------  --------------  ---------------  ------------  ------------------  --------------  --------------  ---------------  ----------------\n";
 
     // Perform random trial routes. These routes are single-source-all-destination
     // Dijkstra's algorithm. After all of these routes are found, the cost of each
@@ -318,6 +378,8 @@ static void profile_lookahead_overestimation(std::ofstream& os,
     size_t num_trials = 0;
     std::set<RRNodeId> tried_nodes;
     float max_difference = 0.0f;
+    double sep_squared_error_sum = 0.0;
+    size_t num_sep_targets = 0;
     auto rng = vtr::RandomNumberGenerator(0);
     for (unsigned i = 0; i < max_attempts; i++) {
         // If the number of successful trials is equal to our target number of
@@ -352,7 +414,9 @@ static void profile_lookahead_overestimation(std::ofstream& os,
                               router_opts,
                               max_difference,
                               num_trials,
-                              max_overestimation_per_type);
+                              max_overestimation_per_type,
+                              sep_squared_error_sum,
+                              num_sep_targets);
 
         num_trials++;
     }
@@ -364,6 +428,12 @@ static void profile_lookahead_overestimation(std::ofstream& os,
 
     // Print the total maximum difference.
     os << vtr::string_fmt("Worst overestimation between heuristic and actual: %.3g\n", max_difference);
+
+    // Print the overall separable-delay MSE (across all trials), if computed.
+    if (num_sep_targets > 0) {
+        double overall_sep_mse = sep_squared_error_sum / (double)num_sep_targets;
+        os << vtr::string_fmt("Overall Separable Delay Mean Squared Error (across all trials): %.3g\n", overall_sep_mse);
+    }
 
     // Print the overestimation per node type.
     for (size_t l = 0; l < max_overestimation_per_type.size(); l++) {

--- a/vpr/src/route/router_lookahead/router_lookahead_report.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_report.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "router_lookahead_report.h"
+#include <cstdlib>
 #include <fstream>
+#include <map>
 #include <memory>
 #include "connection_router_interface.h"
 #include "d_ary_heap.h"
@@ -91,6 +93,16 @@ struct t_overestimation_info {
  *  @param num_sep_targets
  *      Accumulator (across all trials) for the number of targets used to compute
  *      sep_squared_error_sum.
+ *  @param heur_squared_error_sum
+ *      Accumulator (across all trials) for the sum of squared errors between the
+ *      heuristic delay estimate and the actual path delay.
+ *  @param num_heur_targets
+ *      Accumulator (across all trials) for the number of targets used to compute
+ *      heur_squared_error_sum.
+ *  @param mse_per_manhattan_distance
+ *      Accumulator (across all trials) mapping a target's Manhattan distance
+ *      (|delta_x| + |delta_y|) to the sum of squared heuristic errors and the
+ *      number of targets at that distance.
  */
 static void profile_sample_routes(std::ofstream& os,
                                   RRNodeId sample_rr_node,
@@ -102,7 +114,10 @@ static void profile_sample_routes(std::ofstream& os,
                                   size_t num_trials,
                                   vtr::array<e_rr_type, t_overestimation_info, (size_t)e_rr_type::NUM_RR_TYPES>& max_overestimation_per_type,
                                   double& sep_squared_error_sum,
-                                  size_t& num_sep_targets) {
+                                  size_t& num_sep_targets,
+                                  double& heur_squared_error_sum,
+                                  size_t& num_heur_targets,
+                                  std::map<int, std::pair<double, size_t>>& mse_per_manhattan_distance) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const RRGraphView& rr_graph = device_ctx.rr_graph;
     RoutingContext& route_ctx = g_vpr_ctx.mutable_routing();
@@ -218,7 +233,17 @@ static void profile_sample_routes(std::ofstream& os,
 
         // Keep track of the sum of the squared errors.
         double error = heuristic_delay - path_delay;
-        squared_error_sum += (error * error);
+        double squared_error = error * error;
+        squared_error_sum += squared_error;
+
+        // Bin the squared error by the Manhattan distance (|delta_x| + |delta_y|)
+        // between the source and the target so the report can show how the
+        // lookahead's accuracy varies with distance.
+        auto [dx, dy] = util::get_xy_deltas(sample_rr_node, rr_node_id);
+        int manhattan_distance = std::abs(dx) + std::abs(dy);
+        auto& manhattan_bin = mse_per_manhattan_distance[manhattan_distance];
+        manhattan_bin.first += squared_error;
+        manhattan_bin.second++;
 
         // Keep track of the total path and heuristic costs of each path.
         total_path_cost += path_delay;
@@ -230,6 +255,11 @@ static void profile_sample_routes(std::ofstream& os,
     // across all trials.
     sep_squared_error_sum += sep_squared_error_sum_this_iter;
     num_sep_targets += num_sep_targets_this_iter;
+
+    // Fold this trial's heuristic squared error statistics into the running
+    // totals across all trials.
+    heur_squared_error_sum += squared_error_sum;
+    num_heur_targets += num_targets;
 
     // Reset the global path costs to prepare for the next route.
     router.reset_path_costs();
@@ -377,6 +407,9 @@ static void profile_lookahead_overestimation(std::ofstream& os,
     float max_difference = 0.0f;
     double sep_squared_error_sum = 0.0;
     size_t num_sep_targets = 0;
+    double heur_squared_error_sum = 0.0;
+    size_t num_heur_targets = 0;
+    std::map<int, std::pair<double, size_t>> mse_per_manhattan_distance;
     auto rng = vtr::RandomNumberGenerator(0);
     for (unsigned i = 0; i < max_attempts; i++) {
         // If the number of successful trials is equal to our target number of
@@ -413,7 +446,10 @@ static void profile_lookahead_overestimation(std::ofstream& os,
                               num_trials,
                               max_overestimation_per_type,
                               sep_squared_error_sum,
-                              num_sep_targets);
+                              num_sep_targets,
+                              heur_squared_error_sum,
+                              num_heur_targets,
+                              mse_per_manhattan_distance);
 
         num_trials++;
     }
@@ -425,6 +461,12 @@ static void profile_lookahead_overestimation(std::ofstream& os,
 
     // Print the total maximum difference.
     os << vtr::string_fmt("Worst overestimation between heuristic and actual: %.3g\n", max_difference);
+
+    // Print the overall (average) heuristic MSE across all samples/trials.
+    if (num_heur_targets > 0) {
+        double overall_heur_mse = heur_squared_error_sum / (double)num_heur_targets;
+        os << vtr::string_fmt("Total Average Mean Squared Error (across all samples): %.3g\n", overall_heur_mse);
+    }
 
     // Print the overall separable-delay MSE (across all trials), if computed.
     if (num_sep_targets > 0) {
@@ -454,6 +496,25 @@ static void profile_lookahead_overestimation(std::ofstream& os,
         os << vtr::string_fmt("\t\t\tHeuristic Cost: %g\n", overestimation_info.heuristic_delay);
         os << vtr::string_fmt("\t\t\tActual Path Cost: %g\n", overestimation_info.path_delay);
     }
+
+    // Print a table of the heuristic MSE broken down by the Manhattan distance
+    // between the source and the target. This shows how the lookahead's accuracy
+    // varies with distance.
+    os << "\n";
+    os << "Mean Squared Error per Manhattan Distance:\n";
+    os << "--------------------  ------------  --------------------\n";
+    os << "Manhattan Distance    Num. Targets  Mean Squared Error  \n";
+    os << "--------------------  ------------  --------------------\n";
+    for (const auto& [manhattan_distance, error_info] : mse_per_manhattan_distance) {
+        double sum_squared_error = error_info.first;
+        size_t num_targets = error_info.second;
+        double mean_squared_error = sum_squared_error / (double)num_targets;
+        os << vtr::string_fmt("%20d  %12zu  %20.3g\n",
+                              manhattan_distance,
+                              num_targets,
+                              mean_squared_error);
+    }
+    os << "--------------------  ------------  --------------------\n";
 
     os << "=================================================================\n";
     os << "\n";

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -254,7 +254,7 @@ static void compute_wire_cost_map_for_axis(const std::vector<t_segment_inf>& seg
                         const int sample_y = profile_x ? fixed_coord : coord;
                         RRNodeId start_node;
                         if (is_chanxy(chan_type)) {
-                            start_node = util::get_chanxy_start_node(from_layer_num, sample_x, sample_y,
+                            start_node = get_chanxy_start_node_sep(from_layer_num, sample_x, sample_y,
                                                                      direction, chan_type, segment_inf.seg_index, 0);
                         } else {
                             VTR_ASSERT(is_chanz(chan_type));

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -1,8 +1,273 @@
 #include "router_lookahead_separable.h"
 
+#include <memory>
+#include "connection_router_interface.h"
 #include "globals.h"
+#include "router_lookahead_map.h"
+#include "router_lookahead_map_utils.h"
+#include "vpr_context.h"
 #include "vpr_error.h"
+#include "vpr_utils.h"
 #include "vtr_time.h"
+
+/* iterates over the children of the specified node and selectively pushes them onto the priority queue.
+ * This is a copy of the (static) expand_dijkstra_neighbours() in router_lookahead_map_utils.cpp, adapted
+ * to always restrict the expansion to a bounding box (no interposer-cut handling, since that is not yet
+ * supported by this lookahead). */
+static void expand_separable_wire_dijkstra_neighbours(util::PQ_Entry parent_entry,
+                                                       vtr::vector<RRNodeId, float>& node_visited_costs,
+                                                       vtr::vector<RRNodeId, bool>& node_expanded,
+                                                       std::priority_queue<util::PQ_Entry>& pq,
+                                                       const t_bb& bb) {
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+
+    RRNodeId parent = parent_entry.rr_node;
+
+    for (t_edge_size edge : rr_graph.edges(parent)) {
+        RRNodeId child_node = rr_graph.edge_sink_node(parent, edge);
+        // Don't expand the nodes inside the clusters since the intra-cluster lookahead
+        // is computed separately.
+        if (!is_inter_cluster_node(rr_graph, child_node)) {
+            continue;
+        }
+
+        // Don't expand nodes whose adjusted position falls outside of the bounding box.
+        auto [child_x, child_y] = util::get_adjusted_rr_position(child_node);
+        if (child_x < bb.xmin || child_x > bb.xmax || child_y < bb.ymin || child_y > bb.ymax) {
+            continue;
+        }
+
+        int switch_ind = size_t(rr_graph.edge_switch(parent, edge));
+
+        if (rr_graph.node_type(child_node) == e_rr_type::SINK) return;
+
+        /* skip this child if it has already been expanded from */
+        if (node_expanded[child_node]) {
+            continue;
+        }
+
+        util::PQ_Entry child_entry(child_node, switch_ind, parent_entry.delay,
+                                   parent_entry.R_upstream, parent_entry.congestion_upstream, false);
+
+        /* skip this child if it has been visited with smaller cost */
+        if (node_visited_costs[child_node] >= 0 && node_visited_costs[child_node] < child_entry.cost) {
+            continue;
+        }
+
+        /* finally, record the cost with which the child was visited and put the child entry on the queue */
+        node_visited_costs[child_node] = child_entry.cost;
+        pq.push(child_entry);
+    }
+}
+
+/// @brief The device axis (x or y) whose travel cost a separable wire cost map profiles.
+enum class e_profile_axis {
+    X, ///< Profiles horizontal travel; populates an x_wire_cost_map (keyed by x1/x2).
+    Y  ///< Profiles vertical travel; populates a y_wire_cost_map (keyed by y1/y2).
+};
+
+/* Runs Dijkstra's algorithm from start_node, restricted to the given bounding box, until all reachable
+ * nodes within the box have been visited. Each time an IPIN is visited, the minimum delay/congestion to
+ * reach the IPIN's location along the profiling axis is recorded in wire_cost_map, keyed by
+ * [from_layer_num][ipin_layer][chan_index][seg_index][direction_index][start_coord][ipin_coord], where
+ * start_coord/ipin_coord are the x (profile_x) or y (!profile_x) coordinates of the start node and IPIN.
+ *
+ * This is a copy of the (static) run_dijkstra() in router_lookahead_map_utils.cpp, adapted to record
+ * entries into a separable wire_cost_map instead of the (delta_x, delta_y)-indexed routing_cost_map. */
+static void run_separable_wire_dijkstra(RRNodeId start_node,
+                                        int start_coord,
+                                        bool profile_x,
+                                        unsigned from_layer_num,
+                                        int chan_index,
+                                        int seg_index,
+                                        int direction_index,
+                                        const t_bb& bb,
+                                        util::t_dijkstra_data& data,
+                                        vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map) {
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+
+    vtr::vector<RRNodeId, bool>& node_expanded = data.node_expanded;
+    node_expanded.resize(rr_graph.num_nodes());
+    std::fill(node_expanded.begin(), node_expanded.end(), false);
+
+    vtr::vector<RRNodeId, float>& node_visited_costs = data.node_visited_costs;
+    node_visited_costs.resize(rr_graph.num_nodes());
+    std::fill(node_visited_costs.begin(), node_visited_costs.end(), -1.0);
+
+    std::priority_queue<util::PQ_Entry>& pq = data.pq;
+    while (!pq.empty()) {
+        pq.pop();
+    }
+
+    // First entry has no upstream delay or congestion
+    pq.emplace(start_node, UNDEFINED, 0, 0, 0, true);
+
+    while (!pq.empty()) {
+        util::PQ_Entry current = pq.top();
+        pq.pop();
+
+        RRNodeId curr_node = current.rr_node;
+
+        // Check that we haven't already expanded from this node
+        if (node_expanded[curr_node]) {
+            continue;
+        }
+
+        // If this node is an IPIN, record its cost to reach in wire_cost_map, keeping the smallest
+        // delay seen so far for this (start_coord, ipin_coord) pair.
+        if (rr_graph.node_type(curr_node) == e_rr_type::IPIN) {
+            auto [ipin_x, ipin_y] = util::get_adjusted_rr_position(curr_node);
+            const int ipin_coord = profile_x ? ipin_x : ipin_y;
+            int ipin_layer = rr_graph.node_layer_low(curr_node);
+
+            util::Cost_Entry& cost_entry = wire_cost_map[from_layer_num][ipin_layer][chan_index][seg_index][direction_index][start_coord][ipin_coord];
+            if (!cost_entry.valid() || current.delay < cost_entry.delay) {
+                cost_entry = util::Cost_Entry(current.delay, current.congestion_upstream);
+            }
+        }
+
+        expand_separable_wire_dijkstra_neighbours(current, node_visited_costs, node_expanded, pq, bb);
+        node_expanded[curr_node] = true;
+    }
+}
+
+/* Populates wire_cost_map for the given profiling axis. Sample nodes are taken along a line through the
+ * middle of the device that is perpendicular to the profiling axis (a middle-height row when profiling x,
+ * a middle-width column when profiling y), and a Dijkstra flood is run from each, restricted to a few
+ * rows/columns around that line but spanning the full extent of the profiling axis. */
+static void compute_wire_cost_map_for_axis(const std::vector<t_segment_inf>& segment_infs,
+                                           e_profile_axis axis,
+                                           vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map) {
+    // look at compute_router_wire_lookahead in router_lookahead_map.cpp for reference.
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const auto& grid = device_ctx.grid;
+    const auto& rr_graph = device_ctx.rr_graph;
+
+    const bool profile_x = (axis == e_profile_axis::X);
+
+    const size_t num_layers = grid.get_num_layers();
+    // The wire look-ahead table has a dimension for channel type (CHANX/CHANY/CHANZ). In 2-d
+    // architectures there is no CHANZ, so that dimension is dropped down to CHANX/CHANY only.
+    const size_t chan_type_dim_size = (num_layers == 1) ? 2 : 3;
+    // INC/DEC/BIDIR
+    constexpr size_t direction_dim_size = 3;
+
+    // Size of the profiling-axis dimension: device width when profiling x, height when profiling y.
+    const size_t axis_dim_size = profile_x ? grid.width() : grid.height();
+
+    // Re-allocate
+    wire_cost_map = vtr::NdMatrix<util::Cost_Entry, 7>({num_layers,
+                                                        num_layers,
+                                                        chan_type_dim_size,
+                                                        segment_infs.size(),
+                                                        direction_dim_size,
+                                                        axis_dim_size,
+                                                        axis_dim_size});
+    wire_cost_map.fill(util::Cost_Entry());
+
+    // Sample along a line through the middle of the device, perpendicular to the profiling axis:
+    // a middle-height row when profiling x, a middle-width column when profiling y.
+    const int fixed_coord = profile_x ? (int)(2 * grid.height() / 3) : (int)grid.width() / 2;
+
+    for (size_t from_layer_num = 0; from_layer_num < num_layers; from_layer_num++) {
+        // If arch file specifies die_number="layer_num" doesn't have inter-cluster
+        // programmable routing resources, then we shouldn't profile wire segment types on
+        // the current layer
+        if (!device_ctx.inter_cluster_prog_routing_resources[from_layer_num]) {
+            continue;
+        }
+
+        // Restrict the Dijkstra flood to a few rows/columns around the sample line (to keep the flood
+        // cheap), but the full extent of the profiling axis.
+        t_bb bb;
+        if (profile_x) {
+            bb = t_bb(0, grid.width() - 1,
+                      std::max(0, fixed_coord - 2), std::min<int>(grid.height() - 1, fixed_coord + 2),
+                      (int)from_layer_num, (int)from_layer_num);
+        } else {
+            bb = t_bb(std::max(0, fixed_coord - 2), std::min<int>(grid.width() - 1, fixed_coord + 2),
+                      0, grid.height() - 1,
+                      (int)from_layer_num, (int)from_layer_num);
+        }
+
+        for (const t_segment_inf& segment_inf : segment_infs) {
+            std::vector<e_rr_type> chan_types;
+            if (segment_inf.parallel_axis == e_parallel_axis::X_AXIS) {
+                chan_types.push_back(e_rr_type::CHANX);
+            } else if (segment_inf.parallel_axis == e_parallel_axis::Y_AXIS) {
+                chan_types.push_back(e_rr_type::CHANY);
+            } else if (segment_inf.parallel_axis == e_parallel_axis::Z_AXIS) {
+                chan_types.push_back(e_rr_type::CHANZ);
+            } else {
+                VTR_ASSERT(segment_inf.parallel_axis == e_parallel_axis::BOTH_AXIS);
+                // Both for BOTH_AXIS segments and special segments such as clock_networks we want to search in both directions.
+                chan_types.insert(chan_types.end(), {e_rr_type::CHANX, e_rr_type::CHANY});
+            }
+
+            for (e_rr_type chan_type : chan_types) {
+                const int chan_index = util::chan_type_to_index(chan_type);
+
+                for (Direction direction : {Direction::INC, Direction::DEC, Direction::BIDIR}) {
+                    const int direction_index = static_cast<int>(direction);
+
+                    // get sample points at each position along the profiling axis on the sample line
+                    std::vector<RRNodeId> sample_nodes;
+                    for (int coord = 1; coord < (int)axis_dim_size; coord++) {
+                        const int sample_x = profile_x ? coord : fixed_coord;
+                        const int sample_y = profile_x ? fixed_coord : coord;
+                        RRNodeId start_node;
+                        if (is_chanxy(chan_type)) {
+                            start_node = util::get_chanxy_start_node(from_layer_num, sample_x, sample_y,
+                                                                     direction, chan_type, segment_inf.seg_index, 0);
+                        } else {
+                            VTR_ASSERT(is_chanz(chan_type));
+                            start_node = util::get_chanz_start_node(sample_x, sample_y, segment_inf.seg_index, 0, direction);
+                        }
+
+                        if (start_node) {
+                            sample_nodes.emplace_back(start_node);
+                        }
+                    }
+
+                    if (sample_nodes.empty()) {
+                        continue;
+                    }
+
+                    // Run a dijkstra flood from each sample node, recording the minimum cost to reach
+                    // each IPIN's location along the profiling axis. dijkstra_data is created outside the
+                    // loop and passed by reference to run_separable_wire_dijkstra() to avoid repeated
+                    // memory allocation/de-allocation.
+                    util::t_dijkstra_data dijkstra_data;
+                    for (RRNodeId sample_node : sample_nodes) {
+                        // Use the driver end of the wire along the profiling axis as the start coordinate.
+                        const bool dec = rr_graph.node_direction(sample_node) == Direction::DEC;
+                        int start_coord;
+                        if (profile_x) {
+                            start_coord = dec ? rr_graph.node_xhigh(sample_node) : rr_graph.node_xlow(sample_node);
+                        } else {
+                            start_coord = dec ? rr_graph.node_yhigh(sample_node) : rr_graph.node_ylow(sample_node);
+                        }
+
+                        run_separable_wire_dijkstra(sample_node, start_coord, profile_x, from_layer_num,
+                                                    chan_index, segment_inf.seg_index, direction_index, bb,
+                                                    dijkstra_data, wire_cost_map);
+                    }
+                }
+            }
+        }
+    }
+}
+
+static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segment_infs,
+                                          int /*route_verbosity*/,
+                                          bool /*device_model_warnings*/,
+                                          t_x_wire_cost_map& x_wire_cost_map,
+                                          t_y_wire_cost_map& y_wire_cost_map) {
+    compute_wire_cost_map_for_axis(segment_infs, e_profile_axis::X, x_wire_cost_map);
+    compute_wire_cost_map_for_axis(segment_infs, e_profile_axis::Y, y_wire_cost_map);
+}
 
 /**
  * @note This lookahead is currently a skeleton: the class compiles and can be
@@ -19,11 +284,33 @@ SeparableLookahead::SeparableLookahead(const t_det_routing_arch& det_routing_arc
     , device_model_warnings_(device_model_warnings)
     , interposer_base_cost_multiplier_(interposer_base_cost_multiplier) {
     has_interposer_cuts_ = g_vpr_ctx.device().grid.has_interposer_cuts();
+
+    // Delegate SOURCE/OPIN distance queries to a standard MapLookahead.
+    map_lookahead_ = std::make_unique<MapLookahead>(det_routing_arch, is_flat, route_verbosity, device_model_warnings, interposer_base_cost_multiplier);
 }
 
-float SeparableLookahead::get_expected_cost(RRNodeId /*current_node*/, RRNodeId /*target_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
-    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_expected_cost");
-    return 0.f;
+float SeparableLookahead::get_expected_cost(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+
+    e_rr_type from_rr_type = rr_graph.node_type(current_node);
+
+    VTR_ASSERT_SAFE(rr_graph.node_type(target_node) == e_rr_type::SINK);
+
+    if (is_flat_) {
+        return get_expected_cost_flat_router(current_node, target_node, params, R_upstream);
+    } else {
+        if (from_rr_type == e_rr_type::CHANX || from_rr_type == e_rr_type::CHANY || from_rr_type == e_rr_type::CHANZ
+            || from_rr_type == e_rr_type::SOURCE || from_rr_type == e_rr_type::OPIN) {
+            // Get the total cost using the combined delay and congestion costs
+            auto [delay_cost, cong_cost] = get_expected_delay_and_cong(current_node, target_node, params, R_upstream);
+            return delay_cost + cong_cost;
+        } else if (from_rr_type == e_rr_type::IPIN) { // Change if you're allowing route-throughs
+            return device_ctx.rr_indexed_data[RRIndexedDataId(SINK_COST_INDEX)].base_cost;
+        } else { // Change this if you want to investigate route-throughs
+            return 0.f;
+        }
+    }
 }
 
 float SeparableLookahead::get_expected_cost_flat_router(RRNodeId /*current_node*/, RRNodeId /*target_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
@@ -31,13 +318,98 @@ float SeparableLookahead::get_expected_cost_flat_router(RRNodeId /*current_node*
     return 0.f;
 }
 
-std::pair<float, float> SeparableLookahead::get_expected_delay_and_cong(RRNodeId /*from_node*/, RRNodeId /*to_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
-    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_expected_delay_and_cong");
-    return std::make_pair(0.f, 0.f);
+std::pair<float, float> SeparableLookahead::get_expected_delay_and_cong(RRNodeId from_node, RRNodeId to_node, const t_conn_cost_params& params, float R_upstream) const {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+
+    int from_layer_num = rr_graph.node_layer_low(from_node);
+    int to_layer_num = rr_graph.node_layer_low(to_node);
+    auto [delta_x, delta_y] = util::get_xy_deltas(from_node, to_node);
+    delta_x = std::abs(delta_x);
+    delta_y = std::abs(delta_y);
+
+    float expected_delay_cost = std::numeric_limits<float>::infinity();
+    float expected_cong_cost = std::numeric_limits<float>::infinity();
+
+    e_rr_type from_type = rr_graph.node_type(from_node);
+    if (from_type == e_rr_type::SOURCE || from_type == e_rr_type::OPIN) {
+        // SOURCE/OPIN cost estimation is delegated to the standard MapLookahead.
+        return map_lookahead_->get_expected_delay_and_cong(from_node, to_node, params, R_upstream);
+    } else if (from_type == e_rr_type::CHANX || from_type == e_rr_type::CHANY || from_type == e_rr_type::CHANZ) {
+        // From a wire we look up the separable x and y travel costs directly in the absolute-coordinate
+        // wire cost maps and add them. The maps are keyed by [from_layer][to_layer][chan][seg][dir]
+        // [start_coord][target_coord], where start_coord is the driver end of the wire (matching how the
+        // maps were profiled) and target_coord is the adjusted position of the target.
+
+        Direction from_dir = rr_graph.node_direction(from_node);
+
+        // For CHANZ nodes, if the direction is
+        // 1) Incremental --> `chanz_node` now drives other nodes on node_layer_high(chanz_node).
+        // 2) Decremental --> `chanz_node` now drives other nodes on node_layer_low(chanz_node).
+        // 3) Bidirectional --> `chanz_node` now drives other nodes on both layers, so we choose the target layer
+        if (from_type == e_rr_type::CHANZ) {
+            if (from_dir == Direction::INC) {
+                from_layer_num = rr_graph.node_layer_high(from_node);
+            } else if (from_dir == Direction::BIDIR) {
+                from_layer_num = to_layer_num;
+            }
+        }
+
+        RRIndexedDataId from_cost_index = rr_graph.node_cost_index(from_node);
+        int from_seg_index = device_ctx.rr_indexed_data[from_cost_index].seg_index;
+        VTR_ASSERT(from_seg_index >= 0);
+
+        const int chan_index = util::chan_type_to_index(from_type);
+        const int dir_index = static_cast<int>(from_dir);
+
+        // Start coordinate: the driver end of the wire (xhigh/yhigh for DEC wires, xlow/ylow otherwise),
+        // matching the start_coord used when the maps were profiled.
+        const bool dec = (from_dir == Direction::DEC);
+        const int from_x = dec ? rr_graph.node_xhigh(from_node) : rr_graph.node_xlow(from_node);
+        const int from_y = dec ? rr_graph.node_yhigh(from_node) : rr_graph.node_ylow(from_node);
+
+        // Target coordinate: the adjusted position of the target node.
+        auto [to_x, to_y] = util::get_adjusted_rr_position(to_node);
+
+        const util::Cost_Entry& x_cost = x_wire_cost_map_[from_layer_num][to_layer_num][chan_index][from_seg_index][dir_index][from_x][to_x];
+        const util::Cost_Entry& y_cost = y_wire_cost_map_[from_layer_num][to_layer_num][chan_index][from_seg_index][dir_index][from_y][to_y];
+
+        expected_delay_cost = x_cost.delay + y_cost.delay;
+        expected_cong_cost = x_cost.congestion + y_cost.congestion;
+
+    } else if (from_type == e_rr_type::IPIN) { // Change if you're allowing route-throughs
+        return std::make_pair(0., device_ctx.rr_indexed_data[RRIndexedDataId(SINK_COST_INDEX)].base_cost);
+    } else { // Change this if you want to investigate route-throughs
+        return std::make_pair(0., 0.);
+    }
+
+    // If we have no profiled path for this distance the cost is infinite; fall back to a large (but
+    // finite) sentinel so the router de-prioritizes, but does not forbid, exploring this path.
+    if (!std::isfinite(expected_delay_cost)) {
+        expected_delay_cost = ROUTER_LOOKAHEAD_NO_PATH_SENTINEL;
+    }
+    if (!std::isfinite(expected_cong_cost)) {
+        expected_cong_cost = ROUTER_LOOKAHEAD_NO_PATH_SENTINEL;
+    }
+
+    if (expected_delay_cost == ROUTER_LOOKAHEAD_NO_PATH_SENTINEL || expected_cong_cost == ROUTER_LOOKAHEAD_NO_PATH_SENTINEL) {
+        return map_lookahead_->get_expected_delay_and_cong(from_node, to_node, params, R_upstream);
+    }
+    expected_delay_cost *= params.criticality;
+    expected_cong_cost *= (1.0f - params.criticality);
+
+    return std::make_pair(expected_delay_cost, expected_cong_cost);
 }
 
-void SeparableLookahead::compute(const std::vector<t_segment_inf>& /*segment_inf*/) {
+void SeparableLookahead::compute(const std::vector<t_segment_inf>& segment_inf) {
+    vtr::ScopedStartFinishTimer timer("Computing router lookahead separable");
 
+    // First compute the delay map when starting from the various wire types
+    // (CHANX/CHANY/CHANZ) in the routing architecture
+    compute_router_wire_lookahead(segment_inf, route_verbosity_, device_model_warnings_, x_wire_cost_map_, y_wire_cost_map_);
+
+    // Build the delegate MapLookahead, which provides the SOURCE/OPIN distance estimates.
+    map_lookahead_->compute(segment_inf);
 }
 
 void SeparableLookahead::compute_intra_tile() {
@@ -60,9 +432,8 @@ void SeparableLookahead::write_intra_cluster(const std::string& /*file*/) const 
     NOT_IMPLEMENTED_ERROR("SeparableLookahead::write_intra_cluster");
 }
 
-float SeparableLookahead::get_opin_distance_min_delay(int /*physical_tile_idx*/, int /*from_layer*/, int /*to_layer*/, int /*dx*/, int /*dy*/) const {
-    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_opin_distance_min_delay");
-    return 0.f;
+float SeparableLookahead::get_opin_distance_min_delay(int physical_tile_idx, int from_layer, int to_layer, int dx, int dy) const {
+    return map_lookahead_->get_opin_distance_min_delay(physical_tile_idx, from_layer, to_layer, dx, dy);
 }
 
 void read_router_lookahead_separable(const std::string& /*file*/) {

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -1,0 +1,76 @@
+#include "router_lookahead_separable.h"
+
+#include "globals.h"
+#include "vpr_error.h"
+#include "vtr_time.h"
+
+/**
+ * @note This lookahead is currently a skeleton: the class compiles and can be
+ *       selected via --router_lookahead separable, but none of its methods are
+ *       implemented yet.
+ */
+#define NOT_IMPLEMENTED_ERROR(func_name) \
+    VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "%s is not implemented yet", func_name)
+
+SeparableLookahead::SeparableLookahead(const t_det_routing_arch& det_routing_arch, bool is_flat, int route_verbosity, bool device_model_warnings, float interposer_base_cost_multiplier)
+    : det_routing_arch_(det_routing_arch)
+    , is_flat_(is_flat)
+    , route_verbosity_(route_verbosity)
+    , device_model_warnings_(device_model_warnings)
+    , interposer_base_cost_multiplier_(interposer_base_cost_multiplier) {
+    has_interposer_cuts_ = g_vpr_ctx.device().grid.has_interposer_cuts();
+}
+
+float SeparableLookahead::get_expected_cost(RRNodeId /*current_node*/, RRNodeId /*target_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_expected_cost");
+    return 0.f;
+}
+
+float SeparableLookahead::get_expected_cost_flat_router(RRNodeId /*current_node*/, RRNodeId /*target_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_expected_cost_flat_router");
+    return 0.f;
+}
+
+std::pair<float, float> SeparableLookahead::get_expected_delay_and_cong(RRNodeId /*from_node*/, RRNodeId /*to_node*/, const t_conn_cost_params& /*params*/, float /*R_upstream*/) const {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_expected_delay_and_cong");
+    return std::make_pair(0.f, 0.f);
+}
+
+void SeparableLookahead::compute(const std::vector<t_segment_inf>& /*segment_inf*/) {
+
+}
+
+void SeparableLookahead::compute_intra_tile() {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::compute_intra_tile");
+}
+
+void SeparableLookahead::read(const std::string& /*file*/) {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::read");
+}
+
+void SeparableLookahead::read_intra_cluster(const std::string& /*file*/) {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::read_intra_cluster");
+}
+
+void SeparableLookahead::write(const std::string& /*file_name*/) const {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::write");
+}
+
+void SeparableLookahead::write_intra_cluster(const std::string& /*file*/) const {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::write_intra_cluster");
+}
+
+float SeparableLookahead::get_opin_distance_min_delay(int /*physical_tile_idx*/, int /*from_layer*/, int /*to_layer*/, int /*dx*/, int /*dy*/) const {
+    NOT_IMPLEMENTED_ERROR("SeparableLookahead::get_opin_distance_min_delay");
+    return 0.f;
+}
+
+void read_router_lookahead_separable(const std::string& /*file*/) {
+    NOT_IMPLEMENTED_ERROR("read_router_lookahead_separable");
+}
+
+void write_router_lookahead_separable(const std::string& /*file*/) {
+    NOT_IMPLEMENTED_ERROR("write_router_lookahead_separable");
+}
+
+#undef NOT_IMPLEMENTED_ERROR

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -5,10 +5,45 @@
 #include "globals.h"
 #include "router_lookahead_map.h"
 #include "router_lookahead_map_utils.h"
+#include "rr_node_types.h"
 #include "vpr_context.h"
 #include "vpr_error.h"
 #include "vpr_utils.h"
 #include "vtr_time.h"
+
+static RRNodeId get_chanxy_start_node_sep(int layer, int start_x, int start_y, Direction direction, e_rr_type rr_type, int seg_index, int track_offset) {
+    const auto& device_ctx = g_vpr_ctx.device();
+    const auto& rr_graph = device_ctx.rr_graph;
+    const auto& node_lookup = rr_graph.node_lookup();
+
+    VTR_ASSERT(rr_type == e_rr_type::CHANX || rr_type == e_rr_type::CHANY);
+
+    RRNodeId result = RRNodeId::INVALID();
+
+    // Find first node in channel that has specified segment index and goes in the desired direction.
+    // Unlike get_chanxy_start_node(int, int, int, int, int, e_rr_type, int, int), this only matches nodes
+    // whose direction is exactly the requested one (a BIDIR node is not treated as a match for INC/DEC).
+    for (const RRNodeId node_id : node_lookup.find_channel_nodes(layer, start_x, start_y, rr_type)) {
+        VTR_ASSERT(rr_graph.node_type(node_id) == rr_type);
+
+        Direction node_direction = rr_graph.node_direction(node_id);
+        RRIndexedDataId node_cost_ind = rr_graph.node_cost_index(node_id);
+        int node_seg_ind = device_ctx.rr_indexed_data[node_cost_ind].seg_index;
+        auto [driver_x, driver_y] = util::get_adjusted_rr_position(node_id);
+        if (node_direction == Direction::BIDIR || (driver_x == start_x && driver_y == start_y)) {
+            if (node_direction == direction && node_seg_ind == seg_index) {
+                // Found first track that has the specified segment index and goes in the desired direction
+                result = node_id;
+                if (track_offset == 0) {
+                    break;
+                }
+                track_offset -= 2;
+            }
+        }
+    }
+
+    return result;
+}
 
 /* iterates over the children of the specified node and selectively pushes them onto the priority queue.
  * This is a copy of the (static) expand_dijkstra_neighbours() in router_lookahead_map_utils.cpp, adapted

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -50,10 +50,10 @@ static RRNodeId get_chanxy_start_node_sep(int layer, int start_x, int start_y, D
  * to always restrict the expansion to a bounding box (no interposer-cut handling, since that is not yet
  * supported by this lookahead). */
 static void expand_separable_wire_dijkstra_neighbours(util::PQ_Entry parent_entry,
-                                                       vtr::vector<RRNodeId, float>& node_visited_costs,
-                                                       vtr::vector<RRNodeId, bool>& node_expanded,
-                                                       std::priority_queue<util::PQ_Entry>& pq,
-                                                       const t_bb& bb) {
+                                                      vtr::vector<RRNodeId, float>& node_visited_costs,
+                                                      vtr::vector<RRNodeId, bool>& node_expanded,
+                                                      std::priority_queue<util::PQ_Entry>& pq,
+                                                      const t_bb& bb) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const auto& rr_graph = device_ctx.rr_graph;
 
@@ -255,7 +255,7 @@ static void compute_wire_cost_map_for_axis(const std::vector<t_segment_inf>& seg
                         RRNodeId start_node;
                         if (is_chanxy(chan_type)) {
                             start_node = get_chanxy_start_node_sep(from_layer_num, sample_x, sample_y,
-                                                                     direction, chan_type, segment_inf.seg_index, 0);
+                                                                   direction, chan_type, segment_inf.seg_index, 0);
                         } else {
                             VTR_ASSERT(is_chanz(chan_type));
                             start_node = util::get_chanz_start_node(sample_x, sample_y, segment_inf.seg_index, 0, direction);

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.h
@@ -8,6 +8,54 @@
 #include "router_lookahead_interposer.h"
 
 /**
+ * @brief Provides delay/congestion estimates to travel to a point with a given
+ * x-coordinate, considering only the x component of the route.
+ *
+ * This is a 7D array storing the cost to travel from a node of type CHANX/CHANY/CHANZ
+ * whose x-coordinate is x1, to a point whose x-coordinate is x2, on the "layer_num" layer.
+ *
+ * To store this information:
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number of the target node.
+ * - The third index represents the type of channel (X/Y/Z) that the node under consideration belongs to.
+ * - The forth is the segment type (specified in the architecture file under the "segmentlist" tag).
+ * - The fifth is the wire direction (INC/DEC/BIDIR) of the node under consideration.
+ * - The sixth is x1.
+ * - The last one is x2.
+ *
+ * @note [0..num_layers][0..num_layers][0..2][0..num_seg_types-1][0..2][0..device_ctx.grid.width()-1][0..device_ctx.grid.width()-1]
+ * - [0..2] (3rd index) entry distinguish between CHANX/CHANY/CHANZ start nodes respectively
+ * - [0..2] (5th index) entry distinguish between INC/DEC/BIDIR wire directions respectively (see Direction in rr_node_types.h)
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number that the target node is on.
+ */
+typedef vtr::NdMatrix<util::Cost_Entry, 7> t_x_wire_cost_map;
+
+/**
+ * @brief Provides delay/congestion estimates to travel to a point with a given
+ * y-coordinate, considering only the y component of the route.
+ *
+ * This is a 7D array storing the cost to travel from a node of type CHANX/CHANY/CHANZ
+ * whose y-coordinate is y1, to a point whose y-coordinate is y2, on the "layer_num" layer.
+ *
+ * To store this information:
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number of the target node.
+ * - The third index represents the type of channel (X/Y/Z) that the node under consideration belongs to.
+ * - The forth is the segment type (specified in the architecture file under the "segmentlist" tag).
+ * - The fifth is the wire direction (INC/DEC/BIDIR) of the node under consideration.
+ * - The sixth is y1.
+ * - The last one is y2.
+ *
+ * @note [0..num_layers][0..num_layers][0..2][0..num_seg_types-1][0..2][0..device_ctx.grid.height()-1][0..device_ctx.grid.height()-1]
+ * - [0..2] (3rd index) entry distinguish between CHANX/CHANY/CHANZ start nodes respectively
+ * - [0..2] (5th index) entry distinguish between INC/DEC/BIDIR wire directions respectively (see Direction in rr_node_types.h)
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number that the target node is on.
+ */
+typedef vtr::NdMatrix<util::Cost_Entry, 7> t_y_wire_cost_map;
+
+/**
  * @brief RouterLookahead implementation which estimates delay/congestion by
  *        treating the x and y components of a route independently (i.e. the
  *        cost is separable in x and y), rather than as a joint function of
@@ -26,10 +74,15 @@ class SeparableLookahead : public RouterLookahead {
     std::unordered_map<int, util::t_ipin_primitive_sink_delays> intra_tile_pin_primitive_pin_delay; // [physical_tile_type][from_pin_physical_num][sink_physical_num] -> cost
     // Lookup table to store the minimum cost to reach to a primitive pin from the root-level IPINs
     std::unordered_map<int, std::unordered_map<int, util::Cost_Entry>> tile_min_cost; // [physical_tile_type][sink_physical_num] -> cost
-    // Lookup table to store the minimum cost for each dx and dy
-    vtr::NdMatrix<util::Cost_Entry, 4> chann_distance_based_min_cost; // [from_layer_num][to_layer_num][dx][dy] -> cost
-    vtr::NdMatrix<util::Cost_Entry, 5> opin_distance_based_min_cost;  // [physical_tile_idx][from_layer_num][to_layer_num][dx][dy] -> cost
+
+    // A MapLookahead used to answer SOURCE/OPIN distance queries (get_opin_distance_min_delay, and the
+    // SOURCE/OPIN case of get_expected_delay_and_cong). The separable lookahead only overrides the
+    // wire-to-target (CHAN) cost estimation; OPIN/SOURCE handling is delegated to this object.
+    std::unique_ptr<RouterLookahead> map_lookahead_;
     std::optional<InterposerLookahead> interposer_lookahead_;
+
+    t_x_wire_cost_map x_wire_cost_map_;
+    t_y_wire_cost_map y_wire_cost_map_;
 
     const t_det_routing_arch& det_routing_arch_;
     bool is_flat_;
@@ -50,50 +103,6 @@ class SeparableLookahead : public RouterLookahead {
     void write_intra_cluster(const std::string& file) const override;
     float get_opin_distance_min_delay(int physical_tile_idx, int from_layer, int to_layer, int dx, int dy) const override;
 };
-
-/**
- * @brief Provides delay/congestion estimates to travel to a point with a given
- * x-coordinate, considering only the x component of the route.
- *
- * This is a 6D array storing the cost to travel from a node of type CHANX/CHANY/CHANZ
- * whose x-coordinate is x1, to a point whose x-coordinate is x2, on the "layer_num" layer.
- *
- * To store this information:
- * - The first index is the layer number that the node under consideration is on.
- * - The second index is the layer number of the target node.
- * - The third index represents the type of channel (X/Y/Z) that the node under consideration belongs to.
- * - The forth is the segment type (specified in the architecture file under the "segmentlist" tag).
- * - The fifth is x1.
- * - The last one is x2.
- *
- * @note [0..num_layers][0..num_layers][0..2][0..num_seg_types-1][0..device_ctx.grid.width()-1][0..device_ctx.grid.width()-1]
- * - [0..2] entry distinguish between CHANX/CHANY/CHANZ start nodes respectively
- * - The first index is the layer number that the node under consideration is on.
- * - The second index is the layer number that the target node is on.
- */
-typedef vtr::NdMatrix<util::Cost_Entry, 6> t_x_wire_cost_map;
-
-/**
- * @brief Provides delay/congestion estimates to travel to a point with a given
- * y-coordinate, considering only the y component of the route.
- *
- * This is a 6D array storing the cost to travel from a node of type CHANX/CHANY/CHANZ
- * whose y-coordinate is y1, to a point whose y-coordinate is y2, on the "layer_num" layer.
- *
- * To store this information:
- * - The first index is the layer number that the node under consideration is on.
- * - The second index is the layer number of the target node.
- * - The third index represents the type of channel (X/Y/Z) that the node under consideration belongs to.
- * - The forth is the segment type (specified in the architecture file under the "segmentlist" tag).
- * - The fifth is y1.
- * - The last one is y2.
- *
- * @note [0..num_layers][0..num_layers][0..2][0..num_seg_types-1][0..device_ctx.grid.height()-1][0..device_ctx.grid.height()-1]
- * - [0..2] entry distinguish between CHANX/CHANY/CHANZ start nodes respectively
- * - The first index is the layer number that the node under consideration is on.
- * - The second index is the layer number that the target node is on.
- */
-typedef vtr::NdMatrix<util::Cost_Entry, 6> t_y_wire_cost_map;
 
 void read_router_lookahead_separable(const std::string& file);
 void write_router_lookahead_separable(const std::string& file);

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include "vtr_ndmatrix.h"
+#include "router_lookahead.h"
+#include "router_lookahead_map_utils.h"
+#include "router_lookahead_interposer.h"
+
+/**
+ * @brief RouterLookahead implementation which estimates delay/congestion by
+ *        treating the x and y components of a route independently (i.e. the
+ *        cost is separable in x and y), rather than as a joint function of
+ *        (delta_x, delta_y) as done by MapLookahead.
+ */
+class SeparableLookahead : public RouterLookahead {
+  public:
+    explicit SeparableLookahead(const t_det_routing_arch& det_routing_arch, bool is_flat, int route_verbosity, bool device_model_warnings, float interposer_base_cost_multiplier);
+
+  private:
+    float get_expected_cost_flat_router(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const;
+
+    //Look-up table from SOURCE/OPIN to CHANX/CHANY of various types
+    util::t_src_opin_delays src_opin_delays;
+    // Lookup table from a tile pins to the primitive classes inside that tile
+    std::unordered_map<int, util::t_ipin_primitive_sink_delays> intra_tile_pin_primitive_pin_delay; // [physical_tile_type][from_pin_physical_num][sink_physical_num] -> cost
+    // Lookup table to store the minimum cost to reach to a primitive pin from the root-level IPINs
+    std::unordered_map<int, std::unordered_map<int, util::Cost_Entry>> tile_min_cost; // [physical_tile_type][sink_physical_num] -> cost
+    // Lookup table to store the minimum cost for each dx and dy
+    vtr::NdMatrix<util::Cost_Entry, 4> chann_distance_based_min_cost; // [from_layer_num][to_layer_num][dx][dy] -> cost
+    vtr::NdMatrix<util::Cost_Entry, 5> opin_distance_based_min_cost;  // [physical_tile_idx][from_layer_num][to_layer_num][dx][dy] -> cost
+    std::optional<InterposerLookahead> interposer_lookahead_;
+
+    const t_det_routing_arch& det_routing_arch_;
+    bool is_flat_;
+    int route_verbosity_;
+    bool device_model_warnings_;
+    bool has_interposer_cuts_;
+    const float interposer_base_cost_multiplier_;
+
+  protected:
+    float get_expected_cost(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const override;
+    std::pair<float, float> get_expected_delay_and_cong(RRNodeId from_node, RRNodeId to_node, const t_conn_cost_params& params, float R_upstream) const override;
+
+    void compute(const std::vector<t_segment_inf>& segment_inf) override;
+    void compute_intra_tile() override;
+    void read(const std::string& file) override;
+    void read_intra_cluster(const std::string& file) override;
+    void write(const std::string& file_name) const override;
+    void write_intra_cluster(const std::string& file) const override;
+    float get_opin_distance_min_delay(int physical_tile_idx, int from_layer, int to_layer, int dx, int dy) const override;
+};
+
+/**
+ * @brief Provides delay/congestion estimates to travel to a point with a given
+ * x-coordinate, considering only the x component of the route.
+ *
+ * This is a 6D array storing the cost to travel from a node of type CHANX/CHANY/CHANZ
+ * whose x-coordinate is x1, to a point whose x-coordinate is x2, on the "layer_num" layer.
+ *
+ * To store this information:
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number of the target node.
+ * - The third index represents the type of channel (X/Y/Z) that the node under consideration belongs to.
+ * - The forth is the segment type (specified in the architecture file under the "segmentlist" tag).
+ * - The fifth is x1.
+ * - The last one is x2.
+ *
+ * @note [0..num_layers][0..num_layers][0..2][0..num_seg_types-1][0..device_ctx.grid.width()-1][0..device_ctx.grid.width()-1]
+ * - [0..2] entry distinguish between CHANX/CHANY/CHANZ start nodes respectively
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number that the target node is on.
+ */
+typedef vtr::NdMatrix<util::Cost_Entry, 6> t_x_wire_cost_map;
+
+/**
+ * @brief Provides delay/congestion estimates to travel to a point with a given
+ * y-coordinate, considering only the y component of the route.
+ *
+ * This is a 6D array storing the cost to travel from a node of type CHANX/CHANY/CHANZ
+ * whose y-coordinate is y1, to a point whose y-coordinate is y2, on the "layer_num" layer.
+ *
+ * To store this information:
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number of the target node.
+ * - The third index represents the type of channel (X/Y/Z) that the node under consideration belongs to.
+ * - The forth is the segment type (specified in the architecture file under the "segmentlist" tag).
+ * - The fifth is y1.
+ * - The last one is y2.
+ *
+ * @note [0..num_layers][0..num_layers][0..2][0..num_seg_types-1][0..device_ctx.grid.height()-1][0..device_ctx.grid.height()-1]
+ * - [0..2] entry distinguish between CHANX/CHANY/CHANZ start nodes respectively
+ * - The first index is the layer number that the node under consideration is on.
+ * - The second index is the layer number that the target node is on.
+ */
+typedef vtr::NdMatrix<util::Cost_Entry, 6> t_y_wire_cost_map;
+
+void read_router_lookahead_separable(const std::string& file);
+void write_router_lookahead_separable(const std::string& file);


### PR DESCRIPTION
Add a separable router lookahead with different tables for (x1,x2) and (y1,y2). We fallback to the map lookahead when we don't have any samples for a query or for placement delay model related queries. Haven't tested using this for place delay model yet, but I will soon and raise another PR for it.

Also some changes to the lookahead report that i did while developing this. Doesn't really matter for this branch really, didn't feel like spending time to remove the code. Will clean it up for master eventually.