### PR TITLE
[Scripts] Fixed Bug in Parsing

### DIFF
--- a/vtr_flow/scripts/python_libs/vtr/__init__.py
+++ b/vtr_flow/scripts/python_libs/vtr/__init__.py
@@ -18,7 +18,6 @@ from .util import (
     get_active_run_dir,
     get_next_run_dir,
     verify_file,
-    pretty_print_table,
     find_task_dir,
     RunDir,
 )

--- a/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
+++ b/vtr_flow/scripts/python_libs/vtr/parse_vtr_task.py
@@ -26,7 +26,6 @@ from vtr import (
     load_pass_requirements,
     load_parse_results,
     parse_vtr_flow,
-    pretty_print_table,
     find_task_dir,
     CommandError,
     InspectError,
@@ -285,7 +284,6 @@ def parse_files(config_jobs, run_dir, flow_metrics_basename=FIRST_PARSE_FILE):
                         header = False
                     # Second line is the data
                     print(lines[1], file=out_f, end="")
-                pretty_print_table(job_parse_results_filepath)
             else:
                 print(
                     "Warning: Flow result file not found (task QoR will be incomplete): {} ".format(
@@ -352,7 +350,6 @@ def check_golden_results_for_task(config, alt_tasks_dir=None):
                 second_results_filepath,
                 second_name="second parse file",
             )
-            pretty_print_table(second_results_filepath)
 
         else:
             golden_results_filepath = str(
@@ -363,7 +360,6 @@ def check_golden_results_for_task(config, alt_tasks_dir=None):
                 task_results_filepath,
                 golden_results_filepath,
             )
-        pretty_print_table(task_results_filepath)
 
     if num_qor_failures == 0:
         print("{}...[Pass]".format("/".join(str((Path(config.config_dir).parent)).split("/")[-3:])))
@@ -521,9 +517,6 @@ def summarize_qor(configs, alt_tasks_dir=None):
                     first = False
                 for line in in_file:
                     print("{}\t{}".format(config.task_name, line), file=out, end="")
-            pretty_print_table(
-                str(Path(find_latest_run_dir(config, alt_tasks_dir)) / QOR_PARSE_FILE)
-            )
 
 
 def calc_geomean(args, configs):

--- a/vtr_flow/scripts/python_libs/vtr/util.py
+++ b/vtr_flow/scripts/python_libs/vtr/util.py
@@ -18,8 +18,6 @@ from pathlib import PurePath
 from pathlib import Path
 from typing import List, Tuple
 
-from prettytable import PrettyTable
-
 import vtr.error
 from vtr.error import CommandError
 from vtr import paths
@@ -319,28 +317,6 @@ def check_cmd(command):
     """
 
     return Path(command).exists()
-
-
-def pretty_print_table(file, border=False):
-    """Convert file to a pretty, easily read table"""
-    table = PrettyTable()
-    table.border = border
-    reader = None
-    with open(file, "r", encoding="utf-8") as csv_file:
-        reader = csv.reader(csv_file, delimiter="\t")
-        first = True
-        for row in reader:
-            row = [row_item.strip() + "\t" for row_item in row]
-            while row[-1] == "\t":
-                row = row[:-1]
-            if first:
-                table.field_names = list(row)
-                table.align = "l"
-                first = False
-            else:
-                table.add_row(row)
-    with open(file, "w+", encoding="utf-8") as out_file:
-        print(table, file=out_file)
 
 
 def write_tab_delimitted_csv(filepath, rows):


### PR DESCRIPTION
When parsing task results, we sometimes got random failures where it says something like "vpr_status not found in parse_results" when it obviously was there.

I tracked down the issue to this function which was corrupting the parse_results and made it hard for later scripts to work with it.

It looks like this function was used for a different purpose in the past and ended up going unused. All the function does now is just regenerate the table; but I do not think its worth messing up our scripts.

I removed this function and it resolved the issues with the task parsing and golden generation.