### PR TITLE
[Pack][Pin Counting] Fix pin counting committed net size bug

### DIFF
--- a/vpr/src/pack/cluster_pin_counter.cpp
+++ b/vpr/src/pack/cluster_pin_counter.cpp
@@ -89,32 +89,10 @@ void ClusterPinCounter::reset_lookahead() {
     }
 }
 
-// TODO [BUG]: this loop grows committed to match lookahead but never shrinks,
-// even when lookahead is smaller (e.g., a net is absorbed inside the
-// cluster). This is a bug inherited from the legacy pin counting code,
-// where committed was stored as unordered_map<pin_index, net> and updated
-// with insert() which never overwrites existing keys, so committed size
-// could only grow across commits. Kept for the scope of this class refactor
-// so behaviour is preserved. The fix is to assign lookahead directly
-// to committed, as I implemented intuitively first and observed differences
-// with legacy. Leaving this QoR changing small fix to next PR.
 void ClusterPinCounter::commit_lookahead() {
-    for (auto& kv : per_pb_state_) {
-        PerPbState& state = kv.second;
-        for (size_t c = 0; c < state.committed_input_pin_class_nets.size(); c++) {
-            auto& committed = state.committed_input_pin_class_nets[c];
-            const auto& lookahead = state.lookahead_input_pin_class_nets[c];
-            if (lookahead.size() > committed.size()) {
-                committed = lookahead;
-            }
-        }
-        for (size_t c = 0; c < state.committed_output_pin_class_nets.size(); c++) {
-            auto& committed = state.committed_output_pin_class_nets[c];
-            const auto& lookahead = state.lookahead_output_pin_class_nets[c];
-            if (lookahead.size() > committed.size()) {
-                committed = lookahead;
-            }
-        }
+    for (auto& [pb, state] : per_pb_state_) {
+        state.committed_input_pin_class_nets  = state.lookahead_input_pin_class_nets;
+        state.committed_output_pin_class_nets = state.lookahead_output_pin_class_nets;
     }
 }
 

--- a/vpr/src/pack/cluster_pin_counter.cpp
+++ b/vpr/src/pack/cluster_pin_counter.cpp
@@ -98,7 +98,7 @@ void ClusterPinCounter::reset_lookahead() {
 
 void ClusterPinCounter::commit_lookahead() {
     for (auto& [pb, state] : per_pb_state_) {
-        state.committed_input_pin_class_nets  = state.lookahead_input_pin_class_nets;
+        state.committed_input_pin_class_nets = state.lookahead_input_pin_class_nets;
         state.committed_output_pin_class_nets = state.lookahead_output_pin_class_nets;
     }
 }


### PR DESCRIPTION
Before the pin counting class PR (#3719), the legacy code was using unordered_map to store the committed nets and updating it with only insert(), which does not overwrite existing keys. So, the committed size could only stay the same or grow across commits while actually it may need to shrink when a net gets absorbed in a later commit. 

This PR is fixing this issue by promoting the lookahead to committed when we accept the candidate molecule. 

I tried on both VTR Chain Largest and Titan benchmarks and observed a QoR change on only one circuit in VTR Chain Largest (bgm.v). So, the fix has minimal QoR change but makes the pin counting more consistent.

Adding the results below.