### PR TITLE
Add commit records to NetCostHandler and PlacerTimingContext

### DIFF
--- a/vpr/src/place/move_transactions.cpp
+++ b/vpr/src/place/move_transactions.cpp
@@ -48,6 +48,16 @@ e_block_move_result t_pl_blocks_to_be_moved::record_block_move(ClusterBlockId bl
     return e_block_move_result::VALID;
 }
 
+void t_pl_blocks_to_be_moved::set_moved_blocks(const std::vector<t_pl_moved_block>& moves) {
+    VTR_ASSERT_SAFE(moved_blocks.empty() && moved_from.empty() && moved_to.empty() && affected_pins.empty());
+
+    moved_blocks = moves;
+    for (const t_pl_moved_block& moved_block : moved_blocks) {
+        moved_from.push_back(moved_block.old_loc);
+        moved_to.push_back(moved_block.new_loc);
+    }
+}
+
 std::set<t_pl_loc> t_pl_blocks_to_be_moved::determine_locations_emptied_by_move() const {
     std::set<t_pl_loc> moved_from_set;
     std::set<t_pl_loc> moved_to_set;

--- a/vpr/src/place/move_transactions.h
+++ b/vpr/src/place/move_transactions.h
@@ -88,6 +88,13 @@ struct t_pl_blocks_to_be_moved {
                                           const BlkLocRegistry& blk_loc_registry);
 
     /**
+     * @brief Loads a previously recorded list of moved blocks into this object,
+     * so the same move can be applied to another placement state.
+     * This object must be empty.
+     */
+    void set_moved_blocks(const std::vector<t_pl_moved_block>& moves);
+
+    /**
      * @brief Examines the currently proposed move and determines any empty locations.
      */
     std::set<t_pl_loc> determine_locations_emptied_by_move() const;

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -958,6 +958,15 @@ void NetCostHandler::update_move_nets() {
     }
 }
 
+void NetCostHandler::copy_committed_state_from(const NetCostHandler& other) {
+    VTR_ASSERT_MSG(!congestion_modeling_started_ && !other.congestion_modeling_started_,
+                   "Copying committed state does not support congestion modeling.");
+    VTR_ASSERT(net_bb_.size() == other.net_bb_.size());
+    VTR_ASSERT_SAFE(std::ranges::all_of(ts_nets_to_update_, [this](ClusterNetId net_id) { return net_ts_slot_[net_id] == NO_TS_SLOT; }));
+
+    net_bb_ = other.net_bb_;
+}
+
 void NetCostHandler::reset_move_nets() {
     // Release the slots of the affected nets. The proposed state is simply discarded.
     for (const ClusterNetId net_id : ts_nets_to_update_) {

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -958,6 +958,29 @@ void NetCostHandler::update_move_nets() {
     }
 }
 
+void NetCostHandler::extract_commit_record(std::vector<t_net_commit_entry>& record) const {
+    VTR_ASSERT_SAFE_MSG(!congestion_modeling_started_,
+                        "Commit records do not support congestion modeling.");
+    const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
+
+    const size_t num_affected_nets = ts_nets_to_update_.size();
+    record.resize(num_affected_nets);
+
+    for (size_t slot = 0; slot < num_affected_nets; slot++) {
+        const ClusterNetId net_id = ts_nets_to_update_[slot];
+        const t_ts_net_info& ts_net = ts_net_info_[slot];
+        t_net_commit_entry& entry = record[slot];
+
+        entry.net_id = net_id;
+        entry.bb_coords = ts_net.coords;
+        entry.update_edges = cluster_ctx.clb_nlist.net_sinks(net_id).size() >= SMALL_NET;
+        if (entry.update_edges) {
+            entry.bb_num_on_edges = ts_net.num_on_edges;
+        }
+        entry.net_cost = ts_net.proposed_cost;
+    }
+}
+
 void NetCostHandler::copy_committed_state_from(const NetCostHandler& other) {
     VTR_ASSERT_MSG(!congestion_modeling_started_ && !other.congestion_modeling_started_,
                    "Copying committed state does not support congestion modeling.");

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -321,6 +321,12 @@ void NetCostHandler::record_affected_net_(const ClusterNetId net) {
     }
 }
 
+bool NetCostHandler::move_in_flight_() const {
+    // update_move_nets() and reset_move_nets() release the slots but leave ts_nets_to_update_ as is,
+    // so a move is in flight iff some recorded net still holds a slot.
+    return std::ranges::any_of(ts_nets_to_update_, [this](ClusterNetId net_id) { return net_ts_slot_[net_id] != NO_TS_SLOT; });
+}
+
 void NetCostHandler::update_net_info_on_pin_move_(const PlaceDelayModel* delay_model,
                                                   const PlacerCriticalities* criticalities,
                                                   const ClusterPinId pin_id,
@@ -902,7 +908,7 @@ void NetCostHandler::find_affected_nets_and_update_costs(const PlaceDelayModel* 
     const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
 
     // update_move_nets() or reset_move_nets() must have released the slots of the previous move.
-    VTR_ASSERT_SAFE(std::ranges::all_of(ts_nets_to_update_, [this](ClusterNetId net_id) { return net_ts_slot_[net_id] == NO_TS_SLOT; }));
+    VTR_ASSERT_SAFE(!move_in_flight_());
     ts_nets_to_update_.clear();
 
     // Go through all the blocks moved.
@@ -969,6 +975,9 @@ void NetCostHandler::extract_commit_record(std::vector<t_net_commit_entry>& reco
 
     for (size_t slot = 0; slot < num_affected_nets; slot++) {
         const ClusterNetId net_id = ts_nets_to_update_[slot];
+        // The move must still be in flight, otherwise the proposed state is stale.
+        VTR_ASSERT_SAFE_MSG(net_ts_slot_[net_id] == slot,
+                            "A commit record can only be extracted while the move is in flight.");
         const t_ts_net_info& ts_net = ts_net_info_[slot];
         t_net_commit_entry& entry = record[slot];
 
@@ -983,9 +992,10 @@ void NetCostHandler::extract_commit_record(std::vector<t_net_commit_entry>& reco
 }
 
 void NetCostHandler::apply_commit_record(const std::vector<t_net_commit_entry>& record) {
-    // The applying handler has no move in flight, so its slots are already released.
     VTR_ASSERT_SAFE_MSG(!congestion_modeling_started_,
                         "Commit records do not support congestion modeling.");
+    VTR_ASSERT_SAFE_MSG(!move_in_flight_(),
+                        "A commit record cannot be applied while a move is in flight.");
 
     for (const t_net_commit_entry& entry : record) {
         t_net_bb_info& net_bb = net_bb_[entry.net_id];
@@ -1002,7 +1012,8 @@ void NetCostHandler::copy_committed_state_from(const NetCostHandler& other) {
     VTR_ASSERT_MSG(!congestion_modeling_started_ && !other.congestion_modeling_started_,
                    "Copying committed state does not support congestion modeling.");
     VTR_ASSERT(net_bb_.size() == other.net_bb_.size());
-    VTR_ASSERT_SAFE(std::ranges::all_of(ts_nets_to_update_, [this](ClusterNetId net_id) { return net_ts_slot_[net_id] == NO_TS_SLOT; }));
+    VTR_ASSERT_SAFE_MSG(!move_in_flight_() && !other.move_in_flight_(),
+                        "Committed state cannot be copied while a move is in flight.");
 
     net_bb_ = other.net_bb_;
 }

--- a/vpr/src/place/net_cost_handler.cpp
+++ b/vpr/src/place/net_cost_handler.cpp
@@ -934,6 +934,7 @@ void NetCostHandler::find_affected_nets_and_update_costs(const PlaceDelayModel* 
 
 void NetCostHandler::update_move_nets() {
     // Copy the proposed state of every affected net into the committed state and release its slot.
+    // extract_commit_record() and apply_commit_record() must be kept consistent with the values committed here.
     const ClusteringContext& cluster_ctx = g_vpr_ctx.clustering();
 
     for (size_t slot = 0; slot < ts_nets_to_update_.size(); slot++) {
@@ -978,6 +979,22 @@ void NetCostHandler::extract_commit_record(std::vector<t_net_commit_entry>& reco
             entry.bb_num_on_edges = ts_net.num_on_edges;
         }
         entry.net_cost = ts_net.proposed_cost;
+    }
+}
+
+void NetCostHandler::apply_commit_record(const std::vector<t_net_commit_entry>& record) {
+    // The applying handler has no move in flight, so its slots are already released.
+    VTR_ASSERT_SAFE_MSG(!congestion_modeling_started_,
+                        "Commit records do not support congestion modeling.");
+
+    for (const t_net_commit_entry& entry : record) {
+        t_net_bb_info& net_bb = net_bb_[entry.net_id];
+
+        net_bb.coords = entry.bb_coords;
+        if (entry.update_edges) {
+            net_bb.num_on_edges = entry.bb_num_on_edges;
+        }
+        net_bb.cost = entry.net_cost;
     }
 }
 

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -206,6 +206,13 @@ class NetCostHandler {
      */
     void copy_committed_state_from(const NetCostHandler& other);
 
+    /**
+     * @brief Records the values update_move_nets() would commit for the move under evaluation.
+     * @note Must be called after find_affected_nets_and_update_costs() and before the move is committed or reverted.
+     * @note Not supported while congestion modeling is enabled.
+     */
+    void extract_commit_record(std::vector<t_net_commit_entry>& record) const;
+
   private:
     /// Indicates whether congestion cost modeling is enabled.
     bool congestion_modeling_started_;

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -198,6 +198,14 @@ class NetCostHandler {
     /// @brief Returns the routing congestion channel utilization threshold this handler was built with.
     double congestion_chan_util_threshold() const { return congestion_chan_util_threshold_; }
 
+    /**
+     * @brief Copies the committed net state from `other`, which must have been
+     * constructed with identical parameters.
+     * @note Neither handler may have a move in flight.
+     * @note Not supported while congestion modeling is enabled.
+     */
+    void copy_committed_state_from(const NetCostHandler& other);
+
   private:
     /// Indicates whether congestion cost modeling is enabled.
     bool congestion_modeling_started_;

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -195,6 +195,9 @@ class NetCostHandler {
      */
     const ChannelMetric<vtr::NdMatrix<double, 3>>& get_chan_util() const;
 
+    /// @brief Returns the routing congestion channel utilization threshold this handler was built with.
+    double congestion_chan_util_threshold() const { return congestion_chan_util_threshold_; }
+
   private:
     /// Indicates whether congestion cost modeling is enabled.
     bool congestion_modeling_started_;

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -213,6 +213,13 @@ class NetCostHandler {
      */
     void extract_commit_record(std::vector<t_net_commit_entry>& record) const;
 
+    /**
+     * @brief Writes an extracted commit record into this handler's committed state.
+     * @note This handler must have no move in flight.
+     * @note Not supported while congestion modeling is enabled.
+     */
+    void apply_commit_record(const std::vector<t_net_commit_entry>& record);
+
   private:
     /// Indicates whether congestion cost modeling is enabled.
     bool congestion_modeling_started_;

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -45,6 +45,27 @@ struct t_net_cost_terms {
     double cong_cost = 0.;
 };
 
+/**
+ * @brief The committed values an evaluated move writes for one affected net,
+ * i.e. what update_move_nets() would copy out of the proposed state.
+ *
+ * A commit record is a vector of these entries, one per affected net. It is
+ * captured with NetCostHandler::extract_commit_record() and replayed on another
+ * handler with apply_commit_record(), so an accepted move can be committed
+ * there without re-evaluating it.
+ */
+struct t_net_commit_entry {
+    ClusterNetId net_id;
+    /// New bounding box.
+    t_bb bb_coords;
+    /// New number of blocks on each edge of the bounding box. Valid only when update_edges is true.
+    t_bb bb_num_on_edges;
+    /// New wirelength (bounding box) cost of the net.
+    double net_cost = 0.;
+    /// True for nets with at least SMALL_NET sinks, whose edge counts are maintained incrementally.
+    bool update_edges = false;
+};
+
 class NetCostHandler {
   public:
     NetCostHandler() = delete;

--- a/vpr/src/place/net_cost_handler.h
+++ b/vpr/src/place/net_cost_handler.h
@@ -494,6 +494,12 @@ class NetCostHandler {
     void record_affected_net_(const ClusterNetId net);
 
     /**
+     * @brief Returns true if a move has been evaluated by find_affected_nets_and_update_costs()
+     * and not yet committed by update_move_nets() or reverted by reset_move_nets().
+     */
+    bool move_in_flight_() const;
+
+    /**
      * @brief To mitigate round-off errors, every once in a while, the costs of nets are summed up from scratch.
      *        This function is called to do that for bb and congestion cost.
      *        It doesn't calculate the BBs or channel usage estimate from scratch,

--- a/vpr/src/place/placer_state.cpp
+++ b/vpr/src/place/placer_state.cpp
@@ -71,6 +71,15 @@ void PlacerTimingContext::extract_connection_commit_record(const std::vector<Clu
     }
 }
 
+void PlacerTimingContext::apply_connection_commit_record(const std::vector<t_connection_commit_entry>& record) {
+    // Mirrors the writing side of commit_td_cost(), minus the proposed_* resets.
+    // The applying state has no move in flight.
+    for (const t_connection_commit_entry& entry : record) {
+        connection_delay[entry.net_id][entry.ipin] = entry.connection_delay;
+        connection_timing_cost[entry.net_id][entry.ipin] = entry.connection_timing_cost;
+    }
+}
+
 void PlacerTimingContext::revert_td_cost(const t_pl_blocks_to_be_moved& blocks_affected) {
 #ifndef VTR_ASSERT_SAFE_ENABLED
     (void)blocks_affected;

--- a/vpr/src/place/placer_state.cpp
+++ b/vpr/src/place/placer_state.cpp
@@ -1,6 +1,7 @@
 
 #include "placer_state.h"
 
+#include "clustered_netlist.h"
 #include "globals.h"
 #include "move_transactions.h"
 
@@ -50,6 +51,23 @@ void PlacerTimingContext::commit_td_cost(const t_pl_blocks_to_be_moved& blocks_a
         proposed_connection_delay[net_id][ipin] = INVALID_DELAY;
         connection_timing_cost[net_id][ipin] = proposed_connection_timing_cost[net_id][ipin];
         proposed_connection_timing_cost[net_id][ipin] = INVALID_DELAY;
+    }
+}
+
+void PlacerTimingContext::extract_connection_commit_record(const std::vector<ClusterPinId>& affected_pins,
+                                                           std::vector<t_connection_commit_entry>& record) const {
+    // Mirrors the reading side of commit_td_cost().
+    const ClusteredNetlist& clb_nlist = g_vpr_ctx.clustering().clb_nlist;
+
+    record.clear();
+    record.reserve(affected_pins.size());
+
+    for (ClusterPinId pin_id : affected_pins) {
+        t_connection_commit_entry& entry = record.emplace_back();
+        entry.net_id = clb_nlist.pin_net(pin_id);
+        entry.ipin = clb_nlist.pin_net_index(pin_id);
+        entry.connection_delay = proposed_connection_delay[entry.net_id][entry.ipin];
+        entry.connection_timing_cost = proposed_connection_timing_cost[entry.net_id][entry.ipin];
     }
 }
 

--- a/vpr/src/place/placer_state.h
+++ b/vpr/src/place/placer_state.h
@@ -62,6 +62,13 @@ struct PlacerTimingContext : public Context {
     void revert_td_cost(const t_pl_blocks_to_be_moved& blocks_affected);
 
     /**
+     * @brief Records the values commit_td_cost() would commit for the given affected pins.
+     * @note Must be called before the move is committed or reverted on this state.
+     */
+    void extract_connection_commit_record(const std::vector<ClusterPinId>& affected_pins,
+                                          std::vector<t_connection_commit_entry>& record) const;
+
+    /**
      * @brief Net connection delays based on the committed block positions.
      *
      * Index ranges: [0..cluster_ctx.clb_nlist.nets().size()-1][1..num_pins-1]

--- a/vpr/src/place/placer_state.h
+++ b/vpr/src/place/placer_state.h
@@ -69,6 +69,12 @@ struct PlacerTimingContext : public Context {
                                           std::vector<t_connection_commit_entry>& record) const;
 
     /**
+     * @brief Writes an extracted commit record into the committed connection delays and timing costs.
+     * @note This state must have no move in flight.
+     */
+    void apply_connection_commit_record(const std::vector<t_connection_commit_entry>& record);
+
+    /**
      * @brief Net connection delays based on the committed block positions.
      *
      * Index ranges: [0..cluster_ctx.clb_nlist.nets().size()-1][1..num_pins-1]

--- a/vpr/src/place/placer_state.h
+++ b/vpr/src/place/placer_state.h
@@ -15,6 +15,20 @@
 #include "PlacerTimingCosts.h"
 
 /**
+ * @brief The committed timing values an evaluated move writes for one affected connection.
+ *
+ * A commit record is a vector of these entries. It is captured with
+ * PlacerTimingContext::extract_connection_commit_record() on the state that
+ * evaluated the move and replayed on another state with apply_connection_commit_record().
+ */
+struct t_connection_commit_entry {
+    ClusterNetId net_id;
+    int ipin;
+    float connection_delay;
+    double connection_timing_cost;
+};
+
+/**
  * @brief State relating to the timing driven data.
  *
  * These structures are used when the placer is using a timing driven


### PR DESCRIPTION
This PR adds the ability to capture what an accepted move would commit, and replay it on another placer state without re-evaluating the move.