### PR TITLE
[Docs] Speeding up ReadTheDocs Build Time

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,10 +10,11 @@ sphinx:
   builder: dirhtml
   configuration: doc/src/conf.py
 
-# Only the HTML site is published. Building htmlzip/PDF/epub as well roughly
-# quadrupled the work (each is a separate full Sphinx run) and pushed the build
-# past Read the Docs' time limit. Re-add specific formats here if they are needed.
-formats: []
+# Build the HTML site and the downloadable PDF. Each format is a separate full
+# Sphinx run; also building htmlzip and epub pushed the build past Read the Docs'
+# time limit, so those are left off. Add them back here only if needed.
+formats:
+  - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,10 @@ sphinx:
   builder: dirhtml
   configuration: doc/src/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# Only the HTML site is published. Building htmlzip/PDF/epub as well roughly
+# quadrupled the work (each is a separate full Sphinx run) and pushed the build
+# past Read the Docs' time limit. Re-add specific formats here if they are needed.
+formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 build:

--- a/doc/_doxygen/vpr.dox
+++ b/doc/_doxygen/vpr.dox
@@ -8,6 +8,7 @@ EXTRACT_STATIC         = YES
 WARN_IF_UNDOCUMENTED   = NO
 INPUT                  = ../../vpr ../../libs/libarchfpga/
 RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */test/* */tests/* */gen/*
 GENERATE_HTML          = NO
 GENERATE_LATEX         = NO
 GENERATE_XML           = YES

--- a/doc/src/mosaic/index.rst
+++ b/doc/src/mosaic/index.rst
@@ -14,9 +14,3 @@ Mosaic is a Yosys-based synthesis frontend for VTR, it is an alternative to Pamr
 Select Mosaic with ``-start mosaic`` on :ref:`run_vtr_flow`. Parmys remains the default frontend. Mosaic writes a LUT-mapped BLIF (``<circuit>.mosaic.blif``), so the flow skips the external ABC stage and continues into VPR.
 
 The default VTR build includes Mosaic (``WITH_MOSAIC``, default ``ON``). The plugin is installed at ``build/share/yosys/plugins/mosaic.so``.
-
-.. toctree::
-   :maxdepth: 2
-
-   users
-   developers


### PR DESCRIPTION
The ReadTheDocs build is currently failing due to a 15 minute timeout. Trying to improve the runtime by reducing redundant work.