### PR TITLE
Draw critical path endpoint markers + total delay time message

### DIFF
--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1758,6 +1758,7 @@ bool rgb_is_same(ezgl::color color1, ezgl::color color2) {
     color2.alpha = 255;
     return (color1 == color2);
 }
+
 t_draw_layer_display get_element_visibility_and_transparency(int src_layer, int sink_layer) {
     t_draw_layer_display element_visibility;
     t_draw_state* draw_state = get_draw_state_vars();
@@ -1765,16 +1766,17 @@ t_draw_layer_display get_element_visibility_and_transparency(int src_layer, int 
     element_visibility.visible = true;
     bool cross_layer_enabled = draw_state->cross_layer_display.visible;
 
-    //To only show elements (net flylines,noc links,etc...) that are connected to currently active layers on the screen
-    if (!draw_state->draw_layer_display[sink_layer].visible || !draw_state->draw_layer_display[src_layer].visible || (!cross_layer_enabled && src_layer != sink_layer)) {
-        element_visibility.visible = false; /* Don't Draw */
-    }
-
     if (src_layer != sink_layer) {
-        //assign transparency from cross layer option if connection is between different layers
+        if (!cross_layer_enabled) {
+            element_visibility.visible = false; /* Don't Draw */
+        }
+        // Assign transparency from cross layer option if connection is between different layers.
         element_visibility.alpha = draw_state->cross_layer_display.alpha;
     } else {
-        //otherwise assign transparency of current layer
+        if (!draw_state->draw_layer_display[sink_layer].visible || !draw_state->draw_layer_display[src_layer].visible) {
+            element_visibility.visible = false; /* Don't Draw */
+        }
+        // Assign transparency of current layer.
         element_visibility.alpha = draw_state->draw_layer_display[src_layer].alpha;
     }
 

--- a/vpr/src/draw/draw.cpp
+++ b/vpr/src/draw/draw.cpp
@@ -1773,7 +1773,7 @@ t_draw_layer_display get_element_visibility_and_transparency(int src_layer, int 
         // Assign transparency from cross layer option if connection is between different layers.
         element_visibility.alpha = draw_state->cross_layer_display.alpha;
     } else {
-        if (!draw_state->draw_layer_display[sink_layer].visible || !draw_state->draw_layer_display[src_layer].visible) {
+        if (!draw_state->draw_layer_display[src_layer].visible) {
             element_visibility.visible = false; /* Don't Draw */
         }
         // Assign transparency of current layer.

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -571,7 +571,10 @@ void draw_x(float x, float y, float size, ezgl::renderer* g) {
     g->draw_line({x - size, y - size}, {x + size, y + size});
 }
 
-void draw_star_fixed_px(double x, double y, double size, ezgl::renderer* g) {
+void draw_star_fixed_px(ezgl::point2d star_coords, double size, ezgl::renderer* g) {
+    double x = star_coords.x;
+    double y = star_coords.y;
+
     // The star size is defined in pixels, but drawing is performed in world coordinates.
     double size_in_world = size / get_pixels_per_world_unit(g);
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -571,34 +571,34 @@ void draw_x(float x, float y, float size, ezgl::renderer* g) {
     g->draw_line({x - size, y - size}, {x + size, y + size});
 }
 
-void draw_star_fixed_px(ezgl::point2d star_coords, double size, ezgl::renderer* g) {
+void draw_star_fixed_px(ezgl::point2d star_coords, double size_in_pixels, ezgl::renderer* g) {
     double x = star_coords.x;
     double y = star_coords.y;
 
     // The star size is defined in pixels, but drawing is performed in world coordinates.
-    double size_in_world = size / get_pixels_per_world_unit(g);
+    double size_in_world = size_in_pixels / get_pixels_per_world_unit(g);
 
     // Check the function declaration for what "square" refers to if not clear.
     // To replicate a star shape, we let the distance from the star center to the square side
-    // (equivalent to half the length of the square side) be one fourth of the star size.
-    double half_sqr_len = size_in_world / 4.0;
+    // (equivalent to half the width of the square) be one fourth of the star size.
+    double half_sqr_width = size_in_world / 4.0;
 
     // The star vertices, all calculated based on the star center.
     std::vector<ezgl::point2d> endpoints;
     // Top left corner of the square.
-    endpoints.push_back({x - half_sqr_len, y + half_sqr_len});
+    endpoints.push_back({x - half_sqr_width, y + half_sqr_width});
     // Tip of the top triangle (check the function declaration for what "triangle" refers to if not clear.)
     endpoints.push_back({x, y + size_in_world});
     // Top right corner of the square.
-    endpoints.push_back({x + half_sqr_len, y + half_sqr_len});
+    endpoints.push_back({x + half_sqr_width, y + half_sqr_width});
     // Tip of the right triangle.
     endpoints.push_back({x + size_in_world, y});
     // Bottom right corner of the square.
-    endpoints.push_back({x + half_sqr_len, y - half_sqr_len});
+    endpoints.push_back({x + half_sqr_width, y - half_sqr_width});
     // Tip of the bottom triangle.
     endpoints.push_back({x, y - size_in_world});
     // Bottom left corner of the square.
-    endpoints.push_back({x - half_sqr_len, y - half_sqr_len});
+    endpoints.push_back({x - half_sqr_width, y - half_sqr_width});
     // Tip of the left triangle.
     endpoints.push_back({x - size_in_world, y});
 

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -571,6 +571,37 @@ void draw_x(float x, float y, float size, ezgl::renderer* g) {
     g->draw_line({x - size, y - size}, {x + size, y + size});
 }
 
+void draw_star_fixed_px(double x, double y, double size, ezgl::renderer* g) {
+    // The star size is defined in pixels, but drawing is performed in world coordinates.
+    double size_in_world = size / get_pixels_per_world_unit(g);
+
+    // Check the function declaration for what "sqaure" refers to if not clear.
+    // To replicate a star shape, we let the distance from the star center to the square side
+    // (eqivalent to half the length of the square side) be one fourth of the star size.
+    double half_sqr_len = size_in_world / 4.0;
+
+    // The star vertices, all calculated based on the star center.
+    std::vector<ezgl::point2d> endpoints;
+    // Top left corner of the square.
+    endpoints.push_back({x - half_sqr_len, y + half_sqr_len});
+    // Tip of the top triangle (check the function declaration for what "triangle" refers to if not clear.)
+    endpoints.push_back({x, y + size_in_world});
+    // Top right corner of the square.
+    endpoints.push_back({x + half_sqr_len, y + half_sqr_len});
+    // Tip of the right triangle.
+    endpoints.push_back({x + size_in_world, y});
+    // Bottom right corner of the square.
+    endpoints.push_back({x + half_sqr_len, y - half_sqr_len});
+    // Tip of the bottom triangle.
+    endpoints.push_back({x, y - size_in_world});
+    // Bottom left corner of the square.
+    endpoints.push_back({x - half_sqr_len, y - half_sqr_len});
+    // Tip of the left triangle.
+    endpoints.push_back({x - size_in_world, y});
+
+    g->fill_poly(endpoints);
+}
+
 /* Draws the nets in the positions fixed by the router.  If draw_net_type is *
  * ALL_NETS, draw all the nets.  If it is HIGHLIGHTED, draw only the nets    *
  * that are not coloured black (useful for drawing over the rr_graph).       */

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -578,9 +578,9 @@ void draw_star_fixed_px(ezgl::point2d star_coords, double size, ezgl::renderer* 
     // The star size is defined in pixels, but drawing is performed in world coordinates.
     double size_in_world = size / get_pixels_per_world_unit(g);
 
-    // Check the function declaration for what "sqaure" refers to if not clear.
+    // Check the function declaration for what "square" refers to if not clear.
     // To replicate a star shape, we let the distance from the star center to the square side
-    // (eqivalent to half the length of the square side) be one fourth of the star size.
+    // (equivalent to half the length of the square side) be one fourth of the star size.
     double half_sqr_len = size_in_world / 4.0;
 
     // The star vertices, all calculated based on the star center.

--- a/vpr/src/draw/draw_basic.cpp
+++ b/vpr/src/draw/draw_basic.cpp
@@ -578,12 +578,12 @@ void draw_star_fixed_px(ezgl::point2d star_coords, double size_in_pixels, ezgl::
     // The star size is defined in pixels, but drawing is performed in world coordinates.
     double size_in_world = size_in_pixels / get_pixels_per_world_unit(g);
 
-    // Check the function declaration for what "square" refers to if not clear.
-    // To replicate a star shape, we let the distance from the star center to the square side
-    // (equivalent to half the width of the square) be one fourth of the star size.
+    // The square we use to fill the star center has a width of size_in_world / 2.
     double half_sqr_width = size_in_world / 4.0;
 
     // The star vertices, all calculated based on the star center.
+    // With the square fixed at the star center, four triangles (tip pointing outwards) are affixed to its four sides.
+    // The triangle's base has the same width as the square, and its tip serves as a star point.
     std::vector<ezgl::point2d> endpoints;
     // Top left corner of the square.
     endpoints.push_back({x - half_sqr_width, y + half_sqr_width});

--- a/vpr/src/draw/draw_basic.h
+++ b/vpr/src/draw/draw_basic.h
@@ -60,11 +60,11 @@ void draw_x(float x, float y, float size, ezgl::renderer* g);
  * @brief Draws a filled star centered at the specified world-coordinate location with a fixed pixel size.
  *
  * The star size is in screen (pixel) coordinates, so it appears the same at any zoom level.
- * The star can be imagined as a square with four triangles (tip pointing outwards) affixed to its four sides.
- * The triangle's base has the same length as the sqaure's side.
+ * The star is four-pointed, with the distance from the center to a star point of size_in_pixels.
+ * The center of the star is filled in with a square of width size_in_pixels / 2.
  *
  * @param star_coords 2D star coordinates in world units.
- * @param size_in_pixels Distance from the star center to the previously mentioned traingle's tip, in pixels.
+ * @param size_in_pixels Distance from the center to a star point, in pixels.
  * @param g Renderer used to perform drawing.
  */
 void draw_star_fixed_px(ezgl::point2d star_coords, double size_in_pixels, ezgl::renderer* g);

--- a/vpr/src/draw/draw_basic.h
+++ b/vpr/src/draw/draw_basic.h
@@ -65,12 +65,11 @@ void draw_x(float x, float y, float size, ezgl::renderer* g);
  * as the sqaure's side. We specify the star by creating a std::vector of ezgl::point2d where the point2ds are
  * the contiguous star vertices.
  *
- * @param x Center x coordinate in world units.
- * @param y Center y coordinate in world units.
+ * @param star_coords 2D star coordinates in world units.
  * @param size Distance from the star center to the previously mentioned traingle's tip, in pixels.
  * @param g Renderer used to perform drawing.
  */
-void draw_star_fixed_px(double x, double y, double size, ezgl::renderer* g);
+void draw_star_fixed_px(ezgl::point2d star_coords, double size, ezgl::renderer* g);
 
 /* Draws the nets in the positions fixed by the router.  If draw_net_type is *
  * ALL_NETS, draw all the nets.  If it is HIGHLIGHTED, draw only the nets    *

--- a/vpr/src/draw/draw_basic.h
+++ b/vpr/src/draw/draw_basic.h
@@ -53,6 +53,22 @@ void draw_routing_bb(ezgl::renderer* g);
 /* Draws an X centered at (x,y). The width and height of the X are each 2 * size. */
 void draw_x(float x, float y, float size, ezgl::renderer* g);
 
+/**
+ * @brief Draws a filled star centered at the specified world-coordinate location with a fixed pixel size.
+ *
+ * The star size is converted from pixels to world units using the current renderer zoom level, so it
+ * appears with a consistent on-screen size while zooming. The star can be imagined as a square with
+ * four triangles (tip pointing outwards) affixed to its four sides. The triangle's base has the same length
+ * as the sqaure's side. We specify the star by creating a std::vector of ezgl::point2d where the point2ds are
+ * the contiguous star vertices.
+ *
+ * @param x Center x coordinate in world units.
+ * @param y Center y coordinate in world units.
+ * @param size Distance from the star center to the previously mentioned traingle's tip, in pixels.
+ * @param g Renderer used to perform drawing.
+ */
+void draw_star_fixed_px(double x, double y, double size, ezgl::renderer* g);
+
 /* Draws the nets in the positions fixed by the router.  If draw_net_type is *
  * ALL_NETS, draw all the nets.  If it is HIGHLIGHTED, draw only the nets    *
  * that are not coloured black (useful for drawing over the rr_graph).       */

--- a/vpr/src/draw/draw_basic.h
+++ b/vpr/src/draw/draw_basic.h
@@ -59,17 +59,15 @@ void draw_x(float x, float y, float size, ezgl::renderer* g);
 /**
  * @brief Draws a filled star centered at the specified world-coordinate location with a fixed pixel size.
  *
- * The star size is converted from pixels to world units using the current renderer zoom level, so it
- * appears with a consistent on-screen size while zooming. The star can be imagined as a square with
- * four triangles (tip pointing outwards) affixed to its four sides. The triangle's base has the same length
- * as the sqaure's side. We specify the star by creating a std::vector of ezgl::point2d where the point2ds are
- * the contiguous star vertices.
+ * The star size is in screen (pixel) coordinates, so it appears the same at any zoom level.
+ * The star can be imagined as a square with four triangles (tip pointing outwards) affixed to its four sides.
+ * The triangle's base has the same length as the sqaure's side.
  *
  * @param star_coords 2D star coordinates in world units.
- * @param size Distance from the star center to the previously mentioned traingle's tip, in pixels.
+ * @param size_in_pixels Distance from the star center to the previously mentioned traingle's tip, in pixels.
  * @param g Renderer used to perform drawing.
  */
-void draw_star_fixed_px(ezgl::point2d star_coords, double size, ezgl::renderer* g);
+void draw_star_fixed_px(ezgl::point2d star_coords, double size_in_pixels, ezgl::renderer* g);
 
 /* Draws the nets in the positions fixed by the router.  If draw_net_type is *
  * ALL_NETS, draw all the nets.  If it is HIGHLIGHTED, draw only the nets    *

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -39,6 +39,8 @@ static constexpr double EDGE_OFFSET_FRACTION = 0.1;
  */
 static constexpr int MAX_EDGE_OFFSET_UNIT = 40;
 
+static constexpr int ENDPOINT_STAR_SIZE = 12;
+
 /**
  * @brief Highly contrasting colours that are useful for visualization.
  */
@@ -335,16 +337,18 @@ static void draw_timing_edge_flylines(const tatum::TimingPath& path, ezgl::rende
                 // Draw an arrow at the edge center.
                 draw_triangle_along_line_fixed_px(g, start, end, EDGE_CENTER, TIMING_EDGE_ARROW_SCALE * DEFAULT_ARROW_SIZE);
 
-                const double side_len = get_pixels_per_world_unit(g) < 1 ? 10 : 10 / get_pixels_per_world_unit(g);
-                
-                if (edge_idx != 0) {
-                    ezgl::point2d buttom_left = start - ezgl::point2d{0 , side_len / 2};
-                    g->fill_rectangle(buttom_left, side_len / 2, side_len);
+                // Draw a green star at the beginning the timing path.
+                if (edge_idx == 0) {
+                    g->set_color(ezgl::GREEN, flyline_visibility.alpha);
+                    draw_star_fixed_px(start.x, start.y, ENDPOINT_STAR_SIZE, g);
                 }
 
-                if (edge_idx != path.data_arrival_path().elements().size() - 2) {
-                    ezgl::point2d buttom_left = end - ezgl::point2d{side_len / 2, side_len / 2};
-                    g->fill_rectangle(buttom_left, side_len / 2, side_len);
+                // Draw a red star at the end of the timing path.
+                // path.data_arrival_path().elements().size() returns the total number of nodes, hence we need to
+                // subtract 1 to get the total number of edges. Since we are using index here, we need to subtract another 1.
+                if (edge_idx == path.data_arrival_path().elements().size() - 2) {
+                    g->set_color(ezgl::RED, flyline_visibility.alpha);
+                    draw_star_fixed_px(end.x, end.y, ENDPOINT_STAR_SIZE, g);
                 }
             }
 

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -41,7 +41,7 @@ static constexpr double EDGE_OFFSET_FRACTION = 0.1;
 static constexpr int MAX_EDGE_OFFSET_UNIT = 40;
 
 /**
- * @brief The size of the stars drawn at the beginning and end of the critical path, in pixels.
+ * @brief The size of the star drawn at the beginning and end of the critical path, in pixels.
  * 
  * This value refers to the distance in pixels from the star center to the star tip.
  */

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -334,6 +334,18 @@ static void draw_timing_edge_flylines(const tatum::TimingPath& path, ezgl::rende
                 g->draw_line(start, end);
                 // Draw an arrow at the edge center.
                 draw_triangle_along_line_fixed_px(g, start, end, EDGE_CENTER, TIMING_EDGE_ARROW_SCALE * DEFAULT_ARROW_SIZE);
+
+                const double side_len = get_pixels_per_world_unit(g) < 1 ? 10 : 10 / get_pixels_per_world_unit(g);
+                
+                if (edge_idx != 0) {
+                    ezgl::point2d buttom_left = start - ezgl::point2d{0 , side_len / 2};
+                    g->fill_rectangle(buttom_left, side_len / 2, side_len);
+                }
+
+                if (edge_idx != path.data_arrival_path().elements().size() - 2) {
+                    ezgl::point2d buttom_left = end - ezgl::point2d{side_len / 2, side_len / 2};
+                    g->fill_rectangle(buttom_left, side_len / 2, side_len);
+                }
             }
 
             edge_idx++;

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -983,15 +983,15 @@ static void draw_total_delay(std::vector<t_label_drawing_info>& final_label_draw
     ss << " ns";
     std::string total_delay_str = ss.str();
 
-    // The canvas has an inverted y axis. Therefore, bottom right appears to be top right on the screen, which is what we aim for.
-    ezgl::point2d bottom_right = g->get_visible_screen().bottom_right();
+    // The rightmost screen x coordinate.
+    double screen_right = g->get_visible_screen().right();
     // String dimension in pixels.
     ezgl::t_text_dimension str_dimension = g->get_text_dimension(total_delay_str);
 
     // Use the screen (pixel) coordinates to draw the total delay string at a fixed screen location.
     g->set_coordinate_system(ezgl::SCREEN);
-    // Due to the same inverted y axis reason, adding str_dimension.height to y actually lowers down the string from the screen top.
-    g->draw_text(ezgl::point2d{bottom_right.x - str_dimension.width, bottom_right.y + str_dimension.height}, total_delay_str);
+    // The canvas has an inverted y axis. Therefore, adding str_dimension.height to y actually lowers down the string from the screen top.
+    g->draw_text(ezgl::point2d{screen_right - str_dimension.width, str_dimension.height}, total_delay_str);
     g->set_coordinate_system(ezgl::WORLD);
 }
 

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -40,17 +40,22 @@ static constexpr double EDGE_OFFSET_FRACTION = 0.1;
  */
 static constexpr int MAX_EDGE_OFFSET_UNIT = 40;
 
-static constexpr int ENDPOINT_STAR_SIZE = 12;
+/**
+ * @brief The size of the stars drawn at the beginning and end of the critical path, in pixels.
+ * 
+ * This value refers to the distance in pixels from the star center to the star tip.
+ */
+static constexpr int ENDPOINT_STAR_SIZE = 16;
 
 /**
  * @brief Highly contrasting colours that are useful for visualization.
  */
 const std::vector<ezgl::color> kelly_max_contrast_colors = {
     //ezgl::color(242, 243, 244), //white: skip white since it doesn't contrast well with VPR's light background.
-    ezgl::color(34, 34, 34),    //black
-    ezgl::color(243, 195, 0),   //yellow
-    ezgl::color(135, 86, 146),  //purple
-    ezgl::color(243, 132, 0),   //orange
+    ezgl::color(34, 34, 34),   //black
+    ezgl::color(243, 195, 0),  //yellow
+    ezgl::color(135, 86, 146), //purple
+    ezgl::color(243, 132, 0),  //orange
     //ezgl::color(161, 202, 241), //light blue: skip due to poor contrast.
     ezgl::color(190, 0, 50),    //red
     ezgl::color(194, 178, 128), //buf
@@ -68,6 +73,16 @@ const std::vector<ezgl::color> kelly_max_contrast_colors = {
     ezgl::color(101, 69, 34),   //yellowish brown
     ezgl::color(226, 88, 34),   //reddish orange
     ezgl::color(43, 61, 38)     //olive green
+};
+
+/**
+ * @brief Identifies which endpoint of a critical path needs to be drawn.
+ */
+enum class e_crit_path_endpoint_type {
+    /// First node in the critical path.
+    START,
+    /// Last node in the critical path.
+    END,
 };
 
 /**
@@ -125,12 +140,25 @@ struct t_label_drawing_info {
 };
 
 /**
- * @brief Draws dashed flylines between consecutive nodes in a timing path.
+ * @brief Draws dashed flylines between consecutive nodes in a timing path, and draws a star at the beginning and end of the path.
  *
  * @param path Timing path whose consecutive node pairs define the flylines.
  * @param g Pointer to the ezgl::renderer object.
  */
 static void draw_timing_edge_flylines(const tatum::TimingPath& path, ezgl::renderer* g);
+
+/**
+ * @brief Fills a star at one endpoint of a critical path and draws the critical path index at the center.
+ *
+ * The endpoint type (START or END) determines the star color.
+ * The critical path index is drawn at the star center.
+ *
+ * @param endpoint_type Whether the endpoint is the start or end of the critical path.
+ * @param endpoint_coords Drawing coordinates of the endpoint in world units.
+ * @param crit_path_idx Index of the critical path (0 when only one path is chosen).
+ * @param g Renderer used to perform drawing.
+ */
+static void draw_crit_path_endpoint(e_crit_path_endpoint_type endpoint_type, ezgl::point2d endpoint_coords, unsigned crit_path_idx, ezgl::renderer* g);
 
 /**
  * @brief Draws routed connections for consecutive nodes in a timing path.
@@ -188,12 +216,14 @@ static void draw_server_mode_flylines_and_labels(ezgl::point2d start, ezgl::poin
 #endif /* NO_SERVER */
 
 /**
- * @brief Calculate label positions that give the least number of overlaps and then draws all visible delay labels.
+ * @brief Greedily calculate delay label positions for the least number of overlaps and then draws all visible labels.
  *
+ * In addition, a message that shows the total delay time is drawn at the screen's top right corner.
+ * 
  * @param path Timing path whose consecutive node pairs define the timing edges to place delay labels.
  * @param g Pointer to the ezgl::renderer object.
  */
-static void calculate_and_draw_labels(const tatum::TimingPath& path, ezgl::renderer* g);
+static void calculate_and_draw_delay(const tatum::TimingPath& path, ezgl::renderer* g);
 
 /**
  * @brief Calculates delay, visibility, rotation, and initial bounding-box information for each timing edge.
@@ -266,6 +296,15 @@ static bool check_if_bboxes_overlap(const ezgl::rectangle& bbox1, const ezgl::re
 static void draw_labels(std::vector<t_label_drawing_info>& final_label_drawing_info, ezgl::renderer* g);
 
 /**
+ * @brief Draws a meesage that shows the total delay time tied to the given critical path index.
+ *
+ * @param final_label_drawing_info Per-edge delay label drawing information whose delay values are summed.
+ * @param crit_path_idx Index of the critical path (0 when only one path is chosen).
+ * @param g Renderer used to perform drawing.
+ */
+static void draw_total_delay(std::vector<t_label_drawing_info>& final_label_drawing_info, unsigned crit_path_idx, ezgl::renderer* g);
+
+/**
  * @brief Calculates the color tied to a timing edge index deterministically. For long critical paths there may be repeats.
  * 
  * @param edge_idx Timing edge index.
@@ -308,8 +347,8 @@ static int get_tnode_layer_num(tatum::NodeId node);
  *
  * @return The start/end drawing coordinates for the flyline, or std::nullopt if the flyline is skipped.
  */
-static std::optional<t_flyline_draw_coords> get_timing_flyline_draw_coords(tatum::NodeId src_node,
-                                                                           tatum::NodeId sink_node);
+static t_flyline_draw_coords get_timing_flyline_draw_coords(tatum::NodeId src_node,
+                                                            tatum::NodeId sink_node);
 
 /**
  * @brief Returns the drawing coordinates of a timing node.
@@ -363,7 +402,7 @@ void draw_crit_path(ezgl::renderer* g) {
     if (draw_state->show_crit_path_flylines) {
         draw_timing_edge_flylines(path, g);
         if (draw_state->show_crit_path_delays) {
-            calculate_and_draw_labels(path, g);
+            calculate_and_draw_delay(path, g);
         }
     }
 
@@ -394,37 +433,28 @@ static void draw_timing_edge_flylines(const tatum::TimingPath& path, ezgl::rende
             if (flyline_visibility.visible) {
                 g->set_color(color, flyline_visibility.alpha);
 
-                // Calculate the drawing coordinates for the flyline.
-                // Use optional because the function may return std::nullopt (see the function definition for reasons),
-                // in which case the label is skipped.
-                std::optional<t_flyline_draw_coords> timing_flyline_draw_coords = get_timing_flyline_draw_coords(prev_node, node);
-                if (!timing_flyline_draw_coords) {
-                    edge_idx++;
-                    prev_node = node;
-                    continue;
+                // Calculate the drawing coordinates of the flyline.
+                t_flyline_draw_coords timing_flyline_draw_coords = get_timing_flyline_draw_coords(prev_node, node);
+                ezgl::point2d start = timing_flyline_draw_coords.start;
+                ezgl::point2d end = timing_flyline_draw_coords.end;
+
+                // No flyline to draw when the two timing nodes collapse to the same drawing point.
+                if (!timing_flyline_draw_coords.collapse_to_point) {
+                    g->draw_line(start, end);
+                    // Draw an arrow at the flyline center.
+                    draw_triangle_along_line_fixed_px(g, start, end, EDGE_CENTER, TIMING_EDGE_ARROW_SCALE * DEFAULT_ARROW_SIZE);
                 }
-                ezgl::point2d start = timing_flyline_draw_coords->start;
-                ezgl::point2d end = timing_flyline_draw_coords->end;
 
-                g->draw_line(start, end);
-                // Draw an arrow at the flyline center.
-                draw_triangle_along_line_fixed_px(g, start, end, EDGE_CENTER, TIMING_EDGE_ARROW_SCALE * DEFAULT_ARROW_SIZE);
-
-                // Draw a green star at the beginning the timing path.
+                // Draw a star at the beginning and end of the timing path.
                 if (edge_idx == 0) {
-                    g->set_color(ezgl::GREEN, flyline_visibility.alpha);
-                    draw_star_fixed_px(start.x, start.y, ENDPOINT_STAR_SIZE, g);
+                    draw_crit_path_endpoint(e_crit_path_endpoint_type::START, start, 0, g);
                 }
-
-                // Draw a red star at the end of the timing path.
                 // path.data_arrival_path().elements().size() returns the total number of nodes, hence we need to
                 // subtract 1 to get the total number of edges. Since we are using index here, we need to subtract another 1.
                 if (edge_idx == path.data_arrival_path().elements().size() - 2) {
-                    g->set_color(ezgl::RED, flyline_visibility.alpha);
-                    draw_star_fixed_px(end.x, end.y, ENDPOINT_STAR_SIZE, g);
+                    draw_crit_path_endpoint(e_crit_path_endpoint_type::END, end, 0, g);
                 }
             }
-
             edge_idx++;
         }
         prev_node = node;
@@ -432,6 +462,28 @@ static void draw_timing_edge_flylines(const tatum::TimingPath& path, ezgl::rende
 
     g->set_line_dash(ezgl::line_dash::none);
     g->set_line_width(0);
+}
+
+static void draw_crit_path_endpoint(e_crit_path_endpoint_type endpoint_type, ezgl::point2d endpoint_coords, unsigned crit_path_idx, ezgl::renderer* g) {
+    if (endpoint_type == e_crit_path_endpoint_type::START) {
+        // Medium Green. We do not use the default ezgl::GREEN due to poor contrast.
+        g->set_color({0x00, 0xCC, 0x00});
+    } else if (endpoint_type == e_crit_path_endpoint_type::END) {
+        g->set_color(ezgl::RED);
+    } else {
+        VTR_LOG_ERROR("Illegal e_crit_path_endpoint value provided! Legal values are START and END.");
+        return;
+    }
+
+    // Draw a star shape at the endpoint.
+    draw_star_fixed_px(endpoint_coords, ENDPOINT_STAR_SIZE, g);
+
+    // Draw the critical path index at the star center.
+    // Useful when multiple critical paths are drawn simultaneously and we want to distinguish them.
+    g->set_font_size(16);
+    // Use white for good contrast with the two star colors.
+    g->set_color(ezgl::WHITE);
+    g->draw_text(endpoint_coords, std::to_string(crit_path_idx));
 }
 
 static void draw_routed_timing_connections(const tatum::TimingPath& path, ezgl::renderer* g) {
@@ -559,7 +611,7 @@ static void draw_connections_from_cluster_netlist(AtomPinId atom_src_pin, AtomPi
     }
 }
 
-static void calculate_and_draw_labels(const tatum::TimingPath& path, ezgl::renderer* g) {
+static void calculate_and_draw_delay(const tatum::TimingPath& path, ezgl::renderer* g) {
     // The ratio between pixels and world units spanning the screen width.
     // Used to perform screen-to-world conversions for label bounding boxes that primarily use pixels.
     double pixels_per_world_unit = get_pixels_per_world_unit(g);
@@ -576,12 +628,20 @@ static void calculate_and_draw_labels(const tatum::TimingPath& path, ezgl::rende
     std::vector<t_label_drawing_info> final_label_drawing_info =
         hide_still_cluttered_labels(std::move(post_decluttering_label_drawing_info));
 
+    // Draw non-hidden delay labels on the timing edge flylines.
     draw_labels(final_label_drawing_info, g);
+
+    // Draw a meesage that shows the total delay time at the screen's top right corner.
+    draw_total_delay(final_label_drawing_info, 0, g);
 }
 
 static std::vector<t_label_drawing_info> calculate_basic_label_drawing_info(const tatum::TimingPath& path,
                                                                             double pixels_per_world_unit,
                                                                             ezgl::renderer* g) {
+    // Set font size to correctly calculate text (label) dimension later.
+    g->set_font_size(16);
+
+    // Per-edge label drawing info.
     std::vector<t_label_drawing_info> basic_label_drawing_info;
     // The callers of this function have ensured that path is not empty, but having a safety check is still decent.
     VTR_ASSERT_SAFE(path.data_arrival_path().elements().size() > 0);
@@ -603,7 +663,7 @@ static std::vector<t_label_drawing_info> calculate_basic_label_drawing_info(cons
             // Check visibility of layers where source and sink reside.
             t_draw_layer_display flyline_visibility = get_timing_flyline_visibility(prev_node, node);
 
-            // Hide the label if the corresponding timing edge flyline is not visible
+            // Hide the label if the corresponding timing edge flyline is not visible.
             if (!flyline_visibility.visible) {
                 drawing_info.hide_label = true;
                 edge_idx++;
@@ -622,28 +682,26 @@ static std::vector<t_label_drawing_info> calculate_basic_label_drawing_info(cons
             drawing_info.delay_time = delay_time;
 
             std::stringstream ss;
-            // Set precision to three decimals.
-            ss.precision(3);
-            // Use std::fixed to explicitly show three decimals for visual consistency among labels
-            // (e.g. 1.5 is consistent with std::stringstream::precision(3) but still needs to be extended to 1.500).
-            ss << std::fixed << delay_time;
+            // Set precision to three decimals and use std::fixed to explicitly show three decimals for visual consistency among labels
+            // (Note: 1.5, for example, is consistent with std::setprecision(3) but still needs to be extended to 1.500 by std::fixed).
+            ss << std::setprecision(3) << std::fixed << delay_time;
             // This local std::string will help construct the label bounding box later.
             std::string delay_label_str = ss.str();
             drawing_info.delay_label_str = delay_label_str;
 
             // Calculate where the corresponding timing edge flyline is placed.
-            // Use optional because the function may return std::nullopt (see the function definition for details),
-            // in which case the label is skipped.
-            std::optional<t_flyline_draw_coords> timing_flyline_draw_coords = get_timing_flyline_draw_coords(prev_node, node);
-            if (!timing_flyline_draw_coords) {
+            t_flyline_draw_coords timing_flyline_draw_coords = get_timing_flyline_draw_coords(prev_node, node);
+            // No flyline to draw when the two timing nodes collapse to the same drawing point,
+            // and hence no label to draw.
+            if (timing_flyline_draw_coords.collapse_to_point) {
                 drawing_info.hide_label = true;
                 edge_idx++;
                 prev_node = node;
                 prev_arr_time = arr_time;
                 continue;
             }
-            ezgl::point2d start = timing_flyline_draw_coords->start;
-            ezgl::point2d end = timing_flyline_draw_coords->end;
+            ezgl::point2d start = timing_flyline_draw_coords.start;
+            ezgl::point2d end = timing_flyline_draw_coords.end;
 
             // After this step, start and end are just a relative concept.
             // This step is to ensure that start is always to the physical left of end,
@@ -651,12 +709,12 @@ static std::vector<t_label_drawing_info> calculate_basic_label_drawing_info(cons
             if (start.x > end.x) {
                 std::swap(start, end);
             }
-
             double min_y = std::min(start.y, end.y);
             double max_y = std::max(start.y, end.y);
             // It is already ensured in the previous step that start.x < end.x.
             ezgl::rectangle edge_bbox({start.x, min_y}, {end.x, max_y});
 
+            // Calculate the length of the corresponding timing edge.
             drawing_info.edge_length = std::sqrt(std::pow(edge_bbox.width(), 2) + std::pow(edge_bbox.height(), 2));
 
             // Since start.x < end.x, the result from atan2() is always between - pi / 2 and pi/ 2.
@@ -903,9 +961,38 @@ static void draw_labels(std::vector<t_label_drawing_info>& final_label_drawing_i
             g->draw_text(drawing_info.label_bbox.center(), drawing_info.delay_label_str);
         }
     }
-
-    g->set_font_size(14);
     g->set_text_rotation(0);
+}
+
+static void draw_total_delay(std::vector<t_label_drawing_info>& final_label_drawing_info, unsigned crit_path_idx, ezgl::renderer* g) {
+    g->set_color(ezgl::BLACK);
+    g->set_font_size(20);
+    g->set_text_rotation(0);
+
+    float total_delay_time = 0.0;
+    // Iterate on all delay labels to sum up the delay time.
+    for (std::size_t edge_idx = 0; edge_idx < final_label_drawing_info.size(); edge_idx++) {
+        t_label_drawing_info& drawing_info = final_label_drawing_info[edge_idx];
+        total_delay_time += drawing_info.delay_time;
+    }
+
+    // Construct the message to be drawn on screen.
+    std::stringstream ss;
+    ss << "Crit Path [" << crit_path_idx << "]: ";
+    ss << std::setprecision(3) << std::fixed << total_delay_time;
+    ss << " ns";
+    std::string total_delay_str = ss.str();
+
+    // The canvas has an inverted y axis. Therefore, bottom right appears to be top right on the screen, which is what we aim for.
+    ezgl::point2d bottom_right = g->get_visible_screen().bottom_right();
+    // String dimension in pixels.
+    ezgl::t_text_dimension str_dimension = g->get_text_dimension(total_delay_str);
+
+    // Use the screen (pixel) coordinates to draw the total delay string at a fixed screen location.
+    g->set_coordinate_system(ezgl::SCREEN);
+    // Due to the same inverted y axis reason, adding str_dimension.height to y actually lowers down the string from the screen top.
+    g->draw_text(ezgl::point2d{bottom_right.x - str_dimension.width, bottom_right.y + str_dimension.height}, total_delay_str);
+    g->set_coordinate_system(ezgl::WORLD);
 }
 
 static ezgl::color get_color_from_edge_idx(std::size_t edge_idx) {
@@ -939,9 +1026,11 @@ static int get_tnode_layer_num(tatum::NodeId node) {
     return block_locs[clb_block].loc.layer;
 }
 
-static std::optional<t_flyline_draw_coords> get_timing_flyline_draw_coords(tatum::NodeId src_node,
-                                                                           tatum::NodeId sink_node) {
+static t_flyline_draw_coords get_timing_flyline_draw_coords(tatum::NodeId src_node,
+                                                            tatum::NodeId sink_node) {
     t_draw_state* draw_state = get_draw_state_vars();
+    t_flyline_draw_coords flyline_draw_coords;
+    flyline_draw_coords.collapse_to_point = false;
 
     ezgl::point2d start, end;
     if (draw_state->pic_on_screen == e_pic_type::ANALYTICAL_PLACEMENT) {
@@ -951,17 +1040,18 @@ static std::optional<t_flyline_draw_coords> get_timing_flyline_draw_coords(tatum
         APBlockId sink_ap_block = get_tnode_ap_block(sink_node);
 
         if (src_ap_block == sink_ap_block) {
-            return std::nullopt;
+            flyline_draw_coords.collapse_to_point = true;
         }
 
-        start = get_ap_block_draw_coords(src_ap_block);
-        end = get_ap_block_draw_coords(sink_ap_block);
+        flyline_draw_coords.start = get_ap_block_draw_coords(src_ap_block);
+        flyline_draw_coords.end = get_ap_block_draw_coords(sink_ap_block);
     } else {
         // In other stages, timing nodes are mapped to their corresponding atom pin coordinates.
-        start = get_tnode_draw_coord(src_node);
-        end = get_tnode_draw_coord(sink_node);
+        flyline_draw_coords.start = get_tnode_draw_coord(src_node);
+        flyline_draw_coords.end = get_tnode_draw_coord(sink_node);
     }
-    return t_flyline_draw_coords{start, end};
+
+    return flyline_draw_coords;
 }
 
 static ezgl::point2d get_tnode_draw_coord(tatum::NodeId node) {

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -45,12 +45,12 @@ static constexpr int ENDPOINT_STAR_SIZE = 12;
  * @brief Highly contrasting colours that are useful for visualization.
  */
 const std::vector<ezgl::color> kelly_max_contrast_colors = {
-    //ezgl::color(242, 243, 244), //white: skip white since it doesn't contrast well with VPR's light background
+    //ezgl::color(242, 243, 244), //white: skip white since it doesn't contrast well with VPR's light background.
     ezgl::color(34, 34, 34),    //black
     ezgl::color(243, 195, 0),   //yellow
     ezgl::color(135, 86, 146),  //purple
     ezgl::color(243, 132, 0),   //orange
-    ezgl::color(161, 202, 241), //light blue
+    //ezgl::color(161, 202, 241), //light blue: skip due to poor contrast.
     ezgl::color(190, 0, 50),    //red
     ezgl::color(194, 178, 128), //buf
     ezgl::color(132, 132, 130), //gray
@@ -98,6 +98,9 @@ enum class e_label_relative_pos {
  * @brief Contains all attributes of one timing edge delay label needed for drawing and finding a label position that minimizes overlaps.
  */
 struct t_label_drawing_info {
+    /// @brief Delay time across this timing edge in nanoseconds.
+    float delay_time = 0.0;
+
     /// @brief Delay time across this timing edge in nanoseconds, represented in std::string and drawn on screen.
     std::string delay_label_str;
 
@@ -545,12 +548,16 @@ static std::vector<t_label_drawing_info> calculate_basic_label_drawing_info(cons
 
             // Delay time in seconds.
             float delay_time = arr_time - prev_arr_time;
+            // Convert to nanoseconds
+            delay_time = 1e9 * delay_time;
+            drawing_info.delay_time = delay_time;
+
             std::stringstream ss;
             // Set precision to three decimals.
             ss.precision(3);
-            // Store in nanoseconds. Use std::fixed to explicitly show three decimals for visual consistency among labels
-            // (e.g. 1.5 can pass std::stringstream::precision(3) but still needs to be extended to 1.500).
-            ss << std::fixed << 1e9 * delay_time;
+            // Use std::fixed to explicitly show three decimals for visual consistency among labels
+            // (e.g. 1.5 is consistent with std::stringstream::precision(3) but still needs to be extended to 1.500).
+            ss << std::fixed << delay_time;
             // This local std::string will help construct the label bounding box later.
             std::string delay_label_str = ss.str();
             drawing_info.delay_label_str = delay_label_str;
@@ -688,8 +695,8 @@ static std::vector<t_label_drawing_info> hide_still_cluttered_labels(std::vector
         }
 
         // As long as there is one overlap associated with this label, we hide it.
-        // Note: A label being hidden may change the fate of subsequent labels (always positively), and since we redo the overlap calculation
-        // for every label, the update will always be reflected in subsequent iterations and save labels that do not have overlaps amymore.
+        // Note: A hidden label may positively affect the fate of subsequent labels, and hence we must perform a clean calculation for each label
+        // to ensure the most recent status is reflected.
         bool has_overlap = false;
         for (std::size_t edge_idx_to_compare = 0; edge_idx_to_compare < post_decluttering_label_drawing_info.size(); edge_idx_to_compare++) {
             const t_label_drawing_info& drawing_info_to_compare = post_decluttering_label_drawing_info[edge_idx_to_compare];

--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -296,7 +296,7 @@ static bool check_if_bboxes_overlap(const ezgl::rectangle& bbox1, const ezgl::re
 static void draw_labels(std::vector<t_label_drawing_info>& final_label_drawing_info, ezgl::renderer* g);
 
 /**
- * @brief Draws a meesage that shows the total delay time tied to the given critical path index.
+ * @brief Draws a message that shows the total delay time tied to the given critical path index.
  *
  * @param final_label_drawing_info Per-edge delay label drawing information whose delay values are summed.
  * @param crit_path_idx Index of the critical path (0 when only one path is chosen).
@@ -631,7 +631,7 @@ static void calculate_and_draw_delay(const tatum::TimingPath& path, ezgl::render
     // Draw non-hidden delay labels on the timing edge flylines.
     draw_labels(final_label_drawing_info, g);
 
-    // Draw a meesage that shows the total delay time at the screen's top right corner.
+    // Draw a message that shows the total delay time at the screen's top right corner.
     draw_total_delay(final_label_drawing_info, 0, g);
 }
 

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -168,7 +168,7 @@ struct t_draw_layer_display {
 };
 
 /**
- * @brief The drawing coordinates of the beginning and end of a flyline segemnt.
+ * @brief The drawing coordinates of the beginning and end of a flyline segment.
  * 
  * Includes a special boolean to tell if the two points are mapped to the same drawing coordinates.
  */

--- a/vpr/src/draw/draw_types.h
+++ b/vpr/src/draw/draw_types.h
@@ -167,7 +167,14 @@ struct t_draw_layer_display {
     int alpha = 255;
 };
 
+/**
+ * @brief The drawing coordinates of the beginning and end of a flyline segemnt.
+ * 
+ * Includes a special boolean to tell if the two points are mapped to the same drawing coordinates.
+ */
 struct t_flyline_draw_coords {
+    /// True when start and end are mapped to the same drawing coordinates.
+    bool collapse_to_point = false;
     ezgl::point2d start;
     ezgl::point2d end;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Draw a star at the beginning and end of a critical path. Beginning is marked as green and end is marked as red, so it is always fast to keep track of the critical path direction while it's changing.

Inside the star, a number that represents the critical path index is drawn. Currently, we only draw the worst setup timing path, so this index is always 0. In the very next PR, I will modify the relevant functions so that multiple paths can be drawn at the same time, and having this little indicator will be very helpful.
<img width="671" height="398" alt="2026-07-21 104105" src="https://github.com/user-attachments/assets/90be200f-97ed-41ad-a388-254657402274" />

This indicator is in fact also important for the second feature included in this PR: now, when the `Critical Path Delay` UI checkbox is toggled, a message that shows the total delay time of the associated critical path index is drawn fixed at the screen's top right corner. Once we have multiple paths, the index will help us distinguish them.
<img width="719" height="521" alt="2026-07-21 104151" src="https://github.com/user-attachments/assets/07e9d31d-3e79-4c06-9c2d-e4c39e78807b" />


#### Miscellaneous
There is one part of the code that does not have comment, and it is intentional:
In draw_timing_edge_flylines(), draw_crit_path.cpp:

> if (edge_idx == 0) {
         draw_crit_path_endpoint(e_crit_path_endpoint_type::START, start, 0, g);
   }

The 0 in the function call is a magic number, and it is meant to represent the critical path index (which can only be 0 now). In the next PR, I will make the drawing of multiple critical paths available, where a few functions (including this one) will be changed, so I think it is fine to leave this intermediate code here. After all, it will be replaced very soon.

One small thing open to discussion: the stars are affiliated to the flylines (i.e. they are drawn together with the flylines), so if the first and/or last flyline segment is hidden due to the device layer setting, the corresponding stars will become invisible as well. Do people find this natural?

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enhance how the critical path is visually represented, and provide developers the option to see the total delay time.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on different devices using multiple regression tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
