### PR TITLE
[AP] Tunings for the TODAES paper

### DIFF
--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -39,12 +39,12 @@ class APPackMaxDistThManager {
 
     // This is the default scale and offset. Logical blocks that we do not
     // recognize as being of the special categories will have this threshold.
-    static constexpr float default_max_dist_th_scale_ = 0.15f;
-    static constexpr float default_max_dist_th_offset_ = 10.0f;
+    static constexpr float default_max_dist_th_scale_ = 0.0f;
+    static constexpr float default_max_dist_th_offset_ = 7.0f;
 
     // Logic blocks (such as CLBs and LABs) tend to have more resources on the
     // device, thus they have tighter thresholds. This was found to work well.
-    static constexpr float logic_block_max_dist_th_scale_ = 0.02f;
+    static constexpr float logic_block_max_dist_th_scale_ = 0.0f;
     static constexpr float logic_block_max_dist_th_offset_ = 5.0f;
 
     // Memory blocks (i.e. blocks that contain pb_types of the memory class)

--- a/vpr/src/pack/pack.cpp
+++ b/vpr/src/pack/pack.cpp
@@ -346,9 +346,9 @@ bool try_pack(const t_packer_opts& packer_opts,
     // enough -- unrelated clustering has a real quality cost, so we only pay
     // it for the block type(s) that actually need it.
     if (appack_ctx.appack_options.use_appack && packer_opts.allow_unrelated_clustering == e_unrelated_clustering::AUTO) {
-        constexpr float kMinUtilizationForThresholdBump = 0.9f;
-        constexpr float kMaxDistThUtilizationScaleMultiplier = 10.0f;
-        constexpr float kSevereUtilizationCutoff = 1.2f;
+        constexpr float kMinUtilizationForThresholdBump = 0.5f;
+        constexpr float kMaxDistThUtilizationScaleMultiplier = 30.0f;
+        constexpr float kSevereUtilizationCutoff = 1.5f;
 
         std::unordered_set<t_logical_block_type_ptr> severe_block_types;
         bool any_type_needs_denser_packing = false;
@@ -387,6 +387,7 @@ bool try_pack(const t_packer_opts& packer_opts,
             float th_multiplier = 1.0f + (utilization_clamped - kMinUtilizationForThresholdBump) / (kSevereUtilizationCutoff - kMinUtilizationForThresholdBump) * (kMaxDistThUtilizationScaleMultiplier - 1.0f);
             float base_max_dist_th = appack_ctx.max_distance_threshold_manager.get_max_dist_threshold(type);
             appack_ctx.max_distance_threshold_manager.set_max_dist_threshold(type, base_max_dist_th * th_multiplier);
+            VTR_LOG("\t%s: %g\n", type.name.c_str(), base_max_dist_th * th_multiplier);
 
             if (utilization >= kSevereUtilizationCutoff)
                 severe_block_types.insert(&type);


### PR DESCRIPTION
Now that the architecture is a lot more dense, AP has significantly less room to improve the solution. AP is still improving wirelength by 2-5%, and CPD is slightly improving; but its not as high as it was before.

This tuning was mainly focused on keeping the run time down and preventing repacks.