### PR TITLE
[Place] Prefer scarce sites during initial placement

### DIFF
--- a/vpr/src/place/initial_placement.cpp
+++ b/vpr/src/place/initial_placement.cpp
@@ -1396,9 +1396,11 @@ static vtr::vector<ClusterBlockId, t_block_score> assign_block_scores(const Plac
     //initialize number of placed connections to zero for all blocks
     for (auto blk_id : cluster_ctx.clb_nlist.blocks()) {
         block_scores[blk_id].number_of_placed_connections = 0;
+        const t_logical_block_type_ptr block_type = cluster_ctx.clb_nlist.block_type(blk_id);
+        block_scores[blk_id].num_compatible_locations =
+            grid_tiles.total_type_tiles(block_type);
         if (is_cluster_constrained(blk_id)) {
             const PartitionRegion& pr = floorplan_ctx.cluster_constraints[blk_id];
-            auto block_type = cluster_ctx.clb_nlist.block_type(blk_id);
             double floorplan_score = get_floorplan_score(blk_id, pr, block_type, grid_tiles);
             block_scores[blk_id].tiles_outside_of_floorplan_constraints = floorplan_score;
         }
@@ -1413,6 +1415,21 @@ static vtr::vector<ClusterBlockId, t_block_score> assign_block_scores(const Plac
     }
 
     return block_scores;
+}
+
+bool initial_placement_block_score_less(const t_block_score& lhs,
+                                        const t_block_score& rhs) {
+    int lhs_score = lhs.macro_size + lhs.number_of_placed_connections + SORT_WEIGHT_PER_TILES_OUTSIDE_OF_PR * lhs.tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCK * lhs.failed_to_place_in_prev_attempts;
+    int rhs_score = rhs.macro_size + rhs.number_of_placed_connections + SORT_WEIGHT_PER_TILES_OUTSIDE_OF_PR * rhs.tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCK * rhs.failed_to_place_in_prev_attempts;
+
+    if (lhs_score != rhs_score) {
+        return lhs_score < rhs_score;
+    }
+
+    // Place types with fewer compatible locations first. Otherwise a more
+    // flexible type can consume shared sites and strand a constrained type
+    // even when a legal global assignment exists.
+    return lhs.num_compatible_locations > rhs.num_compatible_locations;
 }
 
 static void place_all_blocks(const t_placer_opts& placer_opts,
@@ -1433,10 +1450,7 @@ static void place_all_blocks(const t_placer_opts& placer_opts,
     std::unordered_set<int> unplaced_blk_type_in_curr_itr;
 
     auto criteria = [&block_scores](ClusterBlockId lhs, ClusterBlockId rhs) {
-        int lhs_score = block_scores[lhs].macro_size + block_scores[lhs].number_of_placed_connections + SORT_WEIGHT_PER_TILES_OUTSIDE_OF_PR * block_scores[lhs].tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCK * block_scores[lhs].failed_to_place_in_prev_attempts;
-        int rhs_score = block_scores[rhs].macro_size + block_scores[rhs].number_of_placed_connections + SORT_WEIGHT_PER_TILES_OUTSIDE_OF_PR * block_scores[rhs].tiles_outside_of_floorplan_constraints + SORT_WEIGHT_PER_FAILED_BLOCK * block_scores[rhs].failed_to_place_in_prev_attempts;
-
-        return lhs_score < rhs_score;
+        return initial_placement_block_score_less(block_scores[lhs], block_scores[rhs]);
     };
 
     // Keeps the first locations and number of remained blocks in each column for a specific block type.

--- a/vpr/src/place/initial_placement.h
+++ b/vpr/src/place/initial_placement.h
@@ -30,6 +30,8 @@ constexpr int MAX_NUM_TRIES_TO_PLACE_MACROS_RANDOMLY = 8;
 struct t_block_score {
     int macro_size = 0; //How many members does the macro have, if the block is part of one - this value is zero if the block is not in a macro
 
+    int num_compatible_locations = 0; ///< Number of compatible placement locations on the device.
+
     //The number of tiles NOT covered by the block's floorplan constraints.
     double tiles_outside_of_floorplan_constraints = 0;
 
@@ -39,6 +41,16 @@ struct t_block_score {
     //The number of placed block during initial placement that are connected to the this block.
     int number_of_placed_connections = 0;
 };
+
+/**
+ * @brief Heap ordering for initial-placement block difficulty.
+ *
+ * A score which compares less is placed later. Existing macro, connectivity,
+ * floorplanning, and retry scores take precedence. Equal-scoring blocks with
+ * fewer compatible locations are placed first.
+ */
+bool initial_placement_block_score_less(const t_block_score& lhs,
+                                        const t_block_score& rhs);
 
 /**
  * @brief keeps track of available empty locations of a specific block type during initial placement.

--- a/vpr/test/test_initial_placement.cpp
+++ b/vpr/test/test_initial_placement.cpp
@@ -1,0 +1,25 @@
+#include "catch2/catch_test_macros.hpp"
+
+#include "initial_placement.h"
+
+TEST_CASE("initial placement prefers scarce compatible locations on score ties", "[vpr_place]") {
+    t_block_score flexible;
+    flexible.num_compatible_locations = 100;
+
+    t_block_score scarce;
+    scarce.num_compatible_locations = 10;
+
+    CHECK(initial_placement_block_score_less(flexible, scarce));
+    CHECK_FALSE(initial_placement_block_score_less(scarce, flexible));
+
+    SECTION("the existing difficulty score retains precedence") {
+        flexible.macro_size = 2;
+        CHECK_FALSE(initial_placement_block_score_less(flexible, scarce));
+        CHECK(initial_placement_block_score_less(scarce, flexible));
+    }
+
+    SECTION("equivalent scores are equivalent in the heap ordering") {
+        CHECK_FALSE(initial_placement_block_score_less(flexible, flexible));
+        CHECK_FALSE(initial_placement_block_score_less(scarce, scarce));
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces a tie-breaking heuristic in the initial placement score (`t_block_score`) to prefer placing blocks with fewer compatible locations first. 

When blocks perfectly tie on existing scores (macro size, connectivity, floorplan constraints, and prior failure attempts), the heuristic now compares the `num_compatible_locations` of the block types. This ensures that a more flexible block type does not greedily consume a shared site, which could otherwise strand a heavily constrained block type.

## Testing
- Added a Catch2 unit test in `vpr/test/test_initial_placement.cpp` to verify that `initial_placement_block_score_less` correctly prioritizes scarce blocks while retaining precedence for primary difficulty scores.