### PR TITLE
Remove per-edge assert from serial connection router hot path

### DIFF
--- a/vpr/src/route/serial_connection_router.cpp
+++ b/vpr/src/route/serial_connection_router.cpp
@@ -241,8 +241,6 @@ void SerialConnectionRouter<Heap>::timing_driven_expand_neighbour(const RTExplor
                                                                   const t_bb& bounding_box,
                                                                   RRNodeId target_node,
                                                                   const t_bb& target_bb) {
-    VTR_ASSERT(bounding_box.layer_max < (int)g_vpr_ctx.device().grid.get_num_layers());
-
     const RRNodeId& from_node = current.index;
 
     // BB-pruning


### PR DESCRIPTION
Parallel routers don't have an equivalent assert. It doesn't need to be checked per-edge, and we also assert net bounding box coordinates upon construction.