### PR TITLE
[Logs] Cleaned up blif reading messages

### DIFF
--- a/doc/src/vpr/command_line_usage.rst
+++ b/doc/src/vpr/command_line_usage.rst
@@ -635,6 +635,9 @@ By default VPR will remove buffer LUTs, and iteratively sweep the netlist to rem
     Controls the verbosity of netlist processing (constant generator detection, swept netlist components).
     High values produce more detailed output.
 
+    At ``1`` (the default) only summary counts are printed.
+    At ``2`` or higher the individual netlist components are also listed by name (e.g. every constant generator found while loading the circuit).
+
     **Default**: ``1``
 
 .. _packing_options:

--- a/vpr/src/base/read_blif.cpp
+++ b/vpr/src/base/read_blif.cpp
@@ -40,11 +40,12 @@ vtr::LogicValue to_vtr_logic_value(blifparse::LogicValue);
 
 struct BlifAllocCallback : public blifparse::Callback {
   public:
-    BlifAllocCallback(e_circuit_format blif_format, AtomNetlist& main_netlist, const std::string netlist_id, const LogicalModels& models)
+    BlifAllocCallback(e_circuit_format blif_format, AtomNetlist& main_netlist, const std::string netlist_id, const LogicalModels& models, int verbosity)
         : main_netlist_(main_netlist)
         , netlist_id_(netlist_id)
         , models_(models)
-        , blif_format_(blif_format) {
+        , blif_format_(blif_format)
+        , verbosity_(verbosity) {
         VTR_ASSERT(blif_format_ == e_circuit_format::BLIF
                    || blif_format_ == e_circuit_format::EBLIF);
     }
@@ -55,6 +56,17 @@ struct BlifAllocCallback : public blifparse::Callback {
     void start_parse() override {}
 
     void finish_parse() override {
+        // Report a summary of the constant generators found while parsing. The
+        // individual generator names are only printed at higher verbosity (see
+        // names()), so provide a hint on how to see them.
+        size_t num_const_gens = num_const_zero_gens_ + num_const_one_gens_;
+        if (num_const_gens > 0) {
+            VTR_LOGV(verbosity_ > 0,
+                     "Found %zu constant generator(s) in the netlist (%zu constant-zero, %zu constant-one)%s\n",
+                     num_const_gens, num_const_zero_gens_, num_const_one_gens_,
+                     verbosity_ > 1 ? "" : " (run with --netlist_verbosity 2 to list names)");
+        }
+
         //When parsing is finished we *move* the main netlist
         //into the user object. This ensures we never have two copies
         //(consuming twice the memory).
@@ -164,7 +176,8 @@ struct BlifAllocCallback : public blifparse::Callback {
             //  0
             //
             output_is_const = true;
-            VTR_LOG("Found constant-zero generator '%s'\n", nets[nets.size() - 1].c_str());
+            ++num_const_zero_gens_;
+            VTR_LOGV(verbosity_ > 1, "Found constant-zero generator '%s'\n", nets[nets.size() - 1].c_str());
         } else if (truth_table.size() == 1 && truth_table[0].size() == 1 && truth_table[0][0] == vtr::LogicValue::TRUE) {
             //A single-entry truth table with value '1' in BLIF corresponds to a constant-one
             //  e.g.
@@ -174,7 +187,8 @@ struct BlifAllocCallback : public blifparse::Callback {
             //  1
             //
             output_is_const = true;
-            VTR_LOG("Found constant-one generator '%s'\n", nets[nets.size() - 1].c_str());
+            ++num_const_one_gens_;
+            VTR_LOGV(verbosity_ > 1, "Found constant-one generator '%s'\n", nets[nets.size() - 1].c_str());
         }
 
         //Create output
@@ -629,6 +643,12 @@ struct BlifAllocCallback : public blifparse::Callback {
     std::vector<std::pair<AtomNetId, AtomNetId>> curr_nets_to_merge_;
 
     e_circuit_format blif_format_ = e_circuit_format::BLIF;
+
+    int verbosity_ = 1; ///<Controls how much detail is printed while parsing the netlist
+
+    ///<Number of constant generators found while parsing (used for a summary message)
+    size_t num_const_zero_gens_ = 0;
+    size_t num_const_one_gens_ = 0;
 };
 
 vtr::LogicValue to_vtr_logic_value(blifparse::LogicValue val) {
@@ -715,11 +735,12 @@ bool is_real_param(const std::string& param) {
 
 AtomNetlist read_blif(e_circuit_format circuit_format,
                       const char* blif_file,
-                      const LogicalModels& models) {
+                      const LogicalModels& models,
+                      int verbosity) {
     AtomNetlist netlist;
     std::string netlist_id = vtr::secure_digest_file(blif_file);
 
-    BlifAllocCallback alloc_callback(circuit_format, netlist, netlist_id, models);
+    BlifAllocCallback alloc_callback(circuit_format, netlist, netlist_id, models, verbosity);
     blifparse::blif_parse_filename(blif_file, alloc_callback);
 
     return netlist;

--- a/vpr/src/base/read_blif.h
+++ b/vpr/src/base/read_blif.h
@@ -12,4 +12,5 @@ bool is_real_param(const std::string& param);
 
 AtomNetlist read_blif(e_circuit_format circuit_format,
                       const char* blif_file,
-                      const LogicalModels& models);
+                      const LogicalModels& models,
+                      int verbosity);

--- a/vpr/src/base/read_circuit.cpp
+++ b/vpr/src/base/read_circuit.cpp
@@ -54,10 +54,10 @@ AtomNetlist read_and_process_circuit(e_circuit_format circuit_format, t_vpr_setu
         switch (circuit_format) {
             case e_circuit_format::BLIF:
             case e_circuit_format::EBLIF:
-                netlist = read_blif(circuit_format, circuit_file, arch.models);
+                netlist = read_blif(circuit_format, circuit_file, arch.models, verbosity);
                 break;
             case e_circuit_format::FPGA_INTERCHANGE:
-                netlist = read_interchange_netlist(circuit_file, arch);
+                netlist = read_interchange_netlist(circuit_file, arch, verbosity);
                 break;
             default:
                 VPR_FATAL_ERROR(VPR_ERROR_ATOM_NETLIST,

--- a/vpr/src/base/read_interchange_netlist.cpp
+++ b/vpr/src/base/read_interchange_netlist.cpp
@@ -42,12 +42,14 @@ struct NetlistReader {
                   const std::string netlist_id,
                   const char* netlist_file,
                   const LogicalModels& models,
-                  const t_arch& arch)
+                  const t_arch& arch,
+                  int verbosity)
         : main_netlist_(main_netlist)
         , nr_(netlist_reader)
         , netlist_file_(netlist_file)
         , models_(models)
-        , arch_(arch) {
+        , arch_(arch)
+        , verbosity_(verbosity) {
         // Define top module
         top_cell_instance_ = nr_.getTopInst();
 
@@ -56,11 +58,11 @@ struct NetlistReader {
 
         prepare_port_net_maps();
 
-        VTR_LOG("Reading IOs...\n");
+        VTR_LOGV(verbosity_ > 1, "Reading IOs...\n");
         read_ios();
-        VTR_LOG("Reading names...\n");
+        VTR_LOGV(verbosity_ > 1, "Reading names...\n");
         read_names();
-        VTR_LOG("Reading blocks...\n");
+        VTR_LOGV(verbosity_ > 1, "Reading blocks...\n");
         read_blocks();
     }
 
@@ -73,6 +75,8 @@ struct NetlistReader {
 
     const LogicalModels& models_;
     const t_arch& arch_;
+
+    int verbosity_ = 1; ///<Controls how much detail is printed while parsing the netlist
 
     LogicalNetlist::Netlist::CellInstance::Reader top_cell_instance_;
 
@@ -196,6 +200,10 @@ struct NetlistReader {
         auto port_list = nr_.getPortList();
         auto str_list = nr_.getStrList();
 
+        // Number of constant generators found while parsing (used for a summary message)
+        size_t num_const_zero_gens = 0;
+        size_t num_const_one_gens = 0;
+
         std::vector<std::tuple<size_t, int, std::string>> insts;
         for (auto cell_inst : top_cell.getInsts()) {
             auto cell = decl_list[inst_list[cell_inst].getCell()];
@@ -298,7 +306,8 @@ struct NetlistReader {
                 //  0
                 //
                 output_is_const = true;
-                VTR_LOG("Found constant-zero generator '%s'\n", inst_name.c_str());
+                ++num_const_zero_gens;
+                VTR_LOGV(verbosity_ > 1, "Found constant-zero generator '%s'\n", inst_name.c_str());
             } else if (truth_table.size() == 1 && is_const) {
                 //A single-entry truth table with value '1' in BLIF corresponds to a constant-one
                 //  e.g.
@@ -308,7 +317,8 @@ struct NetlistReader {
                 //  1
                 //
                 output_is_const = true;
-                VTR_LOG("Found constant-one generator '%s'\n", inst_name.c_str());
+                ++num_const_one_gens;
+                VTR_LOGV(verbosity_ > 1, "Found constant-one generator '%s'\n", inst_name.c_str());
             }
 
             AtomBlockId blk_id = main_netlist_.create_block(inst_name, blk_model_id, truth_table);
@@ -341,6 +351,17 @@ struct NetlistReader {
                         break;
                 }
             }
+        }
+
+        // Report a summary of the constant generators found while parsing. The
+        // individual generator names are only printed at higher verbosity, so
+        // provide a hint on how to see them.
+        size_t num_const_gens = num_const_zero_gens + num_const_one_gens;
+        if (num_const_gens > 0) {
+            VTR_LOGV(verbosity_ > 0,
+                     "Found %zu constant generator(s) in the netlist (%zu constant-zero, %zu constant-one)%s\n",
+                     num_const_gens, num_const_zero_gens, num_const_one_gens,
+                     verbosity_ > 1 ? "" : " (run with --netlist_verbosity 2 to list names)");
         }
     }
 
@@ -513,7 +534,8 @@ struct NetlistReader {
 #endif // VTR_ENABLE_CAPNPROTO
 
 AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
-                                     t_arch& arch) {
+                                     t_arch& arch,
+                                     int verbosity) {
 #ifdef VTR_ENABLE_CAPNPROTO
     AtomNetlist netlist;
     std::string netlist_id = vtr::secure_digest_file(ic_netlist_file);
@@ -554,7 +576,7 @@ AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
 
     auto netlist_reader = message_reader.getRoot<LogicalNetlist::Netlist>();
 
-    NetlistReader reader(netlist, netlist_reader, netlist_id, ic_netlist_file, arch.models, arch);
+    NetlistReader reader(netlist, netlist_reader, netlist_id, ic_netlist_file, arch.models, arch, verbosity);
 
     return netlist;
 
@@ -563,6 +585,7 @@ AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
     // If CAPNPROTO is not enabled, throw an error
     (void)ic_netlist_file;
     (void)arch;
+    (void)verbosity;
     throw vtr::VtrError("Unable to read interchange netlist with CAPNPROTO disabled", __FILE__, __LINE__);
 
 #endif // VTR_ENABLE_CAPNPROTO

--- a/vpr/src/base/read_interchange_netlist.h
+++ b/vpr/src/base/read_interchange_netlist.h
@@ -5,4 +5,5 @@
 struct t_arch;
 
 AtomNetlist read_interchange_netlist(const char* ic_netlist_file,
-                                     t_arch& arch);
+                                     t_arch& arch,
+                                     int verbosity);


### PR DESCRIPTION
While reading through the logs for another project, I noticed that the log file was filled with messages saying something like "Found constant-zero generator". For most users, this information is not needed. I replaced this with a summary message that says how many constants (zero / one) were found and hints that you can see the names by increasing the verbosity.

Here is what it looked like before:
<img width="761" height="402" alt="image" src="https://github.com/user-attachments/assets/ba24e5e4-ff82-4dc3-87f6-ad33f0572842" />

Here is what it looks like by default now:
<img width="1108" height="145" alt="image" src="https://github.com/user-attachments/assets/fd6b3964-e00c-4796-a57e-aaf27f2f1c80" />

When `--netlist_verbosity 2` is set, the original output is printed to the logs.