### PR TITLE
Update physical pin cache when restoring checkpoint

### DIFF
--- a/vpr/src/place/place_checkpoint.cpp
+++ b/vpr/src/place/place_checkpoint.cpp
@@ -70,6 +70,13 @@ void restore_best_placement(PlacerState& placer_state,
 
         costs = placement_checkpoint.restore_placement(placer_state.mutable_block_locs(), placer_state.mutable_grid_blocks());
 
+        // The restored placement may put blocks in different tiles/sub-tiles than
+        // the placement they replaced, so the cached physical pin indices must be
+        // re-synced before any pin coordinates are derived from them below.
+        for (const ClusterBlockId block_id : g_vpr_ctx.clustering().clb_nlist.blocks()) {
+            placer_state.mutable_blk_loc_registry().place_sync_external_block_connections(block_id);
+        }
+
         net_cost_handler.comp_bb_cong_cost(e_cost_methods::NORMAL);
 
         //recompute timing from scratch


### PR DESCRIPTION
#3682 added a call to comp_bb_cong_cost() inside restore_best_placement(), right after the checkpoint's block locations are restored. However, the cached physical pin indices (physical_pins_ in BlkLocRegistry) are only re-synced later, at the end of Placer::place(). So the cost recomputation derives pin coordinates from restored block locations combined with pin indices belonging to the pre-restore placement. If any block occupies a different sub-tile in the checkpoint than in the final placement (common for I/O blocks, where several share a tile), the stale pin index reads pin_width_offset out of bounds, producing garbage bounding-box coordinates, which then index the channel-width arrays far out of range and crash VPR with a segfault.