### PR TITLE
Remove the last remaining linked lists from packer code

### DIFF
--- a/vpr/src/analytical_place/global_placement/model_grouper.cpp
+++ b/vpr/src/analytical_place/global_placement/model_grouper.cpp
@@ -43,11 +43,9 @@ static void get_pattern_models_recurr(t_pack_pattern_block* pattern_block,
     models.insert(pattern_block->pb_type->model_id);
 
     // Go through this block's connections and get their pattern models.
-    t_pack_pattern_connections* connection = pattern_block->connections;
-    while (connection != nullptr) {
-        get_pattern_models_recurr(connection->from_block, models, block_visited);
-        get_pattern_models_recurr(connection->to_block, models, block_visited);
-        connection = connection->next;
+    for (const t_pack_pattern_connections& connection : pattern_block->connections) {
+        get_pattern_models_recurr(connection.from_block, models, block_visited);
+        get_pattern_models_recurr(connection.to_block, models, block_visited);
     }
 }
 

--- a/vpr/src/pack/cluster_placement.cpp
+++ b/vpr/src/pack/cluster_placement.cpp
@@ -557,37 +557,35 @@ static bool expand_forced_pack_molecule_placement(t_intra_cluster_placement_stat
                                                   float* cost) {
     t_pb_graph_node* pb_graph_node = primitives_list[pack_pattern_block->block_id];
     t_pb_graph_node* next_primitive;
-    t_pack_pattern_connections* cur;
     t_pb_graph_pin *cur_pin, *next_pin;
     t_pack_pattern_block* next_block;
 
-    cur = pack_pattern_block->connections;
-    while (cur) {
-        if (cur->from_block == pack_pattern_block) {
-            next_block = cur->to_block;
+    for (const t_pack_pattern_connections& cur : pack_pattern_block->connections) {
+        if (cur.from_block == pack_pattern_block) {
+            next_block = cur.to_block;
         } else {
-            next_block = cur->from_block;
+            next_block = cur.from_block;
         }
         const t_pack_molecule& molecule = prepacker.get_molecule(molecule_id);
         if (primitives_list[next_block->block_id] == nullptr && molecule.atom_block_ids[next_block->block_id]) {
             /* first time visiting location */
 
             /* find next primitive based on pattern connections, expand next primitive if not visited */
-            if (cur->from_block == pack_pattern_block) {
+            if (cur.from_block == pack_pattern_block) {
                 /* forward expand to find next block */
                 int from_pin, from_port;
-                from_pin = cur->from_pin->pin_number;
-                from_port = cur->from_pin->port->port_index_by_type;
+                from_pin = cur.from_pin->pin_number;
+                from_port = cur.from_pin->port->port_index_by_type;
                 cur_pin = &pb_graph_node->output_pins[from_port][from_pin];
                 next_pin = expand_pack_molecule_pin_edge(pack_pattern_block->pattern_index, cur_pin, true);
             } else {
                 /* backward expand to find next block */
-                VTR_ASSERT(cur->to_block == pack_pattern_block);
+                VTR_ASSERT(cur.to_block == pack_pattern_block);
                 int to_pin, to_port;
-                to_pin = cur->to_pin->pin_number;
-                to_port = cur->to_pin->port->port_index_by_type;
+                to_pin = cur.to_pin->pin_number;
+                to_port = cur.to_pin->port->port_index_by_type;
 
-                if (cur->from_pin->port->is_clock) {
+                if (cur.from_pin->port->is_clock) {
                     cur_pin = &pb_graph_node->clock_pins[to_port][to_pin];
                 } else {
                     cur_pin = &pb_graph_node->input_pins[to_port][to_pin];
@@ -614,7 +612,6 @@ static bool expand_forced_pack_molecule_placement(t_intra_cluster_placement_stat
                 return false;
             }
         }
-        cur = cur->next;
     }
 
     return true;

--- a/vpr/src/pack/cluster_placement.h
+++ b/vpr/src/pack/cluster_placement.h
@@ -15,7 +15,6 @@ class AtomBlockId;
 
 /**
  * Keeps track of locations that a primitive can go to during packing
- * Linked list for easy insertion/deletion
  */
 struct t_cluster_placement_primitive {
     t_cluster_placement_primitive() {

--- a/vpr/src/pack/pack_patterns.h
+++ b/vpr/src/pack/pack_patterns.h
@@ -19,7 +19,7 @@ struct t_pack_pattern_connections;
  * Data members:
  *      pattern_index : the id of the pattern this block is part of (matches "index" in t_pack_patterns)
  *      pb_type       : the pb_type (primitive) that this block represents (Ex. LUT, Adder, FF, etc.)
- *      connections   : linked list of connections between this t_pack_pattern_block and other
+ *      connections   : the connections between this t_pack_pattern_block and other
  *                      t_pack_pattern_blocks in this pack pattern as defined in the architecture
  *      block_id      : the id of this t_pack_pattern_block within its pack pattern, used to access
  *                      is_block_optional array in t_pack_patterns and also to access the atom_block_ids
@@ -28,19 +28,18 @@ struct t_pack_pattern_connections;
 struct t_pack_pattern_block {
     int pattern_index;
     const t_pb_type* pb_type;
-    t_pack_pattern_connections* connections;
+    std::vector<t_pack_pattern_connections> connections;
     int block_id;
 };
 
 /**
- * Describes a linked list of connections of a t_pack_pattern_block
+ * Describes a connection of a t_pack_pattern_block
  *
  * Data members:
  *      from_block : block driving this connection
  *      from_pin   : specific pin in the from_block driving the connection
  *      to_block   : block driven by this connection
  *      to_pin     : specific pin in the to_block driven by this connection
- *      next       : next connection in the linked list
  */
 struct t_pack_pattern_connections {
     t_pack_pattern_block* from_block;
@@ -48,8 +47,6 @@ struct t_pack_pattern_connections {
 
     t_pack_pattern_block* to_block;
     t_pb_graph_pin* to_pin;
-
-    t_pack_pattern_connections* next;
 };
 
 /**

--- a/vpr/src/pack/pb_type_graph.cpp
+++ b/vpr/src/pack/pb_type_graph.cpp
@@ -432,19 +432,19 @@ static void alloc_and_load_pb_graph(t_pb_graph_node* pb_graph_node,
 }
 
 static void alloc_and_load_pb_graph_pin_sinks(t_pb_graph_node* pb_graph_node) {
-    std::list<t_pb_graph_node*> pb_graph_node_list;
+    std::queue<t_pb_graph_node*> pb_graph_node_q;
 
-    pb_graph_node_list.push_back(pb_graph_node);
+    pb_graph_node_q.push(pb_graph_node);
 
-    while (!pb_graph_node_list.empty()) {
-        auto curr_pb_graph_node = pb_graph_node_list.front();
-        pb_graph_node_list.pop_front();
+    while (!pb_graph_node_q.empty()) {
+        auto curr_pb_graph_node = pb_graph_node_q.front();
+        pb_graph_node_q.pop();
         store_pin_sinks_edge_id(curr_pb_graph_node);
 
         for (int mode_num = 0; mode_num < curr_pb_graph_node->pb_type->num_modes; mode_num++) {
             for (int child_pb_type_num = 0; child_pb_type_num < curr_pb_graph_node->pb_type->modes[mode_num].num_pb_type_children; child_pb_type_num++) {
                 for (int child_pb_num = 0; child_pb_num < curr_pb_graph_node->pb_type->modes[mode_num].pb_type_children[child_pb_type_num].num_pb; child_pb_num++) {
-                    pb_graph_node_list.push_back(&curr_pb_graph_node->child_pb_graph_nodes[mode_num][child_pb_type_num][child_pb_num]);
+                    pb_graph_node_q.push(&curr_pb_graph_node->child_pb_graph_nodes[mode_num][child_pb_type_num][child_pb_num]);
                 }
             }
         }
@@ -521,12 +521,12 @@ static void set_pins_logical_num(t_logical_block_type* logical_block) {
 static std::vector<const t_pb_graph_node*> get_primitive_pb_graph_nodes(t_logical_block_type_ptr logical_block) {
     std::vector<const t_pb_graph_node*> pb_graph_nodes;
 
-    std::list<const t_pb_graph_node*> pb_graph_node_q;
-    pb_graph_node_q.push_back(logical_block->pb_graph_head);
+    std::queue<const t_pb_graph_node*> pb_graph_node_q;
+    pb_graph_node_q.push(logical_block->pb_graph_head);
 
     while (!pb_graph_node_q.empty()) {
         auto pb_graph_node = pb_graph_node_q.front();
-        pb_graph_node_q.pop_front();
+        pb_graph_node_q.pop();
         if (pb_graph_node->is_primitive()) {
             pb_graph_nodes.push_back(pb_graph_node);
         }
@@ -541,7 +541,7 @@ static std::vector<const t_pb_graph_node*> get_primitive_pb_graph_nodes(t_logica
                 for (int pb_idx = 0; pb_idx < num_pb; pb_idx++) {
                     const t_pb_graph_node* child_pb_graph_node = &(pb_graph_node->child_pb_graph_nodes[mode_idx][pb_type_idx][pb_idx]);
                     /* Add the child pb_pb_graph_node to the queue, so that this block and its children get added pb_graph_nodes later */
-                    pb_graph_node_q.push_back(child_pb_graph_node);
+                    pb_graph_node_q.push(child_pb_graph_node);
                 }
             }
         }

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -640,7 +640,6 @@ static void backward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expans
     bool found; /* Error checking, ensure only one fan-out for each pattern net */
     t_pack_pattern_block* source_block = nullptr;
     t_pb_graph_node* source_pb_graph_node = nullptr;
-    t_pack_pattern_connections* pack_pattern_connection = nullptr;
     int curr_pattern_index = packing_pattern.index;
 
     found = expansion_edge->infer_pattern;
@@ -729,21 +728,8 @@ static void backward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expans
             if (destination_pin != nullptr) {
                 VTR_ASSERT(last_added_pattern_block[source_pb_graph_node]->pattern_index == curr_pattern_index);
                 source_block = last_added_pattern_block[source_pb_graph_node];
-                pack_pattern_connection = new t_pack_pattern_connections();
-                pack_pattern_connection->from_block = source_block;
-                pack_pattern_connection->from_pin = expansion_edge->input_pins[i];
-                pack_pattern_connection->to_block = destination_block;
-                pack_pattern_connection->to_pin = destination_pin;
-                pack_pattern_connection->next = source_block->connections;
-                source_block->connections = pack_pattern_connection;
-
-                pack_pattern_connection = new t_pack_pattern_connections();
-                pack_pattern_connection->from_block = source_block;
-                pack_pattern_connection->from_pin = expansion_edge->input_pins[i];
-                pack_pattern_connection->to_block = destination_block;
-                pack_pattern_connection->to_pin = destination_pin;
-                pack_pattern_connection->next = destination_block->connections;
-                destination_block->connections = pack_pattern_connection;
+                source_block->connections.push_back({source_block, expansion_edge->input_pins[i], destination_block, destination_pin});
+                destination_block->connections.push_back({source_block, expansion_edge->input_pins[i], destination_block, destination_pin});
 
                 if (source_block == destination_block) {
                     VPR_FATAL_ERROR(VPR_ERROR_PACK,
@@ -947,20 +933,15 @@ void Prepacker::alloc_and_load_pack_molecules(std::multimap<AtomBlockId, PackMol
 }
 
 static void free_pack_pattern_block(t_pack_pattern_block* pattern_block, t_pack_pattern_block** pattern_block_list) {
-    t_pack_pattern_connections *connection, *next;
     if (pattern_block == nullptr || pattern_block->block_id == UNDEFINED) {
         /* already traversed, return */
         return;
     }
     pattern_block_list[pattern_block->block_id] = pattern_block;
     pattern_block->block_id = UNDEFINED;
-    connection = pattern_block->connections;
-    while (connection) {
-        free_pack_pattern_block(connection->from_block, pattern_block_list);
-        free_pack_pattern_block(connection->to_block, pattern_block_list);
-        next = connection->next;
-        delete connection;
-        connection = next;
+    for (const t_pack_pattern_connections& connection : pattern_block->connections) {
+        free_pack_pattern_block(connection.from_block, pattern_block_list);
+        free_pack_pattern_block(connection.to_block, pattern_block_list);
     }
 }
 
@@ -1098,28 +1079,24 @@ static bool try_expand_molecule(t_pack_molecule& molecule,
         // set this node in the molecule as visited
         molecule.atom_block_ids[pattern_block->block_id] = block_id;
 
-        // starting from the first connections, add all the connections of this block to the queue
-        auto block_connection = pattern_block->connections;
-
-        while (block_connection != nullptr) {
+        // add all the connections of this block to the queue
+        for (const t_pack_pattern_connections& block_connection : pattern_block->connections) {
             // this block is the driver of this connection
-            if (block_connection->from_block == pattern_block) {
+            if (block_connection.from_block == pattern_block) {
                 // find the block this connection is driving and add it to the queue
-                auto sink_blk_id = get_sink_block(block_id, *block_connection, atom_nlist);
+                auto sink_blk_id = get_sink_block(block_id, block_connection, atom_nlist);
                 // add this sink block id with its corresponding pattern block to the queue
-                pattern_block_queue.push(std::make_pair(block_connection->to_block, sink_blk_id));
+                pattern_block_queue.push(std::make_pair(block_connection.to_block, sink_blk_id));
                 // this block is being driven by this connection
-            } else if (block_connection->to_block == pattern_block) {
+            } else if (block_connection.to_block == pattern_block) {
                 // find the block that is driving this connection and it to the queue
-                auto driver_blk_id = get_driving_block(block_id, *block_connection, atom_nlist);
+                auto driver_blk_id = get_driving_block(block_id, block_connection, atom_nlist);
                 // add this driver block id with its corresponding pattern block to the queue
-                pattern_block_queue.push(std::make_pair(block_connection->from_block, driver_blk_id));
+                pattern_block_queue.push(std::make_pair(block_connection.from_block, driver_blk_id));
             }
 
             // this block should be either driving or driven by the connection
-            VTR_ASSERT(block_connection->from_block == pattern_block || block_connection->to_block == pattern_block);
-            // go to the next connection of this pattern block
-            block_connection = block_connection->next;
+            VTR_ASSERT(block_connection.from_block == pattern_block || block_connection.to_block == pattern_block);
         }
     }
     // if all non-optional positions in the pack pattern have atoms
@@ -1228,29 +1205,27 @@ static AtomBlockId get_driving_block(const AtomBlockId block_id,
 static std::unordered_set<t_pb_type*> get_pattern_blocks(const t_pack_patterns& pack_pattern) {
     std::unordered_set<t_pb_type*> pattern_blocks;
 
-    t_pack_pattern_connections* connections = pack_pattern.root_block->connections;
-    if (connections == nullptr) {
+    const std::vector<t_pack_pattern_connections>& root_connections = pack_pattern.root_block->connections;
+    if (root_connections.empty()) {
         return pattern_blocks;
     }
     std::unordered_set<t_pb_graph_pin*> visited_from_pins;
     std::unordered_set<t_pb_graph_pin*> visited_to_pins;
     std::queue<t_pack_pattern_block*> pack_pattern_blocks;
-    pack_pattern_blocks.push(connections->from_block);
+    pack_pattern_blocks.push(root_connections.front().from_block);
 
     /** Start from the root block of the pack pattern and add the connected block to the queue */
     while (!pack_pattern_blocks.empty()) {
         t_pack_pattern_block* current_pattern_block = pack_pattern_blocks.front();
         pack_pattern_blocks.pop();
-        t_pack_pattern_connections* current_connenction = current_pattern_block->connections;
         /*
          * Iterate through all the connections of the current pattern block to
          * add the connected block to the queue
          */
-        while (current_connenction != nullptr) {
-            if (visited_from_pins.find(current_connenction->from_pin) != visited_from_pins.end()) {
-                if (visited_to_pins.find(current_connenction->to_pin) != visited_to_pins.end()) {
+        for (const t_pack_pattern_connections& current_connenction : current_pattern_block->connections) {
+            if (visited_from_pins.find(current_connenction.from_pin) != visited_from_pins.end()) {
+                if (visited_to_pins.find(current_connenction.to_pin) != visited_to_pins.end()) {
                     /* We've already seen this connection */
-                    current_connenction = current_connenction->next;
                     continue;
                 }
             }
@@ -1258,13 +1233,12 @@ static std::unordered_set<t_pb_type*> get_pattern_blocks(const t_pack_patterns& 
              * To avoid visiting the same connection twice, since it is both stored in from_pin and to_pin,
              * add the from_pin and to_pin to the visited sets
              */
-            visited_from_pins.insert(current_connenction->from_pin);
-            visited_to_pins.insert(current_connenction->to_pin);
+            visited_from_pins.insert(current_connenction.from_pin);
+            visited_to_pins.insert(current_connenction.to_pin);
 
             /* The from_pin block belongs to the pattern block */
-            pattern_blocks.insert(current_connenction->from_pin->port->parent_pb_type);
-            pack_pattern_blocks.push(current_connenction->to_block);
-            current_connenction = current_connenction->next;
+            pattern_blocks.insert(current_connenction.from_pin->port->parent_pb_type);
+            pack_pattern_blocks.push(current_connenction.to_block);
         }
     }
     return pattern_blocks;

--- a/vpr/src/pack/prepack.cpp
+++ b/vpr/src/pack/prepack.cpp
@@ -728,8 +728,8 @@ static void backward_expand_pack_pattern_from_edge(const t_pb_graph_edge* expans
             if (destination_pin != nullptr) {
                 VTR_ASSERT(last_added_pattern_block[source_pb_graph_node]->pattern_index == curr_pattern_index);
                 source_block = last_added_pattern_block[source_pb_graph_node];
-                source_block->connections.push_back({source_block, expansion_edge->input_pins[i], destination_block, destination_pin});
-                destination_block->connections.push_back({source_block, expansion_edge->input_pins[i], destination_block, destination_pin});
+                source_block->connections.emplace_back(source_block, expansion_edge->input_pins[i], destination_block, destination_pin);
+                destination_block->connections.emplace_back(source_block, expansion_edge->input_pins[i], destination_block, destination_pin);
 
                 if (source_block == destination_block) {
                     VPR_FATAL_ERROR(VPR_ERROR_PACK,


### PR DESCRIPTION
This PR gets rid of the last remaining linked lists in the packer code. Should resolve #2088 to the best of my knowledge but it's possible that I've missed something.