### PR TITLE
[AP][FL][3D] Max Span Calc Fixup

### DIFF
--- a/vpr/src/pack/appack_max_dist_th_manager.cpp
+++ b/vpr/src/pack/appack_max_dist_th_manager.cpp
@@ -24,7 +24,12 @@ void APPackMaxDistThManager::init(const std::vector<std::string>& max_dist_ths,
                                   const DeviceGrid& device_grid) {
     // Compute the max device distance based on the width and height of the
     // device. This is the L1 (manhattan) distance.
-    max_distance_on_device_ = device_grid.width() + device_grid.height();
+    // TODO: These should really be width - 1 and height - 1 since the largest
+    //       span would be (0,0) to (W-1, H-1). Need to update the default values
+    //       accordingly. This would then allow us to clean up the following layers
+    //       code.
+    float layer_span_contr = device_grid.get_num_layers() > 1 ? device_grid.get_num_layers() : 0;
+    max_distance_on_device_ = device_grid.width() + device_grid.height() + layer_span_contr;
 
     // Automatically set the max distance thresholds.
     auto_set_max_distance_thresholds(logical_block_types, device_grid);


### PR DESCRIPTION
The full legalizer uses the maximum span on the device to compute the maximum displacement threshold during packing. This is usually set as a percent of this span.

For 2D architectures, this span is W + H; while for 3D architectures it is W + H + D. I originally forgot this D, and it looks like it actually makes a difference when I observed the results between the interposer and 3D architectures.

Added the number of layers.