### PR TITLE
Defer router lookahead evaluation until after the backward cost prune

### DIFF
--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -17,7 +17,6 @@
  * When the ConnectionRouter is used, it mutates the provided rr_node_route_inf.
  * The routed path can be found by tracing from the sink node (which is returned)
  * through the rr_node_route_inf. See update_traceback as an example of this tracing.
- *
  */
 
 #include "connection_router_interface.h"

--- a/vpr/src/route/connection_router.h
+++ b/vpr/src/route/connection_router.h
@@ -247,6 +247,11 @@ class ConnectionRouter : public ConnectionRouterInterface {
 
     /**
      * @brief Calculates the cost of reaching to_node
+     * @note Equivalent to evaluate_timing_driven_backward_costs() followed by
+     * evaluate_timing_driven_total_cost(). Callers that prune on the backward
+     * cost alone (e.g. the serial router's pre-push prune when RCV is disabled)
+     * can call the two helpers separately and skip the (expensive) lookahead
+     * evaluation for pruned edges.
      * @param to Neighbor node to calculate costs before being expanded
      * @param cost_params Cost function parameters
      * @param from_node Current node ID being explored
@@ -257,6 +262,33 @@ class ConnectionRouter : public ConnectionRouterInterface {
         const t_conn_cost_params& cost_params,
         RRNodeId from_node,
         RRNodeId target_node);
+
+    /**
+     * @brief Calculates the backward path cost, R_upstream and delay of
+     * reaching to_node (everything except the lookahead-based total cost)
+     * @param to Neighbor node to calculate costs before being expanded
+     * @param cost_params Cost function parameters
+     * @param from_node Current node ID being explored
+     * @return Tdel of to_node, needed by evaluate_timing_driven_total_cost()
+     */
+    float evaluate_timing_driven_backward_costs(RTExploredNode* to,
+                                                const t_conn_cost_params& cost_params,
+                                                RRNodeId from_node);
+
+    /**
+     * @brief Calculates the total cost of to_node (backward cost + expected
+     * cost to the target, or the RCV cost when RCV is enabled)
+     * @note Must be called after evaluate_timing_driven_backward_costs() has
+     * filled in to's backward_path_cost and R_upstream.
+     * @param to Neighbor node to calculate costs before being expanded
+     * @param cost_params Cost function parameters
+     * @param target_node Target node ID to route to
+     * @param Tdel Delay of to_node, returned by evaluate_timing_driven_backward_costs()
+     */
+    void evaluate_timing_driven_total_cost(RTExploredNode* to,
+                                           const t_conn_cost_params& cost_params,
+                                           RRNodeId target_node,
+                                           float Tdel);
 
     /**
      * @brief Evaluate node costs using the RCV algorithm

--- a/vpr/src/route/connection_router.tpp
+++ b/vpr/src/route/connection_router.tpp
@@ -6,6 +6,7 @@
 #include "describe_rr_node.h"
 #include "route_common.h"
 #include "rr_graph_fwd.h"
+#include "vpr_context.h"
 #include "vpr_utils.h"
 
 /** Used for the flat router. The node isn't relevant to the target if
@@ -120,8 +121,8 @@ bool ConnectionRouter<Heap>::timing_driven_route_connection_common_setup(
     RRNodeId sink_node,
     const t_conn_cost_params& cost_params,
     const t_bb& bounding_box) {
-    //Re-add route nodes from the existing route tree to the heap.
-    //They need to be repushed onto the heap since each node's cost is target specific.
+    // Re-add route nodes from the existing route tree to the heap.
+    // They need to be repushed onto the heap since each node's cost is target specific.
 
     add_route_tree_to_heap(rt_root, sink_node, cost_params, bounding_box);
     heap_.build_heap(); // via sifting down everything
@@ -167,7 +168,7 @@ void ConnectionRouter<Heap>::timing_driven_route_connection_from_heap(RRNodeId s
                                                                       const t_bb& bounding_box) {
     VTR_ASSERT_SAFE(heap_.is_valid());
 
-    if (heap_.is_empty_heap()) { //No source
+    if (heap_.is_empty_heap()) { // No source
         VTR_LOGV_DEBUG(router_debug_, "  Initial heap empty (no source)\n");
     }
 
@@ -271,63 +272,63 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* t
      * new_costs.R_upstream: is the upstream resistance at the end of this node
      */
 
-    //Info for the switch connecting from_node to_node (i.e., to->index)
+    // Info for the switch connecting from_node to_node (i.e., to->index)
     int iswitch = rr_nodes_.edge_switch(to->prev_edge);
     bool switch_buffered = rr_switch_inf_[iswitch].buffered();
     bool reached_configurably = rr_switch_inf_[iswitch].configurable();
     float switch_R = rr_switch_inf_[iswitch].R;
     float switch_Cinternal = rr_switch_inf_[iswitch].Cinternal;
 
-    //To node info
+    // To node info
     auto rc_index = rr_graph_->node_rc_index(to->index);
     float node_R = rr_rc_data_[rc_index].R;
 
-    //From node info
+    // From node info
     float from_node_R = rr_rc_data_[rr_graph_->node_rc_index(from_node)].R;
 
-    //Update R_upstream
+    // Update R_upstream
     if (switch_buffered) {
-        to->R_upstream = 0.; //No upstream resistance
+        to->R_upstream = 0.; // No upstream resistance
     } else {
-        //R_Upstream already initialized
+        // R_Upstream already initialized
     }
 
-    to->R_upstream += switch_R; //Switch resistance
-    to->R_upstream += node_R;   //Node resistance
+    to->R_upstream += switch_R; // Switch resistance
+    to->R_upstream += node_R;   // Node resistance
 
-    //Calculate delay
+    // Calculate delay
     float Tdel = get_rr_node_delay_cost(to->index, to->prev_edge);
 
-    //Depending on the switch used, the Tdel of the upstream node (from_node) may change due to
-    //increased loading from the switch's internal capacitance.
+    // Depending on the switch used, the Tdel of the upstream node (from_node) may change due to
+    // increased loading from the switch's internal capacitance.
     //
-    //Even though this delay physically affects from_node, we make the adjustment (now) on the to_node,
-    //since only once we've reached to to_node do we know the connection used (and the switch enabled).
+    // Even though this delay physically affects from_node, we make the adjustment (now) on the to_node,
+    // since only once we've reached to to_node do we know the connection used (and the switch enabled).
     //
-    //To adjust for the time delay, we compute the product of the Rdel associated with from_node and
-    //the internal capacitance of the switch.
+    // To adjust for the time delay, we compute the product of the Rdel associated with from_node and
+    // the internal capacitance of the switch.
     //
-    //First, we will calculate Rdel_adjust (just like in the computation for Rdel, we consider only
-    //half of from_node's resistance).
+    // First, we will calculate Rdel_adjust (just like in the computation for Rdel, we consider only
+    // half of from_node's resistance).
     float Rdel_adjust = to->R_upstream - 0.5 * from_node_R;
 
-    //Second, we adjust the Tdel to account for the delay caused by the internal capacitance.
+    // Second, we adjust the Tdel to account for the delay caused by the internal capacitance.
     Tdel += Rdel_adjust * switch_Cinternal;
 
     float cong_cost = 0.;
     if (reached_configurably) {
         cong_cost = get_rr_cong_cost(to->index, cost_params.pres_fac);
     } else {
-        //Reached by a non-configurable edge.
-        //Therefore the from_node and to_node are part of the same non-configurable node set.
+        // Reached by a non-configurable edge.
+        // Therefore the from_node and to_node are part of the same non-configurable node set.
 #ifdef VTR_ASSERT_SAFE_ENABLED
         VTR_ASSERT_SAFE_MSG(same_non_config_node_set(from_node, to->index),
                             "Non-configurably connected edges should be part of the same node set");
 #endif
 
-        //The congestion cost of all nodes in the set has already been accounted for (when
-        //the current path first expanded a node in the set). Therefore do *not* re-add the congestion
-        //cost.
+        // The congestion cost of all nodes in the set has already been accounted for (when
+        // the current path first expanded a node in the set). Therefore do *not* re-add the congestion
+        // cost.
         cong_cost = 0.;
     }
     if (conn_params_->router_opt_choke_points_ && is_flat_ && rr_graph_->node_type(to->index) == e_rr_type::IPIN) {
@@ -337,15 +338,15 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* t
         }
     }
 
-    //Update the backward cost (upstream already included)
-    to->backward_path_cost += (1. - cost_params.criticality) * cong_cost; //Congestion cost
-    to->backward_path_cost += cost_params.criticality * Tdel;             //Delay cost
+    // Update the backward cost (upstream already included)
+    to->backward_path_cost += (1. - cost_params.criticality) * cong_cost; // Congestion cost
+    to->backward_path_cost += cost_params.criticality * Tdel;             // Delay cost
 
     if (cost_params.bend_cost != 0.) {
         e_rr_type from_type = rr_graph_->node_type(from_node);
         e_rr_type to_type = rr_graph_->node_type(to->index);
         if ((from_type == e_rr_type::CHANX && to_type == e_rr_type::CHANY) || (from_type == e_rr_type::CHANY && to_type == e_rr_type::CHANX)) {
-            to->backward_path_cost += cost_params.bend_cost; //Bend cost
+            to->backward_path_cost += cost_params.bend_cost; // Bend cost
         }
     }
 
@@ -357,8 +358,8 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* t
 
         total_cost = compute_node_cost_using_rcv(cost_params, to->index, target_node, to->path_data->backward_delay, to->path_data->backward_cong, to->R_upstream);
     } else {
-        const auto& device_ctx = g_vpr_ctx.device();
-        //Update total cost
+        const DeviceContext& device_ctx = g_vpr_ctx.device();
+        // Update total cost
         float expected_cost = router_lookahead_.get_expected_cost(to->index, target_node, cost_params, to->R_upstream);
         VTR_LOGV_DEBUG(router_debug_ && !std::isfinite(expected_cost),
                        "        Lookahead from %s (%s) to %s (%s) is non-finite, expected_cost = %f, to->R_upstream = %f\n",

--- a/vpr/src/route/connection_router.tpp
+++ b/vpr/src/route/connection_router.tpp
@@ -209,7 +209,7 @@ void ConnectionRouter<Heap>::timing_driven_route_connection_from_heap(RRNodeId s
 
 //Returns true if both nodes are part of the same non-configurable edge set
 inline bool same_non_config_node_set(RRNodeId from_node, RRNodeId to_node) {
-    auto& device_ctx = g_vpr_ctx.device();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
 
     auto from_itr = device_ctx.rr_node_to_non_config_node_set.find(from_node);
     auto to_itr = device_ctx.rr_node_to_non_config_node_set.find(to_node);
@@ -277,7 +277,7 @@ float ConnectionRouter<Heap>::evaluate_timing_driven_backward_costs(RTExploredNo
     float switch_Cinternal = rr_switch_inf_[iswitch].Cinternal;
 
     // To node info
-    auto rc_index = rr_graph_->node_rc_index(to->index);
+    int16_t rc_index = rr_graph_->node_rc_index(to->index);
     float node_R = rr_rc_data_[rc_index].R;
 
     // From node info
@@ -503,7 +503,7 @@ t_bb ConnectionRouter<Heap>::add_high_fanout_route_tree_to_heap(
                 if (!inside_bb(rr_node_to_add, net_bounding_box))
                     continue;
 
-                auto rt_node_layer_num = rr_graph_->node_layer_low(rr_node_to_add);
+                short rt_node_layer_num = rr_graph_->node_layer_low(rr_node_to_add);
                 if (rt_node_layer_num == target_layer)
                     found_node_on_same_layer = true;
 
@@ -549,6 +549,6 @@ inline bool relevant_node_to_target(const RRGraphView* rr_graph,
                                     RRNodeId node_to_add,
                                     RRNodeId target_node) {
     VTR_ASSERT_SAFE(rr_graph->node_type(target_node) == e_rr_type::SINK);
-    auto node_to_add_type = rr_graph->node_type(node_to_add);
+    e_rr_type node_to_add_type = rr_graph->node_type(node_to_add);
     return node_to_add_type != e_rr_type::IPIN || node_in_same_physical_tile(node_to_add, target_node);
 }

--- a/vpr/src/route/connection_router.tpp
+++ b/vpr/src/route/connection_router.tpp
@@ -259,15 +259,12 @@ float ConnectionRouter<Heap>::compute_node_cost_using_rcv(const t_conn_cost_para
 }
 
 template<typename Heap>
-void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* to,
-                                                               const t_conn_cost_params& cost_params,
-                                                               RRNodeId from_node,
-                                                               RRNodeId target_node) {
+float ConnectionRouter<Heap>::evaluate_timing_driven_backward_costs(RTExploredNode* to,
+                                                                    const t_conn_cost_params& cost_params,
+                                                                    RRNodeId from_node) {
     /* new_costs.backward_cost: is the "known" part of the cost to this node -- the
      * congestion cost of all the routing resources back to the existing route
      * plus the known delay of the total path back to the source.
-     *
-     * new_costs.total_cost: is this "known" backward cost + an expected cost to get to the target.
      *
      * new_costs.R_upstream: is the upstream resistance at the end of this node
      */
@@ -350,6 +347,16 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* t
         }
     }
 
+    return Tdel;
+}
+
+template<typename Heap>
+void ConnectionRouter<Heap>::evaluate_timing_driven_total_cost(RTExploredNode* to,
+                                                               const t_conn_cost_params& cost_params,
+                                                               RRNodeId target_node,
+                                                               float Tdel) {
+    // to->total_cost: is the "known" backward cost + an expected cost to get to the target.
+
     float total_cost = 0.;
 
     if (rcv_path_manager.is_enabled() && to->path_data != nullptr) {
@@ -371,6 +378,15 @@ void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* t
         total_cost += to->backward_path_cost + cost_params.astar_fac * std::max(0.f, expected_cost - cost_params.astar_offset);
     }
     to->total_cost = total_cost;
+}
+
+template<typename Heap>
+void ConnectionRouter<Heap>::evaluate_timing_driven_node_costs(RTExploredNode* to,
+                                                               const t_conn_cost_params& cost_params,
+                                                               RRNodeId from_node,
+                                                               RRNodeId target_node) {
+    float Tdel = evaluate_timing_driven_backward_costs(to, cost_params, from_node);
+    evaluate_timing_driven_total_cost(to, cost_params, target_node, Tdel);
 }
 
 template<typename Heap>

--- a/vpr/src/route/parallel_connection_router.cpp
+++ b/vpr/src/route/parallel_connection_router.cpp
@@ -363,7 +363,10 @@ void ParallelConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost
                                                                const RREdgeId from_edge,
                                                                RRNodeId target_node,
                                                                size_t thread_idx) {
-    const RRNodeId& from_node = current.index;
+    const RRNodeId from_node = current.index;
+
+    // TODO: Port the pre-evaluation prune from SerialConnectionRouter::timing_driven_add_to_heap.
+    // Split evaluate_timing_driven_node_costs() into its backward-costs and total-cost halves.
 
     // Initialize the neighbor RTExploredNode
     RTExploredNode next;

--- a/vpr/src/route/serial_connection_router.cpp
+++ b/vpr/src/route/serial_connection_router.cpp
@@ -325,6 +325,18 @@ void SerialConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_p
                                                              RRNodeId target_node) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const RRNodeId from_node = current.index;
+    const bool rcv_enabled = this->rcv_path_manager.is_enabled();
+
+    float best_total_cost = this->rr_node_route_inf_[to_node].path_cost;
+    float best_back_cost = this->rr_node_route_inf_[to_node].backward_path_cost;
+
+    // Since edge weights are non-negative, the backward cost of reaching to_node
+    // via current can never be less than current's backward cost. If that lower
+    // bound already fails the pre-push backward-cost prune below, skip evaluating
+    // this neighbor entirely.
+    if (!rcv_enabled && best_back_cost <= current.backward_path_cost) {
+        return;
+    }
 
     // Initialize the neighbor RTExploredNode
     RTExploredNode next;
@@ -337,17 +349,16 @@ void SerialConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_p
     // Initialize RCV data struct if needed, otherwise it's set to nullptr
     this->rcv_path_manager.alloc_path_struct(next.path_data);
     // path_data variables are initialized to current values
-    if (this->rcv_path_manager.is_enabled() && this->rcv_path_data[from_node]) {
+    if (rcv_enabled && this->rcv_path_data[from_node]) {
         next.path_data->backward_cong = this->rcv_path_data[from_node]->backward_cong;
         next.path_data->backward_delay = this->rcv_path_data[from_node]->backward_delay;
     }
 
-    this->evaluate_timing_driven_node_costs(&next, cost_params, from_node, target_node);
+    // Compute the backward path cost (and R_upstream/Tdel) first; the (expensive)
+    // lookahead-based total cost is only computed for edges that survive the
+    // backward-cost prune below.
+    float Tdel = this->evaluate_timing_driven_backward_costs(&next, cost_params, from_node);
 
-    float best_total_cost = this->rr_node_route_inf_[to_node].path_cost;
-    float best_back_cost = this->rr_node_route_inf_[to_node].backward_path_cost;
-
-    float new_total_cost = next.total_cost;
     float new_back_cost = next.backward_path_cost;
 
     // We need to only expand this node if it is a better path. And we need to
@@ -359,9 +370,23 @@ void SerialConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_p
     // router paper.
     //
     // When RCV is enabled, prune based on the RCV-specific total path cost (see
-    // in `compute_node_cost_using_rcv` in `evaluate_timing_driven_node_costs`)
+    // in `compute_node_cost_using_rcv` in `evaluate_timing_driven_total_cost`)
     // to allow detours to get better QoR.
-    if ((!this->rcv_path_manager.is_enabled() && best_back_cost > new_back_cost) || (this->rcv_path_manager.is_enabled() && best_total_cost > new_total_cost)) {
+    bool add_to_heap;
+    if (!rcv_enabled) {
+        add_to_heap = best_back_cost > new_back_cost;
+        // Only edges surviving the backward-cost prune pay for the lookahead
+        if (add_to_heap) {
+            this->evaluate_timing_driven_total_cost(&next, cost_params, target_node, Tdel);
+        }
+    } else {
+        this->evaluate_timing_driven_total_cost(&next, cost_params, target_node, Tdel);
+        add_to_heap = best_total_cost > next.total_cost;
+    }
+
+    float new_total_cost = next.total_cost;
+
+    if (add_to_heap) {
         VTR_LOGV_DEBUG(this->router_debug_, "      Expanding to node %d (%s)\n", to_node,
                        describe_rr_node(device_ctx.rr_graph,
                                         device_ctx.grid,
@@ -390,7 +415,7 @@ void SerialConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_p
         VTR_LOGV_DEBUG(this->router_debug_, "        New Total Cost %g New back Cost %g \n", new_total_cost, new_back_cost);
     }
 
-    if (this->rcv_path_manager.is_enabled() && next.path_data != nullptr) {
+    if (rcv_enabled && next.path_data != nullptr) {
         this->rcv_path_manager.free_path_struct(next.path_data);
     }
 }

--- a/vpr/src/route/serial_connection_router.cpp
+++ b/vpr/src/route/serial_connection_router.cpp
@@ -214,6 +214,8 @@ void SerialConnectionRouter<Heap>::timing_driven_expand_neighbours(const RTExplo
     //  - directrf_stratixiv_arch_timing.blif
     //  - gsm_switch_stratixiv_arch_timing.blif
     //
+    // TODO: Also prefetch rr_node_route_inf_[to_node]. It is the first thing touched
+    // per neighbor, by the pre-evaluation prune in timing_driven_add_to_heap().
     for (RREdgeId from_edge : edges) {
         RRNodeId to_node = this->rr_nodes_.edge_sink_node(from_edge);
         this->rr_nodes_.prefetch_node(to_node);

--- a/vpr/src/route/serial_connection_router.cpp
+++ b/vpr/src/route/serial_connection_router.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include "d_ary_heap.h"
 #include "rr_graph_fwd.h"
+#include "vpr_context.h"
 
 /** Used to update router statistics for serial connection router */
 inline void update_serial_router_stats(RouterStats* router_stats,
@@ -191,10 +192,10 @@ void SerialConnectionRouter<Heap>::timing_driven_expand_neighbours(const RTExplo
                                                                    const t_bb& bounding_box,
                                                                    RRNodeId target_node,
                                                                    const t_bb& target_bb) {
-    /* Puts all the rr_nodes adjacent to current on the heap. */
+    // Puts all the rr_nodes adjacent to current on the heap.
 
     // For each node associated with the current heap element, expand all of it's neighbors
-    auto edges = this->rr_nodes_.edge_range(current.index);
+    vtr::StrongIdRange<RREdgeId> edges = this->rr_nodes_.edge_range(current.index);
 
     // This is a simple prefetch that prefetches:
     //  - RR node data reachable from this node
@@ -243,7 +244,7 @@ void SerialConnectionRouter<Heap>::timing_driven_expand_neighbour(const RTExplor
                                                                   const t_bb& target_bb) {
     VTR_ASSERT(bounding_box.layer_max < (int)g_vpr_ctx.device().grid.get_num_layers());
 
-    const RRNodeId& from_node = current.index;
+    const RRNodeId from_node = current.index;
 
     // BB-pruning
     // Disable BB-pruning if RCV is enabled, as this can make it harder for circuits with high negative hold slack to resolve this
@@ -259,13 +260,13 @@ void SerialConnectionRouter<Heap>::timing_driven_expand_neighbour(const RTExplor
                        this->rr_graph_->node_xhigh(to_node), this->rr_graph_->node_yhigh(to_node), this->rr_graph_->node_layer_low(to_node),
                        bounding_box.xmin, bounding_box.ymin, bounding_box.layer_min,
                        bounding_box.xmax, bounding_box.ymax, bounding_box.layer_max);
-        return; /* Node is outside (expanded) bounding box. */
+        return; // Node is outside (expanded) bounding box.
     }
 
-    /* Prune away IPINs that lead to blocks other than the target one.  Avoids  *
-     * the issue of how to cost them properly so they don't get expanded before *
-     * more promising routes, but makes route-through (via CLBs) impossible.   *
-     * Change this if you want to investigate route-throughs.                   */
+    // Prune away IPINs that lead to blocks other than the target one. Avoids
+    // the issue of how to cost them properly so they don't get expanded before
+    // more promising routes, but makes route-through (via CLBs) impossible.
+    // Change this if you want to investigate route-throughs.
     if (target_node != RRNodeId::INVALID()) {
         e_rr_type to_type = this->rr_graph_->node_type(to_node);
         if (to_type == e_rr_type::IPIN) {
@@ -322,8 +323,8 @@ void SerialConnectionRouter<Heap>::timing_driven_add_to_heap(const t_conn_cost_p
                                                              RRNodeId to_node,
                                                              const RREdgeId from_edge,
                                                              RRNodeId target_node) {
-    const auto& device_ctx = g_vpr_ctx.device();
-    const RRNodeId& from_node = current.index;
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    const RRNodeId from_node = current.index;
 
     // Initialize the neighbor RTExploredNode
     RTExploredNode next;

--- a/vpr/src/route/serial_connection_router.cpp
+++ b/vpr/src/route/serial_connection_router.cpp
@@ -16,8 +16,8 @@ void SerialConnectionRouter<Heap>::timing_driven_find_single_shortest_path_from_
                                                                                      const t_conn_cost_params& cost_params,
                                                                                      const t_bb& bounding_box,
                                                                                      const t_bb& target_bb) {
-    const auto& device_ctx = g_vpr_ctx.device();
-    auto& route_ctx = g_vpr_ctx.mutable_routing();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
+    RoutingContext& route_ctx = g_vpr_ctx.mutable_routing();
 
     HeapNode cheapest;
     while (this->heap_.try_pop(cheapest)) {
@@ -71,7 +71,7 @@ vtr::vector<RRNodeId, RTExploredNode> SerialConnectionRouter<Heap>::timing_drive
     this->add_route_tree_to_heap(rt_root, target_node, cost_params, bounding_box);
     this->heap_.build_heap(); // via sifting down everything
 
-    auto res = timing_driven_find_all_shortest_paths_from_heap(cost_params, bounding_box);
+    vtr::vector<RRNodeId, RTExploredNode> res = timing_driven_find_all_shortest_paths_from_heap(cost_params, bounding_box);
     this->heap_.empty_heap();
 
     return res;
@@ -426,7 +426,7 @@ void SerialConnectionRouter<Heap>::add_route_tree_node_to_heap(
     RRNodeId target_node,
     const t_conn_cost_params& cost_params,
     const t_bb& net_bb) {
-    const auto& device_ctx = g_vpr_ctx.device();
+    const DeviceContext& device_ctx = g_vpr_ctx.device();
     const RRNodeId inode = rt_node.inode;
     float backward_path_cost = cost_params.criticality * rt_node.Tdel;
     float R_upstream = rt_node.R_upstream;
@@ -538,7 +538,7 @@ inline void update_serial_router_stats(RouterStats* router_stats,
     }
 
     if constexpr (VTR_ENABLE_DEBUG_LOGGING_CONST_EXPR) {
-        auto node_type = rr_graph->node_type(rr_node_id);
+        e_rr_type node_type = rr_graph->node_type(rr_node_id);
         VTR_ASSERT(node_type != e_rr_type::NUM_RR_TYPES);
 
         if (is_inter_cluster_node(*rr_graph, rr_node_id)) {

--- a/vpr/src/route/serial_connection_router.h
+++ b/vpr/src/route/serial_connection_router.h
@@ -44,7 +44,7 @@ class SerialConnectionRouter : public ConnectionRouter<HeapImplementation> {
         ::reset_path_costs(this->modified_rr_node_inf_);
         // Reset the node (RCV-related) info stored inside the connection router
         if (this->rcv_path_manager.is_enabled()) {
-            for (const auto& node : this->modified_rr_node_inf_) {
+            for (RRNodeId node : this->modified_rr_node_inf_) {
                 this->rcv_path_data[node] = nullptr;
             }
         }


### PR DESCRIPTION
The serial router computed the lookahead cost for every neighbor node, even though the pre-push prune only needs the backward cost. Now the lookahead cost is looked up only for edges that survive the prune.