### PR TITLE
[Multi-Die] Upstreaming Router Sink Order

### DIFF
--- a/libs/libarchfpga/src/device_grid.cpp
+++ b/libs/libarchfpga/src/device_grid.cpp
@@ -162,6 +162,28 @@ bool DeviceGrid::are_locs_on_same_die(t_physical_tile_loc loc_a, t_physical_tile
     return first_id == second_id;
 }
 
+bool DeviceGrid::do_locs_cross_vertical_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const {
+    // Dice are guaranteed to be axis-aligned rectangles, so checking the die at loc_a's row
+    // is sufficient to tell whether a vertical cut separates the two locations' x coordinates;
+    // this is well-defined even when loc_a.y != loc_b.y.
+    int y = loc_a.y;
+    const DeviceDieId first_id = die_id_matrix_[loc_a.layer_num][loc_a.x][y];
+    const DeviceDieId second_id = die_id_matrix_[loc_b.layer_num][loc_b.x][y];
+
+    return first_id != second_id;
+}
+
+bool DeviceGrid::do_locs_cross_horizontal_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const {
+    // Dice are guaranteed to be axis-aligned rectangles, so checking the die at loc_a's column
+    // is sufficient to tell whether a horizontal cut separates the two locations' y coordinates;
+    // this is well-defined even when loc_a.x != loc_b.x.
+    int x = loc_a.x;
+    const DeviceDieId first_id = die_id_matrix_[loc_a.layer_num][x][loc_a.y];
+    const DeviceDieId second_id = die_id_matrix_[loc_b.layer_num][x][loc_b.y];
+
+    return first_id != second_id;
+}
+
 DeviceDieId DeviceGrid::get_loc_die_id(t_physical_tile_loc loc) const {
     return die_id_matrix_[loc.layer_num][loc.x][loc.y];
 }

--- a/libs/libarchfpga/src/device_grid.cpp
+++ b/libs/libarchfpga/src/device_grid.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 #include "physical_types.h"
+#include "vtr_assert.h"
 #include "vtr_expr_eval.h"
 #include "vtr_ndmatrix.h"
 #include "grid_util.h"
@@ -163,6 +164,12 @@ bool DeviceGrid::are_locs_on_same_die(t_physical_tile_loc loc_a, t_physical_tile
 }
 
 bool DeviceGrid::do_locs_cross_vertical_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const {
+    VTR_ASSERT_SAFE_MSG(loc_a.layer_num == loc_b.layer_num,
+                        "This method currently always returns true if loc_a and "
+                        "loc_b are on different layers. This method takes shortcuts "
+                        "to quickly find cuts on 2D devices; it needs to be updated "
+                        "to also handle 3D devices.");
+
     // Dice are guaranteed to be axis-aligned rectangles, so checking the die at loc_a's row
     // is sufficient to tell whether a vertical cut separates the two locations' x coordinates;
     // this is well-defined even when loc_a.y != loc_b.y.
@@ -174,6 +181,12 @@ bool DeviceGrid::do_locs_cross_vertical_cut(t_physical_tile_loc loc_a, t_physica
 }
 
 bool DeviceGrid::do_locs_cross_horizontal_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const {
+    VTR_ASSERT_SAFE_MSG(loc_a.layer_num == loc_b.layer_num,
+                        "This method currently always returns true if loc_a and "
+                        "loc_b are on different layers. This method takes shortcuts "
+                        "to quickly find cuts on 2D devices; it needs to be updated "
+                        "to also handle 3D devices.");
+
     // Dice are guaranteed to be axis-aligned rectangles, so checking the die at loc_a's column
     // is sufficient to tell whether a horizontal cut separates the two locations' y coordinates;
     // this is well-defined even when loc_a.x != loc_b.x.

--- a/libs/libarchfpga/src/device_grid.h
+++ b/libs/libarchfpga/src/device_grid.h
@@ -326,6 +326,16 @@ class DeviceGrid {
     bool are_locs_on_same_die(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const;
 
     /**
+     * @brief Returns true if the straight line between loc_a and loc_b crosses a vertical interposer cut.
+     */
+    bool do_locs_cross_vertical_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const;
+
+    /**
+     * @brief Returns true if the straight line between loc_a and loc_b crosses a horizontal interposer cut.
+     */
+    bool do_locs_cross_horizontal_cut(t_physical_tile_loc loc_a, t_physical_tile_loc loc_b) const;
+
+    /**
      * @brief Get the die identifier of a location. In 2.5D and 3D architectures each die has its own unique identifier.
      * 
      * @param loc (x, y, layer) position that you want the id of.

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -6,6 +6,7 @@
 #include "physical_types.h"
 #include "route_net.h"
 
+#include <algorithm>
 #include <tuple>
 
 #include "connection_based_routing.h"
@@ -201,7 +202,7 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
     }
 
     // compare the sort priority of different sink nodes
-    std::stable_sort(begin(remaining_targets), end(remaining_targets), [&](int a, int b) {
+    std::ranges::stable_sort(remaining_targets, [&](int a, int b) noexcept {
         return pin_sort_priority[a] > pin_sort_priority[b];
     });
 

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -185,17 +185,23 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
                 // same driver/sink pair (i.e. interposer architectures are not also 3D), so the
                 // vertical/horizontal terms below only normalize against their own boundary's
                 // offset (dy or dx), unlike the planar term which already folds in both.
+                // There are specialized routers where the bounding box may not include
+                // the source. We clamp the alignment term to 0 to prevent the terms from
+                // going negative.
                 // TODO: once a 3D interposer architecture exists to validate against, the vertical
                 // and horizontal terms should also fold in a dz/bb_depth component, matching how
                 // the planar term already folds in dx and dy.
                 if (crosses_vertical) {
-                    pin_sort_priority[ipin] += (bb_height > 0) ? die_alignment_multiplier * (1.0f - float(dy) / bb_height) : die_alignment_multiplier;
+                    float align_v = std::max(1.0f - float(dy) / bb_height, 0.0f);
+                    pin_sort_priority[ipin] += (bb_height > 0) ? die_alignment_multiplier * align_v : die_alignment_multiplier;
                 }
                 if (crosses_horizontal) {
-                    pin_sort_priority[ipin] += (bb_width > 0) ? die_alignment_multiplier * (1.0f - float(dx) / bb_width) : die_alignment_multiplier;
+                    float align_h = std::max(1.0f - float(dx) / bb_width, 0.0f);
+                    pin_sort_priority[ipin] += (bb_width > 0) ? die_alignment_multiplier * align_h : die_alignment_multiplier;
                 }
                 if (crosses_planar) {
-                    pin_sort_priority[ipin] += (bb_planar > 0) ? die_alignment_multiplier * (1.0f - float(dx + dy) / bb_planar) : die_alignment_multiplier;
+                    float align_p = std::max(1.0f - float(dx + dy) / bb_planar, 0.0f);
+                    pin_sort_priority[ipin] += (bb_planar > 0) ? die_alignment_multiplier * align_p : die_alignment_multiplier;
                 }
             }
         }

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -2,6 +2,8 @@
 
 /** @file Header implementations for templated net routing fns. */
 
+#include "device_grid.h"
+#include "physical_types.h"
 #include "route_net.h"
 
 #include <tuple>
@@ -130,9 +132,77 @@ inline NetResultFlags route_net(ConnectionRouterType& router,
                                                         is_flat);
     }
 
-    // compare the criticality of different sink nodes
+    // Determines the order remaining_targets is routed in. Starts as a copy of
+    // pin_criticality, but may be further adjusted (e.g. for interposer die crossings
+    // below) to influence routing order without disturbing pin_criticality itself,
+    // which is also used downstream (e.g. cost_params.criticality) to drive the
+    // router's cost function.
+    std::vector<float> pin_sort_priority = pin_criticality;
+
+    const DeviceGrid& device_grid = device_ctx.grid;
+    bool has_interposer_cuts = device_grid.has_interposer_cuts();
+    bool has_multiple_layers = device_grid.get_num_layers() > 1;
+
+    if (has_interposer_cuts || has_multiple_layers) {
+        // Sort-priority terms for sinks that cross a die boundary (an interposer cut in
+        // the x/y plane, or a layer boundary in the z direction for 3D stacked devices).
+        // die_crossing_multiplier rewards any die crossing; die_alignment_multiplier additionally
+        // rewards being inline with the driver across the crossed boundary (scaled down to
+        // 0 as the offset perpendicular to that boundary grows, see dx/dy below).
+        static constexpr float die_crossing_multiplier = 0.0f;
+        static constexpr float die_alignment_multiplier = 0.5f;
+
+        RRNodeId driver_rr = route_ctx.net_rr_terminals[net_id][0];
+        t_physical_tile_loc driver_loc(rr_graph.node_xlow(driver_rr),
+                                       rr_graph.node_ylow(driver_rr),
+                                       rr_graph.node_layer_low(driver_rr));
+
+        // net_bb is used to normalize the die-alignment term below. Note it is slightly
+        // larger than the net's true pin bounding box, since it is expanded by bb_factor
+        // for routing search purposes.
+        int bb_width = net_bb.xmax - net_bb.xmin;
+        int bb_height = net_bb.ymax - net_bb.ymin;
+        int bb_planar = bb_width + bb_height;
+
+        for (int ipin : remaining_targets) {
+            RRNodeId sink_rr = route_ctx.net_rr_terminals[net_id][ipin];
+            t_physical_tile_loc sink_loc(rr_graph.node_xlow(sink_rr),
+                                         rr_graph.node_ylow(sink_rr),
+                                         rr_graph.node_layer_low(sink_rr));
+
+            bool crosses_vertical = has_interposer_cuts && device_grid.do_locs_cross_vertical_cut(driver_loc, sink_loc);
+            bool crosses_horizontal = has_interposer_cuts && device_grid.do_locs_cross_horizontal_cut(driver_loc, sink_loc);
+            bool crosses_planar = has_multiple_layers && (driver_loc.layer_num != sink_loc.layer_num);
+
+            if (crosses_vertical || crosses_horizontal || crosses_planar) {
+                pin_sort_priority[ipin] += die_crossing_multiplier;
+
+                int dx = std::abs(driver_loc.x - sink_loc.x);
+                int dy = std::abs(driver_loc.y - sink_loc.y);
+
+                // NOTE: this assumes interposer cuts and layer boundaries never both apply to the
+                // same driver/sink pair (i.e. interposer architectures are not also 3D), so the
+                // vertical/horizontal terms below only normalize against their own boundary's
+                // offset (dy or dx), unlike the planar term which already folds in both.
+                // TODO: once a 3D interposer architecture exists to validate against, the vertical
+                // and horizontal terms should also fold in a dz/bb_depth component, matching how
+                // the planar term already folds in dx and dy.
+                if (crosses_vertical) {
+                    pin_sort_priority[ipin] += (bb_height > 0) ? die_alignment_multiplier * (1.0f - float(dy) / bb_height) : die_alignment_multiplier;
+                }
+                if (crosses_horizontal) {
+                    pin_sort_priority[ipin] += (bb_width > 0) ? die_alignment_multiplier * (1.0f - float(dx) / bb_width) : die_alignment_multiplier;
+                }
+                if (crosses_planar) {
+                    pin_sort_priority[ipin] += (bb_planar > 0) ? die_alignment_multiplier * (1.0f - float(dx + dy) / bb_planar) : die_alignment_multiplier;
+                }
+            }
+        }
+    }
+
+    // compare the sort priority of different sink nodes
     std::stable_sort(begin(remaining_targets), end(remaining_targets), [&](int a, int b) {
-        return pin_criticality[a] > pin_criticality[b];
+        return pin_sort_priority[a] > pin_sort_priority[b];
     });
 
     /* Update base costs according to fanout and criticality rules */


### PR DESCRIPTION
Brought in router sink order improvments for multi-die FPGAs. In results presented for a paper, we found 1-2% reduced inter-die wire usage, which led to a small runtime improvement.

This brings in changes from a branch used for paper collection. The original branch exposed a few multipliers that we used to turn on and off this feature; I have turned these into static constexprs and set it to values that we found worked well.