### PR TITLE
[Clocks][RouterLookahead] Improved lookahead for clock networks

### DIFF
--- a/libs/librrgraph/src/utils/alloc_and_load_rr_indexed_data.cpp
+++ b/libs/librrgraph/src/utils/alloc_and_load_rr_indexed_data.cpp
@@ -30,10 +30,10 @@ static void load_rr_indexed_data_base_costs(const RRGraphView& rr_graph,
 
 static float get_delay_normalization_fac(const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data, const bool echo_enabled, const char* echo_file_name, bool device_model_warnings);
 
-static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
-                                          vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
-                                          int route_verbosity,
-                                          bool device_model_warnings);
+static vtr::vector<RRIndexedDataId, int> load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
+                                                                      vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
+                                                                      int route_verbosity,
+                                                                      bool device_model_warnings);
 
 /**
  * @brief Computes average R, Tdel, and Cinternal of fan-in switches for a given node.
@@ -56,7 +56,10 @@ static void calculate_average_switch(const RRGraphView& rr_graph,
                                      short& buffered,
                                      const vtr::vector<RRNodeId, std::vector<RREdgeId>>& fan_in_list);
 
-static void fixup_rr_indexed_data_T_values(vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data, size_t num_segment);
+static void fixup_rr_indexed_data_T_values(vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
+                                           const vtr::vector<RRIndexedDataId, int>& num_nodes_of_index,
+                                           const std::vector<t_segment_inf>& segment_inf,
+                                           size_t num_segment);
 
 static std::vector<size_t> count_rr_segment_types(const RRGraphView& rr_graph,
                                                   const vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data);
@@ -161,9 +164,9 @@ void alloc_and_load_rr_indexed_data(const RRGraphView& rr_graph,
         rr_indexed_data[index].seg_index = seg_ptr->seg_index;
     }
 
-    load_rr_indexed_data_T_values(rr_graph, rr_indexed_data, route_verbosity, device_model_warnings);
+    vtr::vector<RRIndexedDataId, int> num_nodes_of_index = load_rr_indexed_data_T_values(rr_graph, rr_indexed_data, route_verbosity, device_model_warnings);
 
-    fixup_rr_indexed_data_T_values(rr_indexed_data, total_num_segment);
+    fixup_rr_indexed_data_T_values(rr_indexed_data, num_nodes_of_index, segment_inf, total_num_segment);
 
     load_rr_indexed_data_base_costs(rr_graph, rr_indexed_data, base_cost_type, echo_enabled, echo_file_name, device_model_warnings);
 
@@ -516,11 +519,14 @@ static float get_delay_normalization_fac(const vtr::vector<RRIndexedDataId, t_rr
  *      - Base cost calculation for each cost_index
  *      - Lookahead map computation
  *      - Placement Delay Matrix computation
+ *
+ * Returns the number of RR nodes found for each cost index. A count of zero means the
+ * cost index's T-values were left at their default of zero.
  */
-static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
-                                          vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
-                                          int route_verbosity,
-                                          bool device_model_warnings) {
+static vtr::vector<RRIndexedDataId, int> load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
+                                                                      vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
+                                                                      int route_verbosity,
+                                                                      bool device_model_warnings) {
     vtr::vector<RRNodeId, std::vector<RREdgeId>> fan_in_list = get_fan_in_list(rr_graph);
 
     vtr::vector<RRIndexedDataId, int> num_nodes_of_index(rr_indexed_data.size(), 0);
@@ -682,6 +688,8 @@ static void load_rr_indexed_data_T_values(const RRGraphView& rr_graph,
     VTR_LOGV_WARN(device_model_warnings && route_verbosity <= 1 && num_nodes_without_outgoing_switches > 0,
                   "Found %zu nodes with no out-going switches. Run VTR with route_verbosity > 1 to see details.\n",
                   num_nodes_without_outgoing_switches);
+
+    return num_nodes_of_index;
 }
 
 static void calculate_average_switch(const RRGraphView& rr_graph,
@@ -750,6 +758,8 @@ static void calculate_average_switch(const RRGraphView& rr_graph,
 }
 
 static void fixup_rr_indexed_data_T_values(vtr::vector<RRIndexedDataId, t_rr_indexed_data>& rr_indexed_data,
+                                           const vtr::vector<RRIndexedDataId, int>& num_nodes_of_index,
+                                           const std::vector<t_segment_inf>& segment_inf,
                                            size_t total_num_segments) {
     // Scan CHANX/CHANY indexed data and search for uninitialized costs.
     //
@@ -769,12 +779,21 @@ static void fixup_rr_indexed_data_T_values(vtr::vector<RRIndexedDataId, t_rr_ind
 
         auto& indexed_data = rr_indexed_data[RRIndexedDataId(cost_index)];
         auto& ortho_indexed_data = rr_indexed_data[RRIndexedDataId(ortho_cost_index)];
-        // Check if this data is uninitialized, but the orthogonal data is
-        // initialized.
-        // Uninitialized data is set to zero by default.
-        bool needs_fixup = indexed_data.T_linear == 0 && indexed_data.T_quadratic == 0 && indexed_data.C_load == 0;
+
+        // Only fix up cost indices whose T-values were never computed because no RR
+        // nodes of that cost index exist (a segment used as CHANX or CHANY but not
+        // both).
+        bool needs_fixup = num_nodes_of_index[RRIndexedDataId(cost_index)] == 0;
         bool ortho_data_valid = ortho_indexed_data.T_linear != 0 || ortho_indexed_data.T_quadratic != 0 || ortho_indexed_data.C_load != 0;
-        if (needs_fixup && ortho_data_valid) {
+
+        // Never copy timing across a segment resource-type boundary (e.g. general
+        // routing <-> clock network). We assume that their delays are not correlated.
+        int seg_index = indexed_data.seg_index;
+        int ortho_seg_index = ortho_indexed_data.seg_index;
+        bool same_res_type = seg_index >= 0 && ortho_seg_index >= 0
+                             && segment_inf[seg_index].res_type == segment_inf[ortho_seg_index].res_type;
+
+        if (needs_fixup && ortho_data_valid && same_res_type) {
             // Copy orthogonal data over.
             indexed_data.T_linear = ortho_indexed_data.T_linear;
             indexed_data.T_quadratic = ortho_indexed_data.T_quadratic;

--- a/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
+++ b/vpr/src/route/router_lookahead/router_lookahead_map_utils.cpp
@@ -15,10 +15,12 @@
 #include "globals.h"
 #include "physical_types.h"
 #include "physical_types_util.h"
+#include "rr_graph_fwd.h"
 #include "vpr_context.h"
 #include "vpr_error.h"
 #include "vpr_utils.h"
 #include "vpr_types.h"
+#include "vtr_assert.h"
 #include "vtr_math.h"
 #include "vtr_time.h"
 #include "route_common.h"
@@ -1419,6 +1421,7 @@ static void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
     const auto& rr_graph = device_ctx.rr_graph;
 
     RRNodeId parent = parent_entry.rr_node;
+    RRSegmentId parent_segment_id = rr_graph.node_segment(parent);
 
     for (t_edge_size edge : rr_graph.edges(parent)) {
         RRNodeId child_node = rr_graph.edge_sink_node(parent, edge);
@@ -1427,6 +1430,22 @@ static void expand_dijkstra_neighbours(util::PQ_Entry parent_entry,
         if (!is_inter_cluster_node(rr_graph, child_node)) {
             continue;
         }
+
+        // If the edge connects between a general segment and clock segment, do not expand.
+        // This dijkstra expansion is used to populate cost maps, which assume that the routes
+        // stay within the general or clock networks.
+        // NOTE: IPINs/OPINs/SOURCEs/SINKs do not have valid segments. This check only cuts
+        //       muxes that connect a GENERAL segment to a GCLK segment or vice versa.
+        RRSegmentId child_segment_id = rr_graph.node_segment(child_node);
+        if (parent_segment_id.is_valid() && child_segment_id.is_valid()) {
+            SegResType parent_res_type = rr_graph.rr_segments(parent_segment_id).res_type;
+            SegResType child_res_type = rr_graph.rr_segments(child_segment_id).res_type;
+            VTR_ASSERT_SAFE(parent_res_type == SegResType::GENERAL || parent_res_type == SegResType::GCLK);
+            VTR_ASSERT_SAFE(child_res_type == SegResType::GENERAL || child_res_type == SegResType::GCLK);
+            if ((parent_res_type == SegResType::GCLK) ^ (child_res_type == SegResType::GCLK))
+                continue;
+        }
+
         int switch_ind = size_t(rr_graph.edge_switch(parent, edge));
 
         if (rr_graph.node_type(child_node) == e_rr_type::SINK) return;

--- a/vpr/src/route/rr_graph_generation/clock_network_builders.cpp
+++ b/vpr/src/route/rr_graph_generation/clock_network_builders.cpp
@@ -31,7 +31,9 @@ void populate_segment_values(int seg_index,
                              e_directionality directionality) {
     segment_inf[seg_index].name = name;
     segment_inf[seg_index].length = length;
-    segment_inf[seg_index].frequency = 1;
+    // We set the frequency to zero to indicate that this segment
+    // is not part of the general routing fabric.
+    segment_inf[seg_index].frequency = 0;
     segment_inf[seg_index].Rmetal = layer.r_metal;
     segment_inf[seg_index].Cmetal = layer.c_metal;
     segment_inf[seg_index].directionality = directionality;

--- a/vtr_flow/arch/clock_networks/clock_sectors/generate_clock_sector_archs.py
+++ b/vtr_flow/arch/clock_networks/clock_sectors/generate_clock_sector_archs.py
@@ -96,6 +96,7 @@ def build_switch_grid(n: int, denom: int) -> Any:
         chan_w="4",
         switch_name="drive_buff",
         switch_block_type="subset",
+        directionality="bidir",
     )
 
     grid.append(comment("Put a drive in the middle of the device"))


### PR DESCRIPTION
These changed improve how the router lookahead is computed when clock networks exist in the FPGA fabric.

When clock networks exist, special segments are created which have the resource type GCLK. It is assumed that these clock network resources are dedicated, fast resources and should only be used by clocks. The problem is that the router lookahead was doing dijkstra floods which were using these segments. This means that the general fabric was assuming that it could use these resources, and the clock fabric was assuming that it could hop off to the general fabric.

To fix this, I added a check during the Dijkstra flood (which is used to find the lookahead costs) which ignores edges that go from/to a GENERAL routing segment to/from a GCLK segment. This bakes the following assumption into the lookahead: Signals that start on general routing will take general routing to the target, and signals that start on clock routing will take clock routing to the target.

I also found an issue with orthogonal segments with clock networks. Clock ribs and spines are only CHANX and CHANY and do not have orthogonal components. This causes an issue when the lookahead is created and these elements have zero delay, since VPR populates zero delay entries with the delays on the orthogonal segments. Fixed this by directly checking if the values are uninitialized and preventing using orthogonal data from different resources.

I also changed the segment frequency of clock segments to zero by default, since this is used in VPR to imply that the segments are not part of the general routing fabric.

I tested this on an architecture with zero delays on the clock network and verified that the lookahead did not have any delay contributions from the clock network.