### PR TITLE
[SinkOrder] Turned back on 3D router sink order

### DIFF
--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -141,11 +141,7 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
 
     const DeviceGrid& device_grid = device_ctx.grid;
     bool has_interposer_cuts = device_grid.has_interposer_cuts();
-
-    // FIXME: 3D FPGAs were not shown to work well with this sink-order stuff yet.
-    //        Force them off for now.
-    // bool has_multiple_layers = device_grid.get_num_layers() > 1;
-    bool has_multiple_layers = false;
+    bool has_multiple_layers = device_grid.get_num_layers() > 1;
 
     if (has_interposer_cuts || has_multiple_layers) {
         // Sort-priority terms for sinks that cross a die boundary (an interposer cut in


### PR DESCRIPTION
Across 3 seeds, this was shown to reduce chanz usage by 1% with no change in quality.