### PR TITLE
Fix always false #ifdef that disabled incremental timing cost updates

### DIFF
--- a/vpr/src/place/timing/PlacerTimingCosts.cpp
+++ b/vpr/src/place/timing/PlacerTimingCosts.cpp
@@ -85,7 +85,13 @@ double PlacerTimingCosts::total_cost_from_scratch(size_t inode) const {
         return 0.;
     }
 
-    //Recompute recursively
+    // Leaf nodes hold the actual connection costs
+    size_t first_leaf = num_nodes_up_to_level((int)num_levels_ - 2);
+    if (inode >= first_leaf) {
+        return connection_costs_[inode];
+    }
+
+    // Recompute recursively
     double node_cost = total_cost_from_scratch(left_child(inode))
                        + total_cost_from_scratch(right_child(inode));
 

--- a/vpr/src/place/timing/PlacerTimingCosts.h
+++ b/vpr/src/place/timing/PlacerTimingCosts.h
@@ -168,7 +168,7 @@ class PlacerTimingCosts {
      *        in the face of modified connection costs.
      */
     double total_cost() {
-        float cost = total_cost_recurr(0); //Root
+        double cost = total_cost_recurr(0); // Root
 
         VTR_ASSERT_DEBUG_MSG(cost == total_cost_from_scratch(0),
                              "Expected incremental and from-scratch costs to be consistent");

--- a/vpr/src/place/timing/place_timing_update.cpp
+++ b/vpr/src/place/timing/place_timing_update.cpp
@@ -333,7 +333,7 @@ void comp_td_costs(const PlaceDelayModel* delay_model,
         if (cluster_ctx.clb_nlist.net_is_ignored(net_id)) continue;
 
         for (size_t ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net_id).size(); ipin++) {
-            float conn_timing_cost = comp_td_connection_cost(delay_model, place_crit, placer_state, net_id, ipin);
+            double conn_timing_cost = comp_td_connection_cost(delay_model, place_crit, placer_state, net_id, ipin);
 
             // Record new value
             connection_timing_cost[net_id][ipin] = conn_timing_cost;

--- a/vpr/src/place/timing/place_timing_update.cpp
+++ b/vpr/src/place/timing/place_timing_update.cpp
@@ -12,7 +12,7 @@
 #include "place_util.h"
 #include "vtr_time.h"
 
-/* Routines local to place_timing_update.cpp */
+// Routines local to place_timing_update.cpp
 static double comp_td_connection_cost(const PlaceDelayModel* delay_model,
                                       const PlacerCriticalities& place_crit,
                                       const PlacerState& placer_state,
@@ -44,16 +44,16 @@ void initialize_timing_info(const PlaceCritParams& crit_params,
     const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
     const ClusteredNetlist& clb_nlist = cluster_ctx.clb_nlist;
 
-    //As a safety measure, for the first time update,
-    //invalidate all timing edges via the pin invalidator
-    //by passing in all the clb sink pins
+    // As a safety measure, for the first time update,
+    // invalidate all timing edges via the pin invalidator
+    // by passing in all the clb sink pins
     for (ClusterNetId net_id : clb_nlist.nets()) {
         for (ClusterPinId pin_id : clb_nlist.net_sinks(net_id)) {
             pin_timing_invalidator->invalidate_connection(pin_id);
         }
     }
 
-    //Perform first time update for all timing related classes
+    // Perform first time update for all timing related classes
     perform_full_timing_update(crit_params,
                                delay_model,
                                criticalities,
@@ -63,10 +63,10 @@ void initialize_timing_info(const PlaceCritParams& crit_params,
                                costs,
                                placer_state);
 
-    //Don't warn again about unconstrained nodes again during placement
+    // Don't warn again about unconstrained nodes again during placement
     timing_info->set_warn_unconstrained(false);
 
-    //Clear all update_td_costs() runtime stat variables
+    // Clear all update_td_costs() runtime stat variables
     PlacerRuntimeContext& p_runtime_ctx = placer_state.mutable_runtime();
     p_runtime_ctx.f_update_td_costs_connections_elapsed_sec = 0.f;
     p_runtime_ctx.f_update_td_costs_nets_elapsed_sec = 0.f;
@@ -91,7 +91,7 @@ void perform_full_timing_update(const PlaceCritParams& crit_params,
                                 SetupTimingInfo* timing_info,
                                 t_placer_costs* costs,
                                 PlacerState& placer_state) {
-    /* Update all timing related classes. */
+    // Update all timing related classes.
     criticalities->enable_update();
     setup_slacks->enable_update();
     update_timing_classes(crit_params,
@@ -100,13 +100,13 @@ void perform_full_timing_update(const PlaceCritParams& crit_params,
                           setup_slacks,
                           pin_timing_invalidator);
 
-    /* Update the timing cost with new connection criticalities. */
+    // Update the timing cost with new connection criticalities.
     update_timing_cost(delay_model,
                        criticalities,
                        placer_state,
                        &costs->timing_cost);
 
-    /* Commit the setup slacks since they are updated. */
+    // Commit the setup slacks since they are updated.
     commit_setup_slacks(setup_slacks, placer_state);
 }
 
@@ -140,16 +140,16 @@ void update_timing_classes(const PlaceCritParams& crit_params,
                            PlacerCriticalities* criticalities,
                            PlacerSetupSlacks* setup_slacks,
                            NetPinTimingInvalidator* pin_timing_invalidator) {
-    /* Run STA to update slacks and adjusted/relaxed criticalities. */
+    // Run STA to update slacks and adjusted/relaxed criticalities.
     timing_info->update();
 
-    /* Update the placer's criticalities (e.g. sharpen with crit_exponent). */
+    // Update the placer's criticalities (e.g. sharpen with crit_exponent).
     criticalities->update_criticalities(crit_params);
 
-    /* Update the placer's raw setup slacks. */
+    // Update the placer's raw setup slacks.
     setup_slacks->update_setup_slacks();
 
-    /* Clear invalidation state. */
+    // Clear invalidation state.
     pin_timing_invalidator->reset();
 }
 
@@ -198,7 +198,7 @@ void commit_setup_slacks(const PlacerSetupSlacks* setup_slacks,
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     ClbNetPinsMatrix<float>& connection_setup_slack = placer_state.mutable_timing().connection_setup_slack;
 
-    /* Incremental: only go through sink pins with modified setup slack */
+    // Incremental: only go through sink pins with modified setup slack
     PlacerSetupSlacks::pin_range clb_pins_modified = setup_slacks->pins_with_modified_setup_slack();
     for (ClusterPinId pin_id : clb_pins_modified) {
         ClusterNetId net_id = clb_nlist.pin_net(pin_id);
@@ -224,7 +224,7 @@ bool verify_connection_setup_slacks(const PlacerSetupSlacks* setup_slacks,
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
     const ClbNetPinsMatrix<float>& connection_setup_slack = placer_state.timing().connection_setup_slack;
 
-    /* Go through every single sink pin to check that the slack values are the same */
+    // Go through every single sink pin to check that the slack values are the same
     for (ClusterNetId net_id : clb_nlist.nets()) {
         for (size_t ipin = 1; ipin < clb_nlist.net_pins(net_id).size(); ++ipin) {
             if (connection_setup_slack[net_id][ipin] != setup_slacks->setup_slack(net_id, ipin)) {
@@ -267,7 +267,7 @@ void update_td_costs(const PlaceDelayModel* delay_model,
     PlacerRuntimeContext& p_runtime_ctx = placer_state.mutable_runtime();
     PlacerTimingCosts& connection_timing_cost = p_timing_ctx.connection_timing_cost;
 
-    //Update the modified pin timing costs
+    // Update the modified pin timing costs
     {
         vtr::Timer timer;
         PlacerCriticalities::pin_range clb_pins_modified = place_crit.pins_with_modified_criticality();
@@ -284,14 +284,14 @@ void update_td_costs(const PlaceDelayModel* delay_model,
 
             double new_timing_cost = comp_td_connection_cost(delay_model, place_crit, placer_state, clb_net, ipin);
 
-            //Record new value
+            // Record new value
             connection_timing_cost[clb_net][ipin] = new_timing_cost;
         }
 
         p_runtime_ctx.f_update_td_costs_connections_elapsed_sec += timer.elapsed_sec();
     }
 
-    //Re-total timing costs of all nets
+    // Re-total timing costs of all nets
     {
         vtr::Timer timer;
         *timing_cost = connection_timing_cost.total_cost();
@@ -335,13 +335,13 @@ void comp_td_costs(const PlaceDelayModel* delay_model,
         for (size_t ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net_id).size(); ipin++) {
             float conn_timing_cost = comp_td_connection_cost(delay_model, place_crit, placer_state, net_id, ipin);
 
-            /* Record new value */
+            // Record new value
             connection_timing_cost[net_id][ipin] = conn_timing_cost;
         }
-        /* Store net timing cost for more efficient incremental updating */
+        // Store net timing cost for more efficient incremental updating
         net_timing_cost[net_id] = sum_td_net_cost(net_id, placer_state);
     }
-    /* Make sure timing cost does not go above MIN_TIMING_COST. */
+    // Make sure timing cost does not go above MIN_TIMING_COST.
     *timing_cost = sum_td_costs(placer_state);
 }
 

--- a/vpr/src/place/timing/place_timing_update.cpp
+++ b/vpr/src/place/timing/place_timing_update.cpp
@@ -238,7 +238,7 @@ bool verify_connection_setup_slacks(const PlacerSetupSlacks* setup_slacks,
 /**
  * @brief Incrementally updates timing cost based on the current delays and criticality estimates.
  *
- * Unlike comp_td_costs(), this only updates connections who's criticality has changed.
+ * Unlike comp_td_costs(), this only updates connections whose criticality has changed.
  * This is a superset of those connections whose connection delay has changed. For a
  * from-scratch recalculation, refer to comp_td_cost().
  *
@@ -348,7 +348,7 @@ void comp_td_costs(const PlaceDelayModel* delay_model,
 /**
  * @brief Calculates the timing cost of the specified connection.
  *
- * This routine assumes that it is only called either compt_td_cost() or
+ * This routine assumes that it is only called either comp_td_cost() or
  * update_td_costs(). Otherwise, various assertions below would fail.
  */
 static double comp_td_connection_cost(const PlaceDelayModel* delay_model,

--- a/vpr/src/place/timing/place_timing_update.cpp
+++ b/vpr/src/place/timing/place_timing_update.cpp
@@ -41,8 +41,8 @@ void initialize_timing_info(const PlaceCritParams& crit_params,
                             SetupTimingInfo* timing_info,
                             t_placer_costs* costs,
                             PlacerState& placer_state) {
-    const auto& cluster_ctx = g_vpr_ctx.clustering();
-    const auto& clb_nlist = cluster_ctx.clb_nlist;
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    const ClusteredNetlist& clb_nlist = cluster_ctx.clb_nlist;
 
     //As a safety measure, for the first time update,
     //invalidate all timing edges via the pin invalidator
@@ -67,7 +67,7 @@ void initialize_timing_info(const PlaceCritParams& crit_params,
     timing_info->set_warn_unconstrained(false);
 
     //Clear all update_td_costs() runtime stat variables
-    auto& p_runtime_ctx = placer_state.mutable_runtime();
+    PlacerRuntimeContext& p_runtime_ctx = placer_state.mutable_runtime();
     p_runtime_ctx.f_update_td_costs_connections_elapsed_sec = 0.f;
     p_runtime_ctx.f_update_td_costs_nets_elapsed_sec = 0.f;
     p_runtime_ctx.f_update_td_costs_sum_nets_elapsed_sec = 0.f;
@@ -195,11 +195,11 @@ void update_timing_cost(const PlaceDelayModel* delay_model,
  */
 void commit_setup_slacks(const PlacerSetupSlacks* setup_slacks,
                          PlacerState& placer_state) {
-    const auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    auto& connection_setup_slack = placer_state.mutable_timing().connection_setup_slack;
+    const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
+    ClbNetPinsMatrix<float>& connection_setup_slack = placer_state.mutable_timing().connection_setup_slack;
 
     /* Incremental: only go through sink pins with modified setup slack */
-    auto clb_pins_modified = setup_slacks->pins_with_modified_setup_slack();
+    PlacerSetupSlacks::pin_range clb_pins_modified = setup_slacks->pins_with_modified_setup_slack();
     for (ClusterPinId pin_id : clb_pins_modified) {
         ClusterNetId net_id = clb_nlist.pin_net(pin_id);
         size_t pin_index_in_net = clb_nlist.pin_net_index(pin_id);
@@ -221,8 +221,8 @@ void commit_setup_slacks(const PlacerSetupSlacks* setup_slacks,
  */
 bool verify_connection_setup_slacks(const PlacerSetupSlacks* setup_slacks,
                                     const PlacerState& placer_state) {
-    const auto& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    const auto& connection_setup_slack = placer_state.timing().connection_setup_slack;
+    const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
+    const ClbNetPinsMatrix<float>& connection_setup_slack = placer_state.timing().connection_setup_slack;
 
     /* Go through every single sink pin to check that the slack values are the same */
     for (ClusterNetId net_id : clb_nlist.nets()) {
@@ -260,17 +260,17 @@ void update_td_costs(const PlaceDelayModel* delay_model,
                      PlacerState& placer_state,
                      double* timing_cost) {
     vtr::Timer t;
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& clb_nlist = cluster_ctx.clb_nlist;
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    const ClusteredNetlist& clb_nlist = cluster_ctx.clb_nlist;
 
-    auto& p_timing_ctx = placer_state.mutable_timing();
-    auto& p_runtime_ctx = placer_state.mutable_runtime();
-    auto& connection_timing_cost = p_timing_ctx.connection_timing_cost;
+    PlacerTimingContext& p_timing_ctx = placer_state.mutable_timing();
+    PlacerRuntimeContext& p_runtime_ctx = placer_state.mutable_runtime();
+    PlacerTimingCosts& connection_timing_cost = p_timing_ctx.connection_timing_cost;
 
     //Update the modified pin timing costs
     {
         vtr::Timer timer;
-        auto clb_pins_modified = place_crit.pins_with_modified_criticality();
+        PlacerCriticalities::pin_range clb_pins_modified = place_crit.pins_with_modified_criticality();
         for (ClusterPinId clb_pin : clb_pins_modified) {
             if (clb_nlist.pin_type(clb_pin) == PinType::DRIVER) continue;
 
@@ -323,11 +323,11 @@ void comp_td_costs(const PlaceDelayModel* delay_model,
                    const PlacerCriticalities& place_crit,
                    PlacerState& placer_state,
                    double* timing_cost) {
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& p_timing_ctx = placer_state.mutable_timing();
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    PlacerTimingContext& p_timing_ctx = placer_state.mutable_timing();
 
-    auto& connection_timing_cost = p_timing_ctx.connection_timing_cost;
-    auto& net_timing_cost = p_timing_ctx.net_timing_cost;
+    PlacerTimingCosts& connection_timing_cost = p_timing_ctx.connection_timing_cost;
+    vtr::vector<ClusterNetId, double>& net_timing_cost = p_timing_ctx.net_timing_cost;
 
     for (ClusterNetId net_id : cluster_ctx.clb_nlist.nets()) {
         if (cluster_ctx.clb_nlist.net_is_ignored(net_id)) continue;
@@ -356,7 +356,7 @@ static double comp_td_connection_cost(const PlaceDelayModel* delay_model,
                                       const PlacerState& placer_state,
                                       ClusterNetId net,
                                       int ipin) {
-    const auto& p_timing_ctx = placer_state.timing();
+    const PlacerTimingContext& p_timing_ctx = placer_state.timing();
     const auto& block_locs = placer_state.block_locs();
 
     VTR_ASSERT_SAFE_MSG(ipin > 0, "Shouldn't be calculating connection timing cost for driver pins");
@@ -378,9 +378,9 @@ static double comp_td_connection_cost(const PlaceDelayModel* delay_model,
 ///@brief Returns the timing cost of the specified 'net' based on the values in connection_timing_cost.
 static double sum_td_net_cost(ClusterNetId net,
                               const PlacerState& placer_state) {
-    const auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& p_timing_ctx = placer_state.timing();
-    auto& connection_timing_cost = p_timing_ctx.connection_timing_cost;
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    const PlacerTimingContext& p_timing_ctx = placer_state.timing();
+    const PlacerTimingCosts& connection_timing_cost = p_timing_ctx.connection_timing_cost;
 
     double net_td_cost = 0;
     for (unsigned ipin = 1; ipin < cluster_ctx.clb_nlist.net_pins(net).size(); ipin++) {
@@ -392,9 +392,9 @@ static double sum_td_net_cost(ClusterNetId net,
 
 ///@brief Returns the total timing cost across all nets based on the values in net_timing_cost.
 static double sum_td_costs(const PlacerState& placer_state) {
-    const auto& cluster_ctx = g_vpr_ctx.clustering();
-    const auto& p_timing_ctx = placer_state.timing();
-    const auto& net_timing_cost = p_timing_ctx.net_timing_cost;
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    const PlacerTimingContext& p_timing_ctx = placer_state.timing();
+    const vtr::vector<ClusterNetId, double>& net_timing_cost = p_timing_ctx.net_timing_cost;
 
     double td_cost = 0;
     for (ClusterNetId net_id : cluster_ctx.clb_nlist.nets()) {

--- a/vpr/src/place/timing/place_timing_update.cpp
+++ b/vpr/src/place/timing/place_timing_update.cpp
@@ -169,11 +169,11 @@ void update_timing_cost(const PlaceDelayModel* delay_model,
                         const PlacerCriticalities* criticalities,
                         PlacerState& placer_state,
                         double* timing_cost) {
-#ifdef INCR_COMP_TD_COSTS
-    update_td_costs(delay_model, *criticalities, placer_state, timing_cost);
-#else
-    comp_td_costs(delay_model, *criticalities, placer_state, timing_cost);
-#endif
+    if constexpr (INCR_COMP_TD_COSTS) {
+        update_td_costs(delay_model, *criticalities, placer_state, timing_cost);
+    } else {
+        comp_td_costs(delay_model, *criticalities, placer_state, timing_cost);
+    }
 }
 
 /**

--- a/vpr/src/place/timing/place_timing_update.cpp
+++ b/vpr/src/place/timing/place_timing_update.cpp
@@ -10,6 +10,7 @@
 #include "PlacerSetupSlacks.h"
 #include "placer_state.h"
 #include "place_util.h"
+#include "vtr_math.h"
 #include "vtr_time.h"
 
 // Routines local to place_timing_update.cpp
@@ -243,15 +244,17 @@ bool verify_connection_setup_slacks(const PlacerSetupSlacks* setup_slacks,
  * from-scratch recalculation, refer to comp_td_cost().
  *
  * We must be careful calculating the total timing cost incrementally, due to limited
- * floating point precision, so that we get a bit-identical result matching the one
- * calculated by comp_td_costs().
+ * floating point precision, so that the result stays consistent with the one calculated
+ * from scratch by comp_td_costs().
  *
  * In particular, we can not simply calculate the incremental delta's caused by changed
  * connection timing costs and adjust the timing cost. Due to limited precision, the results
- * of floating point math operations are order dependent and we would get a different result.
+ * of floating point math operations are order dependent and the accumulated round-off would
+ * drift away from the from-scratch value over many updates.
  *
- * To get around this, we calculate the timing costs hierarchically, to ensure that we
- * calculate the sum with the same order of operations as comp_td_costs().
+ * To get around this, we sum the timing costs with a fixed order of operations,
+ * using the binary tree of partial sums in PlacerTimingCosts. This keeps the result
+ * within round-off of comp_td_costs() no matter how many updates are performed.
  *
  * See PlacerTimingCosts object used to represent connection_timing_costs for details.
  */
@@ -301,7 +304,11 @@ void update_td_costs(const PlaceDelayModel* delay_model,
 #ifdef VTR_ASSERT_DEBUG_ENABLED
     double check_timing_cost = 0.;
     comp_td_costs(delay_model, place_crit, placer_state, &check_timing_cost);
-    VTR_ASSERT_DEBUG_MSG(check_timing_cost == *timing_cost,
+    // The incremental total is summed via the PlacerTimingCosts binary tree, while
+    // comp_td_costs() sums linearly (per net, then over nets). Floating point addition
+    // is not associative, so the two totals can differ by round-off; compare with a
+    // small relative tolerance instead of exact equality.
+    VTR_ASSERT_DEBUG_MSG(vtr::isclose(check_timing_cost, *timing_cost),
                          "Total timing cost calculated incrementally in update_td_costs() is "
                          "not consistent with value calculated from scratch in comp_td_costs()");
 #endif
@@ -341,7 +348,6 @@ void comp_td_costs(const PlaceDelayModel* delay_model,
         // Store net timing cost for more efficient incremental updating
         net_timing_cost[net_id] = sum_td_net_cost(net_id, placer_state);
     }
-    // Make sure timing cost does not go above MIN_TIMING_COST.
     *timing_cost = sum_td_costs(placer_state);
 }
 


### PR DESCRIPTION
In `place_timing_update.cpp`, `INCR_COMP_TD_COSTS` is declared as a static constexpr bool variable, but `update_timing_cost()` checked it with `#ifdef INCR_COMP_TD_COSTS`. Since a constexpr variable is not a preprocessor macro, the `#ifdef` was always false, causing the timing costs to be computed from scratch.