### PR TITLE
Cache B2B timing weights

### DIFF
--- a/vpr/src/analytical_place/global_placement/analytical_solver.cpp
+++ b/vpr/src/analytical_place/global_placement/analytical_solver.cpp
@@ -636,6 +636,12 @@ void B2BSolver::solve(unsigned iteration, PartialPlacement& p_placement) {
         }
     }
 
+    // Pre-compute the timing connection weights. They are constant for the whole
+    // B2B loop below, so this avoids recomputing them on every bound update.
+    if (pre_cluster_timing_manager_.is_valid() && iteration != 0) {
+        compute_timing_conn_weights();
+    }
+
     // Run the B2B solver using p_placement as a starting point.
     b2b_solve_loop(iteration, p_placement);
 
@@ -1353,56 +1359,19 @@ void B2BSolver::init_linear_system(PartialPlacement& p_placement, unsigned itera
             for (APPinId sink_pin : netlist_.net_sinks(net_id)) {
                 APBlockId sink_blk = netlist_.pin_block(sink_pin);
 
-                // Get the instantaneous derivative of delay at the given distance
-                // from driver to sink. This will provide a value which is higher
-                // if the tradeoff between delay and wirelength is better, and
-                // lower when the tradeoff between delay and wirelength is worse.
-                auto [d_delay_x, d_delay_y, d_delay_z] = get_delay_derivative(driver_blk,
-                                                                              sink_blk);
-
-                // Since the delay between two blocks may not monotonically increase
-                // (it may go down with distance due to different length wires), it
-                // is possible for the derivative of delay to be negative. The weight
-                // terms in this formulation should not be negative to prevent infinite
-                // answers. To prevent this, clamp the derivative to 0.
-                // TODO: If this is negative, it means that the sink should try to move
-                //       away from the driver. Perhaps add an anchor point to pull the
-                //       sink away.
-                d_delay_x = std::max(d_delay_x, 0.0);
-                d_delay_y = std::max(d_delay_y, 0.0);
-                d_delay_z = std::max(d_delay_z, 0.0);
-
-                // The units for delay are in seconds; however the units for
-                // the wirelength term are in tiles. To ensure the units match,
-                // we need to normalize away the time units. Get normalization
-                // factors to remove the time units.
-                auto [delay_x_norm, delay_y_norm, delay_z_norm] = get_delay_normalization_facs(driver_blk);
-
-                // Get the criticality of this timing edge from driver to sink.
-                double crit = pre_cluster_timing_manager_.get_timing_info().setup_pin_criticality(netlist_.pin_atom_pin(sink_pin));
-
-                // Set the weight of the connection from driver to sink equal to:
-                //      weight_tradeoff_terms * (1 + crit) * d_delay * delay_norm
-                // The intuition is that we want the solver to shrink the distance
-                // from drivers to sinks (which would improve timing) for edges
-                // with the best tradeoff between delay and wire, with a focus
-                // on the more critical edges.
-                // The ap_timing_tradeoff serves to trade-off between the wirelength
-                // and timing net weights. The net weights are the general net weights
-                // based on prior knowledge about the nets.
-                double timing_net_w = ap_timing_tradeoff_ * net_weights_[net_id] * timing_slope_fac_ * (1.0 + crit);
+                const auto& [timing_conn_w_x, timing_conn_w_y, timing_conn_w_z] = timing_conn_weights_[sink_pin];
 
                 add_connection_to_system(driver_blk, sink_blk,
-                                         2 /*num_pins*/, timing_net_w * d_delay_x * delay_x_norm,
+                                         2 /*num_pins*/, timing_conn_w_x,
                                          p_placement.block_x_locs, triplet_list_x, b_x);
 
                 add_connection_to_system(driver_blk, sink_blk,
-                                         2 /*num_pins*/, timing_net_w * d_delay_y * delay_y_norm,
+                                         2 /*num_pins*/, timing_conn_w_y,
                                          p_placement.block_y_locs, triplet_list_y, b_y);
 
                 if (is_multi_die()) {
                     add_connection_to_system(driver_blk, sink_blk,
-                                             2 /*num_pins*/, timing_net_w * d_delay_z * delay_z_norm,
+                                             2 /*num_pins*/, timing_conn_w_z,
                                              p_placement.block_layer_nums, triplet_list_z, b_z);
                 }
             }

--- a/vpr/src/analytical_place/global_placement/analytical_solver.cpp
+++ b/vpr/src/analytical_place/global_placement/analytical_solver.cpp
@@ -1206,6 +1206,66 @@ std::tuple<double, double, double> B2BSolver::get_delay_normalization_facs(APBlo
     return std::make_tuple(1.0 / norm_fac_inv_x, 1.0 / norm_fac_inv_y, 1.0 / norm_fac_inv_z);
 }
 
+void B2BSolver::compute_timing_conn_weights() {
+    timing_conn_weights_.resize(netlist_.pins().size());
+
+    for (APNetId net_id : netlist_.nets()) {
+        if (netlist_.net_is_ignored(net_id))
+            continue;
+
+        APPinId driver_pin = netlist_.net_driver(net_id);
+        APBlockId driver_blk = netlist_.pin_block(driver_pin);
+
+        // The normalization factors depend only on the driver block, so they
+        // are computed once for the whole net rather than once per sink.
+        auto [delay_x_norm, delay_y_norm, delay_z_norm] = get_delay_normalization_facs(driver_blk);
+
+        for (APPinId sink_pin : netlist_.net_sinks(net_id)) {
+            APBlockId sink_blk = netlist_.pin_block(sink_pin);
+
+            // Get the instantaneous derivative of delay at the given distance
+            // from driver to sink. This will provide a value which is higher
+            // if the tradeoff between delay and wirelength is better, and
+            // lower when the tradeoff between delay and wirelength is worse.
+            auto [d_delay_x, d_delay_y, d_delay_z] = get_delay_derivative(driver_blk,
+                                                                          sink_blk);
+
+            // Since the delay between two blocks may not monotonically increase
+            // (it may go down with distance due to different length wires), it
+            // is possible for the derivative of delay to be negative. The weight
+            // terms in this formulation should not be negative to prevent infinite
+            // answers. To prevent this, clamp the derivative to 0.
+            // TODO: If this is negative, it means that the sink should try to move
+            //       away from the driver. Perhaps add an anchor point to pull the
+            //       sink away.
+            d_delay_x = std::max(d_delay_x, 0.0);
+            d_delay_y = std::max(d_delay_y, 0.0);
+            d_delay_z = std::max(d_delay_z, 0.0);
+
+            // Get the criticality of this timing edge from driver to sink.
+            double crit = pre_cluster_timing_manager_.get_timing_info().setup_pin_criticality(netlist_.pin_atom_pin(sink_pin));
+
+            // Set the weight of the connection from driver to sink equal to:
+            //      weight_tradeoff_terms * (1 + crit) * d_delay * delay_norm
+            // The intuition is that we want the solver to shrink the distance
+            // from drivers to sinks (which would improve timing) for edges
+            // with the best tradeoff between delay and wire, with a focus
+            // on the more critical edges.
+            // The ap_timing_tradeoff serves to trade-off between the wirelength
+            // and timing net weights. The net weights are the general net weights
+            // based on prior knowledge about the nets.
+            double timing_net_w = ap_timing_tradeoff_ * net_weights_[net_id] * timing_slope_fac_ * (1.0 + crit);
+
+            // The units for delay are in seconds; however the units for
+            // the wirelength term are in tiles. To ensure the units match,
+            // the normalization factors above remove the time units.
+            timing_conn_weights_[sink_pin] = std::make_tuple(timing_net_w * d_delay_x * delay_x_norm,
+                                                             timing_net_w * d_delay_y * delay_y_norm,
+                                                             timing_net_w * d_delay_z * delay_z_norm);
+        }
+    }
+}
+
 void B2BSolver::init_linear_system(PartialPlacement& p_placement, unsigned iteration) {
     // Reset the linear system
     A_sparse_x = Eigen::SparseMatrix<double>(num_moveable_blocks_, num_moveable_blocks_);

--- a/vpr/src/analytical_place/global_placement/analytical_solver.h
+++ b/vpr/src/analytical_place/global_placement/analytical_solver.h
@@ -713,6 +713,19 @@ class B2BSolver : public AnalyticalSolver {
     std::tuple<double, double, double> get_delay_normalization_facs(APBlockId driver_blk);
 
     /**
+     * @brief Pre-computes the timing connection weight of every sink pin into
+     *        timing_conn_weights_.
+     *
+     * The weights depend only on the legalized placement and the timing
+     * information, both fixed for the duration of a solve() call, so they are
+     * computed once here instead of once per bound update.
+     *
+     * Must be called after the legalized placement has been stored into
+     * block_*_locs_legalized and before the B2B loop is run.
+     */
+    void compute_timing_conn_weights();
+
+    /**
      * @brief Initializes the linear system with the given partial placement.
      *
      * Blocks will be connected to the bounding blocks of their nets using
@@ -803,6 +816,11 @@ class B2BSolver : public AnalyticalSolver {
     vtr::vector<APBlockId, double> block_y_locs_legalized;
     // NOTE: For speed, this vector is unused if a device has only one die.
     vtr::vector<APBlockId, double> block_z_locs_legalized;
+
+    /// @brief The timing connection weight of each sink pin in the netlist, in
+    ///        the x, y, and z dimensions respectively. Recomputed once per
+    ///        solve() call by compute_timing_conn_weights().
+    vtr::vector<APPinId, std::tuple<double, double, double>> timing_conn_weights_;
 
     /// @brief The total number of CG iterations that this solver has performed
     ///        so far. This can be a useful metric for the amount of work the


### PR DESCRIPTION
Compute the B2B timing connection weights once per `solve()` instead of on every update.

Build = `Total time spent building linear system` (B2B Solver Statistics). GP = `## AP Global Placer took`.
| Circuit | Build base | Build opt | Build ratio | GP base | GP opt | GP ratio | Build % of GP |
|---|---:|---:|---:|---:|---:|---:|---:|
| CHERI | 20.442 | 17.649 | 0.863 | 86.72 | 86.28 | 0.995 | 23.6% |
| CH_DFSIN | 9.978 | 8.504 | 0.852 | 42.25 | 41.95 | 0.993 | 23.6% |
| EKF-SLAM_Jacobians | 22.145 | 19.602 | 0.885 | 83.26 | 82.98 | 0.997 | 26.6% |
| JPEG | 9.906 | 8.496 | 0.858 | 42.54 | 42.07 | 0.989 | 23.3% |
| MCML | 7.117 | 5.808 | 0.816 | 44.08 | 43.74 | 0.992 | 16.1% |
| MMM | 8.588 | 7.304 | 0.850 | 37.11 | 36.64 | 0.987 | 23.1% |
| Reed_Solomon | 6.054 | 5.174 | 0.855 | 28.27 | 27.91 | 0.987 | 21.4% |
| SURF_desc | 16.165 | 14.253 | 0.882 | 58.37 | 58.07 | 0.995 | 27.7% |
| carpat | 4.811 | 3.941 | 0.819 | 32.63 | 32.74 | 1.003 | 14.7% |
| fir_cascade | 10.624 | 8.742 | 0.823 | 91.07 | 91.36 | 1.003 | 11.7% |
| jacobi | 10.579 | 9.086 | 0.859 | 40.59 | 39.82 | 0.981 | 26.1% |
| leon2 | 4.463 | 3.726 | 0.835 | 17.53 | 17.08 | 0.974 | 25.5% |
| leon3mp | 9.316 | 8.017 | 0.861 | 37.84 | 37.69 | 0.996 | 24.6% |
| murax | 0.629 | 0.519 | 0.825 | 2.06 | 2.02 | 0.981 | 30.5% |
| picosoc | 3.122 | 2.654 | 0.850 | 12.52 | 12.45 | 0.994 | 24.9% |
| radar20 | 2.191 | 1.805 | 0.824 | 11.89 | 11.81 | 0.993 | 18.4% |
| random | 10.989 | 9.594 | 0.873 | 45.09 | 45.59 | 1.011 | 24.4% |
| smithwaterman | 14.972 | 13.241 | 0.884 | 52.70 | 52.87 | 1.003 | 28.4% |
| stap_steering | 7.896 | 6.624 | 0.839 | 38.17 | 37.90 | 0.993 | 20.7% |
| sudoku_check | 4.708 | 4.105 | 0.872 | 17.67 | 17.72 | 1.003 | 26.6% |
| ucsb_152_tap_fir | 2.232 | 1.773 | 0.794 | 10.20 | 10.14 | 0.994 | 21.9% |
| uoft_raytracer | 5.972 | 5.103 | 0.855 | 33.72 | 33.55 | 0.995 | 17.7% |
| wb_conmax | 4.693 | 4.136 | 0.881 | 17.72 | 17.78 | 1.003 | 26.5% |
| **Total (sum)** | **197.592** | **169.857** | **0.860** | **884.00** | **880.16** | **0.996** | **22.4%** |
| **Geomean of ratios** | | | **0.850** | | | **0.994** | |