### PR TITLE
[AP][FL] Predict the Density of Packing Required

### DIFF
--- a/vpr/src/analytical_place/analytical_placement_flow.cpp
+++ b/vpr/src/analytical_place/analytical_placement_flow.cpp
@@ -250,7 +250,8 @@ void run_analytical_placement_flow(t_vpr_setup& vpr_setup) {
     // that downstream stages (e.g. RAM mapper, global placement) can query realistic
     // device dimensions before packing. The packer may later grow or shrink the device
     // size to match the actual resource requirements after packing completes.
-    DeviceSizeEstimator device_size_estimator(vpr_setup, *device_ctx.arch, prepacker);
+    DeviceSizeEstimator device_size_estimator(vpr_setup, *device_ctx.arch, prepacker,
+                                              /*always_estimate_resource_requirement=*/ap_opts.full_legalizer_type == e_ap_full_legalizer::APPack);
 
     // Infer logical RAMs and assign to physical types to prioritize during packing.
     // For the auto-device flow, reuse the groups already computed by the estimator.
@@ -326,7 +327,8 @@ void run_analytical_placement_flow(t_vpr_setup& vpr_setup) {
                                                                         ram_mapper,
                                                                         vpr_setup,
                                                                         *device_ctx.arch,
-                                                                        device_ctx.grid);
+                                                                        device_ctx.grid,
+                                                                        device_size_estimator.estimated_type_instance_counts());
     full_legalizer->legalize(p_placement);
 
     // Print the number of resources in netlist and number of resources available in architecture

--- a/vpr/src/analytical_place/full_legalization/full_legalizer.cpp
+++ b/vpr/src/analytical_place/full_legalization/full_legalizer.cpp
@@ -71,7 +71,8 @@ std::unique_ptr<FullLegalizer> make_full_legalizer(e_ap_full_legalizer full_lega
                                                    const RamMapper& ram_mapper,
                                                    const t_vpr_setup& vpr_setup,
                                                    const t_arch& arch,
-                                                   const DeviceGrid& device_grid) {
+                                                   const DeviceGrid& device_grid,
+                                                   const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts) {
     switch (full_legalizer_type) {
         case e_ap_full_legalizer::Naive:
             return std::make_unique<NaiveFullLegalizer>(ap_netlist,
@@ -81,7 +82,8 @@ std::unique_ptr<FullLegalizer> make_full_legalizer(e_ap_full_legalizer full_lega
                                                         ram_mapper,
                                                         vpr_setup,
                                                         arch,
-                                                        device_grid);
+                                                        device_grid,
+                                                        estimated_type_instance_counts);
         case e_ap_full_legalizer::APPack:
             return std::make_unique<APPack>(ap_netlist,
                                             atom_netlist,
@@ -90,7 +92,8 @@ std::unique_ptr<FullLegalizer> make_full_legalizer(e_ap_full_legalizer full_lega
                                             ram_mapper,
                                             vpr_setup,
                                             arch,
-                                            device_grid);
+                                            device_grid,
+                                            estimated_type_instance_counts);
         case e_ap_full_legalizer::FlatRecon:
             return std::make_unique<FlatRecon>(ap_netlist,
                                                atom_netlist,
@@ -99,7 +102,8 @@ std::unique_ptr<FullLegalizer> make_full_legalizer(e_ap_full_legalizer full_lega
                                                ram_mapper,
                                                vpr_setup,
                                                arch,
-                                               device_grid);
+                                               device_grid,
+                                               estimated_type_instance_counts);
         default:
             VPR_FATAL_ERROR(VPR_ERROR_AP,
                             "Unrecognized full legalizer type");
@@ -1301,7 +1305,8 @@ void APPack::legalize(const PartialPlacement& p_placement) {
                  pre_cluster_timing_manager_,
                  flat_placement_info,
                  vpr_setup_,
-                 ram_mapper_);
+                 ram_mapper_,
+                 estimated_type_instance_counts_);
     }
 
     // The Packer stores the clusters into a .net file. Load the packing file.

--- a/vpr/src/analytical_place/full_legalization/full_legalizer.h
+++ b/vpr/src/analytical_place/full_legalization/full_legalizer.h
@@ -8,6 +8,7 @@
  *          routed by VTR.
  */
 
+#include <map>
 #include <memory>
 #include <unordered_set>
 #include "ap_flow_enums.h"
@@ -24,7 +25,9 @@ class PreClusterTimingManager;
 class Prepacker;
 class RamMapper;
 struct t_arch;
+struct t_logical_block_type;
 struct t_vpr_setup;
+using t_logical_block_type_ptr = const t_logical_block_type*;
 
 /**
  * @brief The full legalizer in an AP flow
@@ -44,7 +47,8 @@ class FullLegalizer {
                   const RamMapper& ram_mapper,
                   const t_vpr_setup& vpr_setup,
                   const t_arch& arch,
-                  const DeviceGrid& device_grid)
+                  const DeviceGrid& device_grid,
+                  const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts)
         : ap_netlist_(ap_netlist)
         , atom_netlist_(atom_netlist)
         , prepacker_(prepacker)
@@ -52,7 +56,8 @@ class FullLegalizer {
         , ram_mapper_(ram_mapper)
         , vpr_setup_(vpr_setup)
         , arch_(arch)
-        , device_grid_(device_grid) {}
+        , device_grid_(device_grid)
+        , estimated_type_instance_counts_(estimated_type_instance_counts) {}
 
     /**
      * @brief Perform legalization on the given partial placement solution
@@ -101,6 +106,12 @@ class FullLegalizer {
 
     /// @brief The device grid which records where clusters can be placed.
     const DeviceGrid& device_grid_;
+
+    /// @brief Estimated number of instances required for each logical block
+    ///        type, computed before packing (see DeviceSizeEstimator). Used
+    ///        by APPack to decide, per block type, whether unrelated
+    ///        clustering should be enabled from the start.
+    const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts_;
 };
 
 /**
@@ -114,7 +125,8 @@ std::unique_ptr<FullLegalizer> make_full_legalizer(e_ap_full_legalizer full_lega
                                                    const RamMapper& ram_mapper,
                                                    const t_vpr_setup& vpr_setup,
                                                    const t_arch& arch,
-                                                   const DeviceGrid& device_grid);
+                                                   const DeviceGrid& device_grid,
+                                                   const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts);
 
 /**
  * @brief FlatRecon: The Flat Placement Reconstruction Full Legalizer.

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -754,7 +754,8 @@ bool vpr_pack(t_vpr_setup& vpr_setup, const t_arch& arch) {
     // that downstream stages (e.g. RAM mapper) can query realistic device
     // dimensions before packing. The packer may later grow or shrink the device
     // size to match the actual resource requirements after packing completes.
-    DeviceSizeEstimator device_size_estimator(vpr_setup, arch, prepacker);
+    DeviceSizeEstimator device_size_estimator(vpr_setup, arch, prepacker,
+                                              /*always_estimate_resource_requirement=*/g_vpr_ctx.atom().flat_placement_info().valid);
 
     // Infer logical RAMs and assign to physical types to prioritize during packing.
     // For the auto-device flow, reuse the groups already computed by the estimator.
@@ -775,7 +776,8 @@ bool vpr_pack(t_vpr_setup& vpr_setup, const t_arch& arch) {
                     pre_cluster_timing_manager,
                     g_vpr_ctx.atom().flat_placement_info(),
                     vpr_setup,
-                    ram_mapper);
+                    ram_mapper,
+                    device_size_estimator.estimated_type_instance_counts());
 }
 
 void vpr_load_packing(const t_vpr_setup& vpr_setup, const t_arch& arch) {

--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -7,7 +7,6 @@
  *          thresholding optimization used within APPack.
  */
 
-#include <algorithm>
 #include <string>
 #include <vector>
 #include "physical_types.h"
@@ -45,7 +44,7 @@ class APPackMaxDistThManager {
 
     // Logic blocks (such as CLBs and LABs) tend to have more resources on the
     // device, thus they have tighter thresholds. This was found to work well.
-    static constexpr float logic_block_max_dist_th_scale_ = 0.05f;
+    static constexpr float logic_block_max_dist_th_scale_ = 0.02f;
     static constexpr float logic_block_max_dist_th_offset_ = 10.0f;
 
     // Memory blocks (i.e. blocks that contain pb_types of the memory class)
@@ -65,22 +64,6 @@ class APPackMaxDistThManager {
     // logical block type. Increasing this value will reduce the number of fallbacks
     // but may yield worse quality. This is expected to be a number larger than 0.
     static constexpr float max_dist_th_fail_increase_scale = 10.0f;
-
-    // Before packing begins, a pre-packing density estimate may predict that a
-    // logical block type will not fit densely enough on the device (i.e. its
-    // estimated utilization -- estimated instances needed divided by instances
-    // available on the device -- is above 1.0). In that case, the max distance
-    // threshold for that type is scaled up towards this multiple of its normal
-    // (auto-computed) threshold, the amount of scaling depending on how far over
-    // capacity the type looks. See get_utilization_scaled_max_dist_threshold().
-    static constexpr float max_dist_th_utilization_scale_multiplier_ = 4.0f;
-
-    // Estimated utilization (see above) at or above which a logical block type
-    // is considered severely over capacity: widening the max distance threshold
-    // alone is not expected to be enough, so unrelated clustering should also be
-    // used for that type. Below this cutoff, only the max distance threshold is
-    // scaled up (a lighter touch than unrelated clustering).
-    static constexpr float severe_utilization_cutoff_ = 1.5f;
 
   public:
     APPackMaxDistThManager() = default;
@@ -135,51 +118,6 @@ class APPackMaxDistThManager {
                             "Logical block type does not have a max distance threshold");
 
         logical_block_dist_thresholds_[logical_block_ty.index] = new_threshold;
-    }
-
-    /**
-     * @brief Given a logical block type's estimated utilization (estimated
-     *        instances needed divided by instances available on the device),
-     *        returns a max distance threshold scaled up from the type's
-     *        current threshold, interpolating towards
-     *        max_dist_th_utilization_scale_multiplier_ times that threshold
-     *        as utilization approaches severe_utilization_cutoff_.
-     *
-     *        Intended to be called once before packing begins, using a
-     *        pre-packing density estimate, to preemptively widen the
-     *        candidate search radius for block types that look tight -- a
-     *        lighter touch than falling back to unrelated clustering.
-     *
-     *  @param logical_block_ty
-     *      The logical block type whose threshold is being scaled.
-     *  @param utilization
-     *      Estimated instances needed for this type divided by instances
-     *      available on the device. Values <= 1.0 return the threshold
-     *      unchanged.
-     *  @return
-     *      The scaled max distance threshold. Once utilization reaches
-     *      severe_utilization_cutoff_, this saturates at the ceiling value;
-     *      see is_utilization_severe().
-     */
-    inline float get_utilization_scaled_max_dist_threshold(const t_logical_block_type& logical_block_ty,
-                                                            float utilization) const {
-        float base_th = get_max_dist_threshold(logical_block_ty);
-        if (utilization <= 1.0f)
-            return base_th;
-
-        float ceiling_th = base_th * max_dist_th_utilization_scale_multiplier_;
-        float overage_fraction = std::min((utilization - 1.0f) / (severe_utilization_cutoff_ - 1.0f), 1.0f);
-        return base_th + overage_fraction * (ceiling_th - base_th);
-    }
-
-    /**
-     * @brief Returns true if the given estimated utilization is high enough
-     *        that get_utilization_scaled_max_dist_threshold() has saturated
-     *        at its ceiling, meaning unrelated clustering should also be
-     *        used for the corresponding block type.
-     */
-    inline bool is_utilization_severe(float utilization) const {
-        return utilization >= severe_utilization_cutoff_;
     }
 
   private:

--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -7,6 +7,7 @@
  *          thresholding optimization used within APPack.
  */
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include "physical_types.h"
@@ -44,7 +45,7 @@ class APPackMaxDistThManager {
 
     // Logic blocks (such as CLBs and LABs) tend to have more resources on the
     // device, thus they have tighter thresholds. This was found to work well.
-    static constexpr float logic_block_max_dist_th_scale_ = 0.08f;
+    static constexpr float logic_block_max_dist_th_scale_ = 0.05f;
     static constexpr float logic_block_max_dist_th_offset_ = 10.0f;
 
     // Memory blocks (i.e. blocks that contain pb_types of the memory class)
@@ -64,6 +65,22 @@ class APPackMaxDistThManager {
     // logical block type. Increasing this value will reduce the number of fallbacks
     // but may yield worse quality. This is expected to be a number larger than 0.
     static constexpr float max_dist_th_fail_increase_scale = 10.0f;
+
+    // Before packing begins, a pre-packing density estimate may predict that a
+    // logical block type will not fit densely enough on the device (i.e. its
+    // estimated utilization -- estimated instances needed divided by instances
+    // available on the device -- is above 1.0). In that case, the max distance
+    // threshold for that type is scaled up towards this multiple of its normal
+    // (auto-computed) threshold, the amount of scaling depending on how far over
+    // capacity the type looks. See get_utilization_scaled_max_dist_threshold().
+    static constexpr float max_dist_th_utilization_scale_multiplier_ = 4.0f;
+
+    // Estimated utilization (see above) at or above which a logical block type
+    // is considered severely over capacity: widening the max distance threshold
+    // alone is not expected to be enough, so unrelated clustering should also be
+    // used for that type. Below this cutoff, only the max distance threshold is
+    // scaled up (a lighter touch than unrelated clustering).
+    static constexpr float severe_utilization_cutoff_ = 1.5f;
 
   public:
     APPackMaxDistThManager() = default;
@@ -118,6 +135,51 @@ class APPackMaxDistThManager {
                             "Logical block type does not have a max distance threshold");
 
         logical_block_dist_thresholds_[logical_block_ty.index] = new_threshold;
+    }
+
+    /**
+     * @brief Given a logical block type's estimated utilization (estimated
+     *        instances needed divided by instances available on the device),
+     *        returns a max distance threshold scaled up from the type's
+     *        current threshold, interpolating towards
+     *        max_dist_th_utilization_scale_multiplier_ times that threshold
+     *        as utilization approaches severe_utilization_cutoff_.
+     *
+     *        Intended to be called once before packing begins, using a
+     *        pre-packing density estimate, to preemptively widen the
+     *        candidate search radius for block types that look tight -- a
+     *        lighter touch than falling back to unrelated clustering.
+     *
+     *  @param logical_block_ty
+     *      The logical block type whose threshold is being scaled.
+     *  @param utilization
+     *      Estimated instances needed for this type divided by instances
+     *      available on the device. Values <= 1.0 return the threshold
+     *      unchanged.
+     *  @return
+     *      The scaled max distance threshold. Once utilization reaches
+     *      severe_utilization_cutoff_, this saturates at the ceiling value;
+     *      see is_utilization_severe().
+     */
+    inline float get_utilization_scaled_max_dist_threshold(const t_logical_block_type& logical_block_ty,
+                                                            float utilization) const {
+        float base_th = get_max_dist_threshold(logical_block_ty);
+        if (utilization <= 1.0f)
+            return base_th;
+
+        float ceiling_th = base_th * max_dist_th_utilization_scale_multiplier_;
+        float overage_fraction = std::min((utilization - 1.0f) / (severe_utilization_cutoff_ - 1.0f), 1.0f);
+        return base_th + overage_fraction * (ceiling_th - base_th);
+    }
+
+    /**
+     * @brief Returns true if the given estimated utilization is high enough
+     *        that get_utilization_scaled_max_dist_threshold() has saturated
+     *        at its ceiling, meaning unrelated clustering should also be
+     *        used for the corresponding block type.
+     */
+    inline bool is_utilization_severe(float utilization) const {
+        return utilization >= severe_utilization_cutoff_;
     }
 
   private:

--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -45,7 +45,7 @@ class APPackMaxDistThManager {
     // Logic blocks (such as CLBs and LABs) tend to have more resources on the
     // device, thus they have tighter thresholds. This was found to work well.
     static constexpr float logic_block_max_dist_th_scale_ = 0.02f;
-    static constexpr float logic_block_max_dist_th_offset_ = 10.0f;
+    static constexpr float logic_block_max_dist_th_offset_ = 5.0f;
 
     // Memory blocks (i.e. blocks that contain pb_types of the memory class)
     // seem to have very touchy packing; thus these do not have the max

--- a/vpr/src/pack/appack_unrelated_clustering_manager.h
+++ b/vpr/src/pack/appack_unrelated_clustering_manager.h
@@ -61,7 +61,7 @@ class APPackUnrelatedClusteringManager {
     // Logic blocks (such as CLBs and LABs) were found to benefit from a larger
     // search distance and number of attempts than the default. These numbers
     // were found empirically to work well.
-    static constexpr float logic_block_max_unrelated_tile_distance_ = 2.0f;
+    static constexpr float logic_block_max_unrelated_tile_distance_ = 4.0f;
     static constexpr int logic_block_max_unrelated_clustering_attempts_ = 1;
 
   public:

--- a/vpr/src/pack/device_size_estimate.cpp
+++ b/vpr/src/pack/device_size_estimate.cpp
@@ -252,14 +252,16 @@ static bool primitive_has_external_output(const t_pb_graph_node* prim) {
     return false;
 }
 
-std::map<t_logical_block_type_ptr, size_t> DeviceSizeEstimator::estimate_resource_requirement(const Prepacker& prepacker) {
+std::map<t_logical_block_type_ptr, size_t> DeviceSizeEstimator::estimate_resource_requirement(const Prepacker& prepacker, bool store_ram_groups) {
     vtr::ScopedStartFinishTimer timer("Estimate Resource Requirement");
     const auto& atom_ctx = g_vpr_ctx.atom();
 
     // Group RAM atoms and assign to minimum-area types.
-    // Results are stored in ram_groups_ for later use by RamMapper.
-    ram_groups_ = group_ram_atoms(atom_ctx.netlist(), prepacker);
-    assign_ram_groups_by_min_area(ram_groups_, false /*is_fixed_device*/);
+    // If requested, results are stored in ram_groups_ for later use by RamMapper.
+    vtr::vector<LogicalRamGroupId, LogicalRamGroup> ram_groups = group_ram_atoms(atom_ctx.netlist(), prepacker);
+    assign_ram_groups_by_min_area(ram_groups, false /*is_fixed_device*/);
+    if (store_ram_groups)
+        ram_groups_ = ram_groups;
 
     // Group non-RAM molecules by their logical block type.
     vtr::vector<LogicalModelId, std::vector<t_logical_block_type_ptr>>
@@ -306,8 +308,8 @@ std::map<t_logical_block_type_ptr, size_t> DeviceSizeEstimator::estimate_resourc
     }
 
     // Estimate instance counts for RAM types using logical RAM groups.
-    for (LogicalRamGroupId ram_group_id : ram_groups_.keys()) {
-        const LogicalRamGroup& ram_group = ram_groups_[ram_group_id];
+    for (LogicalRamGroupId ram_group_id : ram_groups.keys()) {
+        const LogicalRamGroup& ram_group = ram_groups[ram_group_id];
         t_logical_block_type_ptr logical_type = ram_group.pre_assigned_type ? ram_group.pre_assigned_type : ram_group.candidate_types[0];
         size_t inferred_number_of_instances = std::ceil(vtr::safe_ratio<float>(ram_group.total_memory_slices, ram_group.candidate_capacity.at(logical_type)));
         num_type_instances[logical_type] += inferred_number_of_instances;
@@ -378,7 +380,8 @@ static std::pair<size_t, size_t> read_rr_graph_grid_dims(const std::string& file
 
 DeviceSizeEstimator::DeviceSizeEstimator(t_vpr_setup& vpr_setup,
                                          const t_arch& arch,
-                                         const Prepacker& prepacker) {
+                                         const Prepacker& prepacker,
+                                         bool always_estimate_resource_requirement) {
     vtr::ScopedStartFinishTimer timer("Estimate Device Size");
     const std::string& device_layout = vpr_setup.PackerOpts.device_layout;
     const t_packer_opts& packer_opts = vpr_setup.PackerOpts;
@@ -416,6 +419,8 @@ DeviceSizeEstimator::DeviceSizeEstimator(t_vpr_setup& vpr_setup,
         // resizing during and after packing.
         device_ctx.grid = create_device_grid(device_layout, arch.grid_layouts, width, height);
         device_ctx.grid.set_fixed_by_rr_graph(true);
+        if (always_estimate_resource_requirement)
+            estimated_num_type_instances_ = estimate_resource_requirement(prepacker, /*store_ram_groups=*/false);
         return;
     }
 
@@ -426,6 +431,8 @@ DeviceSizeEstimator::DeviceSizeEstimator(t_vpr_setup& vpr_setup,
         device_ctx.grid = create_device_grid(device_layout, arch.grid_layouts,
                                              num_type_instances,
                                              packer_opts.target_device_utilization);
+        if (always_estimate_resource_requirement)
+            estimated_num_type_instances_ = estimate_resource_requirement(prepacker, /*store_ram_groups=*/false);
         return;
     }
 
@@ -437,12 +444,15 @@ DeviceSizeEstimator::DeviceSizeEstimator(t_vpr_setup& vpr_setup,
                                              {}, packer_opts.target_device_utilization,
                                              vpr_setup.device_width);
         report_device_grid_stats(device_ctx.grid);
+        if (always_estimate_resource_requirement)
+            estimated_num_type_instances_ = estimate_resource_requirement(prepacker, /*store_ram_groups=*/false);
         return;
     }
 
     VTR_LOG("Device layout '%s' selected. Need to estimate device size.\n", device_layout.c_str());
 
     std::map<t_logical_block_type_ptr, size_t> num_type_instances = estimate_resource_requirement(prepacker);
+    estimated_num_type_instances_ = num_type_instances;
     VTR_LOG("Estimated resource requirements:\n");
     for (auto& [type_ptr, count] : num_type_instances)
         VTR_LOG("  %s: %zu requested instances\n", type_ptr->name.c_str(), count);

--- a/vpr/src/pack/device_size_estimate.h
+++ b/vpr/src/pack/device_size_estimate.h
@@ -83,7 +83,8 @@ class DeviceSizeEstimator {
      * @return Map from logical block type to estimated cluster instance count.
      */
     std::map<t_logical_block_type_ptr, size_t> estimate_resource_requirement(
-        const Prepacker& prepacker, bool store_ram_groups = true);
+        const Prepacker& prepacker,
+        bool store_ram_groups = true);
 
     /// @brief RAM groups computed during estimation; exposed via ram_groups()
     ///        for reuse by RamMapper to avoid redundant grouping and area assignment.

--- a/vpr/src/pack/device_size_estimate.h
+++ b/vpr/src/pack/device_size_estimate.h
@@ -32,9 +32,20 @@ struct t_vpr_setup;
  */
 class DeviceSizeEstimator {
   public:
+    /**
+     * @param always_estimate_resource_requirement
+     *      If true, the resource requirement estimate (see
+     *      estimated_type_instance_counts()) is computed even when the
+     *      device size itself does not need estimating (fixed device layout,
+     *      RR graph provided, or auto layout with a fixed width). Defaults to
+     *      false since this estimate involves a mini-packing simulation, and
+     *      most callers only need the device grid sized, not the raw
+     *      per-type estimate.
+     */
     DeviceSizeEstimator(t_vpr_setup& vpr_setup,
                         const t_arch& arch,
-                        const Prepacker& prepacker);
+                        const Prepacker& prepacker,
+                        bool always_estimate_resource_requirement = false);
 
     /// @brief Returns the RAM groups computed during estimation.
     ///        Empty if the device layout was fixed (no estimation needed).
@@ -42,22 +53,43 @@ class DeviceSizeEstimator {
         return ram_groups_;
     }
 
+    /// @brief Returns the estimated number of instances required for each
+    ///        logical block type, computed during device size estimation.
+    ///        Empty unless estimation was performed (device layout was
+    ///        "auto" with no fixed width, or always_estimate_resource_requirement
+    ///        was set to true in the constructor).
+    const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts() const {
+        return estimated_num_type_instances_;
+    }
+
   private:
     /**
      * @brief Estimates the number of instances required for each logical block
      *        type to fit the design.
      *
-     * Groups RAM atoms, assigns them to minimum-area types (stored in
-     * ram_groups_ for RamMapper), and runs a mini-packing simulation for
-     * non-RAM types using pin capacity and cluster placement feasibility
-     * constraints to get required number of instances for each type.
+     * Groups RAM atoms, assigns them to minimum-area types, and runs a
+     * mini-packing simulation for non-RAM types using pin capacity and
+     * cluster placement feasibility constraints to get required number of
+     * instances for each type.
      *
+     * @param prepacker
+     *      Used to query molecule structure and placement feasibility.
+     * @param store_ram_groups
+     *      If true, the RAM groups computed as part of this estimate are
+     *      published to ram_groups_ for reuse by RamMapper. Callers that
+     *      only want the type instance estimate (e.g. for a fixed device,
+     *      where RamMapper must instead do its own capacity-aware grouping)
+     *      should pass false so ram_groups() is left untouched.
      * @return Map from logical block type to estimated cluster instance count.
      */
     std::map<t_logical_block_type_ptr, size_t> estimate_resource_requirement(
-        const Prepacker& prepacker);
+        const Prepacker& prepacker, bool store_ram_groups = true);
 
     /// @brief RAM groups computed during estimation; exposed via ram_groups()
     ///        for reuse by RamMapper to avoid redundant grouping and area assignment.
     vtr::vector<LogicalRamGroupId, LogicalRamGroup> ram_groups_;
+
+    /// @brief Estimated cluster instance counts per logical block type;
+    ///        exposed via estimated_type_instance_counts().
+    std::map<t_logical_block_type_ptr, size_t> estimated_num_type_instances_;
 };

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -1,6 +1,7 @@
 
 #include "pack.h"
 
+#include <algorithm>
 #include <unordered_set>
 #include "PreClusterTimingManager.h"
 #include "device_grid.h"
@@ -344,7 +345,28 @@ bool try_pack(const t_packer_opts& packer_opts,
     // clustering, since widening the threshold alone is not expected to be
     // enough -- unrelated clustering has a real quality cost, so we only pay
     // it for the block type(s) that actually need it.
+    //
+    // TODO: These are tuning knobs; expect to adjust them as more benchmarks
+    //       are evaluated.
+    //  - kMinUtilizationForThresholdBump: AP's clustering tends to come out
+    //    around 10% less dense than the pre-packing estimate predicts, so
+    //    start widening the max distance threshold once the estimate is
+    //    within 10% of a type's capacity, rather than waiting until the
+    //    estimate actually predicts an overflow.
+    //  - kMaxDistThUtilizationScaleMultiplier: a type's max distance
+    //    threshold is linearly scaled from 1x (at
+    //    kMinUtilizationForThresholdBump) up to this multiple of its normal
+    //    (auto-computed) value (at kSevereUtilizationCutoff).
+    //  - kSevereUtilizationCutoff: estimated utilization (estimated
+    //    instances needed / instances available) at or above which a type is
+    //    considered severely over capacity: widening the threshold alone is
+    //    not expected to be enough, so unrelated clustering is also used for
+    //    that type.
     if (appack_ctx.appack_options.use_appack && packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
+        constexpr float kMinUtilizationForThresholdBump = 0.9f;
+        constexpr float kMaxDistThUtilizationScaleMultiplier = 5.0f;
+        constexpr float kSevereUtilizationCutoff = 1.2f;
+
         std::unordered_set<t_logical_block_type_ptr> severe_block_types;
         bool any_type_needs_denser_packing = false;
         for (const t_logical_block_type& type : device_ctx.logical_block_types) {
@@ -358,23 +380,34 @@ bool try_pack(const t_packer_opts& packer_opts,
             auto itr = estimated_type_instance_counts.find(&type);
             size_t estimated_instances = (itr != estimated_type_instance_counts.end()) ? itr->second : 0;
 
-            if (estimated_instances <= num_total_instances)
-                continue; // Estimate predicts this type comfortably fits; leave its settings untouched.
-
-            any_type_needs_denser_packing = true;
-
             if (num_total_instances == 0) {
+                if (estimated_instances == 0)
+                    continue; // Nothing of this type needed; leave untouched.
                 // No capacity at all for this type on the device; widening the
                 // search radius cannot help, so go straight to unrelated clustering.
+                any_type_needs_denser_packing = true;
                 severe_block_types.insert(&type);
                 continue;
             }
 
             float utilization = static_cast<float>(estimated_instances) / static_cast<float>(num_total_instances);
-            float new_max_dist_th = appack_ctx.max_distance_threshold_manager.get_utilization_scaled_max_dist_threshold(type, utilization);
-            appack_ctx.max_distance_threshold_manager.set_max_dist_threshold(type, new_max_dist_th);
+            if (utilization < kMinUtilizationForThresholdBump)
+                continue; // Comfortably fits, even accounting for AP packing less densely than estimated.
 
-            if (appack_ctx.max_distance_threshold_manager.is_utilization_severe(utilization))
+            any_type_needs_denser_packing = true;
+
+            // Linearly scale the multiplier applied to this type's normal max
+            // distance threshold from 1x to kMaxDistThUtilizationScaleMultiplier
+            // as utilization goes from kMinUtilizationForThresholdBump to
+            // kSevereUtilizationCutoff.
+            float utilization_clamped = std::min(utilization, kSevereUtilizationCutoff);
+            float th_multiplier = 1.0f + (utilization_clamped - kMinUtilizationForThresholdBump)
+                                              / (kSevereUtilizationCutoff - kMinUtilizationForThresholdBump)
+                                              * (kMaxDistThUtilizationScaleMultiplier - 1.0f);
+            float base_max_dist_th = appack_ctx.max_distance_threshold_manager.get_max_dist_threshold(type);
+            appack_ctx.max_distance_threshold_manager.set_max_dist_threshold(type, base_max_dist_th * th_multiplier);
+
+            if (utilization >= kSevereUtilizationCutoff)
                 severe_block_types.insert(&type);
         }
 

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -384,9 +384,7 @@ bool try_pack(const t_packer_opts& packer_opts,
             // as utilization goes from kMinUtilizationForThresholdBump to
             // kSevereUtilizationCutoff.
             float utilization_clamped = std::min(utilization, kSevereUtilizationCutoff);
-            float th_multiplier = 1.0f + (utilization_clamped - kMinUtilizationForThresholdBump)
-                                              / (kSevereUtilizationCutoff - kMinUtilizationForThresholdBump)
-                                              * (kMaxDistThUtilizationScaleMultiplier - 1.0f);
+            float th_multiplier = 1.0f + (utilization_clamped - kMinUtilizationForThresholdBump) / (kSevereUtilizationCutoff - kMinUtilizationForThresholdBump) * (kMaxDistThUtilizationScaleMultiplier - 1.0f);
             float base_max_dist_th = appack_ctx.max_distance_threshold_manager.get_max_dist_threshold(type);
             appack_ctx.max_distance_threshold_manager.set_max_dist_threshold(type, base_max_dist_th * th_multiplier);
 

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -335,16 +335,18 @@ bool try_pack(const t_packer_opts& packer_opts,
                              device_ctx.logical_block_types,
                              device_ctx.grid);
 
-    // For APPack, we do a low-effort unrelated clustering for block types
-    // that the pre-packing device size estimate predicts will not fit
-    // densely enough on the device. We found that this can increase density
-    // in a way that better matches how a traditional flow may pack; but with
-    // improved spatial awareness. We only want to pay this quality cost for
-    // block types that actually look tight, so types the estimate does not
-    // flag are left at their normal (higher quality) settings on this first
-    // attempt.
+    // For APPack, use the pre-packing device size estimate to react, per block
+    // type, to types that look like they will not fit densely enough on the
+    // device. This is a graduated response: mild overage (estimated instances
+    // a bit above what's available) just widens that type's max candidate
+    // distance threshold, which finds related candidates a bit further away.
+    // Severe overage additionally falls back to low-effort unrelated
+    // clustering, since widening the threshold alone is not expected to be
+    // enough -- unrelated clustering has a real quality cost, so we only pay
+    // it for the block type(s) that actually need it.
     if (appack_ctx.appack_options.use_appack && packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
-        std::unordered_set<t_logical_block_type_ptr> tight_block_types;
+        std::unordered_set<t_logical_block_type_ptr> severe_block_types;
+        bool any_type_needs_denser_packing = false;
         for (const t_logical_block_type& type : device_ctx.logical_block_types) {
             if (is_empty_type(&type))
                 continue;
@@ -356,26 +358,46 @@ bool try_pack(const t_packer_opts& packer_opts,
             auto itr = estimated_type_instance_counts.find(&type);
             size_t estimated_instances = (itr != estimated_type_instance_counts.end()) ? itr->second : 0;
 
-            if (estimated_instances > num_total_instances)
-                tight_block_types.insert(&type);
+            if (estimated_instances <= num_total_instances)
+                continue; // Estimate predicts this type comfortably fits; leave its settings untouched.
+
+            any_type_needs_denser_packing = true;
+
+            if (num_total_instances == 0) {
+                // No capacity at all for this type on the device; widening the
+                // search radius cannot help, so go straight to unrelated clustering.
+                severe_block_types.insert(&type);
+                continue;
+            }
+
+            float utilization = static_cast<float>(estimated_instances) / static_cast<float>(num_total_instances);
+            float new_max_dist_th = appack_ctx.max_distance_threshold_manager.get_utilization_scaled_max_dist_threshold(type, utilization);
+            appack_ctx.max_distance_threshold_manager.set_max_dist_threshold(type, new_max_dist_th);
+
+            if (appack_ctx.max_distance_threshold_manager.is_utilization_severe(utilization))
+                severe_block_types.insert(&type);
         }
 
-        if (!tight_block_types.empty()) {
+        if (any_type_needs_denser_packing) {
+            VTR_LOG("Device size estimate predicts a tight packing; increased the max candidate distance threshold for the affected block type(s).\n");
+        }
+
+        if (!severe_block_types.empty()) {
             allow_unrelated_clustering = true;
 
             // Restrict unrelated clustering to only the block types the
-            // estimate flagged as tight; other types keep their default
-            // (higher quality) unrelated clustering settings off.
+            // estimate flagged as severely tight; other types keep their
+            // default (higher quality) unrelated clustering settings off.
             for (const t_logical_block_type& type : device_ctx.logical_block_types) {
                 if (is_empty_type(&type))
                     continue;
-                if (!tight_block_types.count(&type))
+                if (!severe_block_types.count(&type))
                     appack_ctx.unrelated_clustering_manager.set_max_unrelated_clustering_attempts(type, 0);
             }
 
-            VTR_LOG("Device size estimate predicts a tight packing for block type(s): ");
+            VTR_LOG("Device size estimate predicts a severe overage for block type(s): ");
             bool first = true;
-            for (t_logical_block_type_ptr type : tight_block_types) {
+            for (t_logical_block_type_ptr type : severe_block_types) {
                 VTR_LOG("%s%s", first ? "" : ", ", type->name.c_str());
                 first = false;
             }

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -345,26 +345,9 @@ bool try_pack(const t_packer_opts& packer_opts,
     // clustering, since widening the threshold alone is not expected to be
     // enough -- unrelated clustering has a real quality cost, so we only pay
     // it for the block type(s) that actually need it.
-    //
-    // TODO: These are tuning knobs; expect to adjust them as more benchmarks
-    //       are evaluated.
-    //  - kMinUtilizationForThresholdBump: AP's clustering tends to come out
-    //    around 10% less dense than the pre-packing estimate predicts, so
-    //    start widening the max distance threshold once the estimate is
-    //    within 10% of a type's capacity, rather than waiting until the
-    //    estimate actually predicts an overflow.
-    //  - kMaxDistThUtilizationScaleMultiplier: a type's max distance
-    //    threshold is linearly scaled from 1x (at
-    //    kMinUtilizationForThresholdBump) up to this multiple of its normal
-    //    (auto-computed) value (at kSevereUtilizationCutoff).
-    //  - kSevereUtilizationCutoff: estimated utilization (estimated
-    //    instances needed / instances available) at or above which a type is
-    //    considered severely over capacity: widening the threshold alone is
-    //    not expected to be enough, so unrelated clustering is also used for
-    //    that type.
     if (appack_ctx.appack_options.use_appack && packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
         constexpr float kMinUtilizationForThresholdBump = 0.9f;
-        constexpr float kMaxDistThUtilizationScaleMultiplier = 5.0f;
+        constexpr float kMaxDistThUtilizationScaleMultiplier = 10.0f;
         constexpr float kSevereUtilizationCutoff = 1.2f;
 
         std::unordered_set<t_logical_block_type_ptr> severe_block_types;

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -237,7 +237,8 @@ bool try_pack(const t_packer_opts& packer_opts,
               const PreClusterTimingManager& pre_cluster_timing_manager,
               const FlatPlacementInfo& flat_placement_info,
               const t_vpr_setup& vpr_setup,
-              const RamMapper& ram_mapper) {
+              const RamMapper& ram_mapper,
+              const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts) {
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     // The clusterer modifies the device context by increasing the size of the
@@ -334,13 +335,51 @@ bool try_pack(const t_packer_opts& packer_opts,
                              device_ctx.logical_block_types,
                              device_ctx.grid);
 
-    // For APPack, we do a low-effort unrelated clustering.
-    // We found that this can increase density in a way that
-    // better matches how a traditional flow may pack; but with
-    // improved spatial awareness.
-    if (appack_ctx.appack_options.use_appack) {
-        if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
+    // For APPack, we do a low-effort unrelated clustering for block types
+    // that the pre-packing device size estimate predicts will not fit
+    // densely enough on the device. We found that this can increase density
+    // in a way that better matches how a traditional flow may pack; but with
+    // improved spatial awareness. We only want to pay this quality cost for
+    // block types that actually look tight, so types the estimate does not
+    // flag are left at their normal (higher quality) settings on this first
+    // attempt.
+    if (appack_ctx.appack_options.use_appack && packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
+        std::unordered_set<t_logical_block_type_ptr> tight_block_types;
+        for (const t_logical_block_type& type : device_ctx.logical_block_types) {
+            if (is_empty_type(&type))
+                continue;
+
+            size_t num_total_instances = 0;
+            for (const t_physical_tile_type_ptr equivalent_tile : type.equivalent_tiles)
+                num_total_instances += device_ctx.grid.num_instances(equivalent_tile, -1);
+
+            auto itr = estimated_type_instance_counts.find(&type);
+            size_t estimated_instances = (itr != estimated_type_instance_counts.end()) ? itr->second : 0;
+
+            if (estimated_instances > num_total_instances)
+                tight_block_types.insert(&type);
+        }
+
+        if (!tight_block_types.empty()) {
             allow_unrelated_clustering = true;
+
+            // Restrict unrelated clustering to only the block types the
+            // estimate flagged as tight; other types keep their default
+            // (higher quality) unrelated clustering settings off.
+            for (const t_logical_block_type& type : device_ctx.logical_block_types) {
+                if (is_empty_type(&type))
+                    continue;
+                if (!tight_block_types.count(&type))
+                    appack_ctx.unrelated_clustering_manager.set_max_unrelated_clustering_attempts(type, 0);
+            }
+
+            VTR_LOG("Device size estimate predicts a tight packing for block type(s): ");
+            bool first = true;
+            for (t_logical_block_type_ptr type : tight_block_types) {
+                VTR_LOG("%s%s", first ? "" : ", ", type->name.c_str());
+                first = false;
+            }
+            VTR_LOG(". Enabling unrelated clustering for these type(s) from the start.\n");
         }
     }
 
@@ -412,13 +451,16 @@ bool try_pack(const t_packer_opts& packer_opts,
             case e_packer_state::SET_UNRELATED_AND_BALANCED: {
                 // 1st pack attempt was unsuccessful (i.e. not dense enough) and we have control of unrelated clustering
                 //
-                // Turn it on to increase packing density
+                // Turn it on to increase packing density.
+                // NOTE: allow_unrelated_clustering may already be true here (e.g. APPack
+                //       may have pre-enabled it for specific block types before the first
+                //       attempt based on the pre-packing density estimate) if this state was
+                //       reached only because balance_block_type_utilization needed enabling;
+                //       setting it again is a harmless no-op in that case.
                 if (packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
-                    VTR_ASSERT(allow_unrelated_clustering == false);
                     allow_unrelated_clustering = true;
                 }
                 if (packer_opts.balance_block_type_utilization == e_balance_block_type_util::AUTO) {
-                    VTR_ASSERT(balance_block_type_util == false);
                     balance_block_type_util = true;
                 }
                 if (appack_ctx.appack_options.use_appack) {

--- a/vpr/src/pack/pack.h
+++ b/vpr/src/pack/pack.h
@@ -45,6 +45,13 @@ using t_logical_block_type_ptr = const t_logical_block_type*;
  *              Pre-computed logical RAM groups with assigned physical types.
  *              Used to guide packing for memory clusters. Defaults to an empty
  *              mapper if not provided.
+ *  @param estimated_type_instance_counts
+ *              Estimated number of instances required for each logical block
+ *              type, computed before packing (see DeviceSizeEstimator). Used
+ *              by APPack to decide, per block type, whether unrelated
+ *              clustering should be enabled from the start. Defaults to an
+ *              empty map if not provided, in which case unrelated clustering
+ *              is left off on the first packing attempt.
  */
 bool try_pack(const t_packer_opts& packer_opts,
               const t_analysis_opts& analysis_opts,
@@ -55,7 +62,8 @@ bool try_pack(const t_packer_opts& packer_opts,
               const PreClusterTimingManager& pre_cluster_timing_manager,
               const FlatPlacementInfo& flat_placement_info,
               const t_vpr_setup& vpr_setup,
-              const RamMapper& ram_mapper = RamMapper{});
+              const RamMapper& ram_mapper = RamMapper{},
+              const std::map<t_logical_block_type_ptr, size_t>& estimated_type_instance_counts = {});
 
 /**
  * @brief Try to fit the block type instances on the given architecture. Will


### PR DESCRIPTION
The iterative retrying of APPack when it predicts high density was
causing issues with run time and quality. Added code to predict if
different resource types would be constrained to increase the options
pre-emptively.

Current AP vs Traditional results on L17:
IS_AP | vtr_flow_elapsed_time | critical_path_delay | routed_wirelength | interposer_nets_crossing
-- | -- | -- | -- | --
TRUE | 2094.137818 | 7.211096763 | 1565805.333 | 2140.703991
FALSE | 1623.82903 | 7.2912558 | 1702890.915 | 2453.101334
  |   |   |   |  
Norm.  | 1.29 | 0.99 | 0.92 | 0.87

Raw results: https://docs.google.com/spreadsheets/d/1zWWTqmlMzsOD8jhpzYyiOMYGaAkiNJIfpXJcwse7er0/edit?gid=893086942#gid=893086942