### PR TITLE
[Pack] Code cleanup: remove force_site and flat_site_index from pb_graph_node / cluster legalizer

### DIFF
--- a/libs/libarchfpga/src/physical_types.h
+++ b/libs/libarchfpga/src/physical_types.h
@@ -1278,11 +1278,6 @@ struct t_mode_power {
  *      total_primitive_count : Total number of this primitive type in the cluster. If there are 10 ALMs per cluster
  *                              and 2 FFs per ALM (given the mode of the parent of this primitive) then the total is 20.
  *                              This member is only used by nodes corresponding to primitive sites.
- *      flat_site_index       : Index of this primitive site within its primitive type within this cluster type.
- *                              Values are in [0...total_primitive_count-1], e.g. if there are 10 ALMs per cluster, 2 FFS
- *                              and 2 LUTs per ALM, then flat site indices for FFs would run from 0 to 19, and flat site
- *                              indices for LUTs would run from 0 to 19. This member is only used by nodes corresponding
- *                              to primitive sites. It is used when reconstructing clusters from a flat placement file.
  *      illegal_modes         : vector containing illegal modes that result in conflicts during routing
  */
 class t_pb_graph_node {
@@ -1340,7 +1335,6 @@ class t_pb_graph_node {
     std::vector<size_t> output_pin_class_sizes; /* Stores the number of pins in each output pin class indexed by output pin class number */
 
     int total_primitive_count; /* total number of this primitive type in the cluster */
-    int flat_site_index;       /* index of this primitive within sites of its type in this cluster  */
 
     /* Interconnect instances for this pb
      * Only used for power

--- a/vpr/src/base/load_flat_place.cpp
+++ b/vpr/src/base/load_flat_place.cpp
@@ -63,7 +63,6 @@ static void print_flat_cluster(FILE* fp,
                                const vtr::vector_map<ClusterBlockId, t_block_loc>& block_locs,
                                const vtr::vector<ClusterBlockId, std::unordered_set<AtomBlockId>>& atoms_lookup) {
     // Atom context used to get the atom_pb for each atom in the cluster.
-    // NOTE: This is only used for getting the flat site index.
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
     // Get the location of this cluster.

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -245,8 +245,7 @@ static float try_place_molecule(t_intra_cluster_placement_stats* cluster_placeme
 LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> build_primitive_candidate_queue(t_intra_cluster_placement_stats* cluster_placement_stats,
                                                                                                           PackMoleculeId molecule_id,
                                                                                                           std::vector<t_pb_graph_node*>& primitives_list,
-                                                                                                          const Prepacker& prepacker,
-                                                                                                          int force_site) {
+                                                                                                          const Prepacker& prepacker) {
     LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> primitives_alive;
     if (cluster_placement_stats->curr_molecule != molecule_id) {
         // New block, requeue tried primitives and in-flight primitives
@@ -275,11 +274,6 @@ LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> build_
     //        - Lower placement cost is preferred.
     //        - Higher total_primitive_count breaks ties.
     //        - Earlier encountered primitives break remaining ties.
-    //   4. If force_site >= 0:
-    //        - Only the primitive matching flat_site_index == force_site
-    //          is considered.
-    //        - The returned priority queue contains at most one element.
-    //        - If the forced site is infeasible, the returned priority queue is empty.
     // The returned priority queue may be empty if no feasible primitive exists.
 
     // Initialize variables
@@ -298,34 +292,6 @@ LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> build_
                     if (!it->second->valid) {
                         cluster_placement_stats->invalidate_primitive_and_increment_iterator(i, it); //iterator is incremented here
                         continue;
-                    }
-
-                    // Check for force site match, if applicable
-                    if (force_site > -1) {
-                        // Check that the forced site index is within the available range
-                        int max_site = it->second->pb_graph_node->total_primitive_count - 1;
-                        if (force_site > max_site) {
-                            VTR_LOG("The specified primitive site (%d) is out of range (max %d)\n",
-                                    force_site, max_site);
-                            break;
-                        }
-                        if (force_site == it->second->pb_graph_node->flat_site_index) {
-                            cost = try_place_molecule(cluster_placement_stats,
-                                                      molecule_id,
-                                                      it->second->pb_graph_node,
-                                                      primitives_list,
-                                                      prepacker);
-                            primitives_alive.clear();
-                            if (cost < std::numeric_limits<float>::max()) {
-                                int total_primitive_count = it->second->pb_graph_node->total_primitive_count;
-                                primitives_alive.push(it->second->pb_graph_node,
-                                                      std::make_tuple(-cost, total_primitive_count, -encounter_order));
-                            }
-                            return primitives_alive;
-                        } else {
-                            ++it;
-                            continue;
-                        }
                     }
 
                     // Try place molecule at current root location

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -183,10 +183,6 @@ void free_cluster_placement_stats(t_intra_cluster_placement_stats* cluster_place
  * @param prepacker
  *              The prepacker object that provides access to the molecule
  *              corresponding to given molecule id.
- * @param force_site
- *              Optional user-specified primitive site on which to place the molecule; if a force_site
- *              argument is provided, the function either selects the specified site or reports failure.
- *              If the force_site argument is set to its default value (-1), vpr selects an available site.
  *
  * @return A LazyPopUniquePriorityQueue containing feasible primitive root
  *         candidates ordered by placement priority. The queue may be empty
@@ -195,8 +191,7 @@ void free_cluster_placement_stats(t_intra_cluster_placement_stats* cluster_place
 LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> build_primitive_candidate_queue(t_intra_cluster_placement_stats* cluster_placement_stats,
                                                                                                           PackMoleculeId molecule_id,
                                                                                                           std::vector<t_pb_graph_node*>& primitives_list,
-                                                                                                          const Prepacker& prepacker,
-                                                                                                          int force_site = -1);
+                                                                                                          const Prepacker& prepacker);
 
 /**
  * @brief Move a candidate root primitive from the valid set to the in-flight set.

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -43,7 +43,6 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
                                     t_pb_graph_node* parent_pb_graph_node,
                                     t_pb_type* pb_type,
                                     const int index,
-                                    const int flat_index,
                                     bool load_power_structures,
                                     int& pin_count_in_cluster,
                                     int& primitive_num);
@@ -172,11 +171,6 @@ static bool check_input_pins_equivalence(const t_pb_graph_pin* cur_pin,
                                          std::map<int, int>& edges_map,
                                          int* line_num);
 
-/* computes the index of a pb graph node at its level of the pb hierarchy */
-static int compute_flat_index_for_child_node(int num_children_of_type,
-                                             int parent_flat_index,
-                                             int child_index);
-
 /**
  * Allocate memory into types and load the pb graph with interconnect edges
  */
@@ -192,10 +186,9 @@ void alloc_and_load_all_pb_graphs(bool load_power_structures, bool is_flat) {
             int pin_count_in_cluster = 0;
             int primitive_num = 0;
             alloc_and_load_pb_graph(type.pb_graph_head,
-                                    nullptr,
+                                    /*parent_pb_graph_node=*/nullptr,
                                     type.pb_type,
-                                    0,
-                                    0,
+                                    /*index=*/0,
                                     load_power_structures,
                                     pin_count_in_cluster,
                                     primitive_num);
@@ -270,7 +263,6 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
                                     t_pb_graph_node* parent_pb_graph_node,
                                     t_pb_type* pb_type,
                                     const int index,
-                                    const int flat_index,
                                     bool load_power_structures,
                                     int& pin_count_in_cluster,
                                     int& primitive_num) {
@@ -285,7 +277,6 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
     pb_graph_node->num_clock_ports = 0;
 
     pb_graph_node->total_primitive_count = 0;
-    pb_graph_node->flat_site_index = 0;
 
     /* Generate ports for pb graph node */
     for (i = 0; i < pb_type->num_ports; i++) {
@@ -406,12 +397,10 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
             int num_children_of_type = pb_type->modes[i].pb_type_children[j].num_pb;
 
             for (k = 0; k < num_children_of_type; k++) {
-                int child_flat_index = compute_flat_index_for_child_node(num_children_of_type, flat_index, k);
                 alloc_and_load_pb_graph(&pb_graph_node->child_pb_graph_nodes[i][j][k],
                                         pb_graph_node,
                                         &pb_type->modes[i].pb_type_children[j],
                                         k,
-                                        child_flat_index,
                                         load_power_structures,
                                         pin_count_in_cluster,
                                         primitive_num);
@@ -439,10 +428,6 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
             pb_node = pb_node->parent_pb_graph_node;
         }
         pb_graph_node->total_primitive_count = total_count;
-
-        // if this is a primitive, then flat_index corresponds
-        // to its index within all primitives of this type
-        pb_graph_node->flat_site_index = flat_index;
     }
 }
 
@@ -1928,23 +1913,4 @@ const t_pb_graph_edge* get_edge_between_pins(const t_pb_graph_pin* driver_pin, c
     }
 
     return nullptr;
-}
-
-/* Date:June 8th, 2024
- * Author: Kate Thurmer
- * Purpose: This subroutine computes the index of a pb graph node at its
- *          level of the pb hierarchy; it is computed by the parent and
- *          passed to each child of each child pb type. When the child is
- *          a primitive, the computed index is its flat site index.
- *          For example, if there are 10 ALMs, each with 2 FFs and 2 LUTs,
- *          then the ALM at index N, when calling this function for
- *          its FF child at index M, would compute the child's index as:
- *          N*(FFs per ALM) + M
- *          e.g. for FF[1] in ALM[5], this returns
- *          5*(2 FFS per ALM) + 1 = 11
- */
-static int compute_flat_index_for_child_node(int num_children_of_type,
-                                             int parent_flat_index,
-                                             int child_index) {
-    return parent_flat_index * num_children_of_type + child_index;
 }


### PR DESCRIPTION
See #3694 for the related issue. 

Removes the dead force_site / flat_site_index code from the packer

The flat_site_index was originally added for flat placement reconstruction. The new version of reconstruction flow (flat-recon) does not use the flat site index and flat site index information has already been dropped from the FlatPlacementInfo and  from [flat placement file format](https://docs.verilogtorouting.org/en/latest/vpr/file_formats/#flat-placement-file-format-fplace) as well. If a user wants to assign an atom to a specific primitive site, they can use the [logic block location option](https://docs.verilogtorouting.org/en/latest/vpr/placement_constraints/#logical-block-location).