### PR TITLE
[WIP][AP][APPack] Made max distance th aware of compressed grid

### DIFF
--- a/vpr/src/pack/appack_max_dist_th_manager.cpp
+++ b/vpr/src/pack/appack_max_dist_th_manager.cpp
@@ -6,8 +6,11 @@
  */
 
 #include "appack_max_dist_th_manager.h"
+#include <algorithm>
+#include <cmath>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include "ap_argparse_utils.h"
 #include "arch_util.h"
@@ -18,6 +21,7 @@
 #include "vpr_utils.h"
 #include "vtr_assert.h"
 #include "vtr_log.h"
+#include "vtr_prefix_sum.h"
 
 void APPackMaxDistThManager::init(const std::vector<std::string>& max_dist_ths,
                                   const std::vector<t_logical_block_type>& logical_block_types,
@@ -34,6 +38,39 @@ void APPackMaxDistThManager::init(const std::vector<std::string>& max_dist_ths,
     VTR_ASSERT(!max_dist_ths.empty());
     if (max_dist_ths.size() != 1 || max_dist_ths[0] != "auto") {
         set_max_distance_thresholds_from_strings(max_dist_ths, logical_block_types);
+    }
+
+    // We build prefix sums across the device grid for each logical block type.
+    // This is used to quickly lookup distances across the device, taking into
+    // account any "holes". For example, columns of DSPs would have large empty
+    // spaces between them; these prefix sums try to take these into account.
+    // NOTE: We build this at the beginning even though the device size may change
+    //       during packing. That should be fine since the flat placement is relative
+    //       to this device size.
+    logical_block_dist_lookups_.resize(logical_block_types.size());
+    for (const t_logical_block_type& lb_type : logical_block_types) {
+        VTR_ASSERT(lb_type.index < static_cast<int>(logical_block_dist_lookups_.size()));
+        // To speed up the search below, we create a set of equivalent physical tile types
+        // that can contain this logical block type.
+        std::unordered_set<int> equivalent_tile_indices;
+        for (t_physical_tile_type_ptr equiv_tile : lb_type.equivalent_tiles) {
+            equivalent_tile_indices.insert(equiv_tile->index);
+        }
+        // We create prefix sums per layer, since different layers can have different layouts.
+        logical_block_dist_lookups_[lb_type.index].resize(device_grid.get_num_layers());
+        for (size_t layer_num = 0; layer_num < device_grid.get_num_layers(); layer_num++) {
+            logical_block_dist_lookups_[lb_type.index][layer_num] = vtr::PrefixSum2D<unsigned>(
+                device_grid.width(), device_grid.height(), [&](size_t x, size_t y) {
+                    // Check if the tile at the given x, y location can accomodate the given logical block.
+                    t_physical_tile_loc loc(x, y, layer_num);
+                    t_physical_tile_type_ptr tile_type = device_grid.get_physical_type(loc);
+                    bool is_compatible_tile = equivalent_tile_indices.contains(tile_type->index);
+                    // If the tile is compatible, we put a 1 in the prefix sum, 0 otherwise.
+                    // When we lookup into the prefix sum for distance, we use this quantity to
+                    // decide how many compatible tiles are between two points.
+                    return is_compatible_tile ? 1 : 0;
+                });
+        }
     }
 
     // Set the initialized flag to true.
@@ -142,4 +179,109 @@ void APPackMaxDistThManager::set_max_distance_thresholds_from_strings(
         int lb_ty_index = lb_type_name_to_index[lb_name];
         logical_block_dist_thresholds_[lb_ty_index] = logical_block_max_dist_th;
     }
+}
+
+/**
+ * @brief Get the number of tiles compatible with the given prefix sum lookup
+ *        that lie strictly between loc1 and loc2 along the cheaper of the two
+ *        axis-aligned L-shaped paths, within a single layer.
+ *
+ * Neither the loc1 tile nor the loc2 tile is counted.
+ *
+ * There are two ways to walk an L-shaped path between loc1 and loc2: move in X
+ * then Y, or move in Y then X. This tries both and returns the min.
+ *
+ * The loc1 and loc2 coordinates are assumed to lie within the device grid.
+ */
+static unsigned get_num_tiles_between(const vtr::PrefixSum2D<unsigned>& lookup,
+                                      const t_flat_pl_loc& loc1,
+                                      const t_flat_pl_loc& loc2) {
+    size_t x1 = static_cast<size_t>(loc1.x);
+    size_t y1 = static_cast<size_t>(loc1.y);
+    size_t x2 = static_cast<size_t>(loc2.x);
+    size_t y2 = static_cast<size_t>(loc2.y);
+
+    size_t x_lo = std::min(x1, x2);
+    size_t x_hi = std::max(x1, x2);
+    size_t y_lo = std::min(y1, y2);
+    size_t y_hi = std::max(y1, y2);
+
+    // The corner is only a real intermediate tile if the path turns. If the
+    // path is axis-aligned, the "corner" is one of the endpoints and must not
+    // be counted.
+    bool path_turns = (x1 != x2) && (y1 != y2);
+
+    // Path 1: walk along X at row y1, then along Y at column x2. The corner
+    // tile is at (x2, y1). The X-leg and Y-leg interiors exclude the endpoints
+    // and the corner; the corner is added back separately when the path turns.
+    unsigned x_then_y = 0;
+    if (x_hi - x_lo >= 2)
+        x_then_y += lookup.get_sum(x_lo + 1, y1, x_hi - 1, y1);
+    if (y_hi - y_lo >= 2)
+        x_then_y += lookup.get_sum(x2, y_lo + 1, x2, y_hi - 1);
+    if (path_turns)
+        x_then_y += lookup.get_sum(x2, y1, x2, y1);
+
+    // Path 2: walk along Y at column x1, then along X at row y2. The corner
+    // tile is at (x1, y2).
+    unsigned y_then_x = 0;
+    if (y_hi - y_lo >= 2)
+        y_then_x += lookup.get_sum(x1, y_lo + 1, x1, y_hi - 1);
+    if (x_hi - x_lo >= 2)
+        y_then_x += lookup.get_sum(x_lo + 1, y2, x_hi - 1, y2);
+    if (path_turns)
+        y_then_x += lookup.get_sum(x1, y2, x1, y2);
+
+    return std::min(x_then_y, y_then_x);
+}
+
+float APPackMaxDistThManager::get_distance_between_points(const t_flat_pl_loc& loc1,
+                                                          const t_flat_pl_loc& loc2,
+                                                          t_logical_block_type_ptr lb_type) const {
+    // NOTE: It is assumed that loc1 and loc2 are on the device. This is currently
+    //       guaranteed by how flat placements are currently constructed. The code
+    //       that looks up into the prefix sums has asserts within it. It is
+    //       challenging to put an assert here for this case since the device size
+    //       can change during placement.
+
+    // This returns the manhattan distance between loc1 and loc2 in valid tile
+    // locations. Tiles that cannot accomodate the given logical block type count
+    // 0 towards the distance; this makes blocks separated by "holes" (such as
+    // different DSP columns) appear as far apart as they actually are.
+    VTR_ASSERT_SAFE(lb_type != nullptr);
+    VTR_ASSERT_SAFE(lb_type->index < static_cast<int>(logical_block_dist_lookups_.size()));
+    const std::vector<vtr::PrefixSum2D<unsigned>>& lb_dist_lookup = logical_block_dist_lookups_[lb_type->index];
+
+    // If both points are in the same tile, there is no distance between them.
+    if (std::floor(loc1.x) == std::floor(loc2.x)
+        && std::floor(loc1.y) == std::floor(loc2.y)
+        && std::floor(loc1.layer) == std::floor(loc2.layer)) {
+        return 0.0f;
+    }
+
+    size_t layer1 = static_cast<size_t>(loc1.layer);
+    size_t layer2 = static_cast<size_t>(loc2.layer);
+    unsigned z_dist = static_cast<unsigned>(std::abs(loc2.layer - loc1.layer));
+
+    // Count the compatible tiles strictly between the two points, ignoring the
+    // z axis. When the points are on different layers, project the 2D path onto
+    // each endpoint's layer, take the cheaper of the two, and add the z hops
+    // separately. This under-counts some 3D paths that would turn on a third
+    // layer, but that is acceptable for max distance thresholding.
+    unsigned tiles_between = get_num_tiles_between(lb_dist_lookup[layer1], loc1, loc2);
+    if (layer1 != layer2) {
+        tiles_between = std::min(tiles_between,
+                                 get_num_tiles_between(lb_dist_lookup[layer2], loc1, loc2));
+    }
+
+    // Add 1 for the cost of leaving loc1's tile. Without this, two compatible
+    // tiles right next to each other would appear as a distance of 0. loc1 and
+    // loc2 are known to be different tiles here.
+    float manh_dist = static_cast<float>(z_dist + tiles_between + 1);
+
+    // TODO: We are ignoring the intra-tile distances. The code above assumes that the locations are integer-aligned,
+    //       but that is not the case in AP. Frankly it should not make a huge difference, but it should be investigated.
+    //       The result may be off by up to ~1 per axis due to where within its tile each location sits.
+
+    return manh_dist;
 }

--- a/vpr/src/pack/appack_max_dist_th_manager.h
+++ b/vpr/src/pack/appack_max_dist_th_manager.h
@@ -9,8 +9,10 @@
 
 #include <string>
 #include <vector>
+#include "flat_placement_types.h"
 #include "physical_types.h"
 #include "vtr_assert.h"
+#include "vtr_prefix_sum.h"
 
 // Forward declarations.
 class DeviceGrid;
@@ -39,7 +41,7 @@ class APPackMaxDistThManager {
 
     // This is the default scale and offset. Logical blocks that we do not
     // recognize as being of the special categories will have this threshold.
-    static constexpr float default_max_dist_th_scale_ = 0.15f;
+    static constexpr float default_max_dist_th_scale_ = 0.02f;
     static constexpr float default_max_dist_th_offset_ = 10.0f;
 
     // Logic blocks (such as CLBs and LABs) tend to have more resources on the
@@ -120,6 +122,28 @@ class APPackMaxDistThManager {
         logical_block_dist_thresholds_[logical_block_ty.index] = new_threshold;
     }
 
+    /**
+     * @brief Gets the distance between the two given locations in "valid tile hops".
+     *
+     * This is the min, over all axis-aligned manhattan paths between loc1 and loc2,
+     * of the number of tiles compatible with lb_type that lie strictly between the
+     * two locations, plus 1 for the cost of leaving loc1's tile, plus the number of
+     * layer hops between them. If loc1 and loc2 are in the same tile, the distance
+     * is 0.
+     *
+     * This is useful for the max distance thresholding since it ignores tile locations which
+     * are not compatible. For example, for DSP columns, DSPs in different columns appear closer than
+     * they actually are.
+     *
+     * Fractional intra-tile offsets are ignored, so the result may be off by up to
+     * ~1 per axis relative to the true distance.
+     *
+     * loc1 and loc2 are assumed to lie within the device grid.
+     */
+    float get_distance_between_points(const t_flat_pl_loc& loc1,
+                                      const t_flat_pl_loc& loc2,
+                                      t_logical_block_type_ptr lb_type) const;
+
   private:
     /**
      * @brief Helper method that initializes the thresholds of all logical
@@ -147,4 +171,9 @@ class APPackMaxDistThManager {
     ///        is the distance of traveling from the bottom-left corner of the device
     ///        to the top right.
     float max_distance_on_device_;
+
+    /// @brief Prefix sums which are used to compute the distance between points.
+    ///        logical_block_dist_lookups_[lb_type_index][layer] -> Per-layer indicator for lb_type at each grid tile.
+    ///        Lookups into this prefix sum counts the number of compatible tiles in that region.
+    std::vector<std::vector<vtr::PrefixSum2D<unsigned>>> logical_block_dist_lookups_;
 };

--- a/vpr/src/pack/greedy_candidate_selector.cpp
+++ b/vpr/src/pack/greedy_candidate_selector.cpp
@@ -1037,7 +1037,9 @@ static void add_molecule_to_pb_stats_candidates(PackMoleculeId molecule_id,
         const t_flat_pl_loc mol_loc = get_molecule_pos(molecule_id,
                                                        prepacker,
                                                        appack_ctx);
-        float dist = get_manhattan_distance(mol_loc, cluster_gain_stats.flat_cluster_position);
+        float dist = appack_ctx.max_distance_threshold_manager.get_distance_between_points(mol_loc,
+                                                                                           cluster_gain_stats.flat_cluster_position,
+                                                                                           cluster_type);
         if (dist > max_dist)
             return;
     }
@@ -1373,11 +1375,13 @@ PackMoleculeId GreedyCandidateSelector::get_unrelated_candidate_for_cluster_appa
         // Pop a position to search from the queue.
         const t_physical_tile_loc& node_loc = search_queue.front();
 
-        // Get the distance from the cluster to the current tile in tiles.
-        float node_dx = std::abs(node_loc.x - cluster_tile_loc.x);
-        float node_dy = std::abs(node_loc.y - cluster_tile_loc.y);
-        float node_dlayer = std::abs(node_loc.layer_num - cluster_tile_loc.layer_num);
-        float dist = node_dx + node_dy + node_dlayer;
+        // Get the distance from the cluster to the current tile.
+        t_flat_pl_loc node_f_loc({.x = static_cast<float>(node_loc.x),
+                                  .y = static_cast<float>(node_loc.y),
+                                  .layer = static_cast<float>(node_loc.layer_num)});
+        float dist = appack_ctx_.max_distance_threshold_manager.get_distance_between_points(node_f_loc,
+                                                                                            cluster_gain_stats.flat_cluster_position,
+                                                                                            cluster_type);
 
         // If this position is too far from the source, skip it.
         if (dist > max_dist) {


### PR DESCRIPTION
For sparse logical block types (like DSPs), I found that the max distance threshold was cutting far more connections that it should be. For DSP, the fact that they were in columns caused the distances between the columns to appear very far away; however, those two columns are relatively close in "DSP space".

I added a method to the max distance threshold manager class that computes how many "valid tiles" for a given type exist between two points. This is similar to how the compressed grid works in placement.

I considered using the compressed grid for this application; but I found that it does not translate well to APPack since molecules may exist in locations which do not align with a valid type. I chose to roll my own prefix-sum approach which ensures that computing the distance is always O(1).

This is performed for the max distance calculation for all logical block types (including CLBs); however, gain attenuation still uses flat position. This is to still encode positional information from global placement.