### PR TITLE
Eliminate redundant lookups and unnecessary copies in packer

### DIFF
--- a/libs/libvtrutil/src/vtr_flat_map.h
+++ b/libs/libvtrutil/src/vtr_flat_map.h
@@ -211,7 +211,12 @@ class flat_map {
         return iter->second;
     }
 
-    ///@brief Insert value
+    /**
+     * @brief Insert value. Like std::map::insert(), an existing entry with an
+     *        equivalent key is left untouched (callers rely on this; do not
+     *        change it to overwrite). Returns (iterator to the entry, true only
+     *        if newly inserted).
+     */
     std::pair<iterator, bool> insert(const value_type& value) {
         auto iter = lower_bound(value.first);
         if (iter != end() && keys_equivalent(iter->first, value.first)) {
@@ -225,7 +230,7 @@ class flat_map {
         }
     }
 
-    ///@brief Emplace function
+    ///@brief Emplace value. Same no-overwrite semantics as insert().
     std::pair<iterator, bool> emplace(const value_type&& value) {
         auto iter = lower_bound(value.first);
         if (iter != end() && keys_equivalent(iter->first, value.first)) {

--- a/vpr/src/pack/appack_context.h
+++ b/vpr/src/pack/appack_context.h
@@ -90,7 +90,7 @@ struct APPackContext : public Context {
      */
     APPackContext(const FlatPlacementInfo& fplace_info,
                   const t_ap_opts& ap_opts,
-                  const std::vector<t_logical_block_type> logical_block_types,
+                  const std::vector<t_logical_block_type>& logical_block_types,
                   const DeviceGrid& device_grid)
         : appack_options(fplace_info, ap_opts)
         , flat_placement_info(fplace_info) {

--- a/vpr/src/pack/attraction_groups.cpp
+++ b/vpr/src/pack/attraction_groups.cpp
@@ -2,8 +2,8 @@
 #include "globals.h"
 
 AttractionInfo::AttractionInfo(bool attraction_groups_on) {
-    const auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const FloorplanningContext& floorplanning_ctx = g_vpr_ctx.floorplanning();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
     int num_parts = floorplanning_ctx.constraints.get_num_partitions();
 
     //Initialize every atom to have no attraction group id
@@ -34,8 +34,8 @@ AttractionInfo::AttractionInfo(bool attraction_groups_on) {
 }
 
 void AttractionInfo::create_att_groups_for_overfull_regions(const std::vector<PartitionRegion>& overfull_partition_regions) {
-    const auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const FloorplanningContext& floorplanning_ctx = g_vpr_ctx.floorplanning();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
     int num_parts = floorplanning_ctx.constraints.get_num_partitions();
 
     //clear the data structures before continuing
@@ -76,8 +76,8 @@ void AttractionInfo::create_att_groups_for_overfull_regions(const std::vector<Pa
 }
 
 void AttractionInfo::create_att_groups_for_all_regions() {
-    const auto& floorplanning_ctx = g_vpr_ctx.floorplanning();
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const FloorplanningContext& floorplanning_ctx = g_vpr_ctx.floorplanning();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
     int num_parts = floorplanning_ctx.constraints.get_num_partitions();
 
     //clear the data structures before continuing

--- a/vpr/src/pack/attraction_groups.cpp
+++ b/vpr/src/pack/attraction_groups.cpp
@@ -117,15 +117,15 @@ void AttractionInfo::create_att_groups_for_all_regions() {
 }
 
 void AttractionInfo::assign_atom_attraction_ids() {
-    //Fill in the group id for the atoms that do have an attraction group
+    // Fill in the group id for the atoms that do have an attraction group
     int num_att_grps = attraction_groups.size();
 
     for (int igroup = 0; igroup < num_att_grps; igroup++) {
         AttractGroupId group_id(igroup);
 
-        AttractionGroup att_group = attraction_groups[group_id];
+        const AttractionGroup& att_group = attraction_groups[group_id];
 
-        for (auto group_atom : att_group.group_atoms) {
+        for (AtomBlockId group_atom : att_group.group_atoms) {
             atom_attraction_group[group_atom] = group_id;
         }
     }

--- a/vpr/src/pack/cluster_legalizer.cpp
+++ b/vpr/src/pack/cluster_legalizer.cpp
@@ -660,7 +660,7 @@ void ClusterLegalizer::update_clustering_chain_info(PackMoleculeId chain_molecul
     // Since for long chains the molecule size is already equal to the
     // total number of adders in the cluster. Therefore, it should
     // always be placed at the very first adder in this cluster.
-    auto chain_root_pins = chain_molecule.pack_pattern->chain_root_pins;
+    const std::vector<std::vector<t_pb_graph_pin*>>& chain_root_pins = chain_molecule.pack_pattern->chain_root_pins;
     for (size_t chainId = 0; chainId < chain_root_pins.size(); chainId++) {
         if (chain_root_pins[chainId][0]->parent_node == root_primitive) {
             clustering_chain_info.chain_id = chainId;

--- a/vpr/src/pack/cluster_legalizer.cpp
+++ b/vpr/src/pack/cluster_legalizer.cpp
@@ -913,7 +913,9 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
         }
     }
 
-    std::vector<t_pb_graph_node*> primitives_list(max_molecule_size_, nullptr);
+    // Reuse the member scratch vector to avoid a heap allocation per candidate molecule.
+    primitives_list_.assign(max_molecule_size_, nullptr);
+    std::vector<t_pb_graph_node*>& primitives_list = primitives_list_;
     e_block_pack_status block_pack_status = e_block_pack_status::BLK_STATUS_UNDEFINED;
     LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> primitives_alive = build_primitive_candidate_queue(cluster.placement_stats,
                                                                                                                                  molecule_id,

--- a/vpr/src/pack/cluster_legalizer.cpp
+++ b/vpr/src/pack/cluster_legalizer.cpp
@@ -915,11 +915,10 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
 
     // Reuse the member scratch vector to avoid a heap allocation per candidate molecule.
     primitives_list_.assign(max_molecule_size_, nullptr);
-    std::vector<t_pb_graph_node*>& primitives_list = primitives_list_;
     e_block_pack_status block_pack_status = e_block_pack_status::BLK_STATUS_UNDEFINED;
     LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> primitives_alive = build_primitive_candidate_queue(cluster.placement_stats,
                                                                                                                                  molecule_id,
-                                                                                                                                 primitives_list,
+                                                                                                                                 primitives_list_,
                                                                                                                                  prepacker_);
 
     while (block_pack_status != e_block_pack_status::BLK_PASSED) {
@@ -932,13 +931,13 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
         std::pair<t_pb_graph_node*, std::tuple<float, int, int>> primitive = primitives_alive.pop();
         t_pb_graph_node* root = primitive.first;
 
-        if (!try_start_root_placement(cluster.placement_stats, molecule_id, root, primitives_list, prepacker_))
+        if (!try_start_root_placement(cluster.placement_stats, molecule_id, root, primitives_list_, prepacker_))
             continue;
 
         block_pack_status = e_block_pack_status::BLK_PASSED;
         size_t failed_location = 0;
         for (size_t i_mol = 0; i_mol < molecule.atom_block_ids.size() && block_pack_status == e_block_pack_status::BLK_PASSED; i_mol++) {
-            VTR_ASSERT((primitives_list[i_mol] == nullptr) == (!molecule.atom_block_ids[i_mol]));
+            VTR_ASSERT((primitives_list_[i_mol] == nullptr) == (!molecule.atom_block_ids[i_mol]));
             failed_location = i_mol + 1;
             AtomBlockId atom_blk_id = molecule.atom_block_ids[i_mol];
             if (!atom_blk_id.is_valid())
@@ -946,7 +945,7 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
             // NOTE: This parent variable is only used in the recursion of this
             //       function.
             t_pb* parent = nullptr;
-            block_pack_status = try_place_atom_block_rec(primitives_list[i_mol],
+            block_pack_status = try_place_atom_block_rec(primitives_list_[i_mol],
                                                          atom_blk_id,
                                                          cluster.pb,
                                                          &parent,
@@ -1035,7 +1034,7 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
                 for (size_t i = 0; i < molecule.atom_block_ids.size(); i++) {
                     AtomBlockId atom_block_id = molecule.atom_block_ids[i];
                     if (atom_block_id) {
-                        packing_signature_tree_->add_lcn(primitives_list[i], atom_block_id);
+                        packing_signature_tree_->add_lcn(primitives_list_[i], atom_block_id);
                     }
                 }
             }
@@ -1101,7 +1100,7 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
                         cluster.placement_stats->has_long_chain = true;
                         const t_clustering_chain_info& clustering_chain_info = clustering_chain_info_[molecule.chain_id];
                         if (clustering_chain_info.chain_id == -1) {
-                            update_clustering_chain_info(molecule_id, primitives_list[molecule.root]);
+                            update_clustering_chain_info(molecule_id, primitives_list_[molecule.root]);
                         }
                     }
                 }
@@ -1121,7 +1120,7 @@ e_block_pack_status ClusterLegalizer::try_pack_molecule(PackMoleculeId molecule_
                     if (!atom_blk_id.is_valid())
                         continue;
 
-                    commit_primitive(cluster.placement_stats, primitives_list[i]);
+                    commit_primitive(cluster.placement_stats, primitives_list_[i]);
 
                     atom_cluster_[atom_blk_id] = cluster_id;
 

--- a/vpr/src/pack/cluster_legalizer.cpp
+++ b/vpr/src/pack/cluster_legalizer.cpp
@@ -68,7 +68,7 @@
  * @return True if there is no constraint, or the candidate matches the constraint.
  */
 static bool check_logical_block_location_constraint(const AtomBlockId blk_id, const t_pb* pb, int verbosity) {
-    const auto& constraints = g_vpr_ctx.floorplanning().constraints;
+    const UserPlaceConstraints& constraints = g_vpr_ctx.floorplanning().constraints;
     std::string logical_block_location = constraints.get_atom_logical_block_location(blk_id);
     if (logical_block_location.empty()) {
         return true;
@@ -222,7 +222,7 @@ static bool check_cluster_floorplanning(AtomBlockId atom_blk_id,
     // Check if the partition is constrained to any specific logical block types.
     if (constraints.is_part_constrained_to_lb_types(part_id)) {
         // If it is, check if this cluster's type is valid.
-        const auto& constrained_block_types = constraints.get_part_lb_type_constraints(part_id);
+        const std::unordered_set<t_logical_block_type_ptr>& constrained_block_types = constraints.get_part_lb_type_constraints(part_id);
         if (!constrained_block_types.contains(cluster_type)) {
             VTR_LOGV(log_verbosity > 3,
                      "\t\t\t Intersect: Atom block %d failed lb-type constraint for cluster type %s\n",
@@ -339,11 +339,11 @@ static enum e_block_pack_status check_chain_root_placement_feasibility(const t_p
 
     bool is_long_chain = prepack_chain_info.is_long_chain;
 
-    const auto& chain_root_pins = mol_pack_patterns->chain_root_pins;
+    const std::vector<std::vector<t_pb_graph_pin*>>& chain_root_pins = mol_pack_patterns->chain_root_pins;
 
     t_model_ports* root_port = chain_root_pins[0][0]->port->model_port;
     AtomNetId chain_net_id;
-    auto port_id = atom_netlist.find_atom_port(blk_id, root_port);
+    AtomPortId port_id = atom_netlist.find_atom_port(blk_id, root_port);
 
     if (port_id) {
         chain_net_id = atom_netlist.port_net(port_id, chain_root_pins[0][0]->pin_number);
@@ -356,7 +356,7 @@ static enum e_block_pack_status check_chain_root_placement_feasibility(const t_p
     // driven by a global gnd or vdd. Therefore even if this is not a long chain
     // but its input pin is driven by a net, the placement legality is checked.
     if (is_long_chain || chain_net_id) {
-        auto chain_id = clustering_chain_info.chain_id;
+        int chain_id = clustering_chain_info.chain_id;
         // if this chain has a chain id assigned to it (implies is_long_chain too)
         if (chain_id != -1) {
             // the chosen primitive should be a valid starting point for the chain
@@ -367,8 +367,8 @@ static enum e_block_pack_status check_chain_root_placement_feasibility(const t_p
             // the chain doesn't have an assigned chain_id yet
         } else {
             block_pack_status = e_block_pack_status::BLK_FAILED_FEASIBLE;
-            for (const auto& chain : chain_root_pins) {
-                for (auto tieOff : chain) {
+            for (const std::vector<t_pb_graph_pin*>& chain : chain_root_pins) {
+                for (t_pb_graph_pin* tieOff : chain) {
                     // check if this chosen primitive is one of the possible
                     // starting points for this chain.
                     if (pb_graph_node == tieOff->parent_node) {
@@ -423,8 +423,8 @@ bool primitive_memory_sibling_feasible(const AtomBlockId blk_id, const t_pb_type
             //driving the output net
 
             //Get the ports from each primitive
-            auto blk_port_id = atom_ctx.netlist().find_atom_port(blk_id, port);
-            auto sib_port_id = atom_ctx.netlist().find_atom_port(sibling_blk_id, port);
+            AtomPortId blk_port_id = atom_ctx.netlist().find_atom_port(blk_id, port);
+            AtomPortId sib_port_id = atom_ctx.netlist().find_atom_port(sibling_blk_id, port);
 
             //Check that all nets (including unconnected nets) match
             for (int ipin = 0; ipin < port->size; ++ipin) {
@@ -612,7 +612,7 @@ try_place_atom_block_rec(const t_pb_graph_node* pb_graph_node,
         // if this block passed and is part of a chained molecule
         const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
         if (block_pack_status == e_block_pack_status::BLK_PASSED && molecule.is_chain()) {
-            auto molecule_root_block = molecule.atom_block_ids[molecule.root];
+            AtomBlockId molecule_root_block = molecule.atom_block_ids[molecule.root];
             // if this is the root block of the chain molecule check its placmeent feasibility
             if (blk_id == molecule_root_block) {
                 VTR_ASSERT(molecule.chain_id.is_valid());
@@ -1456,10 +1456,10 @@ ClusterLegalizer::ClusterLegalizer(const AtomNetlist& atom_netlist,
 }
 
 void ClusterLegalizer::init_feedback_pin_sets() {
-    const auto& lb_types = g_vpr_ctx.device().logical_block_types;
+    const std::vector<t_logical_block_type>& lb_types = g_vpr_ctx.device().logical_block_types;
     valid_feedback_pins_by_type_.resize(lb_types.size());
     for (const t_logical_block_type& lb_type : lb_types) {
-        auto& valid_set = valid_feedback_pins_by_type_[lb_type.index];
+        std::unordered_set<int>& valid_set = valid_feedback_pins_by_type_[lb_type.index];
         if (lb_type.pb_graph_head == nullptr || lb_type.equivalent_tiles.empty()) {
             continue; // empty set: router rejects all feedback pins (safe default)
         }
@@ -1501,7 +1501,7 @@ void ClusterLegalizer::reset() {
 
 void ClusterLegalizer::verify() {
     std::unordered_set<AtomBlockId> atoms_checked;
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
     if (clusters().size() == 0) {
         VTR_LOG_WARN("Packing produced no clustered blocks");
@@ -1510,7 +1510,7 @@ void ClusterLegalizer::verify() {
     /*
      * Check that each atom block connects to one physical primitive and that the primitive links up to the parent clb
      */
-    for (auto blk_id : atom_ctx.netlist().blocks()) {
+    for (AtomBlockId blk_id : atom_ctx.netlist().blocks()) {
         //Each atom should be part of a pb
         const t_pb* atom_pb = atom_pb_lookup().atom_pb(blk_id);
         if (!atom_pb) {
@@ -1557,7 +1557,7 @@ void ClusterLegalizer::verify() {
         check_cluster_atom_blocks(get_cluster_pb(cluster_id), atoms_checked, atom_pb_lookup());
     }
 
-    for (auto blk_id : atom_ctx.netlist().blocks()) {
+    for (AtomBlockId blk_id : atom_ctx.netlist().blocks()) {
         if (!atoms_checked.count(blk_id)) {
             VPR_FATAL_ERROR(VPR_ERROR_PACK,
                             "Atom block %s not found in any cluster.\n",

--- a/vpr/src/pack/cluster_legalizer.h
+++ b/vpr/src/pack/cluster_legalizer.h
@@ -640,6 +640,11 @@ class ClusterLegalizer {
     ///        expensive to calculate from the prepacker.
     size_t max_molecule_size_;
 
+    /// @brief Scratch vector used by try_pack_molecule() to hold the primitive
+    ///        chosen for each molecule atom. A member to avoid reallocating it
+    ///        for every candidate molecule.
+    std::vector<t_pb_graph_node*> primitives_list_;
+
     /// @brief A vector of routing resource nodes within each logical block type
     ///        [0 .. num_logical_block_types-1]
     /// TODO: This really should not be a pointer to a vector... I think this is

--- a/vpr/src/pack/cluster_pin_counter.cpp
+++ b/vpr/src/pack/cluster_pin_counter.cpp
@@ -178,14 +178,14 @@ static bool net_sinks_reachable_in_cluster(const t_pb_graph_pin* driver_pb_gpin,
 static t_pb_graph_pin* get_driver_pb_graph_pin(const t_pb* driver_pb, const AtomPinId driver_pin_id) {
     const AtomNetlist& atom_netlist = g_vpr_ctx.atom().netlist();
 
-    const auto driver_pb_type = driver_pb->pb_graph_node->pb_type;
+    const t_pb_type* driver_pb_type = driver_pb->pb_graph_node->pb_type;
     int output_port = 0;
     // Find the port of the pin driving the net as well as the port model.
-    auto driver_port_id = atom_netlist.pin_port(driver_pin_id);
-    auto driver_model_port = atom_netlist.port_model(driver_port_id);
+    AtomPortId driver_port_id = atom_netlist.pin_port(driver_pin_id);
+    const t_model_ports* driver_model_port = atom_netlist.port_model(driver_port_id);
     // Find the port id of the port containing the driving pin in the driver_pb_type.
     for (int i = 0; i < driver_pb_type->num_ports; i++) {
-        auto& prim_port = driver_pb_type->ports[i];
+        t_port& prim_port = driver_pb_type->ports[i];
         if (prim_port.type == OUT_PORT) {
             if (prim_port.model_port == driver_model_port) {
                 // Get the output pb_graph_pin driving this input net.
@@ -208,10 +208,10 @@ void ClusterPinCounter::compute_and_mark_lookahead_pins_used_for_input_pin(const
     VTR_ASSERT(pb_graph_pin->port->type == IN_PORT);
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
-    const auto driver_blk_id = atom_ctx.netlist().net_driver_block(net_id);
-    const auto driver_pin_id = atom_ctx.netlist().net_driver(net_id);
-    const auto prim_blk_id = atom_to_pb.pb_atom(primitive_pb);
-    const auto driver_pb = atom_to_pb.atom_pb(driver_blk_id);
+    const AtomBlockId driver_blk_id = atom_ctx.netlist().net_driver_block(net_id);
+    const AtomPinId driver_pin_id = atom_ctx.netlist().net_driver(net_id);
+    const AtomBlockId prim_blk_id = atom_to_pb.pb_atom(primitive_pb);
+    const t_pb* driver_pb = atom_to_pb.atom_pb(driver_blk_id);
 
     // If the driver atom is in the same cluster as primitive_pb, find the
     // pb_graph_pin that drives net_id. Otherwise leave it null; the driver
@@ -225,9 +225,9 @@ void ClusterPinCounter::compute_and_mark_lookahead_pins_used_for_input_pin(const
     }
 
     // Starting from the parent pb of the input primitive go up in the hierarchy till the root block
-    for (auto cur_pb = primitive_pb->parent_pb; cur_pb; cur_pb = cur_pb->parent_pb) {
-        const auto depth = cur_pb->pb_graph_node->pb_type->depth;
-        const auto pin_class = pb_graph_pin->parent_pin_class[depth];
+    for (const t_pb* cur_pb = primitive_pb->parent_pb; cur_pb; cur_pb = cur_pb->parent_pb) {
+        const int depth = cur_pb->pb_graph_node->pb_type->depth;
+        const int pin_class = pb_graph_pin->parent_pin_class[depth];
         VTR_ASSERT(pin_class != UNDEFINED);
 
         bool is_reachable = false;
@@ -264,7 +264,7 @@ void ClusterPinCounter::compute_and_mark_lookahead_pins_used_for_output_pin(cons
                                                                             const AtomPBBimap& atom_to_pb) {
     VTR_ASSERT(pb_graph_pin->port->type == OUT_PORT);
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
-    const auto driver_blk_id = atom_ctx.netlist().net_driver_block(net_id);
+    const AtomBlockId driver_blk_id = atom_ctx.netlist().net_driver_block(net_id);
     int num_net_sinks = static_cast<int>(atom_ctx.netlist().net_sinks(net_id).size());
 
     bool all_sinks_in_cur_cluster = false;
@@ -277,9 +277,9 @@ void ClusterPinCounter::compute_and_mark_lookahead_pins_used_for_output_pin(cons
     bool confirmed_absorbed = false;
 
     // Starting from the parent pb of the given primitive, go up in the hierarchy till the root block
-    for (auto cur_pb = primitive_pb->parent_pb; cur_pb; cur_pb = cur_pb->parent_pb) {
-        const auto depth = cur_pb->pb_graph_node->pb_type->depth;
-        const auto pin_class = pb_graph_pin->parent_pin_class[depth];
+    for (const t_pb* cur_pb = primitive_pb->parent_pb; cur_pb; cur_pb = cur_pb->parent_pb) {
+        const int depth = cur_pb->pb_graph_node->pb_type->depth;
+        const int pin_class = pb_graph_pin->parent_pin_class[depth];
         VTR_ASSERT(pin_class != UNDEFINED);
 
         if (confirmed_absorbed) {
@@ -314,7 +314,7 @@ void ClusterPinCounter::compute_and_mark_lookahead_pins_used_for_output_pin(cons
             if (!all_sinks_in_cur_cluster_computed) {
                 const LegalizationClusterId driver_cluster = atom_cluster[driver_blk_id];
                 all_sinks_in_cur_cluster = true;
-                for (auto pin_id : atom_ctx.netlist().net_sinks(net_id)) {
+                for (AtomPinId pin_id : atom_ctx.netlist().net_sinks(net_id)) {
                     if (atom_cluster[atom_ctx.netlist().pin_block(pin_id)] != driver_cluster) {
                         all_sinks_in_cur_cluster = false;
                         break;
@@ -359,8 +359,8 @@ void ClusterPinCounter::compute_and_mark_lookahead_pins_used(
     VTR_ASSERT(cur_pb != nullptr);
 
     // Walk through inputs and outputs marking pins off of the same class.
-    for (auto pin_id : atom_netlist.block_pins(blk_id)) {
-        auto net_id = atom_netlist.pin_net(pin_id);
+    for (AtomPinId pin_id : atom_netlist.block_pins(blk_id)) {
+        AtomNetId net_id = atom_netlist.pin_net(pin_id);
 
         const t_pb_graph_pin* pb_graph_pin = find_pb_graph_pin(atom_netlist, atom_to_pb, pin_id);
 

--- a/vpr/src/pack/cluster_pin_counter.cpp
+++ b/vpr/src/pack/cluster_pin_counter.cpp
@@ -74,7 +74,7 @@ void ClusterPinCounter::mark_lookahead_input(const t_pb* pb, size_t class_id, At
     //       a vector of unordered_maps for clusters with many pins, but that's
     //       likely worse for the common case of small pin classes lower in
     //       the hierarchy. Revisit if this shows up as a bottleneck.
-    if (std::find(class_nets.begin(), class_nets.end(), net) == class_nets.end()) {
+    if (std::ranges::find(class_nets, net) == class_nets.end()) {
         class_nets.push_back(net);
     }
 }

--- a/vpr/src/pack/cluster_pin_counter.cpp
+++ b/vpr/src/pack/cluster_pin_counter.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <unordered_set>
+#include <utility>
 
 #include "atom_netlist.h"
 #include "atom_pb_bimap.h"
@@ -98,8 +99,11 @@ void ClusterPinCounter::reset_lookahead() {
 
 void ClusterPinCounter::commit_lookahead() {
     for (auto& [pb, state] : per_pb_state_) {
-        state.committed_input_pin_class_nets = state.lookahead_input_pin_class_nets;
-        state.committed_output_pin_class_nets = state.lookahead_output_pin_class_nets;
+        // Swapping instead of copying leaves stale nets in the lookahead state,
+        // which is safe because the lookahead state is fully rebuilt
+        // (reset_lookahead + try_update_lookahead_pins_used) before it is read.
+        std::swap(state.committed_input_pin_class_nets, state.lookahead_input_pin_class_nets);
+        std::swap(state.committed_output_pin_class_nets, state.lookahead_output_pin_class_nets);
     }
 }
 

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -150,8 +150,7 @@ void t_intra_cluster_placement_stats::free_primitives() {
 
 t_intra_cluster_placement_stats* alloc_and_load_cluster_placement_stats(t_logical_block_type_ptr cluster_type,
                                                                         int cluster_mode) {
-    t_intra_cluster_placement_stats* cluster_placement_stats = new t_intra_cluster_placement_stats;
-    *cluster_placement_stats = t_intra_cluster_placement_stats();
+    t_intra_cluster_placement_stats* cluster_placement_stats = new t_intra_cluster_placement_stats();
     // TODO: This initialization may be able to be made more efficient.
     //       The reset and setting the mode can be done while loading the placement
     //       stats.

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -108,7 +108,7 @@ void t_intra_cluster_placement_stats::insert_primitive_in_valid_primitives(std::
 }
 
 void t_intra_cluster_placement_stats::flush_queue(std::unordered_multimap<int, t_cluster_placement_primitive*>& queue) {
-    for (auto& it : queue) {
+    for (std::pair<const int, t_cluster_placement_primitive*>& it : queue) {
         insert_primitive_in_valid_primitives(it);
     }
     queue.clear();
@@ -132,17 +132,17 @@ t_pb_type* t_intra_cluster_placement_stats::in_flight_type() {
 }
 
 void t_intra_cluster_placement_stats::free_primitives() {
-    for (auto& primitive : tried)
+    for (std::pair<const int, t_cluster_placement_primitive*>& primitive : tried)
         delete primitive.second;
 
-    for (auto& primitive : in_flight)
+    for (std::pair<const int, t_cluster_placement_primitive*>& primitive : in_flight)
         delete primitive.second;
 
-    for (auto& primitive : invalid)
+    for (std::pair<const int, t_cluster_placement_primitive*>& primitive : invalid)
         delete primitive.second;
 
     for (int j = 0; j < num_pb_types; j++) {
-        for (auto& primitive : valid_primitives[j]) {
+        for (std::pair<const int, t_cluster_placement_primitive*>& primitive : valid_primitives[j]) {
             delete primitive.second;
         }
     }
@@ -319,7 +319,7 @@ LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> build_
 bool move_root_node_to_inflight(t_intra_cluster_placement_stats* cluster_placement_stats,
                                 t_pb_graph_node* target_root) {
     for (int pb_type_idx = 0; pb_type_idx < cluster_placement_stats->num_pb_types; ++pb_type_idx) {
-        auto& valid_primitives = cluster_placement_stats->valid_primitives[pb_type_idx];
+        std::unordered_map<int, t_cluster_placement_primitive*>& valid_primitives = cluster_placement_stats->valid_primitives[pb_type_idx];
         for (auto it = valid_primitives.begin(); it != valid_primitives.end(); /* increment handled inside */) {
             t_cluster_placement_primitive* placement_primitive = it->second;
 
@@ -388,7 +388,7 @@ static void reset_cluster_placement_stats(t_intra_cluster_placement_stats* clust
 
     /* reset flags and cost */
     for (i = 0; i < cluster_placement_stats->num_pb_types; i++) {
-        for (auto& primitive : cluster_placement_stats->valid_primitives[i]) {
+        for (std::pair<const int, t_cluster_placement_primitive*>& primitive : cluster_placement_stats->valid_primitives[i]) {
             primitive.second->incremental_cost = 0;
             primitive.second->valid = true;
         }
@@ -423,7 +423,7 @@ static void load_cluster_placement_stats_for_pb_graph_node(t_intra_cluster_place
          *  - Check the pb_type of this element with the pb_type of pb_graph_node
          *      - if matched --> insert the primitive
          */
-        for (auto& type_primitives : cluster_placement_stats->valid_primitives) {
+        for (std::unordered_map<int, t_cluster_placement_primitive*>& type_primitives : cluster_placement_stats->valid_primitives) {
             auto first_elem = type_primitives.find(0);
             if (first_elem != type_primitives.end() && first_elem->second->pb_graph_node->pb_type == pb_graph_node->pb_type) {
                 type_primitives.insert({type_primitives.size(), placement_primitive});

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -279,12 +279,12 @@ LazyPopUniquePriorityQueue<t_pb_graph_node*, std::tuple<float, int, int>> build_
     // Initialize variables
     float cost = std::numeric_limits<float>::max();
     int encounter_order = 0;
+    const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
 
     // Iterate over each primitive block type in the current cluster_placement_stats
     for (int i = 0; i < cluster_placement_stats->num_pb_types; i++) {
         if (!cluster_placement_stats->valid_primitives[i].empty()) {
             t_cluster_placement_primitive* cur_cluster_placement_primitive = cluster_placement_stats->valid_primitives[i].begin()->second;
-            const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
             if (primitive_type_feasible(molecule.atom_block_ids[molecule.root], cur_cluster_placement_primitive->pb_graph_node->pb_type)) {
                 // Iterate over the unordered_multimap of the valid primitives of a specific pb primitive type
                 for (auto it = cluster_placement_stats->valid_primitives[i].begin(); it != cluster_placement_stats->valid_primitives[i].end(); /*loop increment is done inside the loop*/) {
@@ -561,6 +561,8 @@ static bool expand_forced_pack_molecule_placement(t_intra_cluster_placement_stat
     t_pb_graph_pin *cur_pin, *next_pin;
     t_pack_pattern_block* next_block;
 
+    const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
+
     cur = pack_pattern_block->connections;
     while (cur) {
         if (cur->from_block == pack_pattern_block) {
@@ -568,7 +570,6 @@ static bool expand_forced_pack_molecule_placement(t_intra_cluster_placement_stat
         } else {
             next_block = cur->from_block;
         }
-        const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
         if (primitives_list[next_block->block_id] == nullptr && molecule.atom_block_ids[next_block->block_id]) {
             /* first time visiting location */
 

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -113,9 +113,7 @@ class t_intra_cluster_placement_stats {
      */
     inline t_cluster_placement_primitive* get_pb_graph_node_placement_primitive(const t_pb_graph_node* pb_graph_node) {
         VTR_ASSERT_SAFE(pb_graph_node != nullptr);
-        auto it = pb_graph_node_placement_primitive.find(pb_graph_node);
-        VTR_ASSERT(it != pb_graph_node_placement_primitive.end());
-        return it->second;
+        return pb_graph_node_placement_primitive.at(pb_graph_node);
     }
 
     /**

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -113,8 +113,9 @@ class t_intra_cluster_placement_stats {
      */
     inline t_cluster_placement_primitive* get_pb_graph_node_placement_primitive(const t_pb_graph_node* pb_graph_node) {
         VTR_ASSERT_SAFE(pb_graph_node != nullptr);
-        VTR_ASSERT(pb_graph_node_placement_primitive.count(pb_graph_node) != 0);
-        return pb_graph_node_placement_primitive[pb_graph_node];
+        auto it = pb_graph_node_placement_primitive.find(pb_graph_node);
+        VTR_ASSERT(it != pb_graph_node_placement_primitive.end());
+        return it->second;
     }
 
     /**

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -115,13 +115,15 @@ class t_intra_cluster_placement_stats {
         auto it = pb_graph_node_placement_primitive.find(pb_graph_node);
         VTR_ASSERT(it != pb_graph_node_placement_primitive.end());
 #ifdef __GNUC__
-        // Silences a spurious GCC -Wnull-dereference. __builtin_unreachable() is
-        // not available on MSVC, so it is guarded.
-        if (it == pb_graph_node_placement_primitive.end()) {
-            __builtin_unreachable();
-        }
+// GCC cannot see that the assert above rules out end(), so it reports a
+// spurious -Wnull-dereference here when asserts are compiled out.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
 #endif
         return it->second;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     }
 
     /**

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -114,8 +114,13 @@ class t_intra_cluster_placement_stats {
         VTR_ASSERT_SAFE(pb_graph_node != nullptr);
         auto it = pb_graph_node_placement_primitive.find(pb_graph_node);
         VTR_ASSERT(it != pb_graph_node_placement_primitive.end());
-        if (it == pb_graph_node_placement_primitive.end())
-            __builtin_unreachable(); // silences spurious GCC -Wnull-dereference
+#ifdef __GNUC__
+        // Silences a spurious GCC -Wnull-dereference. __builtin_unreachable() is
+        // not available on MSVC, so it is guarded.
+        if (it == pb_graph_node_placement_primitive.end()) {
+            __builtin_unreachable();
+        }
+#endif
         return it->second;
     }
 

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -114,6 +114,8 @@ class t_intra_cluster_placement_stats {
         VTR_ASSERT_SAFE(pb_graph_node != nullptr);
         auto it = pb_graph_node_placement_primitive.find(pb_graph_node);
         VTR_ASSERT(it != pb_graph_node_placement_primitive.end());
+        if (it == pb_graph_node_placement_primitive.end())
+            __builtin_unreachable(); // silences spurious GCC -Wnull-dereference
         return it->second;
     }
 

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -112,7 +112,9 @@ class t_intra_cluster_placement_stats {
      */
     inline t_cluster_placement_primitive* get_pb_graph_node_placement_primitive(const t_pb_graph_node* pb_graph_node) {
         VTR_ASSERT_SAFE(pb_graph_node != nullptr);
-        return pb_graph_node_placement_primitive.at(pb_graph_node);
+        auto it = pb_graph_node_placement_primitive.find(pb_graph_node);
+        VTR_ASSERT(it != pb_graph_node_placement_primitive.end());
+        return it->second;
     }
 
     /**

--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -167,13 +167,13 @@ bool ClusterRouter::is_saved_route_valid() const {
     // Build a lookup from atom net ID to the terminals recorded in the saved route.
     std::unordered_map<AtomNetId, const std::vector<int>*> saved_map;
     saved_map.reserve(saved_lb_nets_.size());
-    for (const auto& net : saved_lb_nets_)
+    for (const t_intra_lb_net& net : saved_lb_nets_)
         saved_map[net.atom_net_id] = &net.terminals;
 
     // Every current net must appear in the saved route with identical terminals.
     // Identical terminals means the saved route trees cover exactly the same
     // physical pins, so the saved solution is still valid without re-routing.
-    for (const auto& net : intra_lb_nets_) {
+    for (const t_intra_lb_net& net : intra_lb_nets_) {
         auto it = saved_map.find(net.atom_net_id);
         if (it == saved_map.end())
             return false;
@@ -215,14 +215,14 @@ static bool check_edge_for_route_conflicts(std::unordered_map<const t_pb_graph_n
     }
     VTR_ASSERT(!pin->port->is_clock);
 
-    auto* pb_graph_node = pin->parent_node;
+    t_pb_graph_node* pb_graph_node = pin->parent_node;
     VTR_ASSERT(pb_graph_node->pb_type == pin->port->parent_pb_type);
 
     const t_pb_graph_edge* edge = get_edge_between_pins(driver_pin, pin);
     VTR_ASSERT(edge != nullptr);
 
-    auto mode_of_edge = edge->interconnect->parent_mode_index;
-    auto* mode = &pb_graph_node->pb_type->modes[mode_of_edge];
+    int mode_of_edge = edge->interconnect->parent_mode_index;
+    t_mode* mode = &pb_graph_node->pb_type->modes[mode_of_edge];
 
     auto result = mode_map.insert(std::make_pair(pb_graph_node, mode));
 
@@ -280,7 +280,7 @@ void ClusterRouter::add_atom_as_target(const AtomBlockId blk_id, const AtomPBBim
 
     set_reset_pb_modes(pb, true);
 
-    for (auto pin_id : atom_ctx.netlist().block_pins(blk_id)) {
+    for (AtomPinId pin_id : atom_ctx.netlist().block_pins(blk_id)) {
         add_pin_to_rt_terminals_(pin_id, atom_to_pb);
     }
 
@@ -298,7 +298,7 @@ void ClusterRouter::remove_atom_from_target(const AtomBlockId blk_id, const Atom
     const t_pb* pb = atom_to_pb.atom_pb(blk_id);
     set_reset_pb_modes(pb, false);
 
-    for (auto pin_id : atom_ctx.netlist().block_pins(blk_id)) {
+    for (AtomPinId pin_id : atom_ctx.netlist().block_pins(blk_id)) {
         remove_pin_from_rt_terminals_(pin_id, atom_to_pb);
     }
 
@@ -370,7 +370,7 @@ bool ClusterRouter::try_expand_nodes_(const t_intra_lb_net& lb_net,
 
             if (verbosity > 3) {
                 //Print detailed debug info
-                auto& atom_nlist = g_vpr_ctx.atom().netlist();
+                const AtomNetlist& atom_nlist = g_vpr_ctx.atom().netlist();
                 AtomNetId net_id = lb_net.atom_net_id;
                 AtomPinId driver_pin = lb_net.atom_pins[0];
                 AtomPinId sink_pin = lb_net.atom_pins[itarget];
@@ -420,7 +420,7 @@ void ClusterRouter::hot_start_intra_lb_route_(
     for (size_t inet = 0; inet < intra_lb_nets_.size(); inet++)
         atom_net_to_inet.insert({intra_lb_nets_[inet].atom_net_id, inet});
 
-    for (const auto& saved_lb_net : saved_lb_nets_) {
+    for (const t_intra_lb_net& saved_lb_net : saved_lb_nets_) {
         // Skip if the net's terminals have changed since the last save — the
         // saved route tree no longer reaches the right pins.
         auto it = atom_net_to_inet.find(saved_lb_net.atom_net_id);
@@ -548,7 +548,7 @@ bool ClusterRouter::try_intra_lb_route(int verbosity,
             is_routed = is_route_success_();
         } else {
             --inet;
-            auto& atom_ctx = g_vpr_ctx.atom();
+            const AtomContext& atom_ctx = g_vpr_ctx.atom();
             VTR_LOGV(verbosity > 3, "Net '%s' is impossible to route within proposed %s cluster\n",
                      atom_ctx.netlist().net_name(intra_lb_nets_[inet].atom_net_id).c_str(), lb_type_->name.c_str());
             is_routed = false;
@@ -566,7 +566,7 @@ bool ClusterRouter::try_intra_lb_route(int verbosity,
 
         if (verbosity > 3 && !is_impossible) {
             //Report the congested nodes and associated nets
-            auto congested_rr_nodes = find_congested_rr_nodes(*lb_type_graph_, lb_rr_node_stats_);
+            std::vector<int> congested_rr_nodes = find_congested_rr_nodes(*lb_type_graph_, lb_rr_node_stats_);
             if (!congested_rr_nodes.empty()) {
                 VTR_LOG("%s\n", describe_congested_rr_nodes_(congested_rr_nodes).c_str());
             }
@@ -588,7 +588,7 @@ t_pb_routes ClusterRouter::alloc_and_load_pb_route(const IntraLbPbPinLookup& int
     VTR_ASSERT_MSG(!is_clean_ && is_valid_, "Cannot operate on a cleaned / invalid router.");
     t_pb_routes pb_route;
 
-    for (const auto& lb_net : saved_lb_nets_) {
+    for (const t_intra_lb_net& lb_net : saved_lb_nets_) {
         VTR_ASSERT(lb_net.rt_tree.current_node != UNDEFINED);
         load_trace_to_pb_route(pb_route, lb_net.atom_net_id, UNDEFINED, lb_net.rt_tree, lb_type_, intra_lb_pb_pin_lookup);
     }
@@ -631,7 +631,7 @@ static void load_trace_to_pb_route(t_pb_routes& pb_route,
             VTR_ASSERT(pin_route.atom_net_id == net_id);
         }
     }
-    for (const auto& nxt_trace : trace.next_nodes) {
+    for (const t_lb_trace& nxt_trace : trace.next_nodes) {
         load_trace_to_pb_route(pb_route, net_id, cur_pin_id, nxt_trace, logic_block_type, intra_lb_pb_pin_lookup);
     }
 }
@@ -646,7 +646,7 @@ void ClusterRouter::add_pin_to_rt_terminals_(const AtomPinId pin_id,
     std::vector<t_lb_type_rr_node>& lb_type_graph = *lb_type_graph_;
     bool found = false;
     unsigned int ipos;
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
     const t_pb_graph_pin* pb_graph_pin = find_pb_graph_pin(atom_ctx.netlist(), atom_to_pb, pin_id);
     VTR_ASSERT(pb_graph_pin);
@@ -838,7 +838,7 @@ void ClusterRouter::remove_pin_from_rt_terminals_(const AtomPinId pin_id,
 
     VTR_ASSERT(intra_lb_nets_[ipos].atom_pins.size() == intra_lb_nets_[ipos].terminals.size());
 
-    auto port_type = atom_netlist.port_type(port_id);
+    PortType port_type = atom_netlist.port_type(port_id);
     if (port_type == PortType::OUTPUT) {
         /* Net driver pin takes 0th position in terminals */
         int sink_terminal;
@@ -944,7 +944,7 @@ void ClusterRouter::fix_duplicate_equivalent_pins_(const AtomPBBimap& atom_to_pb
             duplicate_terminals[node].push_back(term_idx);
         }
 
-        for (auto kv : duplicate_terminals) {
+        for (std::pair<const int, std::vector<int>> kv : duplicate_terminals) {
             if (kv.second.size() < 2) continue; //Only process duplicates
 
             //Remap all the duplicate terminals so they target the pin instead of the sink
@@ -1006,8 +1006,8 @@ void ClusterRouter::commit_remove_rt_(const t_lb_trace& rt,
     lb_rr_node_stats_[inode].occ += incr;
     VTR_ASSERT(lb_rr_node_stats_[inode].occ >= 0);
 
-    auto& driver_node = lb_type_graph[inode];
-    auto* driver_pin = driver_node.pb_graph_pin;
+    t_lb_type_rr_node& driver_node = lb_type_graph[inode];
+    t_pb_graph_pin* driver_pin = driver_node.pb_graph_pin;
 
     /* Recursively update route tree */
     for (size_t i = 0; i < rt.next_nodes.size(); i++) {
@@ -1015,8 +1015,8 @@ void ClusterRouter::commit_remove_rt_(const t_lb_trace& rt,
         // A conflict is present if there are differing modes between a pb_graph_node
         // and its children.
         if (op == RT_COMMIT && mode_status->try_expand_all_modes) {
-            auto& node = lb_type_graph[rt.next_nodes[i].current_node];
-            auto* pin = node.pb_graph_pin;
+            t_lb_type_rr_node& node = lb_type_graph[rt.next_nodes[i].current_node];
+            t_pb_graph_pin* pin = node.pb_graph_pin;
 
             if (check_edge_for_route_conflicts(mode_map, driver_pin, pin)) {
                 mode_status->is_mode_conflict = true;
@@ -1057,7 +1057,7 @@ static bool is_route_mode_compatible(const t_lb_trace& rt,
     int mode = lb_rr_node_stats[cur_node].mode;
     if (mode == -1) mode = 0;
 
-    for (const auto& child : rt.next_nodes) {
+    for (const t_lb_trace& child : rt.next_nodes) {
         // Verify the edge cur_node -> child.current_node exists in the current mode.
         bool edge_exists = false;
         if (mode < lb_type_graph[cur_node].num_modes) {
@@ -1195,8 +1195,8 @@ void ClusterRouter::expand_node_all_modes_(const t_expansion_node& exp_node,
     int cur_inode = exp_node.node_index;
     float cur_cost = exp_node.cost;
     int cur_mode = lb_rr_node_stats_[cur_inode].mode;
-    auto& node = lb_type_graph[cur_inode];
-    auto* pin = node.pb_graph_pin;
+    t_lb_type_rr_node& node = lb_type_graph[cur_inode];
+    t_pb_graph_pin* pin = node.pb_graph_pin;
 
     for (int mode = 0; mode < lb_type_graph[cur_inode].num_modes; mode++) {
         /* If a mode has been forced, only add edges from that mode, otherwise add edges from all modes. */
@@ -1207,8 +1207,8 @@ void ClusterRouter::expand_node_all_modes_(const t_expansion_node& exp_node,
         /* Check whether a mode is illegal. If it is then the node will not be expanded */
         bool is_illegal = false;
         if (pin != nullptr) {
-            auto* pb_graph_node = pin->parent_node;
-            for (auto illegal_mode : pb_graph_node->illegal_modes) {
+            t_pb_graph_node* pb_graph_node = pin->parent_node;
+            for (int illegal_mode : pb_graph_node->illegal_modes) {
                 if (mode == illegal_mode) {
                     is_illegal = true;
                     break;
@@ -1296,7 +1296,7 @@ void ClusterRouter::print_route_(const char* filename) {
 
     fprintf(fp, "\n\n----------------------------------------------------\n\n");
 
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
 
     for (unsigned int inet = 0; inet < intra_lb_nets_.size(); inet++) {
         AtomNetId net_id = intra_lb_nets_[inet].atom_net_id;
@@ -1314,10 +1314,10 @@ void ClusterRouter::print_trace_(FILE* fp, const t_lb_trace& trace) {
         return;
     }
     for (unsigned int ibranch = 0; ibranch < trace.next_nodes.size(); ibranch++) {
-        auto current_node = trace.current_node;
-        auto current_str = describe_lb_type_rr_node_(current_node);
-        auto next_node = trace.next_nodes[ibranch].current_node;
-        auto next_str = describe_lb_type_rr_node_(next_node);
+        int current_node = trace.current_node;
+        std::string current_str = describe_lb_type_rr_node_(current_node);
+        int next_node = trace.next_nodes[ibranch].current_node;
+        std::string next_str = describe_lb_type_rr_node_(next_node);
         if (trace.next_nodes.size() > 1) {
             fprintf(fp, "\n\tB");
         }
@@ -1427,7 +1427,7 @@ static std::vector<int> find_incoming_rr_nodes(int dst_node, const std::vector<t
 std::string ClusterRouter::describe_congested_rr_nodes_(const std::vector<int>& congested_rr_nodes) {
     std::string description;
 
-    const auto& lb_type_graph = *lb_type_graph_;
+    const std::vector<t_lb_type_rr_node>& lb_type_graph = *lb_type_graph_;
 
     std::multimap<size_t, AtomNetId> congested_rr_node_to_nets; //From rr_node to net
     for (unsigned int inet = 0; inet < intra_lb_nets_.size(); inet++) {
@@ -1460,7 +1460,7 @@ std::string ClusterRouter::describe_congested_rr_nodes_(const std::vector<int>& 
 
     VTR_ASSERT(!congested_rr_node_to_nets.empty());
     VTR_ASSERT(!congested_rr_nodes.empty());
-    auto& atom_ctx = g_vpr_ctx.atom();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
     for (int inode : congested_rr_nodes) {
         const t_lb_type_rr_node& rr_node = lb_type_graph[inode];
         const t_lb_rr_node_stats& rr_node_stats = lb_rr_node_stats_[inode];
@@ -1482,8 +1482,8 @@ std::string ClusterRouter::describe_congested_rr_nodes_(const std::vector<int>& 
 
 void ClusterRouter::reset_intra_lb_route() {
     VTR_ASSERT_MSG(!is_clean_ && is_valid_, "Cannot operate on a cleaned / invalid router.");
-    for (auto& node : *lb_type_graph_) {
-        auto* pin = node.pb_graph_pin;
+    for (t_lb_type_rr_node& node : *lb_type_graph_) {
+        t_pb_graph_pin* pin = node.pb_graph_pin;
         if (pin == nullptr) {
             continue;
         }

--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -12,6 +12,7 @@
  * Date: July 22, 2013
  */
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -227,7 +228,7 @@ static bool check_edge_for_route_conflicts(std::unordered_map<const t_pb_graph_n
 
     /* Insert unpackable mode to the illegal mode list */
     if (mode->disable_packing) {
-        if (std::find(pb_graph_node->illegal_modes.begin(), pb_graph_node->illegal_modes.end(), mode->index) == pb_graph_node->illegal_modes.end()) {
+        if (std::ranges::find(pb_graph_node->illegal_modes, mode->index) == pb_graph_node->illegal_modes.end()) {
             pb_graph_node->illegal_modes.push_back(mode->index);
         }
         return true;
@@ -242,7 +243,7 @@ static bool check_edge_for_route_conflicts(std::unordered_map<const t_pb_graph_n
 
             // The illegal mode is added to the pb_graph_node as it resulted in a conflict during atom-to-atom routing. This mode cannot be used in the consequent cluster
             // generation try.
-            if (std::find(pb_graph_node->illegal_modes.begin(), pb_graph_node->illegal_modes.end(), result.first->second->index) == pb_graph_node->illegal_modes.end()) {
+            if (std::ranges::find(pb_graph_node->illegal_modes, result.first->second->index) == pb_graph_node->illegal_modes.end()) {
                 pb_graph_node->illegal_modes.push_back(result.first->second->index);
             }
 

--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -1433,20 +1433,20 @@ std::string ClusterRouter::describe_congested_rr_nodes_(const std::vector<int>& 
         AtomNetId atom_net = intra_lb_nets_[inet].atom_net_id;
 
         //Walk the lb_traceback to find congested RR nodes for each net
-        std::queue<t_lb_trace> q;
+        std::queue<const t_lb_trace*> q;
 
         if (intra_lb_nets_[inet].rt_tree.current_node != UNDEFINED) {
-            q.push(intra_lb_nets_[inet].rt_tree);
+            q.push(&intra_lb_nets_[inet].rt_tree);
         }
         while (!q.empty()) {
-            t_lb_trace curr = q.front();
+            const t_lb_trace* curr = q.front();
             q.pop();
 
-            for (const t_lb_trace& next_trace : curr.next_nodes) {
-                q.push(next_trace);
+            for (const t_lb_trace& next_trace : curr->next_nodes) {
+                q.push(&next_trace);
             }
 
-            int inode = curr.current_node;
+            int inode = curr->current_node;
             const t_lb_type_rr_node& rr_node = lb_type_graph[inode];
             const t_lb_rr_node_stats& rr_node_stats = lb_rr_node_stats_[inode];
 

--- a/vpr/src/pack/cluster_router.cpp
+++ b/vpr/src/pack/cluster_router.cpp
@@ -617,16 +617,17 @@ static void load_trace_to_pb_route(t_pb_routes& pb_route,
     int cur_pin_id = UNDEFINED;
     const int total_pins = logic_block_type->pb_graph_head->total_pb_pins;
     if (ipin < total_pins) {
-        /* This routing node corresponds with a pin.  This node is virtual (ie. sink or source node) */
+        // This routing node corresponds with a pin.  This node is virtual (ie. sink or source node)
         cur_pin_id = ipin;
-        if (!pb_route.count(ipin)) {
-            pb_route.insert(std::make_pair(cur_pin_id, t_pb_route()));
-            pb_route[cur_pin_id].atom_net_id = net_id;
-            pb_route[cur_pin_id].driver_pb_pin_id = driver_pb_pin_id;
-            const t_pb_graph_pin* pb_graph_pin = intra_lb_pb_pin_lookup.pb_gpin(logic_block_type->index, cur_pin_id);
-            pb_route[cur_pin_id].pb_graph_pin = pb_graph_pin;
+        // insert() leaves the existing entry untouched if cur_pin_id is already in the map.
+        auto [pin_route_it, inserted] = pb_route.insert(std::make_pair(cur_pin_id, t_pb_route()));
+        t_pb_route& pin_route = pin_route_it->second;
+        if (inserted) {
+            pin_route.atom_net_id = net_id;
+            pin_route.driver_pb_pin_id = driver_pb_pin_id;
+            pin_route.pb_graph_pin = intra_lb_pb_pin_lookup.pb_gpin(logic_block_type->index, cur_pin_id);
         } else {
-            VTR_ASSERT(pb_route[cur_pin_id].atom_net_id == net_id);
+            VTR_ASSERT(pin_route.atom_net_id == net_id);
         }
     }
     for (const auto& nxt_trace : trace.next_nodes) {

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -189,7 +189,7 @@ void GreedyCandidateSelector::initialize_unrelated_clustering_data(const t_molec
             int ext_inps = molecule_stats.num_used_ext_inputs;
 
             //Insert the molecule into the unclustered lists by number of external inputs
-            auto& tile_uc_data = appack_unrelated_clustering_data_[mol_pos.layer][mol_pos.x][mol_pos.y];
+            std::vector<std::vector<PackMoleculeId>>& tile_uc_data = appack_unrelated_clustering_data_[mol_pos.layer][mol_pos.x][mol_pos.y];
             tile_uc_data[ext_inps].push_back(mol_id);
         }
     } else {
@@ -256,9 +256,9 @@ ClusterGainStats GreedyCandidateSelector::create_cluster_gain_stats(
     // class type of the seed primitive pb is a memory class.
     // This is used by APPack to turn off certain optimizations which interfere
     // with RAM packing.
-    const auto& seed_mol = prepacker_.get_molecule(cluster_seed_mol_id);
+    const t_pack_molecule& seed_mol = prepacker_.get_molecule(cluster_seed_mol_id);
     AtomBlockId seed_atom = seed_mol.atom_block_ids[seed_mol.root];
-    const auto seed_pb = cluster_legalizer.atom_pb_lookup().atom_pb(seed_atom);
+    const t_pb* seed_pb = cluster_legalizer.atom_pb_lookup().atom_pb(seed_atom);
     cluster_gain_stats.is_memory = seed_pb->pb_graph_node->pb_type->class_type == MEMORY_CLASS;
 
     if (has_ram_groups_ && cluster_gain_stats.is_memory) {
@@ -426,7 +426,7 @@ void GreedyCandidateSelector::mark_and_update_partial_gain(
     if (gain_flag == e_gain_update::GAIN) {
         /* Check if this net is connected to it's driver block multiple times (i.e. as both an output and input)
          * If so, avoid double counting by skipping the first (driving) pin. */
-        auto pins = atom_netlist_.net_pins(net_id);
+        AtomNetlist::pin_range pins = atom_netlist_.net_pins(net_id);
         if (net_output_feeds_driving_block_input_.count(net_id) != 0)
             //We implicitly assume here that net_output_feeds_driver_block_input[net_id] is 2
             //(i.e. the net loops back to the block only once)
@@ -558,7 +558,7 @@ void GreedyCandidateSelector::update_timing_gain_values(
 
     /* Check if this atom net lists its driving atom block twice.  If so, avoid  *
      * double counting this atom block by skipping the first (driving) pin. */
-    auto pins = atom_netlist_.net_pins(net_id);
+    AtomNetlist::pin_range pins = atom_netlist_.net_pins(net_id);
     if (net_output_feeds_driving_block_input_.count(net_id) != 0)
         pins = atom_netlist_.net_sinks(net_id);
 
@@ -887,7 +887,7 @@ void GreedyCandidateSelector::add_cluster_molecule_candidates_by_transitive_conn
                                       cluster_legalizer);
 
     /* Only consider candidates that pass a very simple legality check */
-    for (const auto& transitive_candidate : cluster_gain_stats.transitive_fanout_candidates) {
+    for (const std::pair<const AtomBlockId, PackMoleculeId>& transitive_candidate : cluster_gain_stats.transitive_fanout_candidates) {
         PackMoleculeId molecule_id = transitive_candidate.second;
         if (!cluster_legalizer.is_mol_clustered(molecule_id) && cluster_legalizer.is_molecule_compatible(molecule_id, legalization_cluster_id)) {
             add_molecule_to_pb_stats_candidates(molecule_id,
@@ -940,7 +940,7 @@ void GreedyCandidateSelector::add_cluster_molecule_candidates_by_attraction_grou
     LegalizationClusterId legalization_cluster_id,
     const ClusterLegalizer& cluster_legalizer,
     AttractionInfo& attraction_groups) {
-    auto cluster_type = cluster_legalizer.get_cluster_type(legalization_cluster_id);
+    t_logical_block_type_ptr cluster_type = cluster_legalizer.get_cluster_type(legalization_cluster_id);
 
     /*
      * For each cluster, we want to explore the attraction group molecules as potential
@@ -963,7 +963,7 @@ void GreedyCandidateSelector::add_cluster_molecule_candidates_by_attraction_grou
         LogicalModelId atom_model = atom_netlist_.block_model(atom_id);
         VTR_ASSERT(atom_model.is_valid());
         VTR_ASSERT(!primitive_candidate_block_types_[atom_model].empty());
-        const auto& candidate_types = primitive_candidate_block_types_[atom_model];
+        const std::vector<t_logical_block_type_ptr>& candidate_types = primitive_candidate_block_types_[atom_model];
 
         //Only consider molecules that are unpacked and of the correct type
         if (!cluster_legalizer.is_atom_clustered(atom_id)
@@ -1124,14 +1124,14 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
         } else {
             /* This block has no connection with current cluster, penalize molecule for having this block
              */
-            for (auto pin_id : atom_netlist.block_input_pins(blk_id)) {
-                auto net_id = atom_netlist.pin_net(pin_id);
+            for (AtomPinId pin_id : atom_netlist.block_input_pins(blk_id)) {
+                AtomNetId net_id = atom_netlist.pin_net(pin_id);
                 VTR_ASSERT(net_id);
 
-                auto driver_pin_id = atom_netlist.net_driver(net_id);
+                AtomPinId driver_pin_id = atom_netlist.net_driver(net_id);
                 VTR_ASSERT(driver_pin_id);
 
-                auto driver_blk_id = atom_netlist.pin_block(driver_pin_id);
+                AtomBlockId driver_blk_id = atom_netlist.pin_block(driver_pin_id);
 
                 num_introduced_inputs_of_indirectly_related_block++;
                 for (AtomBlockId blk_id_2 : molecule.atom_block_ids) {
@@ -1242,7 +1242,7 @@ void GreedyCandidateSelector::load_transitive_fanout_candidates(
                         continue;
 
                     // This transitive atom is not packed, score and add
-                    auto& transitive_fanout_candidates = cluster_gain_stats.transitive_fanout_candidates;
+                    std::map<AtomBlockId, PackMoleculeId>& transitive_fanout_candidates = cluster_gain_stats.transitive_fanout_candidates;
 
                     // operator[] value-initializes the gain to 0 if blk_id is not in the map.
                     cluster_gain_stats.gain[blk_id] += 0.001;
@@ -1406,7 +1406,7 @@ PackMoleculeId GreedyCandidateSelector::get_unrelated_candidate_for_cluster_appa
         // break ties based on whoever has more external inputs.
         PackMoleculeId best_candidate = PackMoleculeId::INVALID();
         float best_candidate_distance = std::numeric_limits<float>::max();
-        const auto& uc_data = appack_unrelated_clustering_data_[node_loc.layer_num][node_loc.x][node_loc.y];
+        const std::vector<std::vector<PackMoleculeId>>& uc_data = appack_unrelated_clustering_data_[node_loc.layer_num][node_loc.x][node_loc.y];
         VTR_ASSERT_SAFE(inputs_avail < uc_data.size());
         for (int ext_inps = inputs_avail; ext_inps >= 0; ext_inps--) {
             // Get the molecule by the number of external inputs.

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -295,6 +295,14 @@ void GreedyCandidateSelector::update_cluster_gain_stats_candidate_success(
     // cluster. Also keeps track of which attraction group the cluster belongs
     // to.
     const t_pack_molecule& successful_mol = prepacker_.get_molecule(successful_mol_id);
+
+    // Reset the list of feasible blocks. This state does not depend on the
+    // molecule's atoms, so it only needs to be reset once per molecule.
+    cluster_gain_stats.has_done_connectivity_and_timing = false;
+    cluster_gain_stats.initial_search_for_feasible_blocks = true;
+    cluster_gain_stats.num_candidates_proposed = 0;
+    cluster_gain_stats.feasible_blocks.clear();
+
     for (AtomBlockId blk_id : successful_mol.atom_block_ids) {
         if (!blk_id) {
             continue;
@@ -303,11 +311,6 @@ void GreedyCandidateSelector::update_cluster_gain_stats_candidate_success(
         //Update attraction group
         AttractGroupId atom_grp_id = attraction_groups.get_atom_attraction_group(blk_id);
 
-        /* reset list of feasible blocks */
-        cluster_gain_stats.has_done_connectivity_and_timing = false;
-        cluster_gain_stats.initial_search_for_feasible_blocks = true;
-        cluster_gain_stats.num_candidates_proposed = 0;
-        cluster_gain_stats.feasible_blocks.clear();
         /* TODO: Allow clusters to have more than one attraction group. */
         if (atom_grp_id.is_valid())
             cluster_gain_stats.attraction_grp_id = atom_grp_id;
@@ -356,9 +359,12 @@ void GreedyCandidateSelector::update_cluster_gain_stats_candidate_success(
 
         // TODO: For flat placement reconstruction, should we mark the molecules
         //       in the same tile as the seed of this cluster?
-
-        update_total_gain(cluster_gain_stats, attraction_groups);
     }
+
+    // Recompute the total gain of all marked blocks. update_total_gain fully
+    // recomputes each marked block's gain from its accumulated stats, so it
+    // only needs to run once, after all of the molecule's atoms are marked.
+    update_total_gain(cluster_gain_stats, attraction_groups);
 
     // if this molecule came from the transitive fanout candidates remove it
     cluster_gain_stats.transitive_fanout_candidates.erase(successful_mol.atom_block_ids[successful_mol.root]);

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -133,14 +133,13 @@ void GreedyCandidateSelector::initialize_unrelated_clustering_data(const t_molec
     // gain. (Highest gain).
     std::vector<PackMoleculeId> molecules_vector;
     molecules_vector.assign(prepacker_.molecules().begin(), prepacker_.molecules().end());
-    std::stable_sort(molecules_vector.begin(),
-                     molecules_vector.end(),
-                     [&](PackMoleculeId a_id, PackMoleculeId b_id) {
-                         const t_pack_molecule& a = prepacker_.get_molecule(a_id);
-                         const t_pack_molecule& b = prepacker_.get_molecule(b_id);
+    std::ranges::stable_sort(molecules_vector,
+                             [&](PackMoleculeId a_id, PackMoleculeId b_id) {
+                                 const t_pack_molecule& a = prepacker_.get_molecule(a_id);
+                                 const t_pack_molecule& b = prepacker_.get_molecule(b_id);
 
-                         return a.base_gain > b.base_gain;
-                     });
+                                 return a.base_gain > b.base_gain;
+                             });
 
     if (appack_ctx_.appack_options.use_appack) {
         /**
@@ -968,7 +967,7 @@ void GreedyCandidateSelector::add_cluster_molecule_candidates_by_attraction_grou
 
         //Only consider molecules that are unpacked and of the correct type
         if (!cluster_legalizer.is_atom_clustered(atom_id)
-            && std::find(candidate_types.begin(), candidate_types.end(), cluster_type) != candidate_types.end()) {
+            && std::ranges::find(candidate_types, cluster_type) != candidate_types.end()) {
             available_atoms.push_back(atom_id);
         }
     }

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -487,14 +487,14 @@ void GreedyCandidateSelector::update_connection_gain_values(
     num_internal_connections = num_open_connections = num_stuck_connections = 0;
 
     LegalizationClusterId legalization_cluster_id = cluster_legalizer.get_atom_cluster(clustered_blk_id);
+    // TODO: Should investigate this. Using the atom pb bimap through is_atom_blk_in_cluster_block
+    // in this class is very strange
+    const t_pb* cluster_pb = cluster_legalizer.atom_pb_lookup().atom_pb(clustered_blk_id);
 
     /* may wish to speed things up by ignoring clock nets since they are high fanout */
     for (AtomPinId pin_id : atom_netlist_.net_pins(net_id)) {
         AtomBlockId blk_id = atom_netlist_.pin_block(pin_id);
-        // TODO: Should investigate this. Using the atom pb bimap through is_atom_blk_in_cluster_block
-        // in this class is very strange
         const t_pb* pin_block_pb = cluster_legalizer.atom_pb_lookup().atom_pb(blk_id);
-        const t_pb* cluster_pb = cluster_legalizer.atom_pb_lookup().atom_pb(clustered_blk_id);
 
         if (cluster_legalizer.get_atom_cluster(blk_id) == legalization_cluster_id && is_pb_in_cluster_pb(pin_block_pb, cluster_pb)) {
             num_internal_connections++;

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -411,8 +411,9 @@ void GreedyCandidateSelector::mark_and_update_partial_gain(
         return;
     }
 
-    /* Mark atom net as being visited, if necessary. */
-    if (cluster_gain_stats.num_pins_of_net_in_pb.count(net_id) == 0) {
+    // Insert the net into the visited set; if new, record it in marked_nets.
+    auto [net_pin_count_it, net_is_new] = cluster_gain_stats.num_pins_of_net_in_pb.emplace(net_id, 0);
+    if (net_is_new) {
         cluster_gain_stats.marked_nets.push_back(net_id);
     }
 
@@ -426,7 +427,7 @@ void GreedyCandidateSelector::mark_and_update_partial_gain(
             //(i.e. the net loops back to the block only once)
             pins = atom_netlist_.net_sinks(net_id);
 
-        if (cluster_gain_stats.num_pins_of_net_in_pb.count(net_id) == 0) {
+        if (net_is_new) {
             for (AtomPinId pin_id : pins) {
                 AtomBlockId blk_id = atom_netlist_.pin_block(pin_id);
                 if (!cluster_legalizer.is_atom_clustered(blk_id)) {
@@ -455,10 +456,7 @@ void GreedyCandidateSelector::mark_and_update_partial_gain(
                                       net_relation_to_clustered_block);
         }
     }
-    if (cluster_gain_stats.num_pins_of_net_in_pb.count(net_id) == 0) {
-        cluster_gain_stats.num_pins_of_net_in_pb[net_id] = 0;
-    }
-    cluster_gain_stats.num_pins_of_net_in_pb[net_id]++;
+    net_pin_count_it->second++;
 }
 
 /**

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -514,14 +514,12 @@ void GreedyCandidateSelector::update_connection_gain_values(
                 /* TODO: Gain function accurate only if net has one connection to block,
                  * TODO: Should we handle case where net has multi-connection to block?
                  *       Gain computation is only off by a bit in this case */
-                if (cluster_gain_stats.connection_gain.count(blk_id) == 0) {
-                    cluster_gain_stats.connection_gain[blk_id] = 0;
-                }
-
+                // operator[] value-initializes the connection gain to 0 if blk_id is not in the map.
+                float& blk_connection_gain = cluster_gain_stats.connection_gain[blk_id];
                 if (num_internal_connections > 1) {
-                    cluster_gain_stats.connection_gain[blk_id] -= 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 1 + 0.1);
+                    blk_connection_gain -= 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 1 + 0.1);
                 }
-                cluster_gain_stats.connection_gain[blk_id] += 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 0.1);
+                blk_connection_gain += 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 0.1);
             }
         }
     }
@@ -534,13 +532,12 @@ void GreedyCandidateSelector::update_connection_gain_values(
         AtomBlockId blk_id = atom_netlist_.pin_block(driver_pin_id);
 
         if (!cluster_legalizer.is_atom_clustered(blk_id)) {
-            if (cluster_gain_stats.connection_gain.count(blk_id) == 0) {
-                cluster_gain_stats.connection_gain[blk_id] = 0;
-            }
+            // operator[] value-initializes the connection gain to 0 if blk_id is not in the map.
+            float& blk_connection_gain = cluster_gain_stats.connection_gain[blk_id];
             if (num_internal_connections > 1) {
-                cluster_gain_stats.connection_gain[blk_id] -= 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 0.1 + 1);
+                blk_connection_gain -= 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 0.1 + 1);
             }
-            cluster_gain_stats.connection_gain[blk_id] += 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 0.1);
+            blk_connection_gain += 1 / (float)(num_open_connections + 1.5 * num_stuck_connections + 0.1);
         }
     }
 }
@@ -570,11 +567,10 @@ void GreedyCandidateSelector::update_timing_gain_values(
             if (!cluster_legalizer.is_atom_clustered(blk_id)) {
                 double timing_gain = timing_info.setup_pin_criticality(pin_id);
 
-                if (cluster_gain_stats.timing_gain.count(blk_id) == 0) {
-                    cluster_gain_stats.timing_gain[blk_id] = 0;
-                }
-                if (timing_gain > cluster_gain_stats.timing_gain[blk_id])
-                    cluster_gain_stats.timing_gain[blk_id] = timing_gain;
+                // operator[] value-initializes the timing gain to 0 if blk_id is not in the map.
+                float& blk_timing_gain = cluster_gain_stats.timing_gain[blk_id];
+                if (timing_gain > blk_timing_gain)
+                    blk_timing_gain = timing_gain;
             }
         }
     }
@@ -590,11 +586,10 @@ void GreedyCandidateSelector::update_timing_gain_values(
             for (AtomPinId pin_id : atom_netlist_.net_sinks(net_id)) {
                 double timing_gain = timing_info.setup_pin_criticality(pin_id);
 
-                if (cluster_gain_stats.timing_gain.count(new_blk_id) == 0) {
-                    cluster_gain_stats.timing_gain[new_blk_id] = 0;
-                }
-                if (timing_gain > cluster_gain_stats.timing_gain[new_blk_id])
-                    cluster_gain_stats.timing_gain[new_blk_id] = timing_gain;
+                // operator[] value-initializes the timing gain to 0 if new_blk_id is not in the map.
+                float& blk_timing_gain = cluster_gain_stats.timing_gain[new_blk_id];
+                if (timing_gain > blk_timing_gain)
+                    blk_timing_gain = timing_gain;
             }
         }
     }
@@ -1244,11 +1239,8 @@ void GreedyCandidateSelector::load_transitive_fanout_candidates(
                     // This transitive atom is not packed, score and add
                     auto& transitive_fanout_candidates = cluster_gain_stats.transitive_fanout_candidates;
 
-                    if (cluster_gain_stats.gain.count(blk_id) == 0) {
-                        cluster_gain_stats.gain[blk_id] = 0.001;
-                    } else {
-                        cluster_gain_stats.gain[blk_id] += 0.001;
-                    }
+                    // operator[] value-initializes the gain to 0 if blk_id is not in the map.
+                    cluster_gain_stats.gain[blk_id] += 0.001;
                     PackMoleculeId molecule_id = prepacker_.get_atom_molecule(blk_id);
                     VTR_ASSERT(!cluster_legalizer.is_mol_clustered(molecule_id));
                     const t_pack_molecule& molecule = prepacker_.get_molecule(molecule_id);

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -1118,8 +1118,9 @@ static float get_molecule_gain(PackMoleculeId molecule_id,
         if (!blk_id.is_valid())
             continue;
 
-        if (cluster_gain_stats.gain.count(blk_id) > 0) {
-            gain += cluster_gain_stats.gain[blk_id];
+        auto gain_it = cluster_gain_stats.gain.find(blk_id);
+        if (gain_it != cluster_gain_stats.gain.end()) {
+            gain += gain_it->second;
         } else {
             /* This block has no connection with current cluster, penalize molecule for having this block
              */

--- a/vpr/src/pack/logical_ram_infer.cpp
+++ b/vpr/src/pack/logical_ram_infer.cpp
@@ -48,7 +48,7 @@ group_ram_atoms(const AtomNetlist& atom_nlist, const Prepacker& prepacker) {
             continue;
 
         LogicalModelId root_model_id = atom_nlist.block_model(atom_blk_id);
-        std::vector<t_logical_block_type_ptr> candidate_types =
+        const std::vector<t_logical_block_type_ptr>& candidate_types =
             primitive_candidate_block_types[root_model_id];
 
         // Try to add this atom to an existing sibling-feasible group.
@@ -79,7 +79,7 @@ group_ram_atoms(const AtomNetlist& atom_nlist, const Prepacker& prepacker) {
                 new_group.is_output_registered =
                     blif_model.find("output_type{reg}") != std::string::npos;
             }
-            groups.push_back(new_group);
+            groups.push_back(std::move(new_group));
         }
     }
 
@@ -319,7 +319,7 @@ vtr::vector<PhysicalRamGroupId, PhysicalRamGroup> RamMapper::create_physical_ram
             }
 
             if (!current_group.atoms.empty())
-                physical_groups.push_back(current_group);
+                physical_groups.push_back(std::move(current_group));
             unmapped_atoms = std::move(remaining_atoms);
         }
     }

--- a/vpr/src/pack/logical_ram_infer.cpp
+++ b/vpr/src/pack/logical_ram_infer.cpp
@@ -113,30 +113,30 @@ void assign_ram_groups_by_min_area(vtr::vector<LogicalRamGroupId, LogicalRamGrou
                             * cand->equivalent_tiles[0]->width;
             ram_group.candidate_area_cost[cand] = num_tiles * tile_area;
         }
-        std::sort(ram_group.candidate_types.begin(), ram_group.candidate_types.end(),
-                  [&](t_logical_block_type_ptr type_a, t_logical_block_type_ptr type_b) {
-                      int area_a = ram_group.candidate_area_cost.at(type_a);
-                      int area_b = ram_group.candidate_area_cost.at(type_b);
-                      if (area_a != area_b) return area_a < area_b;
-                      // Tie-break: prefer higher capacity, then by name.
-                      int cap_a = ram_group.candidate_capacity.at(type_a);
-                      int cap_b = ram_group.candidate_capacity.at(type_b);
-                      if (cap_a != cap_b) return cap_a > cap_b;
-                      return std::string(type_a->name) < std::string(type_b->name);
-                  });
+        std::ranges::sort(ram_group.candidate_types,
+                          [&](t_logical_block_type_ptr type_a, t_logical_block_type_ptr type_b) {
+                              int area_a = ram_group.candidate_area_cost.at(type_a);
+                              int area_b = ram_group.candidate_area_cost.at(type_b);
+                              if (area_a != area_b) return area_a < area_b;
+                              // Tie-break: prefer higher capacity, then by name.
+                              int cap_a = ram_group.candidate_capacity.at(type_a);
+                              int cap_b = ram_group.candidate_capacity.at(type_b);
+                              if (cap_a != cap_b) return cap_a > cap_b;
+                              return std::string(type_a->name) < std::string(type_b->name);
+                          });
     }
 
     // Process groups most constrained first (fewest candidate types), then
     // largest (most atoms) first.
     std::vector<LogicalRamGroupId> order(groups.keys().begin(), groups.keys().end());
-    std::stable_sort(order.begin(), order.end(),
-                     [&](LogicalRamGroupId id_a, LogicalRamGroupId id_b) {
-                         const LogicalRamGroup& group_a = groups[id_a];
-                         const LogicalRamGroup& group_b = groups[id_b];
-                         if (group_a.candidate_types.size() != group_b.candidate_types.size())
-                             return group_a.candidate_types.size() < group_b.candidate_types.size();
-                         return group_a.total_memory_slices > group_b.total_memory_slices;
-                     });
+    std::ranges::stable_sort(order,
+                             [&](LogicalRamGroupId id_a, LogicalRamGroupId id_b) {
+                                 const LogicalRamGroup& group_a = groups[id_a];
+                                 const LogicalRamGroup& group_b = groups[id_b];
+                                 if (group_a.candidate_types.size() != group_b.candidate_types.size())
+                                     return group_a.candidate_types.size() < group_b.candidate_types.size();
+                                 return group_a.total_memory_slices > group_b.total_memory_slices;
+                             });
 
     // For fixed devices, pre-compute available capacity per type so that
     // assignment can respect hard capacity limits.

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -40,8 +40,8 @@ static void count_clb_inputs_and_outputs_from_pb_route(const t_pb* pb,
                                                        int ipin,
                                                        e_pin_type pin_type,
                                                        std::unordered_map<AtomNetId, bool>& nets_absorbed,
-                                                       int num_clb_inputs_used[],
-                                                       int num_clb_outputs_used[]) {
+                                                       std::vector<int>& num_clb_inputs_used,
+                                                       std::vector<int>& num_clb_outputs_used) {
     VTR_ASSERT_DEBUG(!pb->pb_route.empty());
     int pb_graph_pin_id = get_pb_graph_node_pin_from_pb_graph_node(pb->pb_graph_node, ipin)->pin_count_in_cluster;
 
@@ -61,9 +61,9 @@ static void count_clb_inputs_and_outputs_from_pb_route(const t_pb* pb,
 
 static void count_stats_from_legalizer(const ClusterLegalizer& cluster_legalizer,
                                        std::unordered_map<AtomNetId, bool>& nets_absorbed,
-                                       int num_clb_types[],
-                                       int num_clb_inputs_used[],
-                                       int num_clb_outputs_used[]) {
+                                       std::vector<int>& num_clb_types,
+                                       std::vector<int>& num_clb_inputs_used,
+                                       std::vector<int>& num_clb_outputs_used) {
     for (LegalizationClusterId cluster_id : cluster_legalizer.clusters()) {
         t_logical_block_type_ptr logical_block = cluster_legalizer.get_cluster_type(cluster_id);
         t_physical_tile_type_ptr physical_tile = pick_physical_type(logical_block);
@@ -87,9 +87,9 @@ static void count_stats_from_legalizer(const ClusterLegalizer& cluster_legalizer
 }
 
 static void count_stats_from_netlist(std::unordered_map<AtomNetId, bool>& nets_absorbed,
-                                     int num_clb_types[],
-                                     int num_clb_inputs_used[],
-                                     int num_clb_outputs_used[]) {
+                                     std::vector<int>& num_clb_types,
+                                     std::vector<int>& num_clb_inputs_used,
+                                     std::vector<int>& num_clb_outputs_used) {
     const AtomContext& atom_ctx = g_vpr_ctx.atom();
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
 
@@ -133,15 +133,9 @@ static void print_stats(const ClusterLegalizer* cluster_legalizer_ptr, bool from
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const AtomNetlist& atom_nlist = g_vpr_ctx.atom().netlist();
 
-    int* num_clb_types = new int[device_ctx.logical_block_types.size()];
-    int* num_clb_inputs_used = new int[device_ctx.logical_block_types.size()];
-    int* num_clb_outputs_used = new int[device_ctx.logical_block_types.size()];
-
-    for (size_t i = 0; i < device_ctx.logical_block_types.size(); i++) {
-        num_clb_types[i] = 0;
-        num_clb_inputs_used[i] = 0;
-        num_clb_outputs_used[i] = 0;
-    }
+    std::vector<int> num_clb_types(device_ctx.logical_block_types.size(), 0);
+    std::vector<int> num_clb_inputs_used(device_ctx.logical_block_types.size(), 0);
+    std::vector<int> num_clb_outputs_used(device_ctx.logical_block_types.size(), 0);
 
     std::unordered_map<AtomNetId, bool> nets_absorbed;
     for (AtomNetId net_id : atom_nlist.nets()) {
@@ -177,9 +171,6 @@ static void print_stats(const ClusterLegalizer* cluster_legalizer_ptr, bool from
     }
     VTR_LOG("Absorbed logical nets %d out of %d nets, %d nets not absorbed.\n",
             total_nets_absorbed, (int)atom_nlist.nets().size(), (int)atom_nlist.nets().size() - total_nets_absorbed);
-    delete[] num_clb_types;
-    delete[] num_clb_inputs_used;
-    delete[] num_clb_outputs_used;
     /* TODO: print more stats */
 }
 

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -67,11 +67,11 @@ static void count_stats_from_legalizer(const ClusterLegalizer& cluster_legalizer
     for (LegalizationClusterId cluster_id : cluster_legalizer.clusters()) {
         t_logical_block_type_ptr logical_block = cluster_legalizer.get_cluster_type(cluster_id);
         t_physical_tile_type_ptr physical_tile = pick_physical_type(logical_block);
+        const t_pb* pb = cluster_legalizer.get_cluster_pb(cluster_id);
         for (int ipin = 0; ipin < logical_block->pb_type->num_pins; ipin++) {
             int physical_pin = get_physical_pin(physical_tile, logical_block, ipin);
             e_pin_type pin_type = get_pin_type_from_pin_physical_num(physical_tile, physical_pin);
 
-            const t_pb* pb = cluster_legalizer.get_cluster_pb(cluster_id);
             if (pb->pb_route.empty())
                 continue;
             count_clb_inputs_and_outputs_from_pb_route(pb,
@@ -614,12 +614,13 @@ static void clustering_xml_blocks_from_legalizer(pugi::xml_node& block_node,
     // its pb_route calculated.
     cluster_legalizer.finalize();
     for (LegalizationClusterId cluster_id : cluster_legalizer.clusters()) {
+        t_pb* pb = cluster_legalizer.get_cluster_pb(cluster_id);
         clustering_xml_block(block_node,
                              cluster_legalizer.get_cluster_type(cluster_id),
                              pb_graph_pin_lookup_from_index_by_type,
-                             cluster_legalizer.get_cluster_pb(cluster_id),
+                             pb,
                              size_t(cluster_id),
-                             cluster_legalizer.get_cluster_pb(cluster_id)->pb_route);
+                             pb->pb_route);
     }
 }
 

--- a/vpr/src/pack/output_clustering.cpp
+++ b/vpr/src/pack/output_clustering.cpp
@@ -429,19 +429,19 @@ static void clustering_xml_block(pugi::xml_node& parent_node, t_logical_block_ty
     if (!pb_type->is_primitive()) {
         block_node.append_attribute("mode") = mode->name;
     } else {
-        const auto& atom_ctx = g_vpr_ctx.atom();
+        const AtomContext& atom_ctx = g_vpr_ctx.atom();
         AtomBlockId atom_blk = atom_ctx.netlist().find_block(pb->name);
         VTR_ASSERT(atom_blk);
 
         pugi::xml_node attrs_node = block_node.append_child("attributes");
-        for (const auto& attr : atom_ctx.netlist().block_attrs(atom_blk)) {
+        for (const std::pair<const std::string, std::string>& attr : atom_ctx.netlist().block_attrs(atom_blk)) {
             pugi::xml_node attr_node = attrs_node.append_child("attribute");
             attr_node.append_attribute("name") = attr.first.c_str();
             attr_node.text().set(attr.second.c_str());
         }
 
         pugi::xml_node params_node = block_node.append_child("parameters");
-        for (const auto& param : atom_ctx.netlist().block_params(atom_blk)) {
+        for (const std::pair<const std::string, std::string>& param : atom_ctx.netlist().block_params(atom_blk)) {
             pugi::xml_node param_node = params_node.append_child("parameter");
             param_node.append_attribute("name") = param.first.c_str();
             param_node.text().set(param.second.c_str());
@@ -478,7 +478,7 @@ static void clustering_xml_block(pugi::xml_node& parent_node, t_logical_block_ty
             if (pb_type->ports[i].equivalent != PortEquivalence::NONE && pb_type->parent_mode != nullptr && pb_type->is_primitive()) {
                 //This is a primitive with equivalent inputs
 
-                auto& atom_ctx = g_vpr_ctx.atom();
+                const AtomContext& atom_ctx = g_vpr_ctx.atom();
                 AtomBlockId atom_blk = atom_ctx.netlist().find_block(pb->name);
                 VTR_ASSERT(atom_blk);
 
@@ -627,7 +627,7 @@ static void clustering_xml_blocks_from_legalizer(pugi::xml_node& block_node,
 static void clustering_xml_blocks_from_netlist(pugi::xml_node& block_node,
                                                const IntraLbPbPinLookup& pb_graph_pin_lookup_from_index_by_type) {
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
-    for (auto blk_id : clb_nlist.blocks()) {
+    for (ClusterBlockId blk_id : clb_nlist.blocks()) {
         /* TODO: Must do check that total CLB pins match top-level pb pins, perhaps check this earlier? */
         clustering_xml_block(block_node,
                              clb_nlist.block_type(blk_id),
@@ -658,8 +658,8 @@ void output_clustering(ClusterLegalizer* cluster_legalizer_ptr, const std::unord
     std::vector<std::string> inputs;
     std::vector<std::string> outputs;
 
-    for (auto blk_id : atom_nlist.blocks()) {
-        auto type = atom_nlist.block_type(blk_id);
+    for (AtomBlockId blk_id : atom_nlist.blocks()) {
+        AtomBlockType type = atom_nlist.block_type(blk_id);
         switch (type) {
             case AtomBlockType::INPAD:
                 if (skip_clustering) {
@@ -691,7 +691,7 @@ void output_clustering(ClusterLegalizer* cluster_legalizer_ptr, const std::unord
     block_node.append_child("outputs").text().set(vtr::join(outputs.begin(), outputs.end(), " ").c_str());
 
     std::vector<std::string> clocks;
-    for (auto net_id : atom_nlist.nets()) {
+    for (AtomNetId net_id : atom_nlist.nets()) {
         if (is_clock.count(net_id)) {
             clocks.push_back(atom_nlist.net_name(net_id));
         }

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -114,7 +114,7 @@ static e_packer_state get_next_packer_state(e_packer_state current_packer_state,
     //         max displacement threshold. This should have the smallest affect on
     //         quality, so we want to do this first.
     if (appack_ctx.appack_options.use_appack) {
-        for (const auto& p : block_type_utils) {
+        for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
             if (p.second <= 1.0f)
                 continue;
 
@@ -184,7 +184,7 @@ static e_packer_state get_next_packer_state(e_packer_state current_packer_state,
     //         max displacement threshold of any overfilled block types, try to
     //         increase them.
     if (appack_ctx.appack_options.use_appack) {
-        for (const auto& p : block_type_utils) {
+        for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
             if (p.second <= 1.0f)
                 continue;
 
@@ -200,7 +200,7 @@ static e_packer_state get_next_packer_state(e_packer_state current_packer_state,
     // Check if we can increase the target density of the overused block types.
     // This is a last resort since increasing the target pin density can have
     // bad affects on quality and routability.
-    for (const auto& p : block_type_utils) {
+    for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
         const t_ext_pin_util& target_pin_util = external_pin_util_targets.get_pin_util(p.first->name);
         if (p.second > 1.0f && (target_pin_util.input_pin_util < 1.0f || target_pin_util.output_pin_util < 1.0f))
             return e_packer_state::INCREASE_OVERUSED_TARGET_PIN_UTILIZATION;
@@ -210,7 +210,7 @@ static e_packer_state get_next_packer_state(e_packer_state current_packer_state,
     //         This will have the worst affect on routability, so we only want
     //         to try this if we have to.
     if (appack_ctx.appack_options.use_appack) {
-        for (const auto& p : block_type_utils) {
+        for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
             if (p.second <= 1.0f)
                 continue;
 
@@ -252,8 +252,8 @@ bool try_pack(const t_packer_opts& packer_opts,
 
     size_t num_p_inputs = 0;
     size_t num_p_outputs = 0;
-    for (auto blk_id : atom_ctx.netlist().blocks()) {
-        auto type = atom_ctx.netlist().block_type(blk_id);
+    for (AtomBlockId blk_id : atom_ctx.netlist().blocks()) {
+        AtomBlockType type = atom_ctx.netlist().block_type(blk_id);
         if (type == AtomBlockType::INPAD) {
             ++num_p_inputs;
         } else if (type == AtomBlockType::OUTPAD) {
@@ -413,7 +413,7 @@ bool try_pack(const t_packer_opts& packer_opts,
                 }
                 if (appack_ctx.appack_options.use_appack) {
                     // Only do unrelated clustering on the overused type instances.
-                    for (const auto& p : block_type_utils) {
+                    for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
                         // Any overutilized block types will use the default options.
                         if (p.second > 1.0f)
                             continue;
@@ -432,7 +432,7 @@ bool try_pack(const t_packer_opts& packer_opts,
             case e_packer_state::INCREASE_OVERUSED_TARGET_PIN_UTILIZATION: {
                 // Get the names of the block types to increase the pin utilization of.
                 std::vector<std::string> block_types_to_increase;
-                for (const auto& p : block_type_utils) {
+                for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
                     t_ext_pin_util current_util = cluster_legalizer.get_target_external_pin_util().get_pin_util(p.first->name);
                     if (p.second > 1.0f && (current_util.input_pin_util < 1.0f || current_util.output_pin_util < 1.0f)) {
                         block_types_to_increase.push_back(p.first->name);
@@ -487,7 +487,7 @@ bool try_pack(const t_packer_opts& packer_opts,
                 VTR_ASSERT(appack_ctx.appack_options.use_appack);
                 VTR_LOG("Packing failed to fit on device. Using high-effort unrelated clustering.\n");
                 VTR_LOG("Pack iteration is %d\n", pack_iteration);
-                for (const auto& p : block_type_utils) {
+                for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
                     if (p.second <= 1.0f)
                         continue;
 
@@ -501,7 +501,7 @@ bool try_pack(const t_packer_opts& packer_opts,
             case e_packer_state::AP_INCREASE_MAX_DISPLACEMENT: {
                 VTR_ASSERT(appack_ctx.appack_options.use_appack);
                 std::vector<t_logical_block_type_ptr> block_types_to_increase;
-                for (const auto& p : block_type_utils) {
+                for (const std::pair<t_logical_block_type_ptr const, float>& p : block_type_utils) {
                     if (p.second <= 1.0f)
                         continue;
 

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -614,9 +614,7 @@ std::unordered_set<AtomNetId> alloc_and_load_is_clock() {
     for (AtomBlockId blk_id : atom_ctx.netlist().blocks()) {
         for (AtomPinId pin_id : atom_ctx.netlist().block_clock_pins(blk_id)) {
             AtomNetId net_id = atom_ctx.netlist().pin_net(pin_id);
-            if (!is_clock.count(net_id)) {
-                is_clock.insert(net_id);
-            }
+            is_clock.insert(net_id);
         }
     }
 

--- a/vpr/src/pack/pack_patterns.h
+++ b/vpr/src/pack/pack_patterns.h
@@ -96,7 +96,7 @@ struct t_pack_patterns {
     t_pack_pattern_block* root_block;
 
     int num_blocks;
-    bool* is_block_optional;
+    std::vector<bool> is_block_optional;
 
     bool is_chain;
     std::vector<std::vector<t_pb_graph_pin*>> chain_root_pins;
@@ -108,7 +108,6 @@ struct t_pack_patterns {
         root_block = nullptr;
         base_cost = 0;
         num_blocks = 0;
-        is_block_optional = nullptr;
         is_chain = false;
     }
 };

--- a/vpr/src/pack/pack_report.cpp
+++ b/vpr/src/pack/pack_report.cpp
@@ -42,46 +42,52 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
     for (auto const& logical_type : device_ctx.logical_block_types) {
         auto type = &logical_type;
         if (is_empty_type(type)) continue;
-        if (!inputs_used.count(type)) continue;
+        auto inputs_used_it = inputs_used.find(type);
+        if (inputs_used_it == inputs_used.end()) continue;
 
-        float max_inputs = static_cast<float>(*std::max_element(inputs_used[type].begin(), inputs_used[type].end()));
-        float min_inputs = static_cast<float>(*std::min_element(inputs_used[type].begin(), inputs_used[type].end()));
-        float avg_inputs = static_cast<float>(std::accumulate(inputs_used[type].begin(), inputs_used[type].end(), 0.f)) / static_cast<float>(inputs_used[type].size());
+        const std::vector<float>& type_inputs_used = inputs_used_it->second;
+        const std::vector<float>& type_outputs_used = outputs_used[type];
+        const size_t num_input_pins = total_input_pins[type];
+        const size_t num_output_pins = total_output_pins[type];
 
-        float max_outputs = *std::max_element(outputs_used[type].begin(), outputs_used[type].end());
-        float min_outputs = *std::min_element(outputs_used[type].begin(), outputs_used[type].end());
-        float avg_outputs = std::accumulate(outputs_used[type].begin(), outputs_used[type].end(), 0.f) / static_cast<float>(outputs_used[type].size());
+        float max_inputs = static_cast<float>(*std::max_element(type_inputs_used.begin(), type_inputs_used.end()));
+        float min_inputs = static_cast<float>(*std::min_element(type_inputs_used.begin(), type_inputs_used.end()));
+        float avg_inputs = static_cast<float>(std::accumulate(type_inputs_used.begin(), type_inputs_used.end(), 0.f)) / static_cast<float>(type_inputs_used.size());
+
+        float max_outputs = *std::max_element(type_outputs_used.begin(), type_outputs_used.end());
+        float min_outputs = *std::min_element(type_outputs_used.begin(), type_outputs_used.end());
+        float avg_outputs = std::accumulate(type_outputs_used.begin(), type_outputs_used.end(), 0.f) / static_cast<float>(type_outputs_used.size());
 
         os << "Type: " << type->name << "\n";
 
         os << "\tInput Pin Usage:\n";
-        os << "\t\tMax: " << max_inputs << " (" << max_inputs / static_cast<float>(total_input_pins[type]) << ")"
+        os << "\t\tMax: " << max_inputs << " (" << max_inputs / static_cast<float>(num_input_pins) << ")"
            << "\n";
-        os << "\t\tAvg: " << avg_inputs << " (" << avg_inputs / static_cast<float>(total_input_pins[type]) << ")"
+        os << "\t\tAvg: " << avg_inputs << " (" << avg_inputs / static_cast<float>(num_input_pins) << ")"
            << "\n";
-        os << "\t\tMin: " << min_inputs << " (" << min_inputs / static_cast<float>(total_input_pins[type]) << ")"
+        os << "\t\tMin: " << min_inputs << " (" << min_inputs / static_cast<float>(num_input_pins) << ")"
            << "\n";
 
-        if (total_input_pins[type] != 0) {
+        if (num_input_pins != 0) {
             os << "\t\tHistogram:\n";
-            auto input_histogram = build_histogram(inputs_used[type], 10, 0, static_cast<float>(total_input_pins[type]));
+            auto input_histogram = build_histogram(type_inputs_used, 10, 0, static_cast<float>(num_input_pins));
             for (const std::string& line : format_histogram(input_histogram)) {
                 os << "\t\t" << line << "\n";
             }
         }
 
         os << "\tOutput Pin Usage:\n";
-        os << "\t\tMax: " << max_outputs << " (" << max_outputs / float(total_output_pins[type]) << ")"
+        os << "\t\tMax: " << max_outputs << " (" << max_outputs / float(num_output_pins) << ")"
            << "\n";
-        os << "\t\tAvg: " << avg_outputs << " (" << avg_outputs / float(total_output_pins[type]) << ")"
+        os << "\t\tAvg: " << avg_outputs << " (" << avg_outputs / float(num_output_pins) << ")"
            << "\n";
-        os << "\t\tMin: " << min_outputs << " (" << min_outputs / float(total_output_pins[type]) << ")"
+        os << "\t\tMin: " << min_outputs << " (" << min_outputs / float(num_output_pins) << ")"
            << "\n";
 
-        if (total_output_pins[type] != 0) {
+        if (num_output_pins != 0) {
             os << "\t\tHistogram:\n";
 
-            auto output_histogram = build_histogram(outputs_used[type], 10, 0, static_cast<float>(total_output_pins[type]));
+            auto output_histogram = build_histogram(type_outputs_used, 10, 0, static_cast<float>(num_output_pins));
             for (auto line : format_histogram(output_histogram)) {
                 os << "\t\t" << line << "\n";
             }

--- a/vpr/src/pack/pack_report.cpp
+++ b/vpr/src/pack/pack_report.cpp
@@ -12,12 +12,12 @@
 void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
     os << "#Packing pin usage report\n";
 
-    auto& cluster_ctx = ctx.clustering();
-    auto& device_ctx = ctx.device();
+    const ClusteringContext& cluster_ctx = ctx.clustering();
+    const DeviceContext& device_ctx = ctx.device();
 
     std::map<t_logical_block_type_ptr, size_t> total_input_pins;
     std::map<t_logical_block_type_ptr, size_t> total_output_pins;
-    for (auto const& type : device_ctx.logical_block_types) {
+    for (const t_logical_block_type& type : device_ctx.logical_block_types) {
         if (is_empty_type(&type)) continue;
 
         t_pb_type* pb_type = type.pb_type;
@@ -29,7 +29,7 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
     std::map<t_logical_block_type_ptr, std::vector<float>> inputs_used;
     std::map<t_logical_block_type_ptr, std::vector<float>> outputs_used;
 
-    for (auto blk : cluster_ctx.clb_nlist.blocks()) {
+    for (ClusterBlockId blk : cluster_ctx.clb_nlist.blocks()) {
         t_logical_block_type_ptr type = cluster_ctx.clb_nlist.block_type(blk);
 
         inputs_used[type].push_back(static_cast<float>(cluster_ctx.clb_nlist.block_input_pins(blk).size() + cluster_ctx.clb_nlist.block_clock_pins(blk).size()));
@@ -40,8 +40,8 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
 
     os << std::fixed << std::setprecision(2);
 
-    for (auto const& logical_type : device_ctx.logical_block_types) {
-        auto type = &logical_type;
+    for (const t_logical_block_type& logical_type : device_ctx.logical_block_types) {
+        t_logical_block_type_ptr type = &logical_type;
         if (is_empty_type(type)) continue;
         if (!inputs_used.contains(type)) continue;
 
@@ -70,7 +70,7 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
 
         if (num_input_pins != 0) {
             os << "\t\tHistogram:\n";
-            auto input_histogram = build_histogram(type_inputs_used, 10, 0, static_cast<float>(num_input_pins));
+            std::vector<HistogramBucket> input_histogram = build_histogram(type_inputs_used, 10, 0, static_cast<float>(num_input_pins));
             for (const std::string& line : format_histogram(input_histogram)) {
                 os << "\t\t" << line << "\n";
             }
@@ -87,8 +87,8 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
         if (num_output_pins != 0) {
             os << "\t\tHistogram:\n";
 
-            auto output_histogram = build_histogram(type_outputs_used, 10, 0, static_cast<float>(num_output_pins));
-            for (auto line : format_histogram(output_histogram)) {
+            std::vector<HistogramBucket> output_histogram = build_histogram(type_outputs_used, 10, 0, static_cast<float>(num_output_pins));
+            for (const std::string& line : format_histogram(output_histogram)) {
                 os << "\t\t" << line << "\n";
             }
         }

--- a/vpr/src/pack/pack_report.cpp
+++ b/vpr/src/pack/pack_report.cpp
@@ -5,6 +5,7 @@
 #include "vpr_utils.h"
 #include "histogram.h"
 
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 
@@ -50,12 +51,12 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
         const size_t num_input_pins = total_input_pins[type];
         const size_t num_output_pins = total_output_pins[type];
 
-        float max_inputs = static_cast<float>(*std::max_element(type_inputs_used.begin(), type_inputs_used.end()));
-        float min_inputs = static_cast<float>(*std::min_element(type_inputs_used.begin(), type_inputs_used.end()));
+        float max_inputs = static_cast<float>(std::ranges::max(type_inputs_used));
+        float min_inputs = static_cast<float>(std::ranges::min(type_inputs_used));
         float avg_inputs = static_cast<float>(std::accumulate(type_inputs_used.begin(), type_inputs_used.end(), 0.f)) / static_cast<float>(type_inputs_used.size());
 
-        float max_outputs = *std::max_element(type_outputs_used.begin(), type_outputs_used.end());
-        float min_outputs = *std::min_element(type_outputs_used.begin(), type_outputs_used.end());
+        float max_outputs = std::ranges::max(type_outputs_used);
+        float min_outputs = std::ranges::min(type_outputs_used);
         float avg_outputs = std::accumulate(type_outputs_used.begin(), type_outputs_used.end(), 0.f) / static_cast<float>(type_outputs_used.size());
 
         os << "Type: " << type->name << "\n";

--- a/vpr/src/pack/pack_report.cpp
+++ b/vpr/src/pack/pack_report.cpp
@@ -43,10 +43,9 @@ void report_packing_pin_usage(std::ostream& os, const VprContext& ctx) {
     for (auto const& logical_type : device_ctx.logical_block_types) {
         auto type = &logical_type;
         if (is_empty_type(type)) continue;
-        auto inputs_used_it = inputs_used.find(type);
-        if (inputs_used_it == inputs_used.end()) continue;
+        if (!inputs_used.contains(type)) continue;
 
-        const std::vector<float>& type_inputs_used = inputs_used_it->second;
+        const std::vector<float>& type_inputs_used = inputs_used[type];
         const std::vector<float>& type_outputs_used = outputs_used[type];
         const size_t num_input_pins = total_input_pins[type];
         const size_t num_output_pins = total_output_pins[type];

--- a/vpr/src/pack/packing_signature_tree.cpp
+++ b/vpr/src/pack/packing_signature_tree.cpp
@@ -224,7 +224,7 @@ void PackingSignatureTree::populate_ecn(ExternalConnectivityNode* ecn) {
         ecn->cluster_inputs.push_back(input_net_pins);
         std::sort(ecn->cluster_inputs.back().begin(), ecn->cluster_inputs.back().end());
     }
-    std::sort(ecn->cluster_inputs.begin(), ecn->cluster_inputs.end());
+    std::ranges::sort(ecn->cluster_inputs);
 
     for (const auto& [output_net_id, output_net_record] : output_nets_) {
         if (output_net_record.external_sinks_count == 0) continue; // net only drives pins inside cluster

--- a/vpr/src/pack/packing_signature_tree.cpp
+++ b/vpr/src/pack/packing_signature_tree.cpp
@@ -60,10 +60,10 @@ void PackingSignatureTree::rollback_to_checkpoint() {
     for (auto it = checkpoint_decremented_output_nets_.begin(); it != checkpoint_decremented_output_nets_.end(); it++) {
         output_nets_[it->first].external_sinks_count += it->second;
     }
-    for (auto net : checkpoint_new_output_nets_) {
+    for (AtomNetId net : checkpoint_new_output_nets_) {
         output_nets_.erase(net);
     }
-    for (auto atom : checkpoint_new_atoms_) {
+    for (AtomBlockId atom : checkpoint_new_atoms_) {
         packed_atoms_.erase(atom);
     }
 }
@@ -163,7 +163,7 @@ LocationAndConnectivityNode* PackingSignatureTree::create_lcn(const t_pb_graph_n
     // Rather than check all the sinks of this block to see if they are already in the cluster,
     // the upper bound of the search space is reduced if we instead check to see if the source
     // of any of the blocks already packed in this cluster is this block.
-    for (auto maybe_sink_atom : packed_atoms_) {
+    for (std::pair<const AtomBlockId, t_primitive_num> maybe_sink_atom : packed_atoms_) {
         AtomBlockId maybe_sink_atom_block_id = maybe_sink_atom.first;
         AtomNetlist::pin_range potential_sink_input_pins = atom_netlist.block_input_pins(maybe_sink_atom_block_id);
         int maybe_sink_primitive_num = maybe_sink_atom.second;

--- a/vpr/src/pack/packing_signature_tree.cpp
+++ b/vpr/src/pack/packing_signature_tree.cpp
@@ -217,16 +217,18 @@ void PackingSignatureTree::add_ecn(e_ecn_legality legality) {
 }
 
 void PackingSignatureTree::populate_ecn(ExternalConnectivityNode* ecn) {
-    for (auto input_net : input_nets_) {
-        if (output_nets_.count(input_net.first) != 0) continue; // net is driven from inside cluster; not an external source
-        std::sort(input_net.second.begin(), input_net.second.end());
-        ecn->cluster_inputs.push_back(input_net.second);
+    for (const auto& [input_net_id, input_net_pins] : input_nets_) {
+        if (output_nets_.count(input_net_id) != 0) continue; // net is driven from inside cluster; not an external source
+        // Copy the pins and sort the copy: the vectors in input_nets_ must keep
+        // their insertion order, which rollback_to_checkpoint relies on.
+        ecn->cluster_inputs.push_back(input_net_pins);
+        std::sort(ecn->cluster_inputs.back().begin(), ecn->cluster_inputs.back().end());
     }
-    std::sort(ecn->cluster_inputs.begin(), ecn->cluster_inputs.end(), [](auto a, auto b) { return a < b; });
+    std::sort(ecn->cluster_inputs.begin(), ecn->cluster_inputs.end());
 
-    for (auto output_net : output_nets_) {
-        if (output_net.second.external_sinks_count == 0) continue; // net only drives pins inside cluster
-        ecn->cluster_outputs.push_back(output_net.second.source_pin);
+    for (const auto& [output_net_id, output_net_record] : output_nets_) {
+        if (output_net_record.external_sinks_count == 0) continue; // net only drives pins inside cluster
+        ecn->cluster_outputs.push_back(output_net_record.source_pin);
     }
     std::sort(ecn->cluster_outputs.begin(), ecn->cluster_outputs.end());
 }

--- a/vpr/src/pack/packing_signature_tree.h
+++ b/vpr/src/pack/packing_signature_tree.h
@@ -249,7 +249,7 @@ typedef std::tuple<t_primitive_num, std::string, BitIndex> PstPin;
 
 /// @brief Hash function definition for PstPin.
 struct PstPinHash {
-    size_t operator()(PstPin pin) const noexcept {
+    size_t operator()(const PstPin& pin) const noexcept {
         size_t hash = 0;
         vtr::hash_combine(hash, std::get<0>(pin));
         vtr::hash_combine(hash, std::get<1>(pin));
@@ -461,14 +461,10 @@ class PackingSignatureTree {
     std::unordered_map<PstPin, PstPinId, PstPinHash> pin_mappings_;
 
     /// @brief Find (or create) and return PstPinId for provided PstPin.
-    inline PstPinId get_pin_mapping(PstPin pin) {
-        auto got = pin_mappings_.find(pin);
-        if (got == pin_mappings_.end()) {
-            PstPinId pin_id = PstPinId(pin_mappings_.size());
-            pin_mappings_[pin] = pin_id;
-            return pin_id;
-        }
-        return got->second;
+    inline PstPinId get_pin_mapping(const PstPin& pin) {
+        // try_emplace only inserts (with the next sequential ID) if pin is
+        // not already in the map.
+        return pin_mappings_.try_emplace(pin, PstPinId(pin_mappings_.size())).first->second;
     }
 
     /// @brief Tracks current number of external sinks for a given source pin.

--- a/vpr/src/pack/packing_signature_tree.h
+++ b/vpr/src/pack/packing_signature_tree.h
@@ -358,10 +358,10 @@ struct LocationAndConnectivityNode {
         : primitive_num(-1) {}
 
     ~LocationAndConnectivityNode() {
-        for (auto lcn : child_lcn) {
+        for (LocationAndConnectivityNode* lcn : child_lcn) {
             delete lcn;
         }
-        for (auto ecn : child_ecn) {
+        for (ExternalConnectivityNode* ecn : child_ecn) {
             delete ecn;
         }
     }
@@ -386,7 +386,7 @@ class PackingSignatureTree {
         , checkpoint_cursor_(nullptr) {}
 
     ~PackingSignatureTree() {
-        for (auto lcn : branches_) {
+        for (LocationAndConnectivityNode* lcn : branches_) {
             delete lcn;
         }
     }

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -178,9 +178,9 @@ void alloc_and_load_all_pb_graphs(bool load_power_structures, bool is_flat) {
     int errors;
     edges_head = nullptr;
     num_edges_head = nullptr;
-    auto& device_ctx = g_vpr_ctx.mutable_device();
+    DeviceContext& device_ctx = g_vpr_ctx.mutable_device();
 
-    for (auto& type : device_ctx.logical_block_types) {
+    for (t_logical_block_type& type : device_ctx.logical_block_types) {
         if (type.pb_type) {
             type.pb_graph_head = new t_pb_graph_node();
             int pin_count_in_cluster = 0;
@@ -210,7 +210,7 @@ void alloc_and_load_all_pb_graphs(bool load_power_structures, bool is_flat) {
         VTR_LOG_ERROR("in pb graph");
         exit(1);
     }
-    for (auto& type : device_ctx.logical_block_types) {
+    for (t_logical_block_type& type : device_ctx.logical_block_types) {
         if (type.pb_type) {
             load_pb_graph_pin_to_pin_annotations(type.pb_graph_head);
         }
@@ -228,7 +228,7 @@ void echo_pb_graph(char* filename) {
     fprintf(fp, "Physical Blocks Graph\n");
     fprintf(fp, "--------------------------------------------\n\n");
 
-    const auto& device_ctx = g_vpr_ctx.device();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
     for (const t_logical_block_type& type : device_ctx.logical_block_types) {
         fprintf(fp, "type %s\n", type.name.c_str());
         if (type.pb_graph_head)
@@ -250,8 +250,8 @@ static int check_pb_graph() {
      * 5.  All pins are connected to edges (warning)
      */
     num_errors = 0;
-    auto& device_ctx = g_vpr_ctx.device();
-    for (auto& type : device_ctx.logical_block_types) {
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    for (const t_logical_block_type& type : device_ctx.logical_block_types) {
         if (type.pb_type) {
             check_pb_node_rec(type.pb_graph_head);
         }
@@ -422,7 +422,7 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
     // update the total number of primitives of that type
     if (pb_graph_node->is_primitive()) {
         int total_count = 1;
-        auto pb_node = pb_graph_node;
+        t_pb_graph_node* pb_node = pb_graph_node;
         while (!pb_node->is_root()) {
             total_count *= pb_node->pb_type->num_pb;
             pb_node = pb_node->parent_pb_graph_node;
@@ -437,7 +437,7 @@ static void alloc_and_load_pb_graph_pin_sinks(t_pb_graph_node* pb_graph_node) {
     pb_graph_node_q.push(pb_graph_node);
 
     while (!pb_graph_node_q.empty()) {
-        auto curr_pb_graph_node = pb_graph_node_q.front();
+        t_pb_graph_node* curr_pb_graph_node = pb_graph_node_q.front();
         pb_graph_node_q.pop();
         store_pin_sinks_edge_id(curr_pb_graph_node);
 
@@ -454,7 +454,7 @@ static void alloc_and_load_pb_graph_pin_sinks(t_pb_graph_node* pb_graph_node) {
 static void set_pins_logical_num(t_logical_block_type* logical_block) {
     /* Index of the pins located on the root-level block starts from 0 -
      * For other pins it starts from the roo_level pb_type.num_pins */
-    auto root_pb_graph_node = logical_block->pb_graph_head;
+    t_pb_graph_node* root_pb_graph_node = logical_block->pb_graph_head;
     std::queue<t_pb_graph_node*> pb_graph_node_to_set_pin_index_q;
 
     std::unordered_map<int, t_pb_graph_pin*>& pb_pin_idx_map = logical_block->pin_logical_num_to_pb_pin_mapping;
@@ -463,9 +463,9 @@ static void set_pins_logical_num(t_logical_block_type* logical_block) {
     pb_graph_node_to_set_pin_index_q.push(root_pb_graph_node);
     /* Iterated over all sub-blocks from the root-level block down to primitives */
     while (!pb_graph_node_to_set_pin_index_q.empty()) {
-        auto curr_pb_graph_node = pb_graph_node_to_set_pin_index_q.front();
+        t_pb_graph_node* curr_pb_graph_node = pb_graph_node_to_set_pin_index_q.front();
         pb_graph_node_to_set_pin_index_q.pop();
-        auto curr_pb_type = curr_pb_graph_node->pb_type;
+        t_pb_type* curr_pb_type = curr_pb_graph_node->pb_type;
 
         /* There are three types of ports which can be defined for each block : Input - Output - Clock
          * In this for loop, we first iterate over the ports of the same type
@@ -492,7 +492,7 @@ static void set_pins_logical_num(t_logical_block_type* logical_block) {
             }
             for (int port_idx = 0; port_idx < num_ports; port_idx++) {
                 for (int pin_idx = 0; pin_idx < num_pins[port_idx]; pin_idx++) {
-                    auto curr_pb_graph_pin = &pins[port_idx][pin_idx];
+                    t_pb_graph_pin* curr_pb_graph_pin = &pins[port_idx][pin_idx];
                     pb_pin_idx_map.insert(std::make_pair(curr_pb_graph_pin->pin_count_in_cluster, curr_pb_graph_pin));
                 }
             }
@@ -506,11 +506,11 @@ static void set_pins_logical_num(t_logical_block_type* logical_block) {
 
         /* Push sub-blocks to the queue */
         for (int mode_idx = 0; mode_idx < curr_pb_type->num_modes; mode_idx++) {
-            auto curr_mode = &curr_pb_type->modes[mode_idx];
+            t_mode* curr_mode = &curr_pb_type->modes[mode_idx];
             for (int pb_type_idx = 0; pb_type_idx < curr_mode->num_pb_type_children; pb_type_idx++) {
                 int num_pb = curr_mode->pb_type_children[pb_type_idx].num_pb;
                 for (int pb_idx = 0; pb_idx < num_pb; pb_idx++) {
-                    auto child_pb_graph_node = &(curr_pb_graph_node->child_pb_graph_nodes[mode_idx][pb_type_idx][pb_idx]);
+                    t_pb_graph_node* child_pb_graph_node = &(curr_pb_graph_node->child_pb_graph_nodes[mode_idx][pb_type_idx][pb_idx]);
                     pb_graph_node_to_set_pin_index_q.push(child_pb_graph_node);
                 }
             }
@@ -525,13 +525,13 @@ static std::vector<const t_pb_graph_node*> get_primitive_pb_graph_nodes(t_logica
     pb_graph_node_q.push(logical_block->pb_graph_head);
 
     while (!pb_graph_node_q.empty()) {
-        auto pb_graph_node = pb_graph_node_q.front();
+        const t_pb_graph_node* pb_graph_node = pb_graph_node_q.front();
         pb_graph_node_q.pop();
         if (pb_graph_node->is_primitive()) {
             pb_graph_nodes.push_back(pb_graph_node);
         }
 
-        auto pb_type = pb_graph_node->pb_type;
+        t_pb_type* pb_type = pb_graph_node->pb_type;
         /* Iterating over different modes of the block */
         for (int mode_idx = 0; mode_idx < pb_graph_node->pb_type->num_modes; mode_idx++) {
             /* Iterating over different block types in the given mode */
@@ -551,8 +551,8 @@ static std::vector<const t_pb_graph_node*> get_primitive_pb_graph_nodes(t_logica
 }
 
 static void add_primitive_logical_classes(t_logical_block_type* logical_block) {
-    auto pb_graph_nodes = get_primitive_pb_graph_nodes(logical_block);
-    for (auto pb_graph_node : pb_graph_nodes) {
+    std::vector<const t_pb_graph_node*> pb_graph_nodes = get_primitive_pb_graph_nodes(logical_block);
+    for (const t_pb_graph_node* pb_graph_node : pb_graph_nodes) {
         int first_class_num = (int)logical_block->primitive_logical_class_inf.size();
         int num_added_classes = 0;
         /* There are three types of ports which can be defined for each block : Input - Output - Clock
@@ -595,7 +595,7 @@ static int add_port_logical_classes(t_logical_block_type* logical_block,
     for (int port_idx = 0; port_idx < num_ports; port_idx++) {
         if (num_pins[port_idx] == 0)
             continue;
-        auto port = pb_graph_pins[port_idx][0].port;
+        t_port* port = pb_graph_pins[port_idx][0].port;
         if (port->equivalent != PortEquivalence::NONE) {
             t_class class_inf;
             int class_num = (int)primitive_logical_class_inf.size();
@@ -610,7 +610,7 @@ static int add_port_logical_classes(t_logical_block_type* logical_block,
             }
 
             for (int pin_idx = 0; pin_idx < num_pins[port_idx]; pin_idx++) {
-                auto pb_graph_pin = &(pb_graph_pins[port_idx][pin_idx]);
+                t_pb_graph_pin* pb_graph_pin = &(pb_graph_pins[port_idx][pin_idx]);
                 class_inf.pinlist.push_back(pb_graph_pin->pin_count_in_cluster);
                 logical_block->primitive_pb_pin_to_logical_class_num_mapping.insert(std::make_pair(pb_graph_pin, class_num));
             }
@@ -630,7 +630,7 @@ static int add_port_logical_classes(t_logical_block_type* logical_block,
                     class_inf.type = e_pin_type::DRIVER;
                 }
 
-                auto pb_graph_pin = &(pb_graph_pins[port_idx][pin_idx]);
+                t_pb_graph_pin* pb_graph_pin = &(pb_graph_pins[port_idx][pin_idx]);
                 class_inf.pinlist.push_back(pb_graph_pin->pin_count_in_cluster);
                 logical_block->primitive_pb_pin_to_logical_class_num_mapping.insert(std::make_pair(pb_graph_pin, class_num));
                 primitive_logical_class_inf.push_back(class_inf);
@@ -918,7 +918,7 @@ static void store_pin_sinks_edge_id(t_pb_graph_node* pb_graph_node) {
             for (int pin_idx = 0; pin_idx < num_pins[port_idx]; ++pin_idx) {
                 t_pb_graph_pin& pb_pin = pins[port_idx][pin_idx];
                 for (int edge_idx = 0; edge_idx < pb_pin.num_output_edges; ++edge_idx) {
-                    auto& output_edge = pb_pin.output_edges[edge_idx];
+                    t_pb_graph_edge* output_edge = pb_pin.output_edges[edge_idx];
                     int num_edge_output_pin = output_edge->num_output_pins;
                     for (int edge_output_pin_idx = 0; edge_output_pin_idx < num_edge_output_pin; ++edge_output_pin_idx) {
                         t_pb_graph_pin* edge_output_pin = output_edge->output_pins[edge_output_pin_idx];
@@ -1081,8 +1081,8 @@ static void alloc_and_load_complete_interc_edges(t_interconnect* interconnect,
         for (i_inpin = 0; i_inpin < num_input_ptrs[i_inset]; i_inpin++) {
             for (i_outset = 0; i_outset < num_output_sets; i_outset++) {
                 for (i_outpin = 0; i_outpin < num_output_ptrs[i_outset]; i_outpin++) {
-                    auto in_pin = input_pb_graph_node_pin_ptrs[i_inset][i_inpin];
-                    auto out_pin = output_pb_graph_node_pin_ptrs[i_outset][i_outpin];
+                    t_pb_graph_pin* in_pin = input_pb_graph_node_pin_ptrs[i_inset][i_inpin];
+                    t_pb_graph_pin* out_pin = output_pb_graph_node_pin_ptrs[i_outset][i_outpin];
                     in_pin->output_edges[in_pin->num_output_edges] = &edges[i_edge];
                     in_pin->num_output_edges++;
                     out_pin->input_edges[out_pin->num_input_edges] = &edges[i_edge];
@@ -1177,8 +1177,8 @@ static void alloc_and_load_direct_interc_edges(t_interconnect* interconnect,
         for (int ipin = 0; ipin < pins_per_set; ++ipin) {
             int iedge = iset * pins_per_set + ipin;
 
-            auto in_pin = input_pb_graph_node_pin_ptrs[0][ipin];
-            auto out_pin = output_pb_graph_node_pin_ptrs[iset][ipin];
+            t_pb_graph_pin* in_pin = input_pb_graph_node_pin_ptrs[0][ipin];
+            t_pb_graph_pin* out_pin = output_pb_graph_node_pin_ptrs[iset][ipin];
 
             edges[iedge].num_input_pins = 1;
             edges[iedge].input_pins = new t_pb_graph_pin*[1];
@@ -1245,12 +1245,12 @@ static void alloc_and_load_mux_interc_edges(t_interconnect* interconnect,
      * Each output pin gains exactly num_input_sets new input edges. */
     for (i_inset = 0; i_inset < num_input_sets; i_inset++) {
         for (i_inpin = 0; i_inpin < pins_per_set; i_inpin++) {
-            auto in_pin = input_pb_graph_node_pin_ptrs[i_inset][i_inpin];
+            t_pb_graph_pin* in_pin = input_pb_graph_node_pin_ptrs[i_inset][i_inpin];
             in_pin->output_edges.resize(in_pin->num_output_edges + 1);
         }
     }
     for (i_outpin = 0; i_outpin < pins_per_set; i_outpin++) {
-        auto out_pin = output_pb_graph_node_pin_ptrs[0][i_outpin];
+        t_pb_graph_pin* out_pin = output_pb_graph_node_pin_ptrs[0][i_outpin];
         out_pin->input_edges.resize(out_pin->num_input_edges + num_input_sets);
     }
 
@@ -1258,8 +1258,8 @@ static void alloc_and_load_mux_interc_edges(t_interconnect* interconnect,
     for (i_inset = 0; i_inset < num_input_sets; i_inset++) {
         for (i_inpin = 0; i_inpin < pins_per_set; i_inpin++) {
             const int edge_idx = i_inset * pins_per_set + i_inpin;
-            auto in_pin = input_pb_graph_node_pin_ptrs[i_inset][i_inpin];
-            auto out_pin = output_pb_graph_node_pin_ptrs[0][i_inpin];
+            t_pb_graph_pin* in_pin = input_pb_graph_node_pin_ptrs[i_inset][i_inpin];
+            t_pb_graph_pin* out_pin = output_pb_graph_node_pin_ptrs[0][i_inpin];
 
             edges[edge_idx].input_pins = new t_pb_graph_pin*[1];
             edges[edge_idx].output_pins = new t_pb_graph_pin*[1];

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -1052,9 +1052,7 @@ static void alloc_and_load_complete_interc_edges(t_interconnect* interconnect,
         out_count += num_output_ptrs[i_outset];
     }
 
-    edges = new t_pb_graph_edge[in_count * out_count];
-    for (int i = 0; i < (in_count * out_count); i++)
-        edges[i] = t_pb_graph_edge();
+    edges = new t_pb_graph_edge[in_count * out_count]();
     cur = new vtr::t_linked_vptr;
     cur->next = edges_head;
     edges_head = cur;
@@ -1134,9 +1132,7 @@ static void alloc_and_load_direct_interc_edges(t_interconnect* interconnect,
     }
 
     /* Allocate memory for edges */
-    t_pb_graph_edge* edges = new t_pb_graph_edge[pins_per_set * num_output_sets];
-    for (int i = 0; i < (pins_per_set * num_output_sets); i++)
-        edges[i] = t_pb_graph_edge();
+    t_pb_graph_edge* edges = new t_pb_graph_edge[pins_per_set * num_output_sets]();
     vtr::t_linked_vptr* cur = new vtr::t_linked_vptr;
     cur->next = edges_head;
     edges_head = cur;
@@ -1234,9 +1230,7 @@ static void alloc_and_load_mux_interc_edges(t_interconnect* interconnect,
     const int pins_per_set = num_output_ptrs[0];
     const int total_edges = num_input_sets * pins_per_set;
 
-    t_pb_graph_edge* edges = new t_pb_graph_edge[total_edges];
-    for (int i = 0; i < total_edges; i++)
-        edges[i] = t_pb_graph_edge();
+    t_pb_graph_edge* edges = new t_pb_graph_edge[total_edges]();
     cur = new vtr::t_linked_vptr;
     cur->next = edges_head;
     edges_head = cur;

--- a/vpr/src/pack/pb_type_graph_annotations.cpp
+++ b/vpr/src/pack/pb_type_graph_annotations.cpp
@@ -283,6 +283,7 @@ static void load_delay_annotations(const int line_num,
         || delay_type == E_ANNOT_PIN_TO_PIN_DELAY_CLOCK_TO_Q_MIN
         || delay_type == E_ANNOT_PIN_TO_PIN_DELAY_CLOCK_TO_Q_MAX) {
         //Annotate primitive sequential timing information
+        t_pb_graph_pin* clock_pin = find_clock_pin(pb_graph_node, clock, line_num);
         k = 0;
         for (i = 0; i < num_in_sets; i++) {
             for (j = 0; j < num_in_ptrs[i]; j++) {
@@ -296,7 +297,7 @@ static void load_delay_annotations(const int line_num,
                     VTR_ASSERT(delay_type == E_ANNOT_PIN_TO_PIN_DELAY_CLOCK_TO_Q_MIN);
                     in_port[i][j]->tco_min = delay_matrix[k][0];
                 }
-                in_port[i][j]->associated_clock_pin = find_clock_pin(pb_graph_node, clock, line_num);
+                in_port[i][j]->associated_clock_pin = clock_pin;
                 k++;
             }
         }

--- a/vpr/src/pack/pb_type_graph_annotations.cpp
+++ b/vpr/src/pack/pb_type_graph_annotations.cpp
@@ -355,7 +355,7 @@ static void load_delay_annotations(const int line_num,
                     t_pb_graph_pin* src_pin = in_port[i][j];
                     for (k = 0; k < src_pin->num_pin_timing; ++k) {
                         t_pb_graph_pin* sink_pin = src_pin->pin_timing[k];
-                        auto edge_pair = std::make_pair(src_pin, sink_pin);
+                        std::pair<t_pb_graph_pin*, t_pb_graph_pin*> edge_pair = std::make_pair(src_pin, sink_pin);
                         VTR_ASSERT_MSG(!existing_edges.contains(edge_pair), "No duplicates");
                         existing_edges.emplace(src_pin, sink_pin);
                     }
@@ -370,7 +370,7 @@ static void load_delay_annotations(const int line_num,
                     for (int m = 0; m < num_out_sets; m++) {
                         for (int n = 0; n < num_out_ptrs[m]; n++) {
                             t_pb_graph_pin* sink_pin = out_port[m][n];
-                            auto edge = std::make_pair(src_pin, sink_pin);
+                            std::pair<t_pb_graph_pin*, t_pb_graph_pin*> edge = std::make_pair(src_pin, sink_pin);
                             if (!existing_edges.contains(edge)) {
                                 new_edges.insert(edge);
                             }

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -189,9 +189,8 @@ static std::vector<t_pack_patterns> alloc_and_load_pack_patterns(const std::vect
              * For carry-chains, since carry-chains are typically quite flexible in terms
              * of size, it is optional whether or not an atom in a netlist matches any
              * particular block inside the chain */
-            packing_patterns[i].is_block_optional = new bool[L_num_blocks];
+            packing_patterns[i].is_block_optional.assign(L_num_blocks, false);
             for (int k = 0; k < L_num_blocks; k++) {
-                packing_patterns[i].is_block_optional[k] = false;
                 if (packing_patterns[i].is_chain && packing_patterns[i].root_block->block_id != k) {
                     packing_patterns[i].is_block_optional[k] = true;
                 }
@@ -395,7 +394,6 @@ static void free_pack_pattern(t_pack_patterns* pack_pattern) {
             pattern_block_list[i] = nullptr;
 
         free(pack_pattern->name);
-        delete[] pack_pattern->is_block_optional;
         free_pack_pattern_block(pack_pattern->root_block, pattern_block_list);
         for (int j = 0; j < num_pack_pattern_blocks; j++) {
             delete pattern_block_list[j];
@@ -1035,7 +1033,7 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
     t_pack_pattern_block* const pattern_root_block = molecule.pack_pattern->root_block;
     // bool array indicating whether a position in a pack pattern is optional or should
     // be filled with an atom for legality
-    bool* const is_block_optional = molecule.pack_pattern->is_block_optional;
+    const std::vector<bool>& is_block_optional = molecule.pack_pattern->is_block_optional;
 
     // create a queue of pattern block and atom block id suggested for this block
     std::queue<std::pair<t_pack_pattern_block*, AtomBlockId>> pattern_block_queue;

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -1598,7 +1598,7 @@ static void find_all_equivalent_chains(t_pack_patterns* chain_pattern, const t_p
         auto reachable_output_pins = find_end_of_path(pin_ptr, chain_pattern->index);
         // sort the reachable output pins to compare them later using set_intersection
         std::stable_sort(reachable_output_pins.begin(), reachable_output_pins.end());
-        reachable_pins.push_back(reachable_output_pins);
+        reachable_pins.push_back(std::move(reachable_output_pins));
     }
 
     // Search for intersections between reachable pins. Intersection
@@ -1653,7 +1653,7 @@ static void update_chain_root_pins(t_pack_patterns* chain_pattern,
          */
         VTR_ASSERT(connected_primitive_pins.size());
 
-        primitive_input_pins.push_back(connected_primitive_pins);
+        primitive_input_pins.push_back(std::move(connected_primitive_pins));
     }
 
     chain_pattern->chain_root_pins = primitive_input_pins;

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -1574,7 +1574,7 @@ static void find_all_equivalent_chains(t_pack_patterns* chain_pattern, const t_p
     // the chain_input_pins vector
     for (int iports = 0; iports < root_block->num_input_ports; iports++) {
         for (int ipins = 0; ipins < root_block->num_input_pins[iports]; ipins++) {
-            auto& input_pin = root_block->input_pins[iports][ipins];
+            t_pb_graph_pin& input_pin = root_block->input_pins[iports][ipins];
             for (int iedge = 0; iedge < input_pin.num_output_edges; iedge++) {
                 if (input_pin.output_edges[iedge]->belongs_to_pattern(chain_pattern->index)) {
                     chain_input_pins.push_back(&input_pin);
@@ -1594,8 +1594,8 @@ static void find_all_equivalent_chains(t_pack_patterns* chain_pattern, const t_p
     // found before following the edges that are annotated with the given pack_pattern
     std::vector<std::vector<t_pb_graph_pin*>> reachable_pins;
 
-    for (const auto& pin_ptr : chain_input_pins) {
-        auto reachable_output_pins = find_end_of_path(pin_ptr, chain_pattern->index);
+    for (t_pb_graph_pin* pin_ptr : chain_input_pins) {
+        std::vector<t_pb_graph_pin*> reachable_output_pins = find_end_of_path(pin_ptr, chain_pattern->index);
         // sort the reachable output pins to compare them later using set_intersection
         std::stable_sort(reachable_output_pins.begin(), reachable_output_pins.end());
         reachable_pins.push_back(std::move(reachable_output_pins));
@@ -1640,7 +1640,7 @@ static void update_chain_root_pins(t_pack_patterns* chain_pattern,
     std::vector<std::vector<t_pb_graph_pin*>> primitive_input_pins;
 
     std::unordered_set<t_pb_type*> pattern_blocks = get_pattern_blocks(*chain_pattern);
-    for (const auto pin_ptr : chain_input_pins) {
+    for (t_pb_graph_pin* pin_ptr : chain_input_pins) {
         std::vector<t_pb_graph_pin*> connected_primitive_pins;
         get_all_connected_primitive_pins(pin_ptr, pattern_blocks, connected_primitive_pins);
 

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -239,7 +239,7 @@ static void discover_pattern_names_in_pb_graph_node(t_pb_graph_node* pb_graph_no
         for (int j = 0; j < pb_graph_node->num_input_pins[i]; j++) {
             bool hasPattern = false;
             for (int k = 0; k < pb_graph_node->input_pins[i][j].num_output_edges; k++) {
-                auto output_edge = pb_graph_node->input_pins[i][j].output_edges[k];
+                t_pb_graph_edge* output_edge = pb_graph_node->input_pins[i][j].output_edges[k];
                 for (int m = 0; m < output_edge->num_pack_patterns; m++) {
                     hasPattern = true;
                     // insert the found pattern name to the hash table. If this pattern is inserted
@@ -272,7 +272,7 @@ static void discover_pattern_names_in_pb_graph_node(t_pb_graph_node* pb_graph_no
         for (int j = 0; j < pb_graph_node->num_output_pins[i]; j++) {
             bool hasPattern = false;
             for (int k = 0; k < pb_graph_node->output_pins[i][j].num_output_edges; k++) {
-                auto output_edge = pb_graph_node->output_pins[i][j].output_edges[k];
+                t_pb_graph_edge* output_edge = pb_graph_node->output_pins[i][j].output_edges[k];
                 for (int m = 0; m < output_edge->num_pack_patterns; m++) {
                     hasPattern = true;
                     // insert the found pattern name to the hash table. If this pattern is inserted
@@ -305,7 +305,7 @@ static void discover_pattern_names_in_pb_graph_node(t_pb_graph_node* pb_graph_no
         for (int j = 0; j < pb_graph_node->num_clock_pins[i]; j++) {
             bool hasPattern = false;
             for (int k = 0; k < pb_graph_node->clock_pins[i][j].num_output_edges; k++) {
-                auto& output_edge = pb_graph_node->clock_pins[i][j].output_edges[k];
+                t_pb_graph_edge* output_edge = pb_graph_node->clock_pins[i][j].output_edges[k];
                 for (int m = 0; m < output_edge->num_pack_patterns; m++) {
                     hasPattern = true;
                     // insert the found pattern name to the hash table. If this pattern is inserted
@@ -370,7 +370,7 @@ static void backward_infer_pattern(t_pb_graph_pin* pb_graph_pin) {
 static std::vector<t_pack_patterns> alloc_and_init_pattern_list_from_hash(const std::unordered_map<std::string, int>& pattern_names) {
     std::vector<t_pack_patterns> nlist(pattern_names.size());
 
-    for (const auto& curr_pattern : pattern_names) {
+    for (const std::pair<const std::string, int>& curr_pattern : pattern_names) {
         VTR_ASSERT(nlist[curr_pattern.second].name == nullptr);
         nlist[curr_pattern.second].name = vtr::strdup(curr_pattern.first.c_str());
         nlist[curr_pattern.second].root_block = nullptr;
@@ -421,7 +421,7 @@ static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
 
     for (i = 0; i < pb_graph_node->num_input_ports; i++) {
         for (j = 0; j < pb_graph_node->num_input_pins[i]; j++) {
-            auto& input_pin = pb_graph_node->input_pins[i][j];
+            t_pb_graph_pin& input_pin = pb_graph_node->input_pins[i][j];
             for (k = 0; k < input_pin.num_output_edges; k++) {
                 for (m = 0; m < input_pin.output_edges[k]->num_pack_patterns; m++) {
                     if (input_pin.output_edges[k]->pack_pattern_indices[m] == pattern_index) {
@@ -434,7 +434,7 @@ static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
 
     for (i = 0; i < pb_graph_node->num_output_ports; i++) {
         for (j = 0; j < pb_graph_node->num_output_pins[i]; j++) {
-            auto& output_pin = pb_graph_node->output_pins[i][j];
+            t_pb_graph_pin& output_pin = pb_graph_node->output_pins[i][j];
             for (k = 0; k < output_pin.num_output_edges; k++) {
                 for (m = 0; m < output_pin.output_edges[k]->num_pack_patterns; m++) {
                     if (output_pin.output_edges[k]->pack_pattern_indices[m] == pattern_index) {
@@ -447,7 +447,7 @@ static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
 
     for (i = 0; i < pb_graph_node->num_clock_ports; i++) {
         for (j = 0; j < pb_graph_node->num_clock_pins[i]; j++) {
-            auto& clock_pin = pb_graph_node->clock_pins[i][j];
+            t_pb_graph_pin& clock_pin = pb_graph_node->clock_pins[i][j];
             for (k = 0; k < clock_pin.num_output_edges; k++) {
                 for (m = 0; m < clock_pin.output_edges[k]->num_pack_patterns; m++) {
                     if (clock_pin.output_edges[k]->pack_pattern_indices[m] == pattern_index) {
@@ -459,7 +459,7 @@ static t_pb_graph_edge* find_expansion_edge_of_pattern(const int pattern_index,
     }
 
     for (i = 0; i < pb_graph_node->pb_type->num_modes; i++) {
-        auto& pb_mode = pb_graph_node->pb_type->modes[i];
+        t_mode& pb_mode = pb_graph_node->pb_type->modes[i];
         for (j = 0; j < pb_mode.num_pb_type_children; j++) {
             for (k = 0; k < pb_mode.pb_type_children[j].num_pb; k++) {
                 edge = find_expansion_edge_of_pattern(pattern_index, &pb_graph_node->child_pb_graph_nodes[i][j][k]);
@@ -851,9 +851,9 @@ void Prepacker::alloc_and_load_pack_molecules(std::multimap<AtomBlockId, PackMol
         VTR_ASSERT(is_used[best_pattern] == false);
         is_used[best_pattern] = true;
 
-        auto blocks = atom_nlist.blocks();
+        AtomNetlist::block_range blocks = atom_nlist.blocks();
         for (auto blk_iter = blocks.begin(); blk_iter != blocks.end(); ++blk_iter) {
-            auto blk_id = *blk_iter;
+            AtomBlockId blk_id = *blk_iter;
 
             PackMoleculeId cur_molecule_id = try_create_molecule(best_pattern,
                                                                  blk_id,
@@ -894,7 +894,7 @@ void Prepacker::alloc_and_load_pack_molecules(std::multimap<AtomBlockId, PackMol
      * If a block belongs to a molecule, then carrying the single atoms around can make the packing problem
      * more difficult because now it needs to consider splitting molecules.
      */
-    for (auto blk_id : atom_nlist.blocks()) {
+    for (AtomBlockId blk_id : atom_nlist.blocks()) {
         t_pb_graph_node* best = get_expected_lowest_cost_primitive_for_atom_block(blk_id, logical_block_types);
         if (!best) {
             VPR_FATAL_ERROR(VPR_ERROR_PACK, "Failed to find any location to pack primitive of type '%s' in architecture",
@@ -963,7 +963,7 @@ PackMoleculeId Prepacker::try_create_molecule(const int pack_pattern_index,
                                               AtomBlockId blk_id,
                                               std::multimap<AtomBlockId, PackMoleculeId>& atom_molecules_multimap,
                                               const AtomNetlist& atom_nlist) {
-    auto pack_pattern = &list_of_pack_patterns[pack_pattern_index];
+    t_pack_patterns* pack_pattern = &list_of_pack_patterns[pack_pattern_index];
 
     // Check pack pattern validity
     if (pack_pattern == nullptr || pack_pattern->num_blocks == 0 || pack_pattern->root_block == nullptr) {
@@ -1000,7 +1000,7 @@ PackMoleculeId Prepacker::try_create_molecule(const int pack_pattern_index,
 
     // update the atom_molcules with the atoms that are mapped to this molecule
     for (int i = 0; i < molecule.pack_pattern->num_blocks; i++) {
-        auto blk_id2 = molecule.atom_block_ids[i];
+        AtomBlockId blk_id2 = molecule.atom_block_ids[i];
         if (!blk_id2) {
             VTR_ASSERT(molecule.pack_pattern->is_block_optional[i]);
             continue;
@@ -1032,10 +1032,10 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
                                 const std::multimap<AtomBlockId, PackMoleculeId>& atom_molecules,
                                 const AtomNetlist& atom_nlist) {
     // root block of the pack pattern, which is the starting point of this pattern
-    const auto pattern_root_block = molecule.pack_pattern->root_block;
+    t_pack_pattern_block* const pattern_root_block = molecule.pack_pattern->root_block;
     // bool array indicating whether a position in a pack pattern is optional or should
     // be filled with an atom for legality
-    const auto is_block_optional = molecule.pack_pattern->is_block_optional;
+    bool* const is_block_optional = molecule.pack_pattern->is_block_optional;
 
     // create a queue of pattern block and atom block id suggested for this block
     std::queue<std::pair<t_pack_pattern_block*, AtomBlockId>> pattern_block_queue;
@@ -1046,15 +1046,15 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
     // with the atom netlist structure
     while (!pattern_block_queue.empty()) {
         // get the front pattern block, atom block id pair from the queue
-        const auto pattern_block_atom_pair = pattern_block_queue.front();
-        const auto pattern_block = pattern_block_atom_pair.first;
-        const auto block_id = pattern_block_atom_pair.second;
+        const std::pair<t_pack_pattern_block*, AtomBlockId> pattern_block_atom_pair = pattern_block_queue.front();
+        t_pack_pattern_block* const pattern_block = pattern_block_atom_pair.first;
+        const AtomBlockId block_id = pattern_block_atom_pair.second;
 
         // remove the front of the queue
         pattern_block_queue.pop();
 
         // get the atom block id of the atom occupying this primitive position in this molecule
-        auto molecule_atom_block_id = molecule.atom_block_ids[pattern_block->block_id];
+        AtomBlockId molecule_atom_block_id = molecule.atom_block_ids[pattern_block->block_id];
 
         // if this primitive position in this molecule is already visited and
         // matches block in the atom netlist go to the next node in the queue
@@ -1085,13 +1085,13 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
             // this block is the driver of this connection
             if (block_connection.from_block == pattern_block) {
                 // find the block this connection is driving and add it to the queue
-                auto sink_blk_id = get_sink_block(block_id, block_connection, atom_nlist);
+                AtomBlockId sink_blk_id = get_sink_block(block_id, block_connection, atom_nlist);
                 // add this sink block id with its corresponding pattern block to the queue
                 pattern_block_queue.push(std::make_pair(block_connection.to_block, sink_blk_id));
                 // this block is being driven by this connection
             } else if (block_connection.to_block == pattern_block) {
                 // find the block that is driving this connection and it to the queue
-                auto driver_blk_id = get_driving_block(block_id, block_connection, atom_nlist);
+                AtomBlockId driver_blk_id = get_driving_block(block_id, block_connection, atom_nlist);
                 // add this driver block id with its corresponding pattern block to the queue
                 pattern_block_queue.push(std::make_pair(block_connection.from_block, driver_blk_id));
             }
@@ -1118,36 +1118,36 @@ static AtomBlockId get_sink_block(const AtomBlockId block_id,
                                   const AtomNetlist& atom_nlist) {
     const t_model_ports* from_port_model = connections.from_pin->port->model_port;
     const int from_pin_number = connections.from_pin->pin_number;
-    auto from_port_id = atom_nlist.find_atom_port(block_id, from_port_model);
+    AtomPortId from_port_id = atom_nlist.find_atom_port(block_id, from_port_model);
 
     const t_model_ports* to_port_model = connections.to_pin->port->model_port;
     const int to_pin_number = connections.to_pin->pin_number;
-    const auto& to_pb_type = connections.to_block->pb_type;
+    const t_pb_type* to_pb_type = connections.to_block->pb_type;
 
     if (!from_port_id.is_valid()) {
         return AtomBlockId::INVALID();
     }
 
-    auto net_id = atom_nlist.port_net(from_port_id, from_pin_number);
+    AtomNetId net_id = atom_nlist.port_net(from_port_id, from_pin_number);
     if (!net_id.is_valid()) {
         return AtomBlockId::INVALID();
     }
 
-    const auto& net_sinks = atom_nlist.net_sinks(net_id);
+    const AtomNetlist::pin_range net_sinks = atom_nlist.net_sinks(net_id);
     // Iterate through all sink blocks and check whether any of them
     // is compatible with the block specified in the pack pattern.
     bool connected_to_latch = false;
     AtomBlockId pattern_sink_block_id = AtomBlockId::INVALID();
-    for (const auto& sink_pin_id : net_sinks) {
-        auto sink_block_id = atom_nlist.pin_block(sink_pin_id);
+    for (AtomPinId sink_pin_id : net_sinks) {
+        AtomBlockId sink_block_id = atom_nlist.pin_block(sink_pin_id);
         // If the sink block has a clock, it is considered stateful (e.g., a latch or flip-flop).
         // Mark this so we can later decide whether to drop the block based on the net’s fanout.
         if (!atom_nlist.block_is_combinational(sink_block_id)) {
             connected_to_latch = true;
         }
         if (primitive_type_feasible(sink_block_id, to_pb_type)) {
-            auto to_port_id = atom_nlist.find_atom_port(sink_block_id, to_port_model);
-            auto to_pin_id = atom_nlist.find_pin(to_port_id, BitIndex(to_pin_number));
+            AtomPortId to_port_id = atom_nlist.find_atom_port(sink_block_id, to_port_model);
+            AtomPinId to_pin_id = atom_nlist.find_pin(to_port_id, BitIndex(to_pin_number));
             if (to_pin_id == sink_pin_id) {
                 pattern_sink_block_id = sink_block_id;
             }
@@ -1174,20 +1174,20 @@ static AtomBlockId get_sink_block(const AtomBlockId block_id,
 static AtomBlockId get_driving_block(const AtomBlockId block_id,
                                      const t_pack_pattern_connections& connections,
                                      const AtomNetlist& atom_nlist) {
-    auto to_port_model = connections.to_pin->port->model_port;
-    auto to_pin_number = connections.to_pin->pin_number;
-    auto to_port_id = atom_nlist.find_atom_port(block_id, to_port_model);
+    const t_model_ports* to_port_model = connections.to_pin->port->model_port;
+    int to_pin_number = connections.to_pin->pin_number;
+    AtomPortId to_port_id = atom_nlist.find_atom_port(block_id, to_port_model);
 
     if (!to_port_id.is_valid()) {
         return AtomBlockId::INVALID();
     }
 
-    auto net_id = atom_nlist.port_net(to_port_id, to_pin_number);
+    AtomNetId net_id = atom_nlist.port_net(to_port_id, to_pin_number);
     if (net_id && atom_nlist.net_sinks(net_id).size() == 1) { /* Single fanout assumption */
-        auto driver_blk_id = atom_nlist.net_driver_block(net_id);
+        AtomBlockId driver_blk_id = atom_nlist.net_driver_block(net_id);
 
         if (to_port_model->is_clock) {
-            auto driver_blk_type = atom_nlist.block_type(driver_blk_id);
+            AtomBlockType driver_blk_type = atom_nlist.block_type(driver_blk_id);
 
             // TODO: support multi-clock primitives.
             //       If the driver block is a .input block, this assertion should not
@@ -1447,7 +1447,7 @@ static std::vector<t_pb_graph_pin*> find_end_of_path(t_pb_graph_pin* input_pin, 
     // pins are explored
     while (!pins_queue.empty()) {
         // get the first pin in the queue
-        auto current_pin = pins_queue.front();
+        t_pb_graph_pin* current_pin = pins_queue.front();
 
         // remove pin from queue
         pins_queue.pop();
@@ -1472,7 +1472,7 @@ static void expand_search(const t_pb_graph_pin* input_pin, std::queue<t_pb_graph
 
     // iterate over all output edges at this pin
     for (int iedge = 0; iedge < input_pin->num_output_edges; iedge++) {
-        const auto& pin_edge = input_pin->output_edges[iedge];
+        const t_pb_graph_edge* pin_edge = input_pin->output_edges[iedge];
         // if this edge is not annotated with this pattern and its pattern cannot be inferred, ignore it.
         if (!pin_edge->annotated_with_pattern(pattern_index) && !pin_edge->infer_pattern) {
             continue;
@@ -1493,10 +1493,10 @@ static void expand_search(const t_pb_graph_pin* input_pin, std::queue<t_pb_graph
     // output edges so the previous for loop won't be entered
     if (input_pin->is_primitive_pin() && input_pin->num_output_edges == 0) {
         // iterate over the output ports of the primitive
-        const auto& pin_pb_graph_node = input_pin->parent_node;
+        const t_pb_graph_node* pin_pb_graph_node = input_pin->parent_node;
         for (int iport = 0; iport < pin_pb_graph_node->num_output_ports; iport++) {
             // iterate over the pins of each port
-            const auto& port_pins = pin_pb_graph_node->num_output_pins[iport];
+            const int port_pins = pin_pb_graph_node->num_output_pins[iport];
             for (int ipin = 0; ipin < port_pins; ipin++) {
                 // add primitive output pins to pins_queue to be explored
                 pins_queue.push(&pin_pb_graph_node->output_pins[iport][ipin]);
@@ -1651,7 +1651,7 @@ static void get_all_connected_primitive_pins(const t_pb_graph_pin* cluster_input
     }
 
     for (int iedge = 0; iedge < cluster_input_pin->num_output_edges; iedge++) {
-        const auto& output_edge = cluster_input_pin->output_edges[iedge];
+        const t_pb_graph_edge* output_edge = cluster_input_pin->output_edges[iedge];
         for (int ipin = 0; ipin < output_edge->num_output_pins; ipin++) {
             if (output_edge->output_pins[ipin]->is_primitive_pin()) {
                 /** Add the output pin to the vector only if it belongs to a pb_type registered in the pattern_blocks set */
@@ -1687,12 +1687,12 @@ static void init_molecule_chain_info(const AtomBlockId blk_id,
     // pattern assigned to it and the input block should be valid
     VTR_ASSERT(molecule.pack_pattern && blk_id);
 
-    auto root_ipin = molecule.pack_pattern->chain_root_pins[0][0];
-    auto model_pin = root_ipin->port->model_port;
-    auto pin_bit = root_ipin->pin_number;
+    t_pb_graph_pin* root_ipin = molecule.pack_pattern->chain_root_pins[0][0];
+    const t_model_ports* model_pin = root_ipin->port->model_port;
+    int pin_bit = root_ipin->pin_number;
 
     // find the atom driving the chain input pin of this atom
-    auto driver_atom_id = atom_nlist.find_atom_pin_driver(blk_id, model_pin, pin_bit);
+    AtomBlockId driver_atom_id = atom_nlist.find_atom_pin_driver(blk_id, model_pin, pin_bit);
 
     // find the molecule this driver atom is mapped to
     auto itr = atom_molecules.find(driver_atom_id);
@@ -1726,17 +1726,17 @@ static void init_molecule_chain_info(const AtomBlockId blk_id,
  * This function prints all the starting points of the carry chains in the architecture
  */
 static void print_chain_starting_points(t_pack_patterns* chain_pattern) {
-    const auto& chain_root_pins = chain_pattern->chain_root_pins;
+    const std::vector<std::vector<t_pb_graph_pin*>>& chain_root_pins = chain_pattern->chain_root_pins;
 
     VTR_LOGV(chain_root_pins.size() > 1, "\nThere are %zu independent chains for chain pattern \"%s\":\n",
              chain_pattern->chain_root_pins.size(), chain_pattern->name);
     VTR_LOGV(chain_root_pins.size() == 1, "\nThere is one chain in this architecture called \"%s\" with the following starting points:\n", chain_pattern->name);
 
     size_t chainId = 0;
-    for (const auto& chain : chain_root_pins) {
+    for (const std::vector<t_pb_graph_pin*>& chain : chain_root_pins) {
         VTR_LOGV(chain_root_pins.size() > 1 && chain.size() > 1, "\n There are %zu starting points for chain id #%zu:\n", chain.size(), chainId++);
         VTR_LOGV(chain_root_pins.size() > 1 && chain.size() == 1, "\n There is 1 starting point for chain id #%zu:\n", chainId++);
-        for (const auto& pin_ptr : chain) {
+        for (const t_pb_graph_pin* pin_ptr : chain) {
             VTR_LOG("\t%s\n", pin_ptr->to_string().c_str());
         }
     }
@@ -1784,7 +1784,7 @@ t_molecule_stats Prepacker::calc_molecule_stats(PackMoleculeId molecule_id,
     const t_pack_molecule& molecule = pack_molecules_[molecule_id];
 
     //Calculate the number of available pins on primitives within the molecule
-    for (auto blk : molecule.atom_block_ids) {
+    for (AtomBlockId blk : molecule.atom_block_ids) {
         if (!blk) continue;
 
         ++molecule_stats.num_blocks; //Record number of valid blocks in molecule
@@ -1804,15 +1804,15 @@ t_molecule_stats Prepacker::calc_molecule_stats(PackMoleculeId molecule_id,
 
     //Calculate the number of externally used pins
     std::set<AtomBlockId> molecule_atoms(molecule.atom_block_ids.begin(), molecule.atom_block_ids.end());
-    for (auto blk : molecule.atom_block_ids) {
+    for (AtomBlockId blk : molecule.atom_block_ids) {
         if (!blk) continue;
 
-        for (auto pin : atom_nlist.block_pins(blk)) {
-            auto net = atom_nlist.pin_net(pin);
+        for (AtomPinId pin : atom_nlist.block_pins(blk)) {
+            AtomNetId net = atom_nlist.pin_net(pin);
 
-            auto pin_type = atom_nlist.pin_type(pin);
+            PinType pin_type = atom_nlist.pin_type(pin);
             if (pin_type == PinType::SINK) {
-                auto driver_blk = atom_nlist.net_driver_block(net);
+                AtomBlockId driver_blk = atom_nlist.net_driver_block(net);
 
                 if (molecule_atoms.count(driver_blk)) {
                     //Pin driven by a block within the molecule
@@ -1826,8 +1826,8 @@ t_molecule_stats Prepacker::calc_molecule_stats(PackMoleculeId molecule_id,
                 VTR_ASSERT(pin_type == PinType::DRIVER);
 
                 bool net_leaves_molecule = false;
-                for (auto sink_pin : atom_nlist.net_sinks(net)) {
-                    auto sink_blk = atom_nlist.pin_block(sink_pin);
+                for (AtomPinId sink_pin : atom_nlist.net_sinks(net)) {
+                    AtomBlockId sink_blk = atom_nlist.pin_block(sink_pin);
 
                     if (!molecule_atoms.count(sink_blk)) {
                         //There is at least one sink outside of the current molecule

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -12,6 +12,7 @@
 
 #include "prepack.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <map>
@@ -1571,7 +1572,7 @@ static void find_all_equivalent_chains(t_pack_patterns* chain_pattern, const t_p
     for (t_pb_graph_pin* pin_ptr : chain_input_pins) {
         std::vector<t_pb_graph_pin*> reachable_output_pins = find_end_of_path(pin_ptr, chain_pattern->index);
         // sort the reachable output pins to compare them later using set_intersection
-        std::stable_sort(reachable_output_pins.begin(), reachable_output_pins.end());
+        std::ranges::stable_sort(reachable_output_pins);
         reachable_pins.push_back(std::move(reachable_output_pins));
     }
 

--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -401,7 +401,7 @@ static void fixup_atom_pb_graph_pin_mapping(void) {
         /* Collect all innermost pb routes */
         std::vector<int> sink_pb_route_ids;
         t_pb* clb_pb = cluster_ctx.clb_nlist.block_pb(clb);
-        for (auto [pb_route_id, pb_route] : clb_pb->pb_route) {
+        for (const auto& [pb_route_id, pb_route] : clb_pb->pb_route) {
             if (pb_route.sink_pb_pin_ids.empty())
                 sink_pb_route_ids.push_back(pb_route_id);
         }

--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -196,8 +196,8 @@ static void sync_pb_routes_to_routing(void) {
         for (auto [source_inode, sink_inode] : conns_to_restore) {
             ClusterBlockId clb = get_cluster_block_from_rr_node(source_inode);
             t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(source_inode),
-                                                                    rr_graph.node_ylow(source_inode),
-                                                                    rr_graph.node_layer_low(source_inode)});
+                                                                                        rr_graph.node_ylow(source_inode),
+                                                                                        rr_graph.node_layer_low(source_inode)});
             int source_pin = rr_graph.node_pin_num(source_inode);
             int sink_pin = rr_graph.node_pin_num(sink_inode);
 
@@ -318,8 +318,8 @@ static void sync_clustered_netlist_to_routing(void) {
                 continue;
 
             t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(rt_node.inode),
-                                                                    rr_graph.node_ylow(rt_node.inode),
-                                                                    rr_graph.node_layer_low(rt_node.inode)});
+                                                                                        rr_graph.node_ylow(rt_node.inode),
+                                                                                        rr_graph.node_layer_low(rt_node.inode)});
 
             int pin_index = rr_graph.node_pin_num(rt_node.inode);
 

--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -45,14 +45,14 @@ static void fixup_atom_pb_graph_pin_mapping(void);
 
 /** Get the ClusterBlockId for a given RRNodeId. */
 inline ClusterBlockId get_cluster_block_from_rr_node(RRNodeId inode) {
-    auto& device_ctx = g_vpr_ctx.device();
-    auto& place_ctx = g_vpr_ctx.placement();
-    auto& rr_graph = device_ctx.rr_graph;
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const PlacementContext& place_ctx = g_vpr_ctx.placement();
+    const RRGraphView& rr_graph = device_ctx.rr_graph;
 
     t_physical_tile_loc node_phy_tile_loc(rr_graph.node_xlow(inode),
                                           rr_graph.node_ylow(inode),
                                           rr_graph.node_layer_low(inode));
-    auto physical_tile = device_ctx.grid.get_physical_type(node_phy_tile_loc);
+    t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type(node_phy_tile_loc);
 
     int source_pin = rr_graph.node_pin_num(inode);
 
@@ -73,20 +73,20 @@ inline ClusterBlockId get_cluster_block_from_rr_node(RRNodeId inode) {
 }
 
 static void get_intra_cluster_connections(const RouteTree& tree, std::vector<std::pair<RRNodeId, RRNodeId>>& out_connections) {
-    auto& rr_graph = g_vpr_ctx.device().rr_graph;
+    const RRGraphView& rr_graph = g_vpr_ctx.device().rr_graph;
 
-    for (auto& node : tree.all_nodes()) {
-        const auto& parent = node.parent();
+    for (const RouteTreeNode& node : tree.all_nodes()) {
+        const vtr::optional<const RouteTreeNode&> parent = node.parent();
         if (!parent) /* Root */
             continue;
 
         /* Find the case where both nodes are IPIN/OPINs and on the same block */
-        auto type = rr_graph.node_type(node.inode);
-        auto parent_type = rr_graph.node_type(parent->inode);
+        e_rr_type type = rr_graph.node_type(node.inode);
+        e_rr_type parent_type = rr_graph.node_type(parent->inode);
 
         if ((type == e_rr_type::IPIN || type == e_rr_type::OPIN) && (parent_type == e_rr_type::IPIN || parent_type == e_rr_type::OPIN)) {
-            auto clb = get_cluster_block_from_rr_node(node.inode);
-            auto parent_clb = get_cluster_block_from_rr_node(parent->inode);
+            ClusterBlockId clb = get_cluster_block_from_rr_node(node.inode);
+            ClusterBlockId parent_clb = get_cluster_block_from_rr_node(parent->inode);
             if (clb == parent_clb)
                 out_connections.push_back({parent->inode, node.inode});
         }
@@ -98,7 +98,7 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
     std::deque<const t_pb_graph_pin*> queue;
     std::unordered_map<const t_pb_graph_pin*, const t_pb_graph_pin*> prev;
 
-    auto& out_pb_routes = out_pb->pb_route;
+    t_pb_routes& out_pb_routes = out_pb->pb_route;
 
     queue.push_back(source_pin);
     prev[source_pin] = NULL;
@@ -115,7 +115,7 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
             break;
         }
 
-        for (auto& edge : cur_pin->output_edges) {
+        for (t_pb_graph_edge* edge : cur_pin->output_edges) {
             VTR_ASSERT(edge->num_output_pins == 1);
             queue.push_back(edge->output_pins[0]);
             prev[edge->output_pins[0]] = cur_pin;
@@ -153,11 +153,11 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
 }
 
 static void sync_pb_routes_to_routing(void) {
-    auto& device_ctx = g_vpr_ctx.device();
-    auto& atom_ctx = g_vpr_ctx.atom();
-    auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
-    auto& route_ctx = g_vpr_ctx.routing();
-    auto& rr_graph = device_ctx.rr_graph;
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const AtomContext& atom_ctx = g_vpr_ctx.atom();
+    ClusteringContext& cluster_ctx = g_vpr_ctx.mutable_clustering();
+    const RoutingContext& route_ctx = g_vpr_ctx.routing();
+    const RRGraphView& rr_graph = device_ctx.rr_graph;
 
     /* Clear out existing pb_routes: they were made by the intra cluster router and are invalid now */
     for (ClusterBlockId clb_blk_id : cluster_ctx.clb_nlist.blocks()) {
@@ -184,7 +184,7 @@ static void sync_pb_routes_to_routing(void) {
 
     /* Go through each route tree and rebuild the pb_routes */
     for (ParentNetId net_id : atom_ctx.netlist().nets()) {
-        auto& tree = route_ctx.route_trees[net_id];
+        const vtr::optional<RouteTree>& tree = route_ctx.route_trees[net_id];
         if (!tree)
             continue; /* No routing at this ParentNetId */
 
@@ -195,7 +195,7 @@ static void sync_pb_routes_to_routing(void) {
         /* Restore the connections */
         for (auto [source_inode, sink_inode] : conns_to_restore) {
             ClusterBlockId clb = get_cluster_block_from_rr_node(source_inode);
-            auto physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(source_inode),
+            t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(source_inode),
                                                                     rr_graph.node_ylow(source_inode),
                                                                     rr_graph.node_layer_low(source_inode)});
             int source_pin = rr_graph.node_pin_num(source_inode);
@@ -226,17 +226,17 @@ static void sync_pb_routes_to_routing(void) {
  * Needs the old ClusterNetIds in atom_ctx.lookup(). Won't work after calling compress() twice,
  * since we won't have access to the old IDs in the IdRemapper anywhere. */
 inline void rebuild_atom_nets_lookup(ClusteredNetlist::IdRemapper& remapped) {
-    auto& atom_ctx = g_vpr_ctx.mutable_atom();
-    auto& atom_lookup = atom_ctx.mutable_lookup();
+    AtomContext& atom_ctx = g_vpr_ctx.mutable_atom();
+    AtomLookup& atom_lookup = atom_ctx.mutable_lookup();
 
-    for (auto parent_net_id : atom_ctx.netlist().nets()) {
-        auto atom_net_id = convert_to_atom_net_id(parent_net_id);
-        auto old_clb_nets_opt = atom_lookup.clb_nets(atom_net_id);
+    for (AtomNetId parent_net_id : atom_ctx.netlist().nets()) {
+        AtomNetId atom_net_id = convert_to_atom_net_id(parent_net_id);
+        vtr::optional<const std::vector<ClusterNetId>&> old_clb_nets_opt = atom_lookup.clb_nets(atom_net_id);
         if (!old_clb_nets_opt)
             continue;
         std::vector<ClusterNetId> old_clb_nets = old_clb_nets_opt.value();
         atom_lookup.remove_atom_net(atom_net_id);
-        for (auto old_clb_net : old_clb_nets) {
+        for (ClusterNetId old_clb_net : old_clb_nets) {
             ClusterNetId new_clb_net = remapped.new_net_id(old_clb_net);
             atom_lookup.add_atom_clb_net(atom_net_id, new_clb_net);
         }
@@ -245,14 +245,14 @@ inline void rebuild_atom_nets_lookup(ClusteredNetlist::IdRemapper& remapped) {
 
 /** Regenerate clustered netlist nets from routing results */
 static void sync_clustered_netlist_to_routing(void) {
-    auto& cluster_ctx = g_vpr_ctx.mutable_clustering();
-    auto& place_ctx = g_vpr_ctx.mutable_placement();
-    auto& route_ctx = g_vpr_ctx.routing();
-    auto& clb_netlist = cluster_ctx.clb_nlist;
-    auto& device_ctx = g_vpr_ctx.device();
-    auto& rr_graph = device_ctx.rr_graph;
-    auto& atom_ctx = g_vpr_ctx.mutable_atom();
-    auto& atom_lookup = atom_ctx.lookup();
+    ClusteringContext& cluster_ctx = g_vpr_ctx.mutable_clustering();
+    PlacementContext& place_ctx = g_vpr_ctx.mutable_placement();
+    const RoutingContext& route_ctx = g_vpr_ctx.routing();
+    ClusteredNetlist& clb_netlist = cluster_ctx.clb_nlist;
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const RRGraphView& rr_graph = device_ctx.rr_graph;
+    AtomContext& atom_ctx = g_vpr_ctx.mutable_atom();
+    const AtomLookup& atom_lookup = atom_ctx.lookup();
 
     /* 1. Remove all nets, pins and ports from the clustered netlist.
      * Do not remove entries for nets without an existing route tree,
@@ -261,8 +261,8 @@ static void sync_clustered_netlist_to_routing(void) {
     std::vector<ClusterPinId> pins_to_remove;
     std::vector<ClusterPortId> ports_to_remove;
 
-    for (auto net_id : clb_netlist.nets()) {
-        auto atom_net_id = atom_lookup.atom_net(net_id);
+    for (ClusterNetId net_id : clb_netlist.nets()) {
+        AtomNetId atom_net_id = atom_lookup.atom_net(net_id);
         if (!route_ctx.route_trees[atom_net_id])
             continue;
 
@@ -270,12 +270,12 @@ static void sync_clustered_netlist_to_routing(void) {
     }
     /* Mark ports and pins for removal. Don't remove a port if
      * it has at least one pin remaining */
-    for (auto port_id : clb_netlist.ports()) {
+    for (ClusterPortId port_id : clb_netlist.ports()) {
         size_t skipped_pins = 0;
 
-        for (auto pin_id : clb_netlist.port_pins(port_id)) {
+        for (ClusterPinId pin_id : clb_netlist.port_pins(port_id)) {
             ClusterNetId clb_net_id = clb_netlist.pin_net(pin_id);
-            auto atom_net_id = atom_lookup.atom_net(clb_net_id);
+            AtomNetId atom_net_id = atom_lookup.atom_net(clb_net_id);
             if (atom_net_id && !route_ctx.route_trees[atom_net_id]) {
                 skipped_pins++;
             } else {
@@ -289,35 +289,35 @@ static void sync_clustered_netlist_to_routing(void) {
 
     /* ClusteredNetlist's iterators rely on internal lookups, so we mark for removal
      * while iterating, then remove in bulk */
-    for (auto net_id : nets_to_remove) {
+    for (ClusterNetId net_id : nets_to_remove) {
         clb_netlist.remove_net(net_id);
         atom_ctx.mutable_lookup().remove_clb_net(net_id);
     }
-    for (auto pin_id : pins_to_remove) {
+    for (ClusterPinId pin_id : pins_to_remove) {
         clb_netlist.remove_pin(pin_id);
     }
-    for (auto port_id : ports_to_remove) {
+    for (ClusterPortId port_id : ports_to_remove) {
         clb_netlist.remove_port(port_id);
     }
 
     /* 2. Reset all internal lookups for netlist */
-    auto remapped = clb_netlist.compress();
+    ClusteredNetlist::IdRemapper remapped = clb_netlist.compress();
     rebuild_atom_nets_lookup(remapped);
 
     /* 3. Walk each routing in the atom netlist. If a node is on the tile, add a ClusterPinId for it.
      * Add the associated net and port too if they don't exist */
-    for (auto parent_net_id : atom_ctx.netlist().nets()) {
-        auto& tree = route_ctx.route_trees[parent_net_id];
+    for (AtomNetId parent_net_id : atom_ctx.netlist().nets()) {
+        const vtr::optional<RouteTree>& tree = route_ctx.route_trees[parent_net_id];
         AtomNetId atom_net_id = convert_to_atom_net_id(parent_net_id);
 
         ClusterNetId clb_net_id;
         int clb_nets_so_far = 0;
-        for (auto& rt_node : tree->all_nodes()) {
-            auto node_type = rr_graph.node_type(rt_node.inode);
+        for (const RouteTreeNode& rt_node : tree->all_nodes()) {
+            e_rr_type node_type = rr_graph.node_type(rt_node.inode);
             if (node_type != e_rr_type::IPIN && node_type != e_rr_type::OPIN)
                 continue;
 
-            auto physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(rt_node.inode),
+            t_physical_tile_type_ptr physical_tile = device_ctx.grid.get_physical_type({rr_graph.node_xlow(rt_node.inode),
                                                                     rr_graph.node_ylow(rt_node.inode),
                                                                     rr_graph.node_layer_low(rt_node.inode)});
 
@@ -385,17 +385,17 @@ static void sync_clustered_netlist_to_routing(void) {
     rebuild_atom_nets_lookup(remapped);
     /* 5. Rebuild place_ctx.physical_pins lookup
      * TODO: maybe we don't need this fn and pin_index is enough? */
-    auto& blk_loc_registry = place_ctx.mutable_blk_loc_registry();
-    auto& physical_pins = place_ctx.mutable_physical_pins();
+    BlkLocRegistry& blk_loc_registry = place_ctx.mutable_blk_loc_registry();
+    vtr::vector_map<ClusterPinId, int>& physical_pins = place_ctx.mutable_physical_pins();
     physical_pins.clear();
-    for (auto clb : clb_netlist.blocks()) {
+    for (ClusterBlockId clb : clb_netlist.blocks()) {
         blk_loc_registry.place_sync_external_block_connections(clb);
     }
 }
 
 static void fixup_atom_pb_graph_pin_mapping(void) {
-    auto& cluster_ctx = g_vpr_ctx.clustering();
-    auto& atom_ctx = g_vpr_ctx.mutable_atom();
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+    AtomContext& atom_ctx = g_vpr_ctx.mutable_atom();
 
     for (ClusterBlockId clb : cluster_ctx.clb_nlist.blocks()) {
         /* Collect all innermost pb routes */

--- a/vpr/src/pack/sync_netlists_to_routing_flat.cpp
+++ b/vpr/src/pack/sync_netlists_to_routing_flat.cpp
@@ -138,24 +138,14 @@ static void route_intra_cluster_conn(const t_pb_graph_pin* source_pin, const t_p
     for (auto it = path.rbegin(); it != path.rend(); ++it) {
         cur_pin = *it;
         int cur_pin_id = cur_pin->pin_count_in_cluster;
-        t_pb_route* cur_pb_route;
 
-        if (out_pb_routes.count(cur_pin_id))
-            cur_pb_route = &out_pb_routes[cur_pin_id];
-        else {
-            t_pb_route pb_route = {
-                net_id,
-                -1,
-                {},
-                cur_pin};
-            out_pb_routes.insert(std::make_pair<>(cur_pin_id, pb_route));
-            cur_pb_route = &out_pb_routes[cur_pin_id];
-        }
+        // insert() leaves the existing entry untouched if cur_pin_id is already in the map.
+        t_pb_route& cur_pb_route = out_pb_routes.insert(std::make_pair(cur_pin_id, t_pb_route{net_id, -1, {}, cur_pin})).first->second;
 
         if (prev_pin_id != -1) {
             t_pb_route& prev_pb_route = out_pb_routes[prev_pin_id];
             prev_pb_route.sink_pb_pin_ids.push_back(cur_pin_id);
-            cur_pb_route->driver_pb_pin_id = prev_pb_route.pb_graph_pin->pin_count_in_cluster;
+            cur_pb_route.driver_pb_pin_id = prev_pb_route.pb_graph_pin->pin_count_in_cluster;
         }
 
         prev_pin_id = cur_pin_id;

--- a/vpr/src/pack/verify_clustering.cpp
+++ b/vpr/src/pack/verify_clustering.cpp
@@ -310,14 +310,16 @@ static unsigned check_clustering_floorplanning_consistency(
             // is non-empty. This implies that a placement could theoretically
             // exist.
             for (AtomBlockId atom_blk_id : atoms_in_clb) {
-                PartitionId atom_part_id = constraints.get_atom_partition(atom_blk_id);
                 // If the atom has no floorplan constraint, continue.
-                if (!atom_has_floorplan_constraint(constraints, atom_blk_id))
+                PartitionId atom_part_id = constraints.get_atom_partition(atom_blk_id);
+                if (!atom_part_id.is_valid())
+                    continue;
+                const PartitionRegion& atom_pr = constraints.get_partition_pr(atom_part_id);
+                if (atom_pr.empty())
                     continue;
                 // Check if an intersection exists between the atom's PR and the
                 // cluster's PR.
                 bool intersection_exists = false;
-                const PartitionRegion& atom_pr = constraints.get_partition_pr(atom_part_id);
                 for (const auto& cluster_region : cluster_pr.get_regions()) {
                     for (const auto& atom_region : atom_pr.get_regions()) {
                         Region intersect_region = intersection(cluster_region, atom_region);
@@ -340,13 +342,15 @@ static unsigned check_clustering_floorplanning_consistency(
             // Compute the intersection of all the atom PRs in the cluster.
             PartitionRegion calc_cluster_pr;
             for (AtomBlockId atom_blk_id : atoms_in_clb) {
-                PartitionId atom_part_id = constraints.get_atom_partition(atom_blk_id);
                 // If the atom has no floorplan constraint, continue.
-                if (!atom_has_floorplan_constraint(constraints, atom_blk_id))
+                PartitionId atom_part_id = constraints.get_atom_partition(atom_blk_id);
+                if (!atom_part_id.is_valid())
+                    continue;
+                const PartitionRegion& atom_pr = constraints.get_partition_pr(atom_part_id);
+                if (atom_pr.empty())
                     continue;
                 // Get the intersection of the atom's PR and the intersection of
                 // all atom PRs that came before.
-                const PartitionRegion& atom_pr = constraints.get_partition_pr(atom_part_id);
                 if (calc_cluster_pr.empty()) {
                     calc_cluster_pr = atom_pr;
                     continue;

--- a/vpr/src/pack/verify_clustering.cpp
+++ b/vpr/src/pack/verify_clustering.cpp
@@ -322,8 +322,8 @@ static unsigned check_clustering_floorplanning_consistency(
                 // Check if an intersection exists between the atom's PR and the
                 // cluster's PR.
                 bool intersection_exists = false;
-                for (const auto& cluster_region : cluster_pr.get_regions()) {
-                    for (const auto& atom_region : atom_pr->get_regions()) {
+                for (const Region& cluster_region : cluster_pr.get_regions()) {
+                    for (const Region& atom_region : atom_pr->get_regions()) {
                         Region intersect_region = intersection(cluster_region, atom_region);
                         if (!intersect_region.empty()) {
                             intersection_exists = true;
@@ -355,8 +355,8 @@ static unsigned check_clustering_floorplanning_consistency(
                     continue;
                 }
                 std::vector<Region> int_regions;
-                for (const auto& cluster_region : calc_cluster_pr.get_regions()) {
-                    for (const auto& atom_region : atom_pr->get_regions()) {
+                for (const Region& cluster_region : calc_cluster_pr.get_regions()) {
+                    for (const Region& atom_region : atom_pr->get_regions()) {
                         Region intersection_region = intersection(cluster_region, atom_region);
                         if (!intersection_region.empty()) {
                             int_regions.push_back(intersection_region);
@@ -383,9 +383,9 @@ static unsigned check_clustering_floorplanning_consistency(
             // constrains all the atoms within the cluster, if cluster_region
             // is a subset of that, it should be equal to or smaller (which
             // are both legal).
-            for (const auto& cluster_region : cluster_pr.get_regions()) {
+            for (const Region& cluster_region : cluster_pr.get_regions()) {
                 bool found_region = false;
-                for (const auto& calc_cluster_region : calc_cluster_pr.get_regions()) {
+                for (const Region& calc_cluster_region : calc_cluster_pr.get_regions()) {
                     // This equality is a deep check. it checks that the actual
                     // rectangles of the regions are equal.
                     if (calc_cluster_region == cluster_region) {
@@ -410,7 +410,7 @@ static unsigned check_clustering_floorplanning_consistency(
                     // If the atom partition exists and is constrained to some lb types,
                     // check that the cluster's logical block type is one of the types
                     // that this atom can implement.
-                    const auto& atom_lb_type_constraints = constraints.get_part_lb_type_constraints(atom_part_id);
+                    const std::unordered_set<t_logical_block_type_ptr>& atom_lb_type_constraints = constraints.get_part_lb_type_constraints(atom_part_id);
                     t_logical_block_type_ptr clb_block_type = clb_nlist.block_type(clb_blk_id);
                     if (!atom_lb_type_constraints.contains(clb_block_type)) {
                         VTR_LOG_ERROR(

--- a/vpr/src/pack/verify_clustering.cpp
+++ b/vpr/src/pack/verify_clustering.cpp
@@ -244,18 +244,23 @@ static unsigned check_clustering_pb_consistency(const ClusteredNetlist& clb_nlis
  */
 
 /**
- * @brief Returns true if an atom is constrained to a region on the FPGA chip.
+ * @brief Returns the PartitionRegion an atom is constrained to on the FPGA chip,
+ *        or nullptr if the atom is not constrained to a region.
  *
- * True when the atom's partition has at least one add_region (non-empty PartitionRegion).
- * False when the atom is unconstrained, or has only logical_block_location with no add_region
+ * Non-null when the atom's partition has at least one add_region (non-empty PartitionRegion).
+ * Null when the atom is unconstrained, or has only logical_block_location with no add_region
  * (pack-only constraint: controls packing inside a logic block, not chip placement).
  */
-static bool atom_has_floorplan_constraint(const UserPlaceConstraints& constraints, AtomBlockId atom_blk_id) {
+static const PartitionRegion* get_atom_floorplan_pr(const UserPlaceConstraints& constraints, AtomBlockId atom_blk_id) {
     PartitionId part_id = constraints.get_atom_partition(atom_blk_id);
     if (!part_id.is_valid()) {
-        return false;
+        return nullptr;
     }
-    return !constraints.get_partition_pr(part_id).empty();
+    const PartitionRegion& part_pr = constraints.get_partition_pr(part_id);
+    if (part_pr.empty()) {
+        return nullptr;
+    }
+    return &part_pr;
 }
 
 static unsigned check_clustering_floorplanning_consistency(
@@ -281,7 +286,7 @@ static unsigned check_clustering_floorplanning_consistency(
             // If the cluster is unconstrained, make sure all the atoms it
             // contains are unconstrained.
             for (AtomBlockId atom_blk_id : atoms_in_clb) {
-                if (atom_has_floorplan_constraint(constraints, atom_blk_id)) {
+                if (get_atom_floorplan_pr(constraints, atom_blk_id) != nullptr) {
                     VTR_LOG_ERROR(
                         "Cluster block %zu is unconstrained but contains "
                         "constrained atom block %zu.\n",
@@ -294,7 +299,7 @@ static unsigned check_clustering_floorplanning_consistency(
             // At least one of the atoms in the cluster must be constrained.
             bool an_atom_is_constrained = false;
             for (AtomBlockId atom_blk_id : atoms_in_clb) {
-                if (atom_has_floorplan_constraint(constraints, atom_blk_id)) {
+                if (get_atom_floorplan_pr(constraints, atom_blk_id) != nullptr) {
                     an_atom_is_constrained = true;
                     break;
                 }
@@ -311,17 +316,14 @@ static unsigned check_clustering_floorplanning_consistency(
             // exist.
             for (AtomBlockId atom_blk_id : atoms_in_clb) {
                 // If the atom has no floorplan constraint, continue.
-                PartitionId atom_part_id = constraints.get_atom_partition(atom_blk_id);
-                if (!atom_part_id.is_valid())
-                    continue;
-                const PartitionRegion& atom_pr = constraints.get_partition_pr(atom_part_id);
-                if (atom_pr.empty())
+                const PartitionRegion* atom_pr = get_atom_floorplan_pr(constraints, atom_blk_id);
+                if (atom_pr == nullptr)
                     continue;
                 // Check if an intersection exists between the atom's PR and the
                 // cluster's PR.
                 bool intersection_exists = false;
                 for (const auto& cluster_region : cluster_pr.get_regions()) {
-                    for (const auto& atom_region : atom_pr.get_regions()) {
+                    for (const auto& atom_region : atom_pr->get_regions()) {
                         Region intersect_region = intersection(cluster_region, atom_region);
                         if (!intersect_region.empty()) {
                             intersection_exists = true;
@@ -343,21 +345,18 @@ static unsigned check_clustering_floorplanning_consistency(
             PartitionRegion calc_cluster_pr;
             for (AtomBlockId atom_blk_id : atoms_in_clb) {
                 // If the atom has no floorplan constraint, continue.
-                PartitionId atom_part_id = constraints.get_atom_partition(atom_blk_id);
-                if (!atom_part_id.is_valid())
-                    continue;
-                const PartitionRegion& atom_pr = constraints.get_partition_pr(atom_part_id);
-                if (atom_pr.empty())
+                const PartitionRegion* atom_pr = get_atom_floorplan_pr(constraints, atom_blk_id);
+                if (atom_pr == nullptr)
                     continue;
                 // Get the intersection of the atom's PR and the intersection of
                 // all atom PRs that came before.
                 if (calc_cluster_pr.empty()) {
-                    calc_cluster_pr = atom_pr;
+                    calc_cluster_pr = *atom_pr;
                     continue;
                 }
                 std::vector<Region> int_regions;
                 for (const auto& cluster_region : calc_cluster_pr.get_regions()) {
-                    for (const auto& atom_region : atom_pr.get_regions()) {
+                    for (const auto& atom_region : atom_pr->get_regions()) {
                         Region intersection_region = intersection(cluster_region, atom_region);
                         if (!intersection_region.empty()) {
                             int_regions.push_back(intersection_region);


### PR DESCRIPTION
When I was reading the packer's code to see how I can use it in another project, I noticed a few patterns that degraded performance. I raise this PR to: 
- Replace count() + operator[] with a single find()
- Hoist loop-invariant lookups
- Avoid unnecessary copies: pass by const reference
- Run `update_total_gain` once per molecule instead of once per atom.

These changes preserve the packer's behavior while making it faster by 1.3% on `titan_other` circuits.