### PR TITLE
Add missing iomanip include

### DIFF
--- a/vpr/src/draw/draw_crit_path.cpp
+++ b/vpr/src/draw/draw_crit_path.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <limits>
 #include <array>
+#include <iomanip>
 
 #include "draw_crit_path.h"
 #include "draw.h"


### PR DESCRIPTION
Fixes a compile error on fedora/my compiler. Apparently Ubuntu GCCs (so far) include iomanip by default.