### PR TITLE
Sep place model

### DIFF
--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1261,7 +1261,9 @@ struct ParsePlaceDelayModel {
         ConvertedValue<PlaceDelayModelType> conv_value;
         if (str == "simple") {
             conv_value.set_value(PlaceDelayModelType::SIMPLE);
-        } else if (str == "delta")
+        } else if (str == "separable")
+            conv_value.set_value(PlaceDelayModelType::SEPARABLE);
+        else if (str == "delta")
             conv_value.set_value(PlaceDelayModelType::DELTA);
         else if (str == "delta_override")
             conv_value.set_value(PlaceDelayModelType::DELTA_OVERRIDE);
@@ -1277,6 +1279,8 @@ struct ParsePlaceDelayModel {
         ConvertedValue<std::string> conv_value;
         if (val == PlaceDelayModelType::SIMPLE)
             conv_value.set_value("simple");
+        else if (val == PlaceDelayModelType::SEPARABLE)
+            conv_value.set_value("separable");
         else if (val == PlaceDelayModelType::DELTA)
             conv_value.set_value("delta");
         else if (val == PlaceDelayModelType::DELTA_OVERRIDE)
@@ -1290,7 +1294,7 @@ struct ParsePlaceDelayModel {
     }
 
     std::vector<std::string> default_choices() {
-        return {"simple", "delta", "delta_override"};
+        return {"simple", "separable", "delta", "delta_override"};
     }
 };
 
@@ -2932,6 +2936,7 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
             " the placement delay model is constructed.\n"
             "Valid options:\n"
             " * 'simple' uses map router lookahead\n"
+            " * 'separable' uses map router lookahead, with independent x and y delay tables\n"
             " * 'delta' uses differences in position only\n"
             " * 'delta_override' uses differences in position with overrides for direct connects\n")
         .default_value("simple")

--- a/vpr/src/base/show_setup.cpp
+++ b/vpr/src/base/show_setup.cpp
@@ -589,8 +589,8 @@ static void show_placer_opts(const t_placer_opts& placer_opts) {
                 VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown delay_model_reducer\n");
             VTR_LOG("placer_opts.delay_model_reducer: %s\n", e_reducer_strings[(size_t)placer_opts.delay_model_reducer].c_str());
 
-            std::string place_delay_model_strings[3] = {"SIMPLE", "DELTA", "DELTA_OVERRIDE"};
-            if ((size_t)placer_opts.delay_model_type > 2)
+            std::string place_delay_model_strings[4] = {"SIMPLE", "SEPARABLE", "DELTA", "DELTA_OVERRIDE"};
+            if ((size_t)placer_opts.delay_model_type > 3)
                 VPR_FATAL_ERROR(VPR_ERROR_UNKNOWN, "Unknown delay_model_type\n");
             VTR_LOG("placer_opts.delay_model_type: %s\n", place_delay_model_strings[(size_t)placer_opts.delay_model_type].c_str());
         }

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -953,6 +953,7 @@ enum e_place_effort_scaling {
 
 enum class PlaceDelayModelType {
     SIMPLE,
+    SEPARABLE,      ///<Lookahead based delay model with independent x and y delay tables
     DELTA,          ///<Delta x/y based delay model
     DELTA_OVERRIDE, ///<Delta x/y based delay model with special case delay overrides
 };

--- a/vpr/src/place/delay_model/PlacementDelayModelCreator.cpp
+++ b/vpr/src/place/delay_model/PlacementDelayModelCreator.cpp
@@ -4,6 +4,7 @@
 
 #include "place_delay_model.h"
 #include "simple_delay_model.h"
+#include "separable_delay_model.h"
 #include "delta_delay_model.h"
 #include "override_delay_model.h"
 
@@ -64,6 +65,8 @@ PlacementDelayModelCreator::create_delay_model(const t_placer_opts& placer_opts,
 
     if (placer_opts.delay_model_type == PlaceDelayModelType::SIMPLE) {
         place_delay_model = std::make_unique<SimpleDelayModel>();
+    } else if (placer_opts.delay_model_type == PlaceDelayModelType::SEPARABLE) {
+        place_delay_model = std::make_unique<SeparableDelayModel>();
     } else if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA) {
         place_delay_model = std::make_unique<DeltaDelayModel>(is_flat);
     } else if (placer_opts.delay_model_type == PlaceDelayModelType::DELTA_OVERRIDE) {

--- a/vpr/src/place/delay_model/separable_delay_model.cpp
+++ b/vpr/src/place/delay_model/separable_delay_model.cpp
@@ -1,0 +1,76 @@
+
+#include "separable_delay_model.h"
+#include "device_grid.h"
+#include "globals.h"
+#include "vpr_context.h"
+#include "vpr_error.h"
+
+void SeparableDelayModel::compute(RouterDelayProfiler& route_profiler,
+                                  const t_placer_opts& /*placer_opts*/,
+                                  const t_router_opts& /*router_opts*/,
+                                  int /*longest_length*/) {
+    const DeviceContext& device = g_vpr_ctx.device();
+    const DeviceGrid& grid = device.grid;
+    const size_t num_physical_tile_types = device.physical_tile_types.size();
+    const size_t num_layers = grid.get_num_layers();
+
+    // One table per axis, indexed by the absolute source and sink coordinate along that axis.
+    // The second index is the layer the source is on and the third is the sink layer.
+    x_delays_ = vtr::NdMatrix<float, 5>({num_physical_tile_types,
+                                        num_layers,
+                                        num_layers,
+                                        grid.width(),
+                                        grid.width()});
+
+    y_delays_ = vtr::NdMatrix<float, 5>({num_physical_tile_types,
+                                        num_layers,
+                                        num_layers,
+                                        grid.height(),
+                                        grid.height()});
+
+    // TODO: Decide how each axis' delay should be profiled. For now each table is filled by probing
+    // the lookahead along its own axis only (a purely horizontal or vertical route), which makes the
+    // two components independent by construction.
+    for (size_t physical_tile_type_idx = 0; physical_tile_type_idx < num_physical_tile_types; ++physical_tile_type_idx) {
+        for (size_t from_layer = 0; from_layer < num_layers; ++from_layer) {
+            for (size_t to_layer = 0; to_layer < num_layers; ++to_layer) {
+                for (size_t from_x = 0; from_x < grid.width(); ++from_x) {
+                    for (size_t to_x = 0; to_x < grid.width(); ++to_x) {
+                        size_t dx = std::abs((int)to_x - (int)from_x);
+                        x_delays_[physical_tile_type_idx][from_layer][to_layer][from_x][to_x] = route_profiler.get_min_delay(physical_tile_type_idx,
+                                                                                                                            from_layer, to_layer,
+                                                                                                                            dx, 0);
+                    }
+                }
+
+                for (size_t from_y = 0; from_y < grid.height(); ++from_y) {
+                    for (size_t to_y = 0; to_y < grid.height(); ++to_y) {
+                        size_t dy = std::abs((int)to_y - (int)from_y);
+                        y_delays_[physical_tile_type_idx][from_layer][to_layer][from_y][to_y] = route_profiler.get_min_delay(physical_tile_type_idx,
+                                                                                                                            from_layer, to_layer,
+                                                                                                                            0, dy);
+                    }
+                }
+            }
+        }
+    }
+}
+
+float SeparableDelayModel::delay(const t_physical_tile_loc& from_loc, int /*from_pin*/, const t_physical_tile_loc& to_loc, int /*to_pin*/) const {
+    const DeviceGrid& grid = g_vpr_ctx.device().grid;
+
+    int from_tile_idx = grid.get_physical_type(from_loc)->index;
+
+    float x_delay = x_delays_[from_tile_idx][from_loc.layer_num][to_loc.layer_num][from_loc.x][to_loc.x];
+    float y_delay = y_delays_[from_tile_idx][from_loc.layer_num][to_loc.layer_num][from_loc.y][to_loc.y];
+
+    return x_delay + y_delay;
+}
+
+void SeparableDelayModel::read(const std::string& /*file*/) {
+    VPR_THROW(VPR_ERROR_PLACE, "SeparableDelayModel::read is not implemented.");
+}
+
+void SeparableDelayModel::write(const std::string& /*file*/) const {
+    VPR_THROW(VPR_ERROR_PLACE, "SeparableDelayModel::write is not implemented.");
+}

--- a/vpr/src/place/delay_model/separable_delay_model.cpp
+++ b/vpr/src/place/delay_model/separable_delay_model.cpp
@@ -27,16 +27,16 @@ void SeparableDelayModel::compute(RouterDelayProfiler& route_profiler,
     // One table per axis, indexed by the absolute source and sink coordinate along that axis.
     // The second index is the layer the source is on and the third is the sink layer.
     x_delays_ = vtr::NdMatrix<float, 5>({num_physical_tile_types,
-                                        num_layers,
-                                        num_layers,
-                                        grid.width(),
-                                        grid.width()});
+                                         num_layers,
+                                         num_layers,
+                                         grid.width(),
+                                         grid.width()});
 
     y_delays_ = vtr::NdMatrix<float, 5>({num_physical_tile_types,
-                                        num_layers,
-                                        num_layers,
-                                        grid.height(),
-                                        grid.height()});
+                                         num_layers,
+                                         num_layers,
+                                         grid.height(),
+                                         grid.height()});
 
     // As in the simple delay model, the delay is the minimum across all the OPINs of the tile type,
     // taken from the router lookahead rather than by running the router. Here each axis is queried
@@ -47,16 +47,16 @@ void SeparableDelayModel::compute(RouterDelayProfiler& route_profiler,
                 for (size_t from_x = 0; from_x < grid.width(); ++from_x) {
                     for (size_t to_x = 0; to_x < grid.width(); ++to_x) {
                         x_delays_[physical_tile_type_idx][from_layer][to_layer][from_x][to_x] = separable_lookahead->get_opin_min_delay_x(physical_tile_type_idx,
-                                                                                                                                         from_layer, to_layer,
-                                                                                                                                         from_x, to_x);
+                                                                                                                                          from_layer, to_layer,
+                                                                                                                                          from_x, to_x);
                     }
                 }
 
                 for (size_t from_y = 0; from_y < grid.height(); ++from_y) {
                     for (size_t to_y = 0; to_y < grid.height(); ++to_y) {
                         y_delays_[physical_tile_type_idx][from_layer][to_layer][from_y][to_y] = separable_lookahead->get_opin_min_delay_y(physical_tile_type_idx,
-                                                                                                                                         from_layer, to_layer,
-                                                                                                                                         from_y, to_y);
+                                                                                                                                          from_layer, to_layer,
+                                                                                                                                          from_y, to_y);
                     }
                 }
             }

--- a/vpr/src/place/delay_model/separable_delay_model.cpp
+++ b/vpr/src/place/delay_model/separable_delay_model.cpp
@@ -2,6 +2,7 @@
 #include "separable_delay_model.h"
 #include "device_grid.h"
 #include "globals.h"
+#include "router_lookahead_separable.h"
 #include "vpr_context.h"
 #include "vpr_error.h"
 
@@ -13,6 +14,15 @@ void SeparableDelayModel::compute(RouterDelayProfiler& route_profiler,
     const DeviceGrid& grid = device.grid;
     const size_t num_physical_tile_types = device.physical_tile_types.size();
     const size_t num_layers = grid.get_num_layers();
+
+    // This model reads the separable lookahead's per-axis, absolute-coordinate cost maps directly, so
+    // it cannot be built on top of any other lookahead.
+    const auto* separable_lookahead = dynamic_cast<const SeparableLookahead*>(route_profiler.get_lookahead());
+    if (separable_lookahead == nullptr) {
+        VPR_FATAL_ERROR(VPR_ERROR_PLACE,
+                        "The separable placement delay model requires the separable router lookahead "
+                        "(--router_lookahead separable).");
+    }
 
     // One table per axis, indexed by the absolute source and sink coordinate along that axis.
     // The second index is the layer the source is on and the third is the sink layer.
@@ -28,27 +38,25 @@ void SeparableDelayModel::compute(RouterDelayProfiler& route_profiler,
                                         grid.height(),
                                         grid.height()});
 
-    // TODO: Decide how each axis' delay should be profiled. For now each table is filled by probing
-    // the lookahead along its own axis only (a purely horizontal or vertical route), which makes the
-    // two components independent by construction.
+    // As in the simple delay model, the delay is the minimum across all the OPINs of the tile type,
+    // taken from the router lookahead rather than by running the router. Here each axis is queried
+    // separately, by absolute coordinate rather than by distance.
     for (size_t physical_tile_type_idx = 0; physical_tile_type_idx < num_physical_tile_types; ++physical_tile_type_idx) {
         for (size_t from_layer = 0; from_layer < num_layers; ++from_layer) {
             for (size_t to_layer = 0; to_layer < num_layers; ++to_layer) {
                 for (size_t from_x = 0; from_x < grid.width(); ++from_x) {
                     for (size_t to_x = 0; to_x < grid.width(); ++to_x) {
-                        size_t dx = std::abs((int)to_x - (int)from_x);
-                        x_delays_[physical_tile_type_idx][from_layer][to_layer][from_x][to_x] = route_profiler.get_min_delay(physical_tile_type_idx,
-                                                                                                                            from_layer, to_layer,
-                                                                                                                            dx, 0);
+                        x_delays_[physical_tile_type_idx][from_layer][to_layer][from_x][to_x] = separable_lookahead->get_opin_min_delay_x(physical_tile_type_idx,
+                                                                                                                                         from_layer, to_layer,
+                                                                                                                                         from_x, to_x);
                     }
                 }
 
                 for (size_t from_y = 0; from_y < grid.height(); ++from_y) {
                     for (size_t to_y = 0; to_y < grid.height(); ++to_y) {
-                        size_t dy = std::abs((int)to_y - (int)from_y);
-                        y_delays_[physical_tile_type_idx][from_layer][to_layer][from_y][to_y] = route_profiler.get_min_delay(physical_tile_type_idx,
-                                                                                                                            from_layer, to_layer,
-                                                                                                                            0, dy);
+                        y_delays_[physical_tile_type_idx][from_layer][to_layer][from_y][to_y] = separable_lookahead->get_opin_min_delay_y(physical_tile_type_idx,
+                                                                                                                                         from_layer, to_layer,
+                                                                                                                                         from_y, to_y);
                     }
                 }
             }

--- a/vpr/src/place/delay_model/separable_delay_model.h
+++ b/vpr/src/place/delay_model/separable_delay_model.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "place_delay_model.h"
+
+/**
+ * @class SeparableDelayModel
+ * @brief A delay model that treats the x and y components of a connection's delay as independent.
+ *
+ * Like SimpleDelayModel, the delay information comes from the router lookahead rather than from
+ * running the router. Unlike SimpleDelayModel, which stores a single delay indexed by (dx, dy),
+ * this model keeps one table per axis and sums their contributions. Each table is indexed by the
+ * absolute source and sink coordinate along its axis rather than by a delta, so architectures whose
+ * routing is non-uniform along a row or column (e.g. a column of hard blocks that interrupts the
+ * channels) are still represented.
+ */
+class SeparableDelayModel : public PlaceDelayModel {
+  public:
+    SeparableDelayModel() {}
+
+    /// @brief Use the information in the router lookahead to fill the delay matrices instead of running the router
+    void compute(RouterDelayProfiler& router,
+                 const t_placer_opts& placer_opts,
+                 const t_router_opts& router_opts,
+                 int longest_length) override;
+
+    float delay(const t_physical_tile_loc& from_loc, int /*from_pin*/, const t_physical_tile_loc& to_loc, int /*to_pin*/) const override;
+
+    void dump_echo(std::string /*filepath*/) const override {}
+
+    void read(const std::string& /*file*/) override;
+    void write(const std::string& /*file*/) const override;
+
+  private:
+    /**
+     * @brief The x component of the minimum delay between two points, per tile type and layer pair.
+     *
+     * As in SimpleDelayModel, the delay is stored per physical tile type and per (source layer, sink
+     * layer) pair, since the connectivity of a physical type may differ between layers and the number
+     * of inter-layer connections need not be uniform across layer pairs.
+     */
+    vtr::NdMatrix<float, 5> x_delays_; // [0..num_physical_type-1][0..num_layers-1][0..num_layers-1][0..max_x][0..max_x]
+
+    /// @brief The y component of the minimum delay. See x_delays_.
+    vtr::NdMatrix<float, 5> y_delays_; // [0..num_physical_type-1][0..num_layers-1][0..num_layers-1][0..max_y][0..max_y]
+};

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -20,6 +20,7 @@ RouterDelayProfiler::RouterDelayProfiler(const Netlist<>& net_list,
           g_vpr_ctx.mutable_routing().rr_node_route_inf,
           is_flat,
           /*route_verbosity=*/1)
+    , lookahead_(lookahead)
     , is_flat_(is_flat) {
     const auto& grid = g_vpr_ctx.device().grid;
     int num_layers = grid.get_num_layers();

--- a/vpr/src/route/router_delay_profiling.h
+++ b/vpr/src/route/router_delay_profiling.h
@@ -32,10 +32,14 @@ class RouterDelayProfiler {
      */
     float get_min_delay(int physical_tile_type_idx, int from_layer, int to_layer, int dx, int dy) const;
 
+    /// @return The router lookahead this profiler derives its delay estimates from.
+    const RouterLookahead* get_lookahead() const { return lookahead_; }
+
   private:
     const Netlist<>& net_list_;
     RouterStats router_stats_;
     SerialConnectionRouter<FourAryHeap> router_;
+    const RouterLookahead* lookahead_;
     vtr::NdMatrix<float, 5> min_delays_; // [physical_type_idx][from_layer][to_layer][dx][dy]
     bool is_flat_;
 };

--- a/vpr/src/route/router_lookahead/router_lookahead_map.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.cpp
@@ -575,6 +575,10 @@ float MapLookahead::get_opin_distance_min_delay(int physical_tile_idx, int from_
     return opin_distance_based_min_cost[physical_tile_idx][from_layer][to_layer][dx][dy].delay;
 }
 
+util::Cost_Entry MapLookahead::get_wire_cost(e_rr_type rr_type, int seg_index, int from_layer_num, int delta_x, int delta_y, int to_layer_num) const {
+    return get_wire_cost_entry(rr_type, seg_index, from_layer_num, delta_x, delta_y, to_layer_num);
+}
+
 /******** Function Definitions ********/
 
 static util::Cost_Entry get_wire_cost_entry(e_rr_type rr_type, int seg_index, int from_layer_num, int delta_x, int delta_y, int to_layer_num) {

--- a/vpr/src/route/router_lookahead/router_lookahead_map.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_map.h
@@ -29,6 +29,15 @@ class MapLookahead : public RouterLookahead {
      */
     std::pair<float, float> get_expected_delay_and_cong_from_deltas(RRNodeId from_node, int delta_x, int delta_y, const t_conn_cost_params& params) const;
 
+    /**
+     * @brief Returns the lookahead map's cost to travel (delta_x, delta_y) from a wire of the given
+     *        channel type and segment type on "from_layer_num", to a point on "to_layer_num".
+     * @attention This exposes a raw lookahead map entry, without any of the adjustments made when
+     *            costing an actual connection. It is intended for reporting, and for other lookaheads
+     *            that want to fall back on this one's estimates.
+     */
+    util::Cost_Entry get_wire_cost(e_rr_type rr_type, int seg_index, int from_layer_num, int delta_x, int delta_y, int to_layer_num) const;
+
   private:
     float get_expected_cost_flat_router(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const;
     //Look-up table from SOURCE/OPIN to CHANX/CHANY of various types

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -1,5 +1,6 @@
 #include "router_lookahead_separable.h"
 
+#include <fstream>
 #include <memory>
 #include "connection_router_interface.h"
 #include "globals.h"
@@ -10,6 +11,7 @@
 #include "vpr_error.h"
 #include "vpr_utils.h"
 #include "vtr_time.h"
+#include "vtr_util.h"
 
 static RRNodeId get_chanxy_start_node_sep(int layer, int start_x, int start_y, Direction direction, e_rr_type rr_type, int seg_index, int track_offset) {
     const auto& device_ctx = g_vpr_ctx.device();
@@ -317,16 +319,27 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
  *
  * "include_opin_access_delay" controls whether the OPIN-to-wire delay is included, so that a caller
  * summing the two axes' delays can charge it to one axis only.
+ *
+ * Wires with no usable entry in the separable map fall back to "map_lookahead"'s estimate for the
+ * equivalent travel along this axis (and none along the other one).
  */
 static float min_opin_axis_delay(const util::t_src_opin_delays& src_opin_delays,
                                  const vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map,
+                                 e_profile_axis axis,
+                                 const MapLookahead& map_lookahead,
                                  int physical_tile_idx,
                                  int from_layer,
                                  int to_layer,
                                  int c1,
                                  int c2,
                                  bool include_opin_access_delay) {
+    const bool profile_x = (axis == e_profile_axis::X);
     float min_delay = std::numeric_limits<float>::infinity();
+
+    // An entry is unusable if it was never profiled, or profiled as unreachable.
+    auto is_usable = [](float delay) {
+        return std::isfinite(delay) && delay != ROUTER_LOOKAHEAD_NO_PATH_SENTINEL;
+    };
 
     for (const auto& tile_opin_map : src_opin_delays[from_layer][physical_tile_idx]) {
         float expected_delay = std::numeric_limits<float>::infinity();
@@ -347,9 +360,22 @@ static float min_opin_axis_delay(const util::t_src_opin_delays& src_opin_delays,
                 float wire_delay = std::numeric_limits<float>::infinity();
                 for (size_t dir_index = 0; dir_index < wire_cost_map.dim_size(4); ++dir_index) {
                     const util::Cost_Entry& entry = wire_cost_map[reachable_wire_inf.layer_number][to_layer][chan_index][reachable_wire_inf.wire_seg_index][dir_index][c1][c2];
-                    if (entry.valid()) {
+                    if (entry.valid() && is_usable(entry.delay)) {
                         wire_delay = std::min(wire_delay, entry.delay);
                     }
+                }
+
+                if (!is_usable(wire_delay)) {
+                    // This lookahead has nothing profiled for this wire at this coordinate pair, so
+                    // use the map lookahead's estimate for the same travel along this axis.
+                    const int delta = std::abs(c2 - c1);
+                    wire_delay = map_lookahead.get_wire_cost(reachable_wire_inf.wire_rr_type,
+                                                             reachable_wire_inf.wire_seg_index,
+                                                             reachable_wire_inf.layer_number,
+                                                             profile_x ? delta : 0,
+                                                             profile_x ? 0 : delta,
+                                                             to_layer)
+                                     .delay;
                 }
 
                 const float access_delay = include_opin_access_delay ? reachable_wire_inf.delay : 0.f;
@@ -378,6 +404,8 @@ static float min_opin_axis_delay(const util::t_src_opin_delays& src_opin_delays,
  */
 static void min_opin_axis_delay_map(const util::t_src_opin_delays& src_opin_delays,
                                     const vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map,
+                                    e_profile_axis axis,
+                                    const MapLookahead& map_lookahead,
                                     bool include_opin_access_delay,
                                     vtr::NdMatrix<float, 5>& axis_min_delay) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
@@ -399,6 +427,8 @@ static void min_opin_axis_delay_map(const util::t_src_opin_delays& src_opin_dela
                     for (int c2 = 0; c2 < axis_dim_size; c2++) {
                         axis_min_delay[tile_type_idx][from_layer_num][to_layer_num][c1][c2] = min_opin_axis_delay(src_opin_delays,
                                                                                                                  wire_cost_map,
+                                                                                                                 axis,
+                                                                                                                 map_lookahead,
                                                                                                                  tile_type_idx,
                                                                                                                  from_layer_num,
                                                                                                                  to_layer_num,
@@ -555,13 +585,16 @@ void SeparableLookahead::compute(const std::vector<t_segment_inf>& segment_inf) 
     // physical tile type's SOURCEs & OPINs. This is what the per-axis OPIN delay queries start from.
     this->src_opin_delays = util::compute_router_src_opin_lookahead(is_flat_, route_verbosity_, device_model_warnings_);
 
+    // Build the delegate MapLookahead, which provides the SOURCE/OPIN distance estimates. This must
+    // happen before the per-axis reduction below, which falls back on its cost map.
+    map_lookahead_->compute(segment_inf);
+
     // Reduce the above down to a minimum delay per axis for each tile type, layer pair and coordinate
     // pair, so that get_opin_min_delay_x()/get_opin_min_delay_y() are simple lookups.
-    min_opin_axis_delay_map(src_opin_delays, x_wire_cost_map_, /*include_opin_access_delay=*/true, opin_x_min_delay_);
-    min_opin_axis_delay_map(src_opin_delays, y_wire_cost_map_, /*include_opin_access_delay=*/false, opin_y_min_delay_);
-
-    // Build the delegate MapLookahead, which provides the SOURCE/OPIN distance estimates.
-    map_lookahead_->compute(segment_inf);
+    min_opin_axis_delay_map(src_opin_delays, x_wire_cost_map_, e_profile_axis::X, map_lookahead_impl(),
+                            /*include_opin_access_delay=*/true, opin_x_min_delay_);
+    min_opin_axis_delay_map(src_opin_delays, y_wire_cost_map_, e_profile_axis::Y, map_lookahead_impl(),
+                            /*include_opin_access_delay=*/false, opin_y_min_delay_);
 }
 
 void SeparableLookahead::compute_intra_tile() {
@@ -576,8 +609,94 @@ void SeparableLookahead::read_intra_cluster(const std::string& /*file*/) {
     NOT_IMPLEMENTED_ERROR("SeparableLookahead::read_intra_cluster");
 }
 
-void SeparableLookahead::write(const std::string& /*file_name*/) const {
-    NOT_IMPLEMENTED_ERROR("SeparableLookahead::write");
+/**
+ * @brief Dumps one axis' wire cost map to a human readable csv file.
+ *
+ * Each row is one entry of the map: the cost of travelling along the profiling axis from coordinate
+ * c1 to coordinate c2, starting from a wire of the given channel type, segment type and direction.
+ *
+ * Entries that this lookahead never profiled are filled in from the delegate MapLookahead, queried
+ * with the equivalent distance along this axis and zero distance along the other one, so that the
+ * dump never contains invalid entries.
+ */
+static void dump_separable_axis_csv(const std::string& file_name,
+                                    const vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map,
+                                    e_profile_axis axis,
+                                    const MapLookahead& map_lookahead) {
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const int num_layers = device_ctx.grid.get_num_layers();
+    const bool profile_x = (axis == e_profile_axis::X);
+    const int axis_dim_size = (int)wire_cost_map.dim_size(5);
+
+    std::ofstream ofs(file_name);
+    if (!ofs.good()) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE, "Unable to open file '%s' for writing\n", file_name.c_str());
+    }
+
+    const char* coord_names = profile_x ? "x1,x2," : "y1,y2,";
+    ofs << "from_layer,"
+           "to_layer,"
+           "chan_type,"
+           "seg_type,"
+           "direction,"
+        << coord_names << "cong_cost,"
+                          "delay_cost\n";
+
+    std::vector<e_rr_type> chan_types{e_rr_type::CHANX, e_rr_type::CHANY};
+    if (num_layers > 1) {
+        chan_types.push_back(e_rr_type::CHANZ);
+    }
+
+    for (int from_layer_num = 0; from_layer_num < num_layers; from_layer_num++) {
+        for (int to_layer_num = 0; to_layer_num < num_layers; to_layer_num++) {
+            for (e_rr_type chan_type : chan_types) {
+                const int chan_index = util::chan_type_to_index(chan_type);
+                for (int seg_index = 0; seg_index < (int)wire_cost_map.dim_size(3); seg_index++) {
+                    for (int dir_index = 0; dir_index < (int)wire_cost_map.dim_size(4); dir_index++) {
+                        for (int c1 = 0; c1 < axis_dim_size; c1++) {
+                            for (int c2 = 0; c2 < axis_dim_size; c2++) {
+                                util::Cost_Entry cost = wire_cost_map[from_layer_num][to_layer_num][chan_index][seg_index][dir_index][c1][c2];
+
+                                if (!cost.valid()) {
+                                    const int delta = std::abs(c2 - c1);
+                                    cost = map_lookahead.get_wire_cost(chan_type,
+                                                                       seg_index,
+                                                                       from_layer_num,
+                                                                       profile_x ? delta : 0,
+                                                                       profile_x ? 0 : delta,
+                                                                       to_layer_num);
+                                }
+
+                                ofs << from_layer_num << ","
+                                    << to_layer_num << ","
+                                    << rr_node_typename[chan_type] << ","
+                                    << seg_index << ","
+                                    << DIRECTION_STRING[dir_index] << ","
+                                    << c1 << ","
+                                    << c2 << ","
+                                    << cost.congestion << ","
+                                    << cost.delay << "\n";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void SeparableLookahead::write(const std::string& file_name) const {
+    if (!vtr::check_file_name_extension(file_name, ".csv")) {
+        VPR_FATAL_ERROR(VPR_ERROR_ROUTE,
+                        "SeparableLookahead::write only supports writing a human readable .csv file, "
+                        "but was given '%s'.",
+                        file_name.c_str());
+    }
+
+    // The two axes' maps have different extents, so they go in a file each, named after the given path.
+    const std::string base_name = file_name.substr(0, file_name.size() - std::string(".csv").size());
+    dump_separable_axis_csv(base_name + "_x.csv", x_wire_cost_map_, e_profile_axis::X, map_lookahead_impl());
+    dump_separable_axis_csv(base_name + "_y.csv", y_wire_cost_map_, e_profile_axis::Y, map_lookahead_impl());
 }
 
 void SeparableLookahead::write_intra_cluster(const std::string& /*file*/) const {

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -305,6 +305,114 @@ static void compute_router_wire_lookahead(const std::vector<t_segment_inf>& segm
 }
 
 /**
+ * @brief Minimum delay across all OPINs of a tile type to travel along a single axis, from
+ *        coordinate c1 to coordinate c2 of the wire cost map for that axis.
+ *
+ * This mirrors min_opin_distance_cost_map() in router_lookahead_map.cpp: for each OPIN of the tile
+ * type it iterates over the wire segments reachable from that OPIN and takes the minimum of the cost
+ * to reach the wire plus the cost of travelling from the wire to the target coordinate. It differs in
+ * that the wire travel cost comes from a single-axis, absolute-coordinate map rather than the
+ * (dx, dy)-indexed one, and that the map has no direction (INC/DEC/BIDIR) information for a reachable
+ * wire, so the minimum over all three directions is taken.
+ *
+ * "include_opin_access_delay" controls whether the OPIN-to-wire delay is included, so that a caller
+ * summing the two axes' delays can charge it to one axis only.
+ */
+static float min_opin_axis_delay(const util::t_src_opin_delays& src_opin_delays,
+                                 const vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map,
+                                 int physical_tile_idx,
+                                 int from_layer,
+                                 int to_layer,
+                                 int c1,
+                                 int c2,
+                                 bool include_opin_access_delay) {
+    float min_delay = std::numeric_limits<float>::infinity();
+
+    for (const auto& tile_opin_map : src_opin_delays[from_layer][physical_tile_idx]) {
+        float expected_delay = std::numeric_limits<float>::infinity();
+
+        for (const auto& layer_src_opin_delay_map : tile_opin_map) {
+            for (const auto& kv : layer_src_opin_delay_map) {
+                const util::t_reachable_wire_inf& reachable_wire_inf = kv.second;
+                if (reachable_wire_inf.wire_rr_type == e_rr_type::SINK) {
+                    continue;
+                }
+
+                const int chan_index = util::chan_type_to_index(reachable_wire_inf.wire_rr_type);
+                if (chan_index >= (int)wire_cost_map.dim_size(2)) {
+                    continue;
+                }
+
+                // The reachable wire info does not record the wire's direction, so consider all of them.
+                float wire_delay = std::numeric_limits<float>::infinity();
+                for (size_t dir_index = 0; dir_index < wire_cost_map.dim_size(4); ++dir_index) {
+                    const util::Cost_Entry& entry = wire_cost_map[reachable_wire_inf.layer_number][to_layer][chan_index][reachable_wire_inf.wire_seg_index][dir_index][c1][c2];
+                    if (entry.valid()) {
+                        wire_delay = std::min(wire_delay, entry.delay);
+                    }
+                }
+
+                const float access_delay = include_opin_access_delay ? reachable_wire_inf.delay : 0.f;
+                expected_delay = std::min(expected_delay, access_delay + wire_delay);
+            }
+        }
+
+        min_delay = std::min(min_delay, expected_delay);
+    }
+
+    // No profiled path along this axis; fall back to the same sentinel the lookahead uses elsewhere so
+    // that an unreachable pair is expensive but does not poison the placement cost with an infinity.
+    if (!std::isfinite(min_delay)) {
+        min_delay = ROUTER_LOOKAHEAD_NO_PATH_SENTINEL;
+    }
+
+    return min_delay;
+}
+
+/**
+ * @brief Fills in the minimum OPIN delay along a single axis for every tile type, layer pair and
+ *        (c1, c2) coordinate pair, by calling min_opin_axis_delay() for each entry.
+ *
+ * This is the separable counterpart of min_opin_distance_cost_map() in router_lookahead_map.cpp: the
+ * per-OPIN minimization is done once here rather than on every query.
+ */
+static void min_opin_axis_delay_map(const util::t_src_opin_delays& src_opin_delays,
+                                    const vtr::NdMatrix<util::Cost_Entry, 7>& wire_cost_map,
+                                    bool include_opin_access_delay,
+                                    vtr::NdMatrix<float, 5>& axis_min_delay) {
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const int num_tile_types = (int)device_ctx.physical_tile_types.size();
+    const int num_layers = device_ctx.grid.get_num_layers();
+    // The wire cost map is square in its last two (coordinate) dimensions.
+    const int axis_dim_size = (int)wire_cost_map.dim_size(5);
+
+    axis_min_delay.resize({static_cast<size_t>(num_tile_types),
+                           static_cast<size_t>(num_layers),
+                           static_cast<size_t>(num_layers),
+                           static_cast<size_t>(axis_dim_size),
+                           static_cast<size_t>(axis_dim_size)});
+
+    for (int tile_type_idx = 0; tile_type_idx < num_tile_types; tile_type_idx++) {
+        for (int from_layer_num = 0; from_layer_num < num_layers; from_layer_num++) {
+            for (int to_layer_num = 0; to_layer_num < num_layers; to_layer_num++) {
+                for (int c1 = 0; c1 < axis_dim_size; c1++) {
+                    for (int c2 = 0; c2 < axis_dim_size; c2++) {
+                        axis_min_delay[tile_type_idx][from_layer_num][to_layer_num][c1][c2] = min_opin_axis_delay(src_opin_delays,
+                                                                                                                 wire_cost_map,
+                                                                                                                 tile_type_idx,
+                                                                                                                 from_layer_num,
+                                                                                                                 to_layer_num,
+                                                                                                                 c1,
+                                                                                                                 c2,
+                                                                                                                 include_opin_access_delay);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
  * @note This lookahead is currently a skeleton: the class compiles and can be
  *       selected via --router_lookahead separable, but none of its methods are
  *       implemented yet.
@@ -443,6 +551,15 @@ void SeparableLookahead::compute(const std::vector<t_segment_inf>& segment_inf) 
     // (CHANX/CHANY/CHANZ) in the routing architecture
     compute_router_wire_lookahead(segment_inf, route_verbosity_, device_model_warnings_, x_wire_cost_map_, y_wire_cost_map_);
 
+    // Next, compute which wire types are accessible (and the cost to reach them) from the different
+    // physical tile type's SOURCEs & OPINs. This is what the per-axis OPIN delay queries start from.
+    this->src_opin_delays = util::compute_router_src_opin_lookahead(is_flat_, route_verbosity_, device_model_warnings_);
+
+    // Reduce the above down to a minimum delay per axis for each tile type, layer pair and coordinate
+    // pair, so that get_opin_min_delay_x()/get_opin_min_delay_y() are simple lookups.
+    min_opin_axis_delay_map(src_opin_delays, x_wire_cost_map_, /*include_opin_access_delay=*/true, opin_x_min_delay_);
+    min_opin_axis_delay_map(src_opin_delays, y_wire_cost_map_, /*include_opin_access_delay=*/false, opin_y_min_delay_);
+
     // Build the delegate MapLookahead, which provides the SOURCE/OPIN distance estimates.
     map_lookahead_->compute(segment_inf);
 }
@@ -469,6 +586,14 @@ void SeparableLookahead::write_intra_cluster(const std::string& /*file*/) const 
 
 float SeparableLookahead::get_opin_distance_min_delay(int physical_tile_idx, int from_layer, int to_layer, int dx, int dy) const {
     return map_lookahead_->get_opin_distance_min_delay(physical_tile_idx, from_layer, to_layer, dx, dy);
+}
+
+float SeparableLookahead::get_opin_min_delay_x(int physical_tile_idx, int from_layer, int to_layer, int x1, int x2) const {
+    return opin_x_min_delay_[physical_tile_idx][from_layer][to_layer][x1][x2];
+}
+
+float SeparableLookahead::get_opin_min_delay_y(int physical_tile_idx, int from_layer, int to_layer, int y1, int y2) const {
+    return opin_y_min_delay_[physical_tile_idx][from_layer][to_layer][y1][y2];
 }
 
 void read_router_lookahead_separable(const std::string& /*file*/) {

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.cpp
@@ -426,15 +426,15 @@ static void min_opin_axis_delay_map(const util::t_src_opin_delays& src_opin_dela
                 for (int c1 = 0; c1 < axis_dim_size; c1++) {
                     for (int c2 = 0; c2 < axis_dim_size; c2++) {
                         axis_min_delay[tile_type_idx][from_layer_num][to_layer_num][c1][c2] = min_opin_axis_delay(src_opin_delays,
-                                                                                                                 wire_cost_map,
-                                                                                                                 axis,
-                                                                                                                 map_lookahead,
-                                                                                                                 tile_type_idx,
-                                                                                                                 from_layer_num,
-                                                                                                                 to_layer_num,
-                                                                                                                 c1,
-                                                                                                                 c2,
-                                                                                                                 include_opin_access_delay);
+                                                                                                                  wire_cost_map,
+                                                                                                                  axis,
+                                                                                                                  map_lookahead,
+                                                                                                                  tile_type_idx,
+                                                                                                                  from_layer_num,
+                                                                                                                  to_layer_num,
+                                                                                                                  c1,
+                                                                                                                  c2,
+                                                                                                                  include_opin_access_delay);
                     }
                 }
             }

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.h
@@ -65,6 +65,20 @@ class SeparableLookahead : public RouterLookahead {
   public:
     explicit SeparableLookahead(const t_det_routing_arch& det_routing_arch, bool is_flat, int route_verbosity, bool device_model_warnings, float interposer_base_cost_multiplier);
 
+    /**
+     * @brief Returns the x component of the minimum delay across all OPINs of the physical tile type
+     *        "physical_tile_idx" on layer "from_layer", travelling from x-coordinate x1 to an IPIN at
+     *        x-coordinate x2 on layer "to_layer".
+     *
+     * This is the absolute-coordinate, single-axis analogue of get_opin_distance_min_delay(). The delay
+     * of reaching a wire from the OPIN is charged to the x component only, so that adding this to
+     * get_opin_min_delay_y() counts the OPIN access delay exactly once.
+     */
+    float get_opin_min_delay_x(int physical_tile_idx, int from_layer, int to_layer, int x1, int x2) const;
+
+    /// @brief The y counterpart of get_opin_min_delay_x(), excluding the OPIN access delay.
+    float get_opin_min_delay_y(int physical_tile_idx, int from_layer, int to_layer, int y1, int y2) const;
+
   private:
     float get_expected_cost_flat_router(RRNodeId current_node, RRNodeId target_node, const t_conn_cost_params& params, float R_upstream) const;
 
@@ -83,6 +97,16 @@ class SeparableLookahead : public RouterLookahead {
 
     t_x_wire_cost_map x_wire_cost_map_;
     t_y_wire_cost_map y_wire_cost_map_;
+
+    /**
+     * @brief Minimum OPIN delay along each axis, precomputed from the wire cost maps and src_opin_delays
+     *        so that the per-OPIN minimization is done once rather than on every query.
+     *
+     * These back get_opin_min_delay_x()/get_opin_min_delay_y(); see those for what the values mean
+     * (in particular, the OPIN access delay is included in the x table only).
+     */
+    vtr::NdMatrix<float, 5> opin_x_min_delay_; // [physical_tile_idx][from_layer_num][to_layer_num][x1][x2] -> delay
+    vtr::NdMatrix<float, 5> opin_y_min_delay_; // [physical_tile_idx][from_layer_num][to_layer_num][y1][y2] -> delay
 
     const t_det_routing_arch& det_routing_arch_;
     bool is_flat_;

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.h
@@ -94,7 +94,7 @@ class SeparableLookahead : public RouterLookahead {
     // SOURCE/OPIN case of get_expected_delay_and_cong). The separable lookahead only overrides the
     // wire-to-target (CHAN) cost estimation; OPIN/SOURCE handling is delegated to this object.
     // It also supplies the fall-back cost for map entries this lookahead never profiled.
-    // Held by base-class pointer because MapLookahead re-declares the RouterLookahead overrides as
+    // Held by base-class pointer because MapLookahead redeclares the RouterLookahead overrides as
     // protected; it is always a MapLookahead.
     std::unique_ptr<RouterLookahead> map_lookahead_;
 

--- a/vpr/src/route/router_lookahead/router_lookahead_separable.h
+++ b/vpr/src/route/router_lookahead/router_lookahead_separable.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "vtr_ndmatrix.h"
 #include "router_lookahead.h"
+#include "router_lookahead_map.h"
 #include "router_lookahead_map_utils.h"
 #include "router_lookahead_interposer.h"
 
@@ -92,7 +93,13 @@ class SeparableLookahead : public RouterLookahead {
     // A MapLookahead used to answer SOURCE/OPIN distance queries (get_opin_distance_min_delay, and the
     // SOURCE/OPIN case of get_expected_delay_and_cong). The separable lookahead only overrides the
     // wire-to-target (CHAN) cost estimation; OPIN/SOURCE handling is delegated to this object.
+    // It also supplies the fall-back cost for map entries this lookahead never profiled.
+    // Held by base-class pointer because MapLookahead re-declares the RouterLookahead overrides as
+    // protected; it is always a MapLookahead.
     std::unique_ptr<RouterLookahead> map_lookahead_;
+
+    /// @brief map_lookahead_ as its concrete type, for the queries MapLookahead adds to the interface.
+    const MapLookahead& map_lookahead_impl() const { return *static_cast<const MapLookahead*>(map_lookahead_.get()); }
     std::optional<InterposerLookahead> interposer_lookahead_;
 
     t_x_wire_cost_map x_wire_cost_map_;


### PR DESCRIPTION
Adds a new place delay model that uses the separable router lookahead. It's pretty good.
(Numbers are normalized to the old place delay model)
<img width="1306" height="189" alt="image" src="https://github.com/user-attachments/assets/6a5bbfad-c8ea-431a-8bea-d80b0358e660" />
