### PR TITLE
Relative placement constraints: file format and loader

### DIFF
--- a/doc/src/vpr/relative_placement_constraints.rst
+++ b/doc/src/vpr/relative_placement_constraints.rst
@@ -102,33 +102,3 @@ The ``<vpr_constraints>`` top-level tag may contain one ``<relative_macro_list>`
 			The site paths of a placed design can be obtained by running VPR with
 			:option:`vpr --write_flat_place` and :option:`vpr --flat_place_verbosity` set to ``2``.
 			**Default:** none (the packer picks the site)
-
-Load-time Checks
-----------------
-
-The relative macros are validated when the constraints file is read, with the file and line reported on error. The file is rejected when:
-
-* a macro name is used more than once;
-* a ``<relative_group>`` has a ``layer_offset`` other than ``0``;
-* two groups of a macro have the same offset (this includes a ``<relative_group>`` at ``(0, 0, 0)``, the reference group's location);
-* an atom appears in two groups of a macro, or in two different macros;
-* the ``<reference_group>`` matches no atom while a ``<relative_group>`` does, since the macro would have no anchor;
-* a ``name_pattern`` with ``is_regex="true"`` is not a valid regular expression;
-* a ``site_path`` is empty or contains whitespace, does not name a primitive of any logical block type, or names a primitive that cannot implement the atom;
-* a pattern with a ``site_path`` matches more than one atom, or the same atom is locked to two different sites.
-
-The following are accepted with a warning:
-
-* a ``name_pattern`` that matches no atom is skipped;
-* a ``<relative_group>`` whose patterns all match nothing is dropped, and a macro left with no relative group (or whose groups all match nothing) is dropped;
-* ``logical_block_location`` on a group's ``<add_atom>`` is ignored, as is ``site_path`` on a partition's ``<add_atom>``.
-
-Semantics and Restrictions
---------------------------
-
-* **One group, one cluster.** All atoms of a group must fit into a single cluster; this is enforced. If a group cannot be packed into one cluster (e.g. it is larger than the cluster type allows, or conflicts with architectural pack patterns), packing fails with an error naming the group. Prepacked molecules (e.g. a LUT and the FF it drives, or carry-chain segments) that mix a constrained atom with unconstrained atoms are pulled into the group's cluster as a whole. A molecule whose atoms belong to two *different* groups is reported as an error: a molecule is indivisible (all its atoms always pack into one cluster), so it can never satisfy constraints that require its atoms to be in different clusters.
-* **Groups never share a cluster.** This holds between groups of the same macro and between groups of different macros. Unconstrained atoms may fill the remaining capacity of any group's cluster.
-* **Offsets must match the device grid.** The placer never adjusts an offset: it only uses positions where every member of the macro lands on a tile that can host its cluster. For example, ``x_offset="1"`` between a RAM cluster and a CLB cluster only works if the device has a CLB column immediately to the right of a RAM column. A cluster's location is the root (bottom-left) grid tile of the physical tile it occupies, so for tiles larger than one grid location the offsets must point at root tiles: if the RAM tile spans four grid rows, the RAM member can only sit on a RAM tile's root row, and the macro can only move vertically in steps of four. If no position on the device satisfies all members, placement fails after an exhaustive search.
-* **Members may have different block types** (e.g. a CLB next to a DSP).
-* **Interaction with carry chains:** a carry chain's atoms may only be listed in one group. A chain spanning several clusters becomes part of that group's macro, with its clusters at the offsets fixed by the chain.
-* Relative macro constraints are validated when a packed netlist (``.net``) or placement (``.place``) file is loaded, so stale files that do not satisfy the constraints are rejected.

--- a/doc/src/vpr/relative_placement_constraints.rst
+++ b/doc/src/vpr/relative_placement_constraints.rst
@@ -1,0 +1,134 @@
+
+Relative Placement Constraints
+==============================
+.. _relative_placement_constraints:
+
+.. warning::
+
+	Relative placement constraints are experimental and under active development.
+	The constraints file format and its loader described here are in place, but packing and placement support for relative macros has not been merged yet.
+	VPR validates a ``<relative_macro_list>`` when it reads the constraints file and then stops with an error, so the constraints are never silently ignored.
+
+VPR supports *relative placement macros*: constraints that fix the placement of groups of primitives **relative to each other**, without pinning them to absolute locations on the chip.
+Each macro consists of one *reference group* and one or more *relative groups* of primitives (a.k.a. atoms).
+The constraints affect both packing and placement:
+
+* **Packing:** the atoms of each group are packed together into a single cluster, and atoms of different groups (of any macro) are never packed into the same cluster. Unconstrained atoms may share a cluster with a group.
+* **Placement:** the clusters created from the groups of one macro form a placement macro (like an architectural carry chain): each relative group's cluster is placed at exactly its ``(x_offset, y_offset, sub_tile_offset)`` from the reference group's cluster, and the whole macro moves as a rigid unit during initial placement and simulated annealing. The placer chooses *where* the macro goes; the constraints fix only the internal geometry.
+
+Relative placement constraints are specified inside the same XML constraints file as :ref:`placement (region) constraints <placement_constraints>` and are read with :option:`vpr --read_vpr_constraints`.
+They compose with region constraints: an atom may belong to both a partition and a relative group, in which case the macro is placed such that the region constraints of all its members are satisfied.
+
+A Relative Placement Constraints File Example
+---------------------------------------------
+
+.. code-block:: xml
+	:caption: An example of relative placement macros in a VPR constraints file.
+	:linenos:
+
+	<vpr_constraints tool_name="vpr">
+		<relative_macro_list>
+			<relative_macro name="dsp_with_ctrl_logic">
+				<reference_group>
+					<add_atom name_pattern="mult_36.out_reg"/> <!-- The anchor of the macro -->
+				</reference_group>
+				<relative_group x_offset="1" y_offset="0" sub_tile_offset="0">
+					<add_atom name_pattern="^ctrl_lut_[0-4]$" is_regex="true"/> <!-- These LUTs are packed into one cluster, placed directly right of the anchor -->
+				</relative_group>
+			</relative_macro>
+			<relative_macro name="bit_sliced_datapath">
+				<reference_group>
+					<add_atom name_pattern="slice0_.*" is_regex="true"/>
+				</reference_group>
+				<relative_group x_offset="0" y_offset="1" sub_tile_offset="0">
+					<add_atom name_pattern="slice1_.*" is_regex="true"/>
+				</relative_group>
+				<relative_group x_offset="0" y_offset="2" sub_tile_offset="0">
+					<add_atom name_pattern="slice2_.*" is_regex="true"/>
+				</relative_group>
+			</relative_macro>
+		</relative_macro_list>
+	</vpr_constraints>
+
+Relative Placement Constraints File Format
+------------------------------------------
+
+The ``<vpr_constraints>`` top-level tag may contain one ``<relative_macro_list>`` tag, which contains an unbounded number of ``<relative_macro>`` tags.
+
+.. arch:tag:: <relative_macro name="string">
+
+	A relative macro is made up of exactly one ``<reference_group>`` (which must come first) followed by one or more ``<relative_group>`` tags.
+
+	:req_param name:
+		A unique name for the macro, used in log and error messages.
+
+	.. arch:tag:: <reference_group>
+
+		The anchor of the macro. The atoms added to this group are packed into one cluster, and all relative groups' offsets are measured from this cluster's location. Contains one or more ``<add_atom>`` tags.
+
+	.. arch:tag:: <relative_group x_offset="int" y_offset="int" sub_tile_offset="int" layer_offset="int">
+
+		A group of atoms packed into one cluster, placed at the given offset from the reference group's cluster. Contains one or more ``<add_atom>`` tags.
+
+		:req_param x_offset:
+			Grid-tile x offset of this group's cluster from the reference cluster. May be negative.
+
+		:req_param y_offset:
+			Grid-tile y offset of this group's cluster from the reference cluster. May be negative.
+
+		:req_param sub_tile_offset:
+			Sub-tile offset of this group's cluster from the reference cluster. Use ``0`` when the tiles have a single sub-tile. This attribute is currently required; a future extension will allow omitting it to mean "any compatible sub-tile".
+
+		:opt_param layer_offset:
+			Layer (die) offset. Must currently be ``0`` (cross-layer relative macros are not supported and are rejected when the file is loaded).
+			**Default:** ``0``
+
+	.. arch:tag:: <add_atom name_pattern="string" is_regex="bool" site_path="string">
+
+		Adds the atoms matching ``name_pattern`` to the enclosing reference or relative group.
+		``name_pattern`` and ``is_regex`` have the same syntax and matching semantics as in a ``<partition>`` (see :ref:`placement constraints <placement_constraints>`); a pattern that matches no atom is skipped with a warning.
+		The ``logical_block_location`` attribute of a partition's ``<add_atom>`` is not supported here and is ignored with a warning.
+
+		:opt_param site_path:
+			The primitive site inside the group's cluster this atom must be placed on.
+
+			A site is given as the **hierarchical path** of the primitive within its cluster (``t_pb_graph_node::hierarchical_type_name()``), for example::
+
+				clb[0][default]/lab[0][default]/fle[3][n1_lut6]/ble6[0][default]/lut6[0]
+
+			The path must name a primitive of one of the architecture's logical block types, and that primitive must be able to implement the atom; since a site holds one atom, a pattern carrying a ``site_path`` may match at most one atom.
+			An atom matched both by a pattern with a ``site_path`` and by one without keeps the lock; two patterns locking the same atom to different sites are an error.
+
+			The site paths of a placed design can be obtained by running VPR with
+			:option:`vpr --write_flat_place` and :option:`vpr --flat_place_verbosity` set to ``2``.
+			**Default:** none (the packer picks the site)
+
+Load-time Checks
+----------------
+
+The relative macros are validated when the constraints file is read, with the file and line reported on error. The file is rejected when:
+
+* a macro name is used more than once;
+* a ``<relative_group>`` has a ``layer_offset`` other than ``0``;
+* two groups of a macro have the same offset (this includes a ``<relative_group>`` at ``(0, 0, 0)``, the reference group's location);
+* an atom appears in two groups of a macro, or in two different macros;
+* the ``<reference_group>`` matches no atom while a ``<relative_group>`` does, since the macro would have no anchor;
+* a ``name_pattern`` with ``is_regex="true"`` is not a valid regular expression;
+* a ``site_path`` is empty or contains whitespace, does not name a primitive of any logical block type, or names a primitive that cannot implement the atom;
+* a pattern with a ``site_path`` matches more than one atom, or the same atom is locked to two different sites.
+
+The following are accepted with a warning:
+
+* a ``name_pattern`` that matches no atom is skipped;
+* a ``<relative_group>`` whose patterns all match nothing is dropped, and a macro left with no relative group (or whose groups all match nothing) is dropped;
+* ``logical_block_location`` on a group's ``<add_atom>`` is ignored, as is ``site_path`` on a partition's ``<add_atom>``.
+
+Semantics and Restrictions
+--------------------------
+
+* **One group, one cluster.** All atoms of a group must fit into a single cluster; this is enforced. If a group cannot be packed into one cluster (e.g. it is larger than the cluster type allows, or conflicts with architectural pack patterns), packing fails with an error naming the group. Prepacked molecules (e.g. a LUT and the FF it drives, or carry-chain segments) that mix a constrained atom with unconstrained atoms are pulled into the group's cluster as a whole. A molecule whose atoms belong to two *different* groups is reported as an error: a molecule is indivisible (all its atoms always pack into one cluster), so it can never satisfy constraints that require its atoms to be in different clusters.
+* **Groups never share a cluster.** This holds between groups of the same macro and between groups of different macros. Unconstrained atoms may fill the remaining capacity of any group's cluster.
+* **Offsets must match the device grid.** The placer never adjusts an offset: it only uses positions where every member of the macro lands on a tile that can host its cluster. For example, ``x_offset="1"`` between a RAM cluster and a CLB cluster only works if the device has a CLB column immediately to the right of a RAM column. A cluster's location is the root (bottom-left) grid tile of the physical tile it occupies, so for tiles larger than one grid location the offsets must point at root tiles: if the RAM tile spans four grid rows, the RAM member can only sit on a RAM tile's root row, and the macro can only move vertically in steps of four. If no position on the device satisfies all members, placement fails after an exhaustive search.
+* **Members may have different block types** (e.g. a CLB next to a DSP).
+* **Interaction with carry chains:** a carry chain's atoms may only be listed in one group. A chain spanning several clusters becomes part of that group's macro, with its clusters at the offsets fixed by the chain.
+* Relative macro constraints are validated when a packed netlist (``.net``) or placement (``.place``) file is loaded, so stale files that do not satisfy the constraints are rejected.

--- a/doc/src/vpr/vpr_constraints.rst
+++ b/doc/src/vpr/vpr_constraints.rst
@@ -2,7 +2,7 @@ VPR Constraints
 =========================
 .. _vpr_constraints:
 
-Users can specify placement and/or global routing constraints on all or part of a design through a constraints file in XML format, as shown in the format below. These constraints are optional and allow detailed control of the region on the chip in which parts of the design are placed, and of the routing of global nets through dedicated (usually clock) networks. 
+Users can specify placement and/or global routing constraints on all or part of a design through a constraints file in XML format, as shown in the format below. These constraints are optional and allow detailed control of the region on the chip in which parts of the design are placed, of the placement of parts of the design relative to each other, and of the routing of global nets through dedicated (usually clock) networks.
 
 .. code-block:: xml
    :caption: The overall format of a VPR constraints file
@@ -10,8 +10,11 @@ Users can specify placement and/or global routing constraints on all or part of 
 
    <vpr_constraints tool_name="vpr">
        <partition_list>
-         <!-- Placement constraints are specified inside this tag -->
+         <!-- Placement (region) constraints are specified inside this tag -->
        </partition_list>
+       <relative_macro_list>
+         <!-- Relative placement constraints are specified inside this tag -->
+       </relative_macro_list>
        <global_route_constraints>
          <!-- Global routing constraints are specified inside this tag -->
        </global_route_constraints>
@@ -19,12 +22,13 @@ Users can specify placement and/or global routing constraints on all or part of 
 
 .. note:: Use the VPR option :option:`vpr --read_vpr_constraints` to specify the VPR constraints file that is to be loaded.
 
-The top-level tag is the ``<vpr_constraints>`` tag. This tag can contain ``<partition_list>`` and ``<global_route_constraints>`` tags. The ``<partition_list>`` tag contains information related to placement constraints, while ``<global_route_constraints>`` contains information about global routing constraints. The details for each of these constraints are given in the respective sections :ref:`Placement Constraints <placement_constraints>` and :ref:`Global Route Constraints <global_routing_constraints>`.
+The top-level tag is the ``<vpr_constraints>`` tag. This tag can contain ``<partition_list>``, ``<relative_macro_list>``, and ``<global_route_constraints>`` tags. The ``<partition_list>`` tag contains information related to placement (region) constraints, the ``<relative_macro_list>`` tag contains relative placement constraints, while ``<global_route_constraints>`` contains information about global routing constraints. The details for each of these constraints are given in the respective sections :ref:`Placement Constraints <placement_constraints>`, :ref:`Relative Placement Constraints <relative_placement_constraints>`, and :ref:`Global Route Constraints <global_routing_constraints>`.
 
 .. toctree::
    :maxdepth: 2
 
    placement_constraints
+   relative_placement_constraints
    global_routing_constraints
 
 

--- a/vpr/src/base/constraints_load.cpp
+++ b/vpr/src/base/constraints_load.cpp
@@ -1,6 +1,6 @@
 #include "constraints_load.h"
 
-void echo_constraints(char* filename, const UserPlaceConstraints& constraints) {
+void echo_constraints(char* filename, const UserPlaceConstraints& constraints, const UserRelativeMacros& relative_macros) {
     FILE* fp;
     fp = vtr::fopen(filename, "w");
 
@@ -9,6 +9,7 @@ void echo_constraints(char* filename, const UserPlaceConstraints& constraints) {
     fprintf(fp, "--------------------------------------------------------------\n");
     fprintf(fp, "\n");
     print_placement_constraints(fp, constraints);
+    print_relative_macros(fp, relative_macros);
 
     fclose(fp);
 }

--- a/vpr/src/base/constraints_load.h
+++ b/vpr/src/base/constraints_load.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "user_place_constraints.h"
+#include "user_relative_macros.h"
 
-///@brief Used to print vpr's floorplanning constraints to an echo file "vpr_constraints.echo"
-void echo_constraints(char* filename, const UserPlaceConstraints& constraints);
+///@brief Used to print vpr's floorplanning constraints and relative placement macros to an echo file "vpr_constraints.echo"
+void echo_constraints(char* filename, const UserPlaceConstraints& constraints, const UserRelativeMacros& relative_macros);

--- a/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
+++ b/vpr/src/base/gen/vpr_constraints_uxsdcxx.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx.py ..\OpenFPGA\vtr-verilog-to-routing\vpr\src\base\vpr_constraints.xsd
- * Input file: C:\Users\OscarPC\source\repos\OpenFPGA\vtr-verilog-to-routing\vpr\src\base\vpr_constraints.xsd
- * md5sum of input file: f19701e568aa29dcebaba9f650acca07
+ * Cmdline: uxsdcxx.py /home/amohaghegh/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * Input file: /home/amohaghegh/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * md5sum of input file: 4c3498d39cf7f98b5c02519373a7cfc7
  */
 
 #include <functional>
@@ -52,6 +52,15 @@ inline void load_partition(const pugi::xml_node& root, T& out, Context& context,
 template<class T, typename Context>
 inline void load_partition_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
 template<class T, typename Context>
+inline void load_reference_group(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+template<class T, typename Context>
+inline void load_relative_group(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+inline void load_relative_group_required_attributes(const pugi::xml_node& root, int* sub_tile_offset, int* x_offset, int* y_offset, const std::function<void(const char*)>* report_error);
+template<class T, typename Context>
+inline void load_relative_macro(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+template<class T, typename Context>
+inline void load_relative_macro_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
+template<class T, typename Context>
 inline void load_set_global_signal(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug);
 inline void load_set_global_signal_required_attributes(const pugi::xml_node& root, enum_route_model_type* route_model, const std::function<void(const char*)>* report_error);
 template<class T, typename Context>
@@ -64,6 +73,14 @@ template<class T>
 inline void write_partition(T& in, std::ostream& os, const void* data, void* iter);
 template<class T>
 inline void write_partition_list(T& in, std::ostream& os, const void* data, void* iter);
+template<class T>
+inline void write_reference_group(T& in, std::ostream& os, const void* data, void* iter);
+template<class T>
+inline void write_relative_group(T& in, std::ostream& os, const void* data, void* iter);
+template<class T>
+inline void write_relative_macro(T& in, std::ostream& os, const void* data, void* iter);
+template<class T>
+inline void write_relative_macro_list(T& in, std::ostream& os, const void* data, void* iter);
 template<class T>
 inline void write_global_route_constraints(T& in, std::ostream& os, const void* data, void* iter);
 template<class T>
@@ -140,8 +157,9 @@ static_assert(alignof(triehash_uu64) == 1, "Unaligned 64-bit access not found.")
 
 enum class atok_t_add_atom { IS_REGEX,
                              LOGICAL_BLOCK_LOCATION,
-                             NAME_PATTERN };
-constexpr const char* atok_lookup_t_add_atom[] = {"is_regex", "logical_block_location", "name_pattern"};
+                             NAME_PATTERN,
+                             SITE_PATH };
+constexpr const char* atok_lookup_t_add_atom[] = {"is_regex", "logical_block_location", "name_pattern", "site_path"};
 
 enum class atok_t_add_region { LAYER_HIGH,
                                LAYER_LOW,
@@ -165,6 +183,24 @@ constexpr const char* atok_lookup_t_partition[] = {"name"};
 
 enum class gtok_t_partition_list { PARTITION };
 constexpr const char* gtok_lookup_t_partition_list[] = {"partition"};
+enum class gtok_t_reference_group { ADD_ATOM };
+constexpr const char* gtok_lookup_t_reference_group[] = {"add_atom"};
+enum class gtok_t_relative_group { ADD_ATOM };
+constexpr const char* gtok_lookup_t_relative_group[] = {"add_atom"};
+enum class atok_t_relative_group { LAYER_OFFSET,
+                                   SUB_TILE_OFFSET,
+                                   X_OFFSET,
+                                   Y_OFFSET };
+constexpr const char* atok_lookup_t_relative_group[] = {"layer_offset", "sub_tile_offset", "x_offset", "y_offset"};
+
+enum class gtok_t_relative_macro { REFERENCE_GROUP,
+                                   RELATIVE_GROUP };
+constexpr const char* gtok_lookup_t_relative_macro[] = {"reference_group", "relative_group"};
+enum class atok_t_relative_macro { NAME };
+constexpr const char* atok_lookup_t_relative_macro[] = {"name"};
+
+enum class gtok_t_relative_macro_list { RELATIVE_MACRO };
+constexpr const char* gtok_lookup_t_relative_macro_list[] = {"relative_macro"};
 
 enum class atok_t_set_global_signal { NAME,
                                       NETWORK_NAME,
@@ -174,8 +210,9 @@ constexpr const char* atok_lookup_t_set_global_signal[] = {"name", "network_name
 enum class gtok_t_global_route_constraints { SET_GLOBAL_SIGNAL };
 constexpr const char* gtok_lookup_t_global_route_constraints[] = {"set_global_signal"};
 enum class gtok_t_vpr_constraints { PARTITION_LIST,
+                                    RELATIVE_MACRO_LIST,
                                     GLOBAL_ROUTE_CONSTRAINTS };
-constexpr const char* gtok_lookup_t_vpr_constraints[] = {"partition_list", "global_route_constraints"};
+constexpr const char* gtok_lookup_t_vpr_constraints[] = {"partition_list", "relative_macro_list", "global_route_constraints"};
 enum class atok_t_vpr_constraints { TOOL_NAME };
 constexpr const char* atok_lookup_t_vpr_constraints[] = {"tool_name"};
 
@@ -187,6 +224,21 @@ inline atok_t_add_atom lex_attr_t_add_atom(const char* in, const std::function<v
             switch (*((triehash_uu64*)&in[0])) {
                 case onechar('i', 0, 64) | onechar('s', 8, 64) | onechar('_', 16, 64) | onechar('r', 24, 64) | onechar('e', 32, 64) | onechar('g', 40, 64) | onechar('e', 48, 64) | onechar('x', 56, 64):
                     return atok_t_add_atom::IS_REGEX;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 9:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('s', 0, 64) | onechar('i', 8, 64) | onechar('t', 16, 64) | onechar('e', 24, 64) | onechar('_', 32, 64) | onechar('p', 40, 64) | onechar('a', 48, 64) | onechar('t', 56, 64):
+                    switch (in[8]) {
+                        case onechar('h', 0, 8):
+                            return atok_t_add_atom::SITE_PATH;
+                            break;
+                        default:
+                            break;
+                    }
                     break;
                 default:
                     break;
@@ -512,6 +564,232 @@ inline gtok_t_partition_list lex_node_t_partition_list(const char* in, const std
     noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <partition_list>.").c_str());
 }
 
+inline gtok_t_reference_group lex_node_t_reference_group(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 8:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('a', 0, 64) | onechar('d', 8, 64) | onechar('d', 16, 64) | onechar('_', 24, 64) | onechar('a', 32, 64) | onechar('t', 40, 64) | onechar('o', 48, 64) | onechar('m', 56, 64):
+                    return gtok_t_reference_group::ADD_ATOM;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <reference_group>.").c_str());
+}
+
+inline gtok_t_relative_group lex_node_t_relative_group(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 8:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('a', 0, 64) | onechar('d', 8, 64) | onechar('d', 16, 64) | onechar('_', 24, 64) | onechar('a', 32, 64) | onechar('t', 40, 64) | onechar('o', 48, 64) | onechar('m', 56, 64):
+                    return gtok_t_relative_group::ADD_ATOM;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <relative_group>.").c_str());
+}
+inline atok_t_relative_group lex_attr_t_relative_group(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 8:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('x', 0, 64) | onechar('_', 8, 64) | onechar('o', 16, 64) | onechar('f', 24, 64) | onechar('f', 32, 64) | onechar('s', 40, 64) | onechar('e', 48, 64) | onechar('t', 56, 64):
+                    return atok_t_relative_group::X_OFFSET;
+                    break;
+                case onechar('y', 0, 64) | onechar('_', 8, 64) | onechar('o', 16, 64) | onechar('f', 24, 64) | onechar('f', 32, 64) | onechar('s', 40, 64) | onechar('e', 48, 64) | onechar('t', 56, 64):
+                    return atok_t_relative_group::Y_OFFSET;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 12:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('l', 0, 64) | onechar('a', 8, 64) | onechar('y', 16, 64) | onechar('e', 24, 64) | onechar('r', 32, 64) | onechar('_', 40, 64) | onechar('o', 48, 64) | onechar('f', 56, 64):
+                    switch (*((triehash_uu32*)&in[8])) {
+                        case onechar('f', 0, 32) | onechar('s', 8, 32) | onechar('e', 16, 32) | onechar('t', 24, 32):
+                            return atok_t_relative_group::LAYER_OFFSET;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 15:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('s', 0, 64) | onechar('u', 8, 64) | onechar('b', 16, 64) | onechar('_', 24, 64) | onechar('t', 32, 64) | onechar('i', 40, 64) | onechar('l', 48, 64) | onechar('e', 56, 64):
+                    switch (*((triehash_uu32*)&in[8])) {
+                        case onechar('_', 0, 32) | onechar('o', 8, 32) | onechar('f', 16, 32) | onechar('f', 24, 32):
+                            switch (in[12]) {
+                                case onechar('s', 0, 8):
+                                    switch (in[13]) {
+                                        case onechar('e', 0, 8):
+                                            switch (in[14]) {
+                                                case onechar('t', 0, 8):
+                                                    return atok_t_relative_group::SUB_TILE_OFFSET;
+                                                    break;
+                                                default:
+                                                    break;
+                                            }
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <relative_group>.").c_str());
+}
+
+inline gtok_t_relative_macro lex_node_t_relative_macro(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 14:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('r', 0, 64) | onechar('e', 8, 64) | onechar('l', 16, 64) | onechar('a', 24, 64) | onechar('t', 32, 64) | onechar('i', 40, 64) | onechar('v', 48, 64) | onechar('e', 56, 64):
+                    switch (*((triehash_uu32*)&in[8])) {
+                        case onechar('_', 0, 32) | onechar('g', 8, 32) | onechar('r', 16, 32) | onechar('o', 24, 32):
+                            switch (in[12]) {
+                                case onechar('u', 0, 8):
+                                    switch (in[13]) {
+                                        case onechar('p', 0, 8):
+                                            return gtok_t_relative_macro::RELATIVE_GROUP;
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 15:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('r', 0, 64) | onechar('e', 8, 64) | onechar('f', 16, 64) | onechar('e', 24, 64) | onechar('r', 32, 64) | onechar('e', 40, 64) | onechar('n', 48, 64) | onechar('c', 56, 64):
+                    switch (*((triehash_uu32*)&in[8])) {
+                        case onechar('e', 0, 32) | onechar('_', 8, 32) | onechar('g', 16, 32) | onechar('r', 24, 32):
+                            switch (in[12]) {
+                                case onechar('o', 0, 8):
+                                    switch (in[13]) {
+                                        case onechar('u', 0, 8):
+                                            switch (in[14]) {
+                                                case onechar('p', 0, 8):
+                                                    return gtok_t_relative_macro::REFERENCE_GROUP;
+                                                    break;
+                                                default:
+                                                    break;
+                                            }
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <relative_macro>.").c_str());
+}
+inline atok_t_relative_macro lex_attr_t_relative_macro(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 4:
+            switch (*((triehash_uu32*)&in[0])) {
+                case onechar('n', 0, 32) | onechar('a', 8, 32) | onechar('m', 16, 32) | onechar('e', 24, 32):
+                    return atok_t_relative_macro::NAME;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized attribute " + std::string(in) + " of <relative_macro>.").c_str());
+}
+
+inline gtok_t_relative_macro_list lex_node_t_relative_macro_list(const char* in, const std::function<void(const char*)>* report_error) {
+    unsigned int len = strlen(in);
+    switch (len) {
+        case 14:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('r', 0, 64) | onechar('e', 8, 64) | onechar('l', 16, 64) | onechar('a', 24, 64) | onechar('t', 32, 64) | onechar('i', 40, 64) | onechar('v', 48, 64) | onechar('e', 56, 64):
+                    switch (*((triehash_uu32*)&in[8])) {
+                        case onechar('_', 0, 32) | onechar('m', 8, 32) | onechar('a', 16, 32) | onechar('c', 24, 32):
+                            switch (in[12]) {
+                                case onechar('r', 0, 8):
+                                    switch (in[13]) {
+                                        case onechar('o', 0, 8):
+                                            return gtok_t_relative_macro_list::RELATIVE_MACRO;
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    noreturn_report(report_error, ("Found unrecognized child " + std::string(in) + " of <relative_macro_list>.").c_str());
+}
+
 inline atok_t_set_global_signal lex_attr_t_set_global_signal(const char* in, const std::function<void(const char*)>* report_error) {
     unsigned int len = strlen(in);
     switch (len) {
@@ -615,6 +893,39 @@ inline gtok_t_vpr_constraints lex_node_t_vpr_constraints(const char* in, const s
                                     switch (in[13]) {
                                         case onechar('t', 0, 8):
                                             return gtok_t_vpr_constraints::PARTITION_LIST;
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 19:
+            switch (*((triehash_uu64*)&in[0])) {
+                case onechar('r', 0, 64) | onechar('e', 8, 64) | onechar('l', 16, 64) | onechar('a', 24, 64) | onechar('t', 32, 64) | onechar('i', 40, 64) | onechar('v', 48, 64) | onechar('e', 56, 64):
+                    switch (*((triehash_uu64*)&in[8])) {
+                        case onechar('_', 0, 64) | onechar('m', 8, 64) | onechar('a', 16, 64) | onechar('c', 24, 64) | onechar('r', 32, 64) | onechar('o', 40, 64) | onechar('_', 48, 64) | onechar('l', 56, 64):
+                            switch (in[16]) {
+                                case onechar('i', 0, 8):
+                                    switch (in[17]) {
+                                        case onechar('s', 0, 8):
+                                            switch (in[18]) {
+                                                case onechar('t', 0, 8):
+                                                    return gtok_t_vpr_constraints::RELATIVE_MACRO_LIST;
+                                                    break;
+                                                default:
+                                                    break;
+                                            }
                                             break;
                                         default:
                                             break;
@@ -805,6 +1116,35 @@ inline void load_add_region_required_attributes(const pugi::xml_node& root, int*
     if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_add_region, report_error);
 }
 
+inline void load_relative_group_required_attributes(const pugi::xml_node& root, int* sub_tile_offset, int* x_offset, int* y_offset, const std::function<void(const char*)>* report_error) {
+    std::bitset<4> astate = 0;
+    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
+        atok_t_relative_group in = lex_attr_t_relative_group(attr.name(), report_error);
+        if (astate[(int)in] == 0)
+            astate[(int)in] = 1;
+        else
+            noreturn_report(report_error, ("Duplicate attribute " + std::string(attr.name()) + " in <relative_group>.").c_str());
+        switch (in) {
+            case atok_t_relative_group::LAYER_OFFSET:
+                /* Attribute layer_offset set after element init */
+                break;
+            case atok_t_relative_group::SUB_TILE_OFFSET:
+                *sub_tile_offset = load_int(attr.value(), report_error);
+                break;
+            case atok_t_relative_group::X_OFFSET:
+                *x_offset = load_int(attr.value(), report_error);
+                break;
+            case atok_t_relative_group::Y_OFFSET:
+                *y_offset = load_int(attr.value(), report_error);
+                break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+    std::bitset<4> test_astate = astate | std::bitset<4>(0b0001);
+    if (!test_astate.all()) attr_error(test_astate, atok_lookup_t_relative_group, report_error);
+}
+
 inline void load_set_global_signal_required_attributes(const pugi::xml_node& root, enum_route_model_type* route_model, const std::function<void(const char*)>* report_error) {
     std::bitset<3> astate = 0;
     for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
@@ -850,6 +1190,9 @@ inline void load_add_atom(const pugi::xml_node& root, T& out, Context& context, 
                 break;
             case atok_t_add_atom::NAME_PATTERN:
                 out.set_add_atom_name_pattern(attr.value(), context);
+                break;
+            case atok_t_add_atom::SITE_PATH:
+                out.set_add_atom_site_path(attr.value(), context);
                 break;
             default:
                 break; /* Not possible. */
@@ -1088,6 +1431,290 @@ inline void load_partition_list(const pugi::xml_node& root, T& out, Context& con
     if (state != 0) dfa_error("end of input", gstate_t_partition_list[state], gtok_lookup_t_partition_list, 1, report_error);
 }
 
+constexpr int NUM_T_REFERENCE_GROUP_STATES = 2;
+constexpr const int NUM_T_REFERENCE_GROUP_INPUTS = 1;
+constexpr int gstate_t_reference_group[NUM_T_REFERENCE_GROUP_STATES][NUM_T_REFERENCE_GROUP_INPUTS] = {
+    {0},
+    {0},
+};
+template<class T, typename Context>
+inline void load_reference_group(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
+    (void)root;
+    (void)out;
+    (void)context;
+    (void)report_error;
+    // Update current file offset in case an error is encountered.
+    *offset_debug = root.offset_debug();
+
+    if (root.first_attribute())
+        noreturn_report(report_error, "Unexpected attribute in <reference_group>.");
+
+    // Preallocate arrays by counting child nodes (if any)
+    size_t add_atom_count = 0;
+    {
+        int next, state = 1;
+        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+            *offset_debug = node.offset_debug();
+            gtok_t_reference_group in = lex_node_t_reference_group(node.name(), report_error);
+            next = gstate_t_reference_group[state][(int)in];
+            if (next == -1)
+                dfa_error(gtok_lookup_t_reference_group[(int)in], gstate_t_reference_group[state], gtok_lookup_t_reference_group, 1, report_error);
+            state = next;
+            switch (in) {
+                case gtok_t_reference_group::ADD_ATOM:
+                    add_atom_count += 1;
+                    break;
+                default:
+                    break; /* Not possible. */
+            }
+        }
+
+        out.preallocate_reference_group_add_atom(context, add_atom_count);
+    }
+    int next, state = 1;
+    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+        *offset_debug = node.offset_debug();
+        gtok_t_reference_group in = lex_node_t_reference_group(node.name(), report_error);
+        next = gstate_t_reference_group[state][(int)in];
+        if (next == -1)
+            dfa_error(gtok_lookup_t_reference_group[(int)in], gstate_t_reference_group[state], gtok_lookup_t_reference_group, 1, report_error);
+        state = next;
+        switch (in) {
+            case gtok_t_reference_group::ADD_ATOM: {
+                auto child_context = out.add_reference_group_add_atom(context);
+                load_add_atom(node, out, child_context, report_error, offset_debug);
+                out.finish_reference_group_add_atom(child_context);
+            } break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+    if (state != 0) dfa_error("end of input", gstate_t_reference_group[state], gtok_lookup_t_reference_group, 1, report_error);
+}
+
+constexpr int NUM_T_RELATIVE_GROUP_STATES = 2;
+constexpr const int NUM_T_RELATIVE_GROUP_INPUTS = 1;
+constexpr int gstate_t_relative_group[NUM_T_RELATIVE_GROUP_STATES][NUM_T_RELATIVE_GROUP_INPUTS] = {
+    {0},
+    {0},
+};
+template<class T, typename Context>
+inline void load_relative_group(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
+    (void)root;
+    (void)out;
+    (void)context;
+    (void)report_error;
+    // Update current file offset in case an error is encountered.
+    *offset_debug = root.offset_debug();
+
+    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
+        atok_t_relative_group in = lex_attr_t_relative_group(attr.name(), report_error);
+        switch (in) {
+            case atok_t_relative_group::LAYER_OFFSET:
+                out.set_relative_group_layer_offset(load_int(attr.value(), report_error), context);
+                break;
+            case atok_t_relative_group::SUB_TILE_OFFSET:
+                /* Attribute sub_tile_offset is already set */
+                break;
+            case atok_t_relative_group::X_OFFSET:
+                /* Attribute x_offset is already set */
+                break;
+            case atok_t_relative_group::Y_OFFSET:
+                /* Attribute y_offset is already set */
+                break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+
+    // Preallocate arrays by counting child nodes (if any)
+    size_t add_atom_count = 0;
+    {
+        int next, state = 1;
+        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+            *offset_debug = node.offset_debug();
+            gtok_t_relative_group in = lex_node_t_relative_group(node.name(), report_error);
+            next = gstate_t_relative_group[state][(int)in];
+            if (next == -1)
+                dfa_error(gtok_lookup_t_relative_group[(int)in], gstate_t_relative_group[state], gtok_lookup_t_relative_group, 1, report_error);
+            state = next;
+            switch (in) {
+                case gtok_t_relative_group::ADD_ATOM:
+                    add_atom_count += 1;
+                    break;
+                default:
+                    break; /* Not possible. */
+            }
+        }
+
+        out.preallocate_relative_group_add_atom(context, add_atom_count);
+    }
+    int next, state = 1;
+    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+        *offset_debug = node.offset_debug();
+        gtok_t_relative_group in = lex_node_t_relative_group(node.name(), report_error);
+        next = gstate_t_relative_group[state][(int)in];
+        if (next == -1)
+            dfa_error(gtok_lookup_t_relative_group[(int)in], gstate_t_relative_group[state], gtok_lookup_t_relative_group, 1, report_error);
+        state = next;
+        switch (in) {
+            case gtok_t_relative_group::ADD_ATOM: {
+                auto child_context = out.add_relative_group_add_atom(context);
+                load_add_atom(node, out, child_context, report_error, offset_debug);
+                out.finish_relative_group_add_atom(child_context);
+            } break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+    if (state != 0) dfa_error("end of input", gstate_t_relative_group[state], gtok_lookup_t_relative_group, 1, report_error);
+}
+
+constexpr int NUM_T_RELATIVE_MACRO_STATES = 3;
+constexpr const int NUM_T_RELATIVE_MACRO_INPUTS = 2;
+constexpr int gstate_t_relative_macro[NUM_T_RELATIVE_MACRO_STATES][NUM_T_RELATIVE_MACRO_INPUTS] = {
+    {-1, 0},
+    {-1, 0},
+    {1, -1},
+};
+template<class T, typename Context>
+inline void load_relative_macro(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
+    (void)root;
+    (void)out;
+    (void)context;
+    (void)report_error;
+    // Update current file offset in case an error is encountered.
+    *offset_debug = root.offset_debug();
+
+    for (pugi::xml_attribute attr = root.first_attribute(); attr; attr = attr.next_attribute()) {
+        atok_t_relative_macro in = lex_attr_t_relative_macro(attr.name(), report_error);
+        switch (in) {
+            case atok_t_relative_macro::NAME:
+                out.set_relative_macro_name(attr.value(), context);
+                break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+
+    // Preallocate arrays by counting child nodes (if any)
+    size_t relative_group_count = 0;
+    {
+        int next, state = 2;
+        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+            *offset_debug = node.offset_debug();
+            gtok_t_relative_macro in = lex_node_t_relative_macro(node.name(), report_error);
+            next = gstate_t_relative_macro[state][(int)in];
+            if (next == -1)
+                dfa_error(gtok_lookup_t_relative_macro[(int)in], gstate_t_relative_macro[state], gtok_lookup_t_relative_macro, 2, report_error);
+            state = next;
+            switch (in) {
+                case gtok_t_relative_macro::REFERENCE_GROUP:
+                    break;
+                case gtok_t_relative_macro::RELATIVE_GROUP:
+                    relative_group_count += 1;
+                    break;
+                default:
+                    break; /* Not possible. */
+            }
+        }
+
+        out.preallocate_relative_macro_relative_group(context, relative_group_count);
+    }
+    int next, state = 2;
+    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+        *offset_debug = node.offset_debug();
+        gtok_t_relative_macro in = lex_node_t_relative_macro(node.name(), report_error);
+        next = gstate_t_relative_macro[state][(int)in];
+        if (next == -1)
+            dfa_error(gtok_lookup_t_relative_macro[(int)in], gstate_t_relative_macro[state], gtok_lookup_t_relative_macro, 2, report_error);
+        state = next;
+        switch (in) {
+            case gtok_t_relative_macro::REFERENCE_GROUP: {
+                auto child_context = out.init_relative_macro_reference_group(context);
+                load_reference_group(node, out, child_context, report_error, offset_debug);
+                out.finish_relative_macro_reference_group(child_context);
+            } break;
+            case gtok_t_relative_macro::RELATIVE_GROUP: {
+                int relative_group_sub_tile_offset;
+                memset(&relative_group_sub_tile_offset, 0, sizeof(relative_group_sub_tile_offset));
+                int relative_group_x_offset;
+                memset(&relative_group_x_offset, 0, sizeof(relative_group_x_offset));
+                int relative_group_y_offset;
+                memset(&relative_group_y_offset, 0, sizeof(relative_group_y_offset));
+                load_relative_group_required_attributes(node, &relative_group_sub_tile_offset, &relative_group_x_offset, &relative_group_y_offset, report_error);
+                auto child_context = out.add_relative_macro_relative_group(context, relative_group_sub_tile_offset, relative_group_x_offset, relative_group_y_offset);
+                load_relative_group(node, out, child_context, report_error, offset_debug);
+                out.finish_relative_macro_relative_group(child_context);
+            } break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+    if (state != 0) dfa_error("end of input", gstate_t_relative_macro[state], gtok_lookup_t_relative_macro, 2, report_error);
+}
+
+constexpr int NUM_T_RELATIVE_MACRO_LIST_STATES = 2;
+constexpr const int NUM_T_RELATIVE_MACRO_LIST_INPUTS = 1;
+constexpr int gstate_t_relative_macro_list[NUM_T_RELATIVE_MACRO_LIST_STATES][NUM_T_RELATIVE_MACRO_LIST_INPUTS] = {
+    {0},
+    {0},
+};
+template<class T, typename Context>
+inline void load_relative_macro_list(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
+    (void)root;
+    (void)out;
+    (void)context;
+    (void)report_error;
+    // Update current file offset in case an error is encountered.
+    *offset_debug = root.offset_debug();
+
+    if (root.first_attribute())
+        noreturn_report(report_error, "Unexpected attribute in <relative_macro_list>.");
+
+    // Preallocate arrays by counting child nodes (if any)
+    size_t relative_macro_count = 0;
+    {
+        int next, state = 1;
+        for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+            *offset_debug = node.offset_debug();
+            gtok_t_relative_macro_list in = lex_node_t_relative_macro_list(node.name(), report_error);
+            next = gstate_t_relative_macro_list[state][(int)in];
+            if (next == -1)
+                dfa_error(gtok_lookup_t_relative_macro_list[(int)in], gstate_t_relative_macro_list[state], gtok_lookup_t_relative_macro_list, 1, report_error);
+            state = next;
+            switch (in) {
+                case gtok_t_relative_macro_list::RELATIVE_MACRO:
+                    relative_macro_count += 1;
+                    break;
+                default:
+                    break; /* Not possible. */
+            }
+        }
+
+        out.preallocate_relative_macro_list_relative_macro(context, relative_macro_count);
+    }
+    int next, state = 1;
+    for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
+        *offset_debug = node.offset_debug();
+        gtok_t_relative_macro_list in = lex_node_t_relative_macro_list(node.name(), report_error);
+        next = gstate_t_relative_macro_list[state][(int)in];
+        if (next == -1)
+            dfa_error(gtok_lookup_t_relative_macro_list[(int)in], gstate_t_relative_macro_list[state], gtok_lookup_t_relative_macro_list, 1, report_error);
+        state = next;
+        switch (in) {
+            case gtok_t_relative_macro_list::RELATIVE_MACRO: {
+                auto child_context = out.add_relative_macro_list_relative_macro(context);
+                load_relative_macro(node, out, child_context, report_error, offset_debug);
+                out.finish_relative_macro_list_relative_macro(child_context);
+            } break;
+            default:
+                break; /* Not possible. */
+        }
+    }
+    if (state != 0) dfa_error("end of input", gstate_t_relative_macro_list[state], gtok_lookup_t_relative_macro_list, 1, report_error);
+}
+
 template<class T, typename Context>
 inline void load_set_global_signal(const pugi::xml_node& root, T& out, Context& context, const std::function<void(const char*)>* report_error, ptrdiff_t* offset_debug) {
     (void)root;
@@ -1202,7 +1829,7 @@ inline void load_vpr_constraints(const pugi::xml_node& root, T& out, Context& co
         }
     }
 
-    std::bitset<2> gstate = 0;
+    std::bitset<3> gstate = 0;
     for (pugi::xml_node node = root.first_child(); node; node = node.next_sibling()) {
         *offset_debug = node.offset_debug();
         gtok_t_vpr_constraints in = lex_node_t_vpr_constraints(node.name(), report_error);
@@ -1216,6 +1843,11 @@ inline void load_vpr_constraints(const pugi::xml_node& root, T& out, Context& co
                 load_partition_list(node, out, child_context, report_error, offset_debug);
                 out.finish_vpr_constraints_partition_list(child_context);
             } break;
+            case gtok_t_vpr_constraints::RELATIVE_MACRO_LIST: {
+                auto child_context = out.init_vpr_constraints_relative_macro_list(context);
+                load_relative_macro_list(node, out, child_context, report_error, offset_debug);
+                out.finish_vpr_constraints_relative_macro_list(child_context);
+            } break;
             case gtok_t_vpr_constraints::GLOBAL_ROUTE_CONSTRAINTS: {
                 auto child_context = out.init_vpr_constraints_global_route_constraints(context);
                 load_global_route_constraints(node, out, child_context, report_error, offset_debug);
@@ -1225,7 +1857,7 @@ inline void load_vpr_constraints(const pugi::xml_node& root, T& out, Context& co
                 break; /* Not possible. */
         }
     }
-    std::bitset<2> test_gstate = gstate | std::bitset<2>(0b11);
+    std::bitset<3> test_gstate = gstate | std::bitset<3>(0b111);
     if (!test_gstate.all()) all_error(test_gstate, gtok_lookup_t_vpr_constraints, report_error);
 }
 
@@ -1243,6 +1875,8 @@ inline void write_partition(T& in, std::ostream& os, Context& context) {
             if ((bool)in.get_add_atom_logical_block_location(child_context))
                 os << " logical_block_location=\"" << in.get_add_atom_logical_block_location(child_context) << "\"";
             os << " name_pattern=\"" << in.get_add_atom_name_pattern(child_context) << "\"";
+            if ((bool)in.get_add_atom_site_path(child_context))
+                os << " site_path=\"" << in.get_add_atom_site_path(child_context) << "\"";
             os << "/>\n";
         }
     }
@@ -1292,6 +1926,89 @@ inline void write_partition_list(T& in, std::ostream& os, Context& context) {
 }
 
 template<class T, typename Context>
+inline void write_reference_group(T& in, std::ostream& os, Context& context) {
+    (void)in;
+    (void)os;
+    (void)context;
+    {
+        for (size_t i = 0, n = in.num_reference_group_add_atom(context); i < n; i++) {
+            auto child_context = in.get_reference_group_add_atom(i, context);
+            os << "<add_atom";
+            os << " is_regex=\"" << in.get_add_atom_is_regex(child_context) << "\"";
+            if ((bool)in.get_add_atom_logical_block_location(child_context))
+                os << " logical_block_location=\"" << in.get_add_atom_logical_block_location(child_context) << "\"";
+            os << " name_pattern=\"" << in.get_add_atom_name_pattern(child_context) << "\"";
+            if ((bool)in.get_add_atom_site_path(child_context))
+                os << " site_path=\"" << in.get_add_atom_site_path(child_context) << "\"";
+            os << "/>\n";
+        }
+    }
+}
+
+template<class T, typename Context>
+inline void write_relative_group(T& in, std::ostream& os, Context& context) {
+    (void)in;
+    (void)os;
+    (void)context;
+    {
+        for (size_t i = 0, n = in.num_relative_group_add_atom(context); i < n; i++) {
+            auto child_context = in.get_relative_group_add_atom(i, context);
+            os << "<add_atom";
+            os << " is_regex=\"" << in.get_add_atom_is_regex(child_context) << "\"";
+            if ((bool)in.get_add_atom_logical_block_location(child_context))
+                os << " logical_block_location=\"" << in.get_add_atom_logical_block_location(child_context) << "\"";
+            os << " name_pattern=\"" << in.get_add_atom_name_pattern(child_context) << "\"";
+            if ((bool)in.get_add_atom_site_path(child_context))
+                os << " site_path=\"" << in.get_add_atom_site_path(child_context) << "\"";
+            os << "/>\n";
+        }
+    }
+}
+
+template<class T, typename Context>
+inline void write_relative_macro(T& in, std::ostream& os, Context& context) {
+    (void)in;
+    (void)os;
+    (void)context;
+    {
+        auto child_context = in.get_relative_macro_reference_group(context);
+        os << "<reference_group>\n";
+        write_reference_group(in, os, child_context);
+        os << "</reference_group>\n";
+    }
+    {
+        for (size_t i = 0, n = in.num_relative_macro_relative_group(context); i < n; i++) {
+            auto child_context = in.get_relative_macro_relative_group(i, context);
+            os << "<relative_group";
+            os << " layer_offset=\"" << in.get_relative_group_layer_offset(child_context) << "\"";
+            os << " sub_tile_offset=\"" << in.get_relative_group_sub_tile_offset(child_context) << "\"";
+            os << " x_offset=\"" << in.get_relative_group_x_offset(child_context) << "\"";
+            os << " y_offset=\"" << in.get_relative_group_y_offset(child_context) << "\"";
+            os << ">";
+            write_relative_group(in, os, child_context);
+            os << "</relative_group>\n";
+        }
+    }
+}
+
+template<class T, typename Context>
+inline void write_relative_macro_list(T& in, std::ostream& os, Context& context) {
+    (void)in;
+    (void)os;
+    (void)context;
+    {
+        for (size_t i = 0, n = in.num_relative_macro_list_relative_macro(context); i < n; i++) {
+            auto child_context = in.get_relative_macro_list_relative_macro(i, context);
+            os << "<relative_macro";
+            os << " name=\"" << in.get_relative_macro_name(child_context) << "\"";
+            os << ">";
+            write_relative_macro(in, os, child_context);
+            os << "</relative_macro>\n";
+        }
+    }
+}
+
+template<class T, typename Context>
 inline void write_global_route_constraints(T& in, std::ostream& os, Context& context) {
     (void)in;
     (void)os;
@@ -1320,6 +2037,14 @@ inline void write_vpr_constraints(T& in, std::ostream& os, Context& context) {
             os << "<partition_list>\n";
             write_partition_list(in, os, child_context);
             os << "</partition_list>\n";
+        }
+    }
+    {
+        if (in.has_vpr_constraints_relative_macro_list(context)) {
+            auto child_context = in.get_vpr_constraints_relative_macro_list(context);
+            os << "<relative_macro_list>\n";
+            write_relative_macro_list(in, os, child_context);
+            os << "</relative_macro_list>\n";
         }
     }
     {

--- a/vpr/src/base/gen/vpr_constraints_uxsdcxx_interface.h
+++ b/vpr/src/base/gen/vpr_constraints_uxsdcxx_interface.h
@@ -4,9 +4,9 @@
  * https://github.com/duck2/uxsdcxx
  * Modify only if your build process doesn't involve regenerating this file.
  *
- * Cmdline: uxsdcxx.py ..\OpenFPGA\vtr-verilog-to-routing\vpr\src\base\vpr_constraints.xsd
- * Input file: C:\Users\OscarPC\source\repos\OpenFPGA\vtr-verilog-to-routing\vpr\src\base\vpr_constraints.xsd
- * md5sum of input file: f19701e568aa29dcebaba9f650acca07
+ * Cmdline: uxsdcxx.py /home/amohaghegh/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * Input file: /home/amohaghegh/vtr-verilog-to-routing/vpr/src/base/vpr_constraints.xsd
+ * md5sum of input file: 4c3498d39cf7f98b5c02519373a7cfc7
  */
 
 #include <functional>
@@ -32,6 +32,10 @@ struct DefaultVprConstraintsContextTypes {
     using AddLogicalBlockReadContext = void*;
     using PartitionReadContext = void*;
     using PartitionListReadContext = void*;
+    using ReferenceGroupReadContext = void*;
+    using RelativeGroupReadContext = void*;
+    using RelativeMacroReadContext = void*;
+    using RelativeMacroListReadContext = void*;
     using SetGlobalSignalReadContext = void*;
     using GlobalRouteConstraintsReadContext = void*;
     using VprConstraintsReadContext = void*;
@@ -40,6 +44,10 @@ struct DefaultVprConstraintsContextTypes {
     using AddLogicalBlockWriteContext = void*;
     using PartitionWriteContext = void*;
     using PartitionListWriteContext = void*;
+    using ReferenceGroupWriteContext = void*;
+    using RelativeGroupWriteContext = void*;
+    using RelativeMacroWriteContext = void*;
+    using RelativeMacroListWriteContext = void*;
     using SetGlobalSignalWriteContext = void*;
     using GlobalRouteConstraintsWriteContext = void*;
     using VprConstraintsWriteContext = void*;
@@ -59,6 +67,7 @@ class VprConstraintsBase {
      *   <xs:attribute name="name_pattern" type="xs:string" use="required" />
      *   <xs:attribute name="is_regex" type="xs:string" default="false" />
      *   <xs:attribute name="logical_block_location" type="xs:string" use="optional" />
+     *   <xs:attribute name="site_path" type="xs:string" use="optional" />
      * </xs:complexType>
      */
     virtual inline const char* get_add_atom_is_regex(typename ContextTypes::AddAtomReadContext& ctx) = 0;
@@ -67,6 +76,8 @@ class VprConstraintsBase {
     virtual inline void set_add_atom_logical_block_location(const char* logical_block_location, typename ContextTypes::AddAtomWriteContext& ctx) = 0;
     virtual inline const char* get_add_atom_name_pattern(typename ContextTypes::AddAtomReadContext& ctx) = 0;
     virtual inline void set_add_atom_name_pattern(const char* name_pattern, typename ContextTypes::AddAtomWriteContext& ctx) = 0;
+    virtual inline const char* get_add_atom_site_path(typename ContextTypes::AddAtomReadContext& ctx) = 0;
+    virtual inline void set_add_atom_site_path(const char* site_path, typename ContextTypes::AddAtomWriteContext& ctx) = 0;
 
     /** Generated for complex type "add_region":
      * <xs:complexType name="add_region">
@@ -144,6 +155,74 @@ class VprConstraintsBase {
     virtual inline size_t num_partition_list_partition(typename ContextTypes::PartitionListReadContext& ctx) = 0;
     virtual inline typename ContextTypes::PartitionReadContext get_partition_list_partition(int n, typename ContextTypes::PartitionListReadContext& ctx) = 0;
 
+    /** Generated for complex type "reference_group":
+     * <xs:complexType name="reference_group">
+     *   <xs:sequence>
+     *     <xs:element name="add_atom" type="add_atom" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     * </xs:complexType>
+     */
+    virtual inline void preallocate_reference_group_add_atom(typename ContextTypes::ReferenceGroupWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::AddAtomWriteContext add_reference_group_add_atom(typename ContextTypes::ReferenceGroupWriteContext& ctx) = 0;
+    virtual inline void finish_reference_group_add_atom(typename ContextTypes::AddAtomWriteContext& ctx) = 0;
+    virtual inline size_t num_reference_group_add_atom(typename ContextTypes::ReferenceGroupReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::AddAtomReadContext get_reference_group_add_atom(int n, typename ContextTypes::ReferenceGroupReadContext& ctx) = 0;
+
+    /** Generated for complex type "relative_group":
+     * <xs:complexType name="relative_group">
+     *   <xs:sequence>
+     *     <xs:element name="add_atom" type="add_atom" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     *   <xs:attribute name="x_offset" type="xs:int" use="required" />
+     *   <xs:attribute name="y_offset" type="xs:int" use="required" />
+     *   <xs:attribute name="sub_tile_offset" type="xs:int" use="required" />
+     *   <xs:attribute name="layer_offset" type="xs:int" default="0" />
+     * </xs:complexType>
+     */
+    virtual inline int get_relative_group_layer_offset(typename ContextTypes::RelativeGroupReadContext& ctx) = 0;
+    virtual inline void set_relative_group_layer_offset(int layer_offset, typename ContextTypes::RelativeGroupWriteContext& ctx) = 0;
+    virtual inline int get_relative_group_sub_tile_offset(typename ContextTypes::RelativeGroupReadContext& ctx) = 0;
+    virtual inline int get_relative_group_x_offset(typename ContextTypes::RelativeGroupReadContext& ctx) = 0;
+    virtual inline int get_relative_group_y_offset(typename ContextTypes::RelativeGroupReadContext& ctx) = 0;
+    virtual inline void preallocate_relative_group_add_atom(typename ContextTypes::RelativeGroupWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::AddAtomWriteContext add_relative_group_add_atom(typename ContextTypes::RelativeGroupWriteContext& ctx) = 0;
+    virtual inline void finish_relative_group_add_atom(typename ContextTypes::AddAtomWriteContext& ctx) = 0;
+    virtual inline size_t num_relative_group_add_atom(typename ContextTypes::RelativeGroupReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::AddAtomReadContext get_relative_group_add_atom(int n, typename ContextTypes::RelativeGroupReadContext& ctx) = 0;
+
+    /** Generated for complex type "relative_macro":
+     * <xs:complexType name="relative_macro">
+     *   <xs:sequence>
+     *     <xs:element name="reference_group" type="reference_group" />
+     *     <xs:element name="relative_group" type="relative_group" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     *   <xs:attribute name="name" type="xs:string" use="required" />
+     * </xs:complexType>
+     */
+    virtual inline const char* get_relative_macro_name(typename ContextTypes::RelativeMacroReadContext& ctx) = 0;
+    virtual inline void set_relative_macro_name(const char* name, typename ContextTypes::RelativeMacroWriteContext& ctx) = 0;
+    virtual inline typename ContextTypes::ReferenceGroupWriteContext init_relative_macro_reference_group(typename ContextTypes::RelativeMacroWriteContext& ctx) = 0;
+    virtual inline void finish_relative_macro_reference_group(typename ContextTypes::ReferenceGroupWriteContext& ctx) = 0;
+    virtual inline typename ContextTypes::ReferenceGroupReadContext get_relative_macro_reference_group(typename ContextTypes::RelativeMacroReadContext& ctx) = 0;
+    virtual inline void preallocate_relative_macro_relative_group(typename ContextTypes::RelativeMacroWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::RelativeGroupWriteContext add_relative_macro_relative_group(typename ContextTypes::RelativeMacroWriteContext& ctx, int sub_tile_offset, int x_offset, int y_offset) = 0;
+    virtual inline void finish_relative_macro_relative_group(typename ContextTypes::RelativeGroupWriteContext& ctx) = 0;
+    virtual inline size_t num_relative_macro_relative_group(typename ContextTypes::RelativeMacroReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::RelativeGroupReadContext get_relative_macro_relative_group(int n, typename ContextTypes::RelativeMacroReadContext& ctx) = 0;
+
+    /** Generated for complex type "relative_macro_list":
+     * <xs:complexType name="relative_macro_list">
+     *   <xs:sequence>
+     *     <xs:element name="relative_macro" type="relative_macro" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     * </xs:complexType>
+     */
+    virtual inline void preallocate_relative_macro_list_relative_macro(typename ContextTypes::RelativeMacroListWriteContext& ctx, size_t size) = 0;
+    virtual inline typename ContextTypes::RelativeMacroWriteContext add_relative_macro_list_relative_macro(typename ContextTypes::RelativeMacroListWriteContext& ctx) = 0;
+    virtual inline void finish_relative_macro_list_relative_macro(typename ContextTypes::RelativeMacroWriteContext& ctx) = 0;
+    virtual inline size_t num_relative_macro_list_relative_macro(typename ContextTypes::RelativeMacroListReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::RelativeMacroReadContext get_relative_macro_list_relative_macro(int n, typename ContextTypes::RelativeMacroListReadContext& ctx) = 0;
+
     /** Generated for complex type "set_global_signal":
      * <xs:complexType name="set_global_signal">
      *   <xs:attribute name="name" type="xs:string" use="required" />
@@ -174,6 +253,7 @@ class VprConstraintsBase {
      * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
      *     <xs:all minOccurs="0">
      *       <xs:element name="partition_list" type="partition_list" />
+     *       <xs:element name="relative_macro_list" type="relative_macro_list" />
      *       <xs:element name="global_route_constraints" type="global_route_constraints" />
      *     </xs:all>
      *     <xs:attribute name="tool_name" type="xs:string" />
@@ -185,6 +265,10 @@ class VprConstraintsBase {
     virtual inline void finish_vpr_constraints_partition_list(typename ContextTypes::PartitionListWriteContext& ctx) = 0;
     virtual inline typename ContextTypes::PartitionListReadContext get_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
     virtual inline bool has_vpr_constraints_partition_list(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
+    virtual inline typename ContextTypes::RelativeMacroListWriteContext init_vpr_constraints_relative_macro_list(typename ContextTypes::VprConstraintsWriteContext& ctx) = 0;
+    virtual inline void finish_vpr_constraints_relative_macro_list(typename ContextTypes::RelativeMacroListWriteContext& ctx) = 0;
+    virtual inline typename ContextTypes::RelativeMacroListReadContext get_vpr_constraints_relative_macro_list(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
+    virtual inline bool has_vpr_constraints_relative_macro_list(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;
     virtual inline typename ContextTypes::GlobalRouteConstraintsWriteContext init_vpr_constraints_global_route_constraints(typename ContextTypes::VprConstraintsWriteContext& ctx) = 0;
     virtual inline void finish_vpr_constraints_global_route_constraints(typename ContextTypes::GlobalRouteConstraintsWriteContext& ctx) = 0;
     virtual inline typename ContextTypes::GlobalRouteConstraintsReadContext get_vpr_constraints_global_route_constraints(typename ContextTypes::VprConstraintsReadContext& ctx) = 0;

--- a/vpr/src/base/user_relative_macros.cpp
+++ b/vpr/src/base/user_relative_macros.cpp
@@ -1,0 +1,66 @@
+#include "user_relative_macros.h"
+
+#include <utility>
+
+#include "vtr_assert.h"
+
+UserRelativeMacroId UserRelativeMacros::add_macro(t_user_relative_macro macro) {
+    UserRelativeMacroId macro_id(macros_.size());
+
+    for (size_t group_idx = 0; group_idx < macro.groups.size(); group_idx++) {
+        const t_user_relative_group& group = macro.groups[group_idx];
+        VTR_ASSERT_MSG(group.atom_site_paths.empty() || group.atom_site_paths.size() == group.atoms.size(),
+                       "A relative placement group must have one atom site path per atom");
+        for (size_t atom_idx = 0; atom_idx < group.atoms.size(); atom_idx++) {
+            bool first_time = atom_locations_.emplace(group.atoms[atom_idx], t_atom_location{macro_id, group_idx, atom_idx}).second;
+            VTR_ASSERT_MSG(first_time, "An atom may belong to at most one relative placement group");
+        }
+    }
+
+    macros_.push_back(std::move(macro));
+    return macro_id;
+}
+
+size_t UserRelativeMacros::get_num_macros() const {
+    return macros_.size();
+}
+
+UserRelativeMacros::macro_range UserRelativeMacros::macros() const {
+    return macros_.keys();
+}
+
+const t_user_relative_macro& UserRelativeMacros::get_macro(UserRelativeMacroId macro_id) const {
+    VTR_ASSERT(macro_id.is_valid() && (size_t)macro_id < macros_.size());
+    return macros_[macro_id];
+}
+
+std::pair<UserRelativeMacroId, int> UserRelativeMacros::get_atom_group(AtomBlockId blk_id) const {
+    // Fast path for the common case of no relative placement macros: callers
+    // on hot packer paths may query every atom.
+    if (atom_locations_.empty()) {
+        return {UserRelativeMacroId::INVALID(), -1};
+    }
+    auto itr = atom_locations_.find(blk_id);
+    if (itr == atom_locations_.end()) {
+        return {UserRelativeMacroId::INVALID(), -1};
+    }
+    return {itr->second.macro_id, (int)itr->second.group_idx};
+}
+
+const std::string& UserRelativeMacros::get_atom_locked_site_path(AtomBlockId blk_id) const {
+    static const std::string unlocked;
+    if (atom_locations_.empty()) {
+        return unlocked;
+    }
+    auto itr = atom_locations_.find(blk_id);
+    if (itr == atom_locations_.end()) {
+        return unlocked;
+    }
+    const t_atom_location& location = itr->second;
+    const t_user_relative_group& group = macros_[location.macro_id].groups[location.group_idx];
+    if (group.atom_site_paths.empty()) {
+        // the whole group was authored without site information
+        return unlocked;
+    }
+    return group.atom_site_paths[location.atom_idx];
+}

--- a/vpr/src/base/user_relative_macros.cpp
+++ b/vpr/src/base/user_relative_macros.cpp
@@ -64,3 +64,29 @@ const std::string& UserRelativeMacros::get_atom_locked_site_path(AtomBlockId blk
     }
     return group.atom_site_paths[location.atom_idx];
 }
+
+void print_relative_macros(FILE* fp, const UserRelativeMacros& relative_macros) {
+    fprintf(fp, "\n Number of relative macros is %zu \n", relative_macros.get_num_macros());
+
+    for (UserRelativeMacroId macro_id : relative_macros.macros()) {
+        const t_user_relative_macro& macro = relative_macros.get_macro(macro_id);
+        fprintf(fp, "\nrelative_macro_id: %zu name: %s\n", size_t(macro_id), macro.name.c_str());
+
+        for (size_t igroup = 0; igroup < macro.groups.size(); igroup++) {
+            const t_user_relative_group& group = macro.groups[igroup];
+            fprintf(fp, "\t%s: offset (x %d, y %d, sub_tile %d, layer %d), %zu atom(s)\n",
+                    igroup == 0 ? "reference group" : "relative group",
+                    group.offset.x, group.offset.y, group.offset.sub_tile, group.offset.layer,
+                    group.atoms.size());
+            fprintf(fp, "\tIds of atoms in group (with site_path if locked):\n");
+            for (size_t iatom = 0; iatom < group.atoms.size(); iatom++) {
+                bool locked = !group.atom_site_paths.empty() && !group.atom_site_paths[iatom].empty();
+                if (locked) {
+                    fprintf(fp, "\t#%zu %s\n", size_t(group.atoms[iatom]), group.atom_site_paths[iatom].c_str());
+                } else {
+                    fprintf(fp, "\t#%zu\n", size_t(group.atoms[iatom]));
+                }
+            }
+        }
+    }
+}

--- a/vpr/src/base/user_relative_macros.h
+++ b/vpr/src/base/user_relative_macros.h
@@ -6,6 +6,7 @@
  *        constraints file.
  */
 
+#include <cstdio>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -128,3 +129,8 @@ class UserRelativeMacros {
     ///        read from the macro through it rather than stored a second time.
     std::unordered_map<AtomBlockId, t_atom_location> atom_locations_;
 };
+
+/**
+ * @brief Print the relative placement macros to an (echo) file.
+ */
+void print_relative_macros(FILE* fp, const UserRelativeMacros& relative_macros);

--- a/vpr/src/base/user_relative_macros.h
+++ b/vpr/src/base/user_relative_macros.h
@@ -1,0 +1,130 @@
+#pragma once
+/**
+ * @file
+ * @brief This file defines the UserRelativeMacros class, which stores
+ *        user-specified relative placement macros read from a VPR
+ *        constraints file.
+ */
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "atom_netlist_fwd.h"
+#include "vpr_types.h"
+#include "vtr_strong_id.h"
+#include "vtr_vector.h"
+
+/// @brief A unique identifier for a user-defined relative placement macro.
+typedef vtr::StrongId<struct user_relative_macro_id_tag> UserRelativeMacroId;
+
+/**
+ * @brief A group of atoms within a user-defined relative placement macro.
+ *
+ * All atoms of a group must be packed into the same cluster. The offset is
+ * relative to the macro's reference group; the reference group itself has a
+ * zero offset.
+ */
+struct t_user_relative_group {
+    /// @brief Atoms belonging to this group (resolved from the name patterns
+    ///        in the constraints file).
+    std::vector<AtomBlockId> atoms;
+
+    /// @brief The primitive site each atom is locked to: atom_site_paths[i] is
+    ///        the site of atoms[i]. An empty string leaves that atom unlocked
+    ///        (the packer picks its site); an empty vector leaves the whole
+    ///        group unlocked.
+    std::vector<std::string> atom_site_paths;
+
+    /// @brief Placement offset of this group's cluster relative to the
+    ///        reference group's cluster. (0, 0, 0, 0) for the reference group.
+    t_pl_offset offset;
+};
+
+/**
+ * @brief A user-defined relative placement macro.
+ *
+ * groups[0] is always the reference group (zero offset); the remaining
+ * entries are the relative groups.
+ */
+struct t_user_relative_macro {
+    /// @brief Unique name of the macro, used in log and error messages.
+    std::string name;
+
+    /// @brief The macro's groups. groups[0] is the reference group.
+    std::vector<t_user_relative_group> groups;
+};
+
+/**
+ * @brief Stores all user-defined relative placement macros.
+ *
+ * An atom may belong to at most one group across all macros.
+ */
+class UserRelativeMacros {
+  public:
+    typedef vtr::vector<UserRelativeMacroId, t_user_relative_macro>::key_range macro_range;
+
+    /**
+     * @brief Take ownership of a macro and register its atoms in the reverse
+     *        lookup.
+     *
+     * The macro is moved into this class, which maintains it from then on: the
+     * loader builds a macro up and hands it over once it is complete. Pass it
+     * with std::move to avoid copying its atom lists and site paths.
+     *
+     * @return The id of the newly added macro.
+     */
+    UserRelativeMacroId add_macro(t_user_relative_macro macro);
+
+    /**
+     * @brief Return the number of stored macros.
+     */
+    size_t get_num_macros() const;
+
+    /**
+     * @brief Return the ids of all stored macros, for range-based iteration.
+     */
+    macro_range macros() const;
+
+    /**
+     * @brief Return the macro with the given id.
+     */
+    const t_user_relative_macro& get_macro(UserRelativeMacroId macro_id) const;
+
+    /**
+     * @brief Return the (macro id, group index) an atom belongs to, or
+     *        (UserRelativeMacroId::INVALID(), -1) if the atom is not part of
+     *        any relative placement macro.
+     */
+    std::pair<UserRelativeMacroId, int> get_atom_group(AtomBlockId blk_id) const;
+
+    /**
+     * @brief Return the hierarchical path of the primitive site the given atom
+     *        is locked to by its relative placement group, or an empty string
+     *        if the atom is in no group or its group leaves it unlocked.
+     *
+     * The returned reference points into the stored macro and stays valid as
+     * long as no macro is added.
+     */
+    const std::string& get_atom_locked_site_path(AtomBlockId blk_id) const;
+
+  private:
+    /// @brief Where an atom sits inside the stored macros.
+    struct t_atom_location {
+        /// @brief The macro the atom belongs to.
+        UserRelativeMacroId macro_id;
+        /// @brief Index into t_user_relative_macro::groups.
+        size_t group_idx;
+        /// @brief Index into t_user_relative_group::atoms.
+        size_t atom_idx;
+    };
+
+    /// @brief All user-defined relative placement macros.
+    vtr::vector<UserRelativeMacroId, t_user_relative_macro> macros_;
+
+    /// @brief Reverse lookup: atom -> its position in macros_. Only holds the
+    ///        atoms that belong to a group; the site path of a locked atom is
+    ///        read from the macro through it rather than stored a second time.
+    std::unordered_map<AtomBlockId, t_atom_location> atom_locations_;
+};

--- a/vpr/src/base/vpr_constraints.cpp
+++ b/vpr/src/base/vpr_constraints.cpp
@@ -15,3 +15,11 @@ const UserPlaceConstraints& VprConstraints::place_constraints() const {
 const UserRouteConstraints& VprConstraints::route_constraints() const {
     return route_constraints_;
 }
+
+UserRelativeMacros& VprConstraints::mutable_relative_macros() {
+    return relative_macros_;
+}
+
+const UserRelativeMacros& VprConstraints::relative_macros() const {
+    return relative_macros_;
+}

--- a/vpr/src/base/vpr_constraints.h
+++ b/vpr/src/base/vpr_constraints.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "user_place_constraints.h"
+#include "user_relative_macros.h"
 #include "user_route_constraints.h"
 
 /**
@@ -21,6 +22,10 @@
  *
  * UserPlaceConstraints: Stores block and region constraints for packing and placement stages.
  * See vpr/src/base/user_place_constraints.h for more detail.
+ *
+ * UserRelativeMacros: Stores relative placement macros, which constrain groups of atoms
+ * to be packed into distinct clusters placed at fixed offsets from each other.
+ * See vpr/src/base/user_relative_macros.h for more detail.
  */
 class VprConstraints {
   public:
@@ -44,7 +49,18 @@ class VprConstraints {
      */
     const UserRouteConstraints& route_constraints() const;
 
+    /**
+     * @brief Get a mutable reference to the UserRelativeMacros instance.
+     */
+    UserRelativeMacros& mutable_relative_macros();
+
+    /**
+     * @brief Get a const reference to the UserRelativeMacros instance.
+     */
+    const UserRelativeMacros& relative_macros() const;
+
   private:
     UserRouteConstraints route_constraints_;
     UserPlaceConstraints placement_constraints_;
+    UserRelativeMacros relative_macros_;
 };

--- a/vpr/src/base/vpr_constraints.xsd
+++ b/vpr/src/base/vpr_constraints.xsd
@@ -28,6 +28,7 @@
     <xs:attribute name="name_pattern" type="xs:string" use="required"/>
     <xs:attribute name="is_regex" type="xs:string" default="false"/>
     <xs:attribute name="logical_block_location" type="xs:string" use="optional"/>
+    <xs:attribute name="site_path" type="xs:string" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="add_region">
@@ -69,6 +70,36 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="reference_group">
+    <xs:sequence>
+      <xs:element name="add_atom" type="add_atom" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="relative_group">
+    <xs:sequence>
+      <xs:element name="add_atom" type="add_atom" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="x_offset" type="xs:int" use="required"/>
+    <xs:attribute name="y_offset" type="xs:int" use="required"/>
+    <xs:attribute name="sub_tile_offset" type="xs:int" use="required"/>
+    <xs:attribute name="layer_offset" type="xs:int" default="0"/>
+  </xs:complexType>
+
+  <xs:complexType name="relative_macro">
+    <xs:sequence>
+      <xs:element name="reference_group" type="reference_group"/>
+      <xs:element name="relative_group" type="relative_group" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="relative_macro_list">
+    <xs:sequence>
+      <xs:element name="relative_macro" type="relative_macro" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
 
 <xs:simpleType name="route_model_type">
     <xs:restriction base="xs:string">
@@ -104,6 +135,7 @@
     <xs:complexType>
       <xs:all minOccurs="0">
         <xs:element name="partition_list" type="partition_list"/>
+        <xs:element name="relative_macro_list" type="relative_macro_list"/>
         <xs:element name="global_route_constraints" type="global_route_constraints"/>
       </xs:all>
 

--- a/vpr/src/base/vpr_constraints_reader.cpp
+++ b/vpr/src/base/vpr_constraints_reader.cpp
@@ -35,6 +35,29 @@ void load_vpr_constraints_file(const char* read_vpr_constraints_name) {
     //Update the floorplanning constraints in the floorplanning constraints context
     auto& floorplanning_ctx = g_vpr_ctx.mutable_floorplanning();
     floorplanning_ctx.constraints = reader.constraints_.place_constraints();
+    floorplanning_ctx.relative_macros = reader.constraints_.relative_macros();
+
+    // A design can carry many macros, and the per-macro
+    // detail is written to the vpr_constraints echo file
+    const UserRelativeMacros& relative_macros = floorplanning_ctx.relative_macros;
+    if (relative_macros.get_num_macros() > 0) {
+        size_t num_groups = 0;
+        size_t num_atoms = 0;
+        size_t num_locked_atoms = 0;
+        for (UserRelativeMacroId macro_id : relative_macros.macros()) {
+            const t_user_relative_macro& macro = relative_macros.get_macro(macro_id);
+            num_groups += macro.groups.size();
+            for (const t_user_relative_group& group : macro.groups) {
+                num_atoms += group.atoms.size();
+                for (const std::string& site_path : group.atom_site_paths) {
+                    if (!site_path.empty())
+                        num_locked_atoms++;
+                }
+            }
+        }
+        VTR_LOG("Read %zu relative placement macro(s): %zu group(s), %zu atom(s), %zu atom(s) locked to a primitive site\n",
+                relative_macros.get_num_macros(), num_groups, num_atoms, num_locked_atoms);
+    }
 
     auto& routing_ctx = g_vpr_ctx.mutable_routing();
     routing_ctx.constraints = reader.constraints_.route_constraints();
@@ -42,6 +65,7 @@ void load_vpr_constraints_file(const char* read_vpr_constraints_name) {
     const auto& ctx_constraints = floorplanning_ctx.constraints;
 
     if (getEchoEnabled() && isEchoFileEnabled(E_ECHO_VPR_CONSTRAINTS)) {
-        echo_constraints(getEchoFileName(E_ECHO_VPR_CONSTRAINTS), ctx_constraints);
+        echo_constraints(getEchoFileName(E_ECHO_VPR_CONSTRAINTS), ctx_constraints, relative_macros);
     }
+
 }

--- a/vpr/src/base/vpr_constraints_reader.cpp
+++ b/vpr/src/base/vpr_constraints_reader.cpp
@@ -68,4 +68,13 @@ void load_vpr_constraints_file(const char* read_vpr_constraints_name) {
         echo_constraints(getEchoFileName(E_ECHO_VPR_CONSTRAINTS), ctx_constraints, relative_macros);
     }
 
+    // Temporary guard: the packer and placer do not honor relative placement
+    // macros yet. Stop here rather than silently ignore the constraints.
+    // Remove once packing and placement support for relative macros is in.
+    if (relative_macros.get_num_macros() > 0) {
+        VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                        "Constraints file '%s' contains relative placement macros, which are not yet honored by the flow. "
+                        "Remove the <relative_macro_list> to run without them.\n",
+                        read_vpr_constraints_name);
+    }
 }

--- a/vpr/src/base/vpr_constraints_serializer.h
+++ b/vpr/src/base/vpr_constraints_serializer.h
@@ -37,12 +37,17 @@
  * For more detail on how the load and write interfaces work with uxsdcxx, refer to 'vpr/src/route/SCHEMA_GENERATOR.md'
  */
 
+#include <algorithm>
 #include <regex>
+#include <unordered_map>
+#include <utility>
 #include "region.h"
 #include "vpr_constraints.h"
+#include "vtr_assert.h"
 #include "partition.h"
 #include "partition_region.h"
 #include "vpr_context.h"
+#include "vpr_utils.h"
 #include "vtr_log.h"
 #include "globals.h" //for the g_vpr_ctx
 #include "clock_modeling.h"
@@ -73,6 +78,11 @@ struct VprConstraintsContextTypes : public uxsd::DefaultVprConstraintsContextTyp
     using AddLogicalBlockReadContext = t_logical_block_type_ptr;
     using PartitionReadContext = partition_info;
     using PartitionListReadContext = void*;
+    // (macro id, group index) pairs identify a group when writing out relative macros
+    using ReferenceGroupReadContext = std::pair<UserRelativeMacroId, int>;
+    using RelativeGroupReadContext = std::pair<UserRelativeMacroId, int>;
+    using RelativeMacroReadContext = UserRelativeMacroId;
+    using RelativeMacroListReadContext = void*;
     using SetGlobalSignalReadContext = std::pair<std::string, RoutingScheme>;
     using GlobalRouteConstraintsReadContext = void*;
     using VprConstraintsReadContext = void*;
@@ -81,6 +91,10 @@ struct VprConstraintsContextTypes : public uxsd::DefaultVprConstraintsContextTyp
     using AddLogicalBlockWriteContext = void*;
     using PartitionWriteContext = void*;
     using PartitionListWriteContext = void*;
+    using ReferenceGroupWriteContext = void*;
+    using RelativeGroupWriteContext = void*;
+    using RelativeMacroWriteContext = void*;
+    using RelativeMacroListWriteContext = void*;
     using SetGlobalSignalWriteContext = void*;
     using GlobalRouteConstraintsWriteContext = void*;
     using VprConstraintsWriteContext = void*;
@@ -100,8 +114,12 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
         report_error_ = report_error_in;
     }
 
-    virtual void start_write() final {}
-    virtual void finish_write() final {}
+    virtual void start_write() final {
+        writing_relative_macros_ = false;
+    }
+    virtual void finish_write() final {
+        writing_relative_macros_ = false;
+    }
 
     // error_encountered will be invoked by the reader implementation whenever
     // any error is encountered.
@@ -128,8 +146,9 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     /** Generated for complex type "add_atom":
      * <xs:complexType name="add_atom">
      *   <xs:attribute name="name_pattern" type="xs:string" use="required" />
-     *   <xs:attribute name="is_regex" type="xs:boolean" default="false" />
+     *   <xs:attribute name="is_regex" type="xs:string" default="false" />
      *   <xs:attribute name="logical_block_location" type="xs:string" use="optional" />
+     *   <xs:attribute name="site_path" type="xs:string" use="optional" />
      * </xs:complexType>
      */
     virtual inline const char* get_add_atom_name_pattern(AtomBlockId& blk_id) final {
@@ -153,6 +172,24 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
 
     virtual inline void set_add_atom_logical_block_location(const char* logical_block_location, void*& /*ctx*/) final {
         logical_block_location_ = logical_block_location;
+    }
+
+    virtual inline const char* get_add_atom_site_path(AtomBlockId& blk_id) final {
+        // The generated writer omits this optional attribute when nullptr is
+        // returned. add_atom is shared with partitions, where a site_path is
+        // meaningless, so it is only written while the relative macros are.
+        if (!writing_relative_macros_) {
+            return nullptr;
+        }
+        const std::string& site_path = constraints_.relative_macros().get_atom_locked_site_path(blk_id);
+        return site_path.empty() ? nullptr : site_path.c_str();
+    }
+
+    virtual inline void set_add_atom_site_path(const char* site_path, void*& /*ctx*/) final {
+        site_path_ = site_path;
+        // an empty site_path is not the same as no site_path at all: the former
+        // is a malformed constraint, the latter means the atom is unlocked
+        site_path_present_ = true;
     }
 
     virtual inline void set_add_atom_is_regex(const char* is_regex, void*& /*ctx*/) final {
@@ -283,10 +320,7 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     virtual inline void preallocate_partition_add_atom(void*& /*ctx*/, size_t /*size*/) final {}
 
     virtual inline void* add_partition_add_atom(void*& /*ctx*/) final {
-        //clear out the temporary data for this atom
-        name_pattern_.clear();
-        logical_block_location_.clear();
-        is_regex_ = false;
+        clear_loaded_add_atom();
         return nullptr;
     }
 
@@ -294,6 +328,13 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
         PartitionId part_id(num_partitions_);
         auto& atom_ctx = g_vpr_ctx.atom();
         bool found = false;
+
+        if (site_path_present_) {
+            // site_path pins an atom to a primitive site inside its cluster,
+            // which is only meaningful for relative placement macros
+            VTR_LOG_WARN("Partition '%s': site_path is not supported on partition atoms, ignoring it for atom pattern %s.\n",
+                         loaded_partition.get_name().c_str(), name_pattern_.c_str());
+        }
 
         if (!is_regex_) { //the name pattern is not a regex, look for an exact match for the atom name
             AtomBlockId atom_id = atom_ctx.netlist().find_block(name_pattern_);
@@ -306,7 +347,7 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
             }
 
         } else { //the name pattern is a regex, look for all atoms matching the regex pattern
-            auto atom_name_regex = std::regex(name_pattern_);
+            std::regex atom_name_regex = compile_atom_name_regex("Partition '" + loaded_partition.get_name() + "'");
             for (auto block_id : atom_ctx.netlist().blocks()) { // loop through all block names and add the names that matches with the name_pattern
                 auto block_name = atom_ctx.netlist().block_name(block_id);
 
@@ -472,6 +513,264 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
         return part_info;
     }
 
+    /** Generated for complex type "reference_group":
+     * <xs:complexType name="reference_group">
+     *   <xs:sequence>
+     *     <xs:element name="add_atom" type="add_atom" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     * </xs:complexType>
+     */
+    virtual inline void preallocate_reference_group_add_atom(void*& /*ctx*/, size_t /*size*/) final {}
+
+    virtual inline void* add_reference_group_add_atom(void*& /*ctx*/) final {
+        clear_loaded_add_atom();
+        return nullptr;
+    }
+
+    virtual inline void finish_reference_group_add_atom(void*& /*ctx*/) final {
+        resolve_atoms_into_loaded_relative_group();
+    }
+
+    virtual inline size_t num_reference_group_add_atom(std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).atoms.size();
+    }
+    virtual inline AtomBlockId get_reference_group_add_atom(int n, std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).atoms[n];
+    }
+
+    /** Generated for complex type "relative_group":
+     * <xs:complexType name="relative_group">
+     *   <xs:sequence>
+     *     <xs:element name="add_atom" type="add_atom" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     *   <xs:attribute name="x_offset" type="xs:int" use="required" />
+     *   <xs:attribute name="y_offset" type="xs:int" use="required" />
+     *   <xs:attribute name="sub_tile_offset" type="xs:int" use="required" />
+     *   <xs:attribute name="layer_offset" type="xs:int" default="0" />
+     * </xs:complexType>
+     */
+    virtual inline int get_relative_group_x_offset(std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).offset.x;
+    }
+    virtual inline int get_relative_group_y_offset(std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).offset.y;
+    }
+    virtual inline int get_relative_group_sub_tile_offset(std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).offset.sub_tile;
+    }
+    virtual inline int get_relative_group_layer_offset(std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).offset.layer;
+    }
+
+    virtual inline void set_relative_group_layer_offset(int layer_offset, void*& /*ctx*/) final {
+        loaded_relative_group_.offset.layer = layer_offset;
+    }
+
+    virtual inline void preallocate_relative_group_add_atom(void*& /*ctx*/, size_t /*size*/) final {}
+
+    virtual inline void* add_relative_group_add_atom(void*& /*ctx*/) final {
+        clear_loaded_add_atom();
+        return nullptr;
+    }
+
+    virtual inline void finish_relative_group_add_atom(void*& /*ctx*/) final {
+        resolve_atoms_into_loaded_relative_group();
+    }
+
+    virtual inline size_t num_relative_group_add_atom(std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).atoms.size();
+    }
+    virtual inline AtomBlockId get_relative_group_add_atom(int n, std::pair<UserRelativeMacroId, int>& group_ctx) final {
+        return get_relative_group_from_ctx(group_ctx).atoms[n];
+    }
+
+    /** Generated for complex type "relative_macro":
+     * <xs:complexType name="relative_macro">
+     *   <xs:sequence>
+     *     <xs:element name="reference_group" type="reference_group" />
+     *     <xs:element name="relative_group" type="relative_group" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     *   <xs:attribute name="name" type="xs:string" use="required" />
+     * </xs:complexType>
+     */
+    virtual inline const char* get_relative_macro_name(UserRelativeMacroId& macro_id) final {
+        temp_macro_string_ = constraints_.relative_macros().get_macro(macro_id).name;
+        return temp_macro_string_.c_str();
+    }
+    virtual inline void set_relative_macro_name(const char* name, void*& /*ctx*/) final {
+        loaded_relative_macro_.name = name;
+    }
+
+    virtual inline void* init_relative_macro_reference_group(void*& /*ctx*/) final {
+        // the reference group is the anchor of the macro: implicit zero offset
+        begin_loaded_relative_group();
+        return nullptr;
+    }
+
+    virtual inline void finish_relative_macro_reference_group(void*& /*ctx*/) final {
+        // the reference group is always groups[0], even when it matched no atoms
+        // (whether an empty reference group is an error is decided when the whole
+        // macro has been read, see finish_relative_macro_list_relative_macro;
+        // keep its failed patterns until then so the diagnostic can name them)
+        VTR_ASSERT(loaded_relative_macro_.groups.empty());
+        loaded_relative_macro_.groups.push_back(loaded_relative_group_);
+        loaded_reference_group_failed_patterns_ = loaded_relative_group_failed_patterns_;
+    }
+
+    virtual inline std::pair<UserRelativeMacroId, int> get_relative_macro_reference_group(UserRelativeMacroId& macro_id) final {
+        return {macro_id, 0};
+    }
+
+    virtual inline void preallocate_relative_macro_relative_group(void*& /*ctx*/, size_t /*size*/) final {}
+
+    virtual inline void* add_relative_macro_relative_group(void*& /*ctx*/, int sub_tile_offset, int x_offset, int y_offset) final {
+        begin_loaded_relative_group();
+        loaded_relative_group_.offset.x = x_offset;
+        loaded_relative_group_.offset.y = y_offset;
+        loaded_relative_group_.offset.sub_tile = sub_tile_offset;
+        loaded_relative_group_.offset.layer = 0; // optional attribute, may be overwritten by set_relative_group_layer_offset
+        return nullptr;
+    }
+
+    virtual inline void finish_relative_macro_relative_group(void*& /*ctx*/) final {
+        if (loaded_relative_group_.offset.layer != 0) {
+            // cross-layer relative macros are not supported yet: no macro code path
+            // exercises nonzero layer offsets, so reject them at load time
+            report_constraints_load_error("Relative macro '" + loaded_relative_macro_.name
+                                          + "': layer_offset must be 0. Cross-layer relative macros are not supported.");
+        }
+
+        if (loaded_relative_group_.atoms.empty()) {
+            VTR_LOG_WARN("Relative macro '%s': the relative_group at %s matched no atoms (failed name_pattern(s): %s), skipping the group.\n",
+                         loaded_relative_macro_.name.c_str(),
+                         offset_description(loaded_relative_group_.offset).c_str(),
+                         join_name_patterns(loaded_relative_group_failed_patterns_).c_str());
+            return;
+        }
+
+        loaded_relative_macro_.groups.push_back(loaded_relative_group_);
+    }
+
+    virtual inline size_t num_relative_macro_relative_group(UserRelativeMacroId& macro_id) final {
+        // groups[0] is the reference group; the rest are the relative groups
+        return constraints_.relative_macros().get_macro(macro_id).groups.size() - 1;
+    }
+    virtual inline std::pair<UserRelativeMacroId, int> get_relative_macro_relative_group(int n, UserRelativeMacroId& macro_id) final {
+        return {macro_id, n + 1};
+    }
+
+    /** Generated for complex type "relative_macro_list":
+     * <xs:complexType name="relative_macro_list">
+     *   <xs:sequence>
+     *     <xs:element name="relative_macro" type="relative_macro" maxOccurs="unbounded" />
+     *   </xs:sequence>
+     * </xs:complexType>
+     */
+    virtual inline void preallocate_relative_macro_list_relative_macro(void*& /*ctx*/, size_t /*size*/) final {}
+
+    virtual inline void* add_relative_macro_list_relative_macro(void*& /*ctx*/) final {
+        loaded_relative_macro_ = t_user_relative_macro();
+        return nullptr;
+    }
+
+    virtual inline void finish_relative_macro_list_relative_macro(void*& /*ctx*/) final {
+        const std::string& macro_name = loaded_relative_macro_.name;
+        const std::vector<t_user_relative_group>& groups = loaded_relative_macro_.groups;
+        VTR_ASSERT(!groups.empty()); // the reference group is always present
+
+        // macro names must be unique since they identify macros in error messages
+        for (UserRelativeMacroId other_macro_id : constraints_.relative_macros().macros()) {
+            if (constraints_.relative_macros().get_macro(other_macro_id).name == macro_name) {
+                report_constraints_load_error("Relative macro name '" + macro_name + "' is used more than once. Macro names must be unique.");
+            }
+        }
+
+        // empty relative groups were dropped when they were read, so any group
+        // past the reference group is non-empty
+        if (groups[0].atoms.empty()) {
+            if (groups.size() == 1) {
+                VTR_LOG_WARN("Relative macro '%s': no group matched any atoms, dropping the macro.\n",
+                             macro_name.c_str());
+            } else {
+                report_constraints_load_error("Relative macro '" + macro_name
+                                              + "': the reference group matched no atoms (failed name_pattern(s): "
+                                              + join_name_patterns(loaded_reference_group_failed_patterns_)
+                                              + ") but a relative group did. The macro has no anchor.");
+            }
+            return;
+        }
+
+        if (groups.size() == 1) {
+            VTR_LOG_WARN("Relative macro '%s': all relative groups matched no atoms, dropping the macro.\n",
+                         macro_name.c_str());
+            return;
+        }
+
+        // two groups at the same offset would require two clusters at the same location
+        for (size_t i = 0; i < groups.size(); i++) {
+            for (size_t j = i + 1; j < groups.size(); j++) {
+                if (groups[i].offset == groups[j].offset) {
+                    // groups[0] is the reference group at the implicit zero offset
+                    std::string where = (i == 0)
+                                            ? "a relative_group is at " + offset_description(groups[j].offset) + ", the reference group's location"
+                                            : "two relative groups are at the same " + offset_description(groups[j].offset);
+                    report_constraints_load_error("Relative macro '" + macro_name + "': " + where
+                                                  + ". Two groups of a macro cannot be placed at the same location.");
+                }
+            }
+        }
+
+        // an atom may belong to at most one group across all relative macros
+        const auto& atom_ctx = g_vpr_ctx.atom();
+        std::unordered_map<AtomBlockId, size_t> atoms_seen;
+        for (size_t igroup = 0; igroup < groups.size(); igroup++) {
+            for (AtomBlockId blk_id : groups[igroup].atoms) {
+                auto [seen_itr, first_time] = atoms_seen.insert({blk_id, igroup});
+                if (!first_time) {
+                    report_constraints_load_error("Relative macro '" + macro_name + "': atom '"
+                                                  + atom_ctx.netlist().block_name(blk_id) + "' appears in "
+                                                  + group_description(groups, seen_itr->second) + " and in "
+                                                  + group_description(groups, igroup)
+                                                  + ". An atom may belong to at most one relative placement group.");
+                }
+
+                UserRelativeMacroId other_macro_id = constraints_.relative_macros().get_atom_group(blk_id).first;
+                if (other_macro_id.is_valid()) {
+                    report_constraints_load_error("Atom '" + atom_ctx.netlist().block_name(blk_id)
+                                                  + "' appears in relative macro '" + macro_name + "' and in relative macro '"
+                                                  + constraints_.relative_macros().get_macro(other_macro_id).name
+                                                  + "'. An atom may belong to at most one relative placement group.");
+                }
+            }
+        }
+
+        constraints_.mutable_relative_macros().add_macro(std::move(loaded_relative_macro_));
+    }
+
+    virtual inline size_t num_relative_macro_list_relative_macro(void*& /*ctx*/) final {
+        return constraints_.relative_macros().get_num_macros();
+    }
+    virtual inline UserRelativeMacroId get_relative_macro_list_relative_macro(int n, void*& /*ctx*/) final {
+        return UserRelativeMacroId(n);
+    }
+
+    virtual inline void* init_vpr_constraints_relative_macro_list(void*& /*ctx*/) final {
+        return nullptr;
+    }
+
+    virtual inline void finish_vpr_constraints_relative_macro_list(void*& /*ctx*/) final {}
+
+    virtual inline void* get_vpr_constraints_relative_macro_list(void*& /*ctx*/) final {
+        // partition_list is written before relative_macro_list (schema order),
+        // so from here on add_atom belongs to a relative macro
+        writing_relative_macros_ = true;
+        return nullptr;
+    }
+
+    virtual inline bool has_vpr_constraints_relative_macro_list(void*& /*ctx*/) final {
+        return constraints_.relative_macros().get_num_macros() > 0;
+    }
+
     /** Generated for complex type "set_global_signal":
      * <xs:complexType name="set_global_signal">
      *   <xs:attribute name="name" type="xs:string" use="required" />
@@ -580,6 +879,7 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
      * <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema">
      *      <xs:all minOccurs="0">
      *       <xs:element name="partition_list" type="partition_list" />
+     *       <xs:element name="relative_macro_list" type="relative_macro_list" />
      *       <xs:element name="global_route_constraints" type="global_route_constraints" />
      *     </xs:all>
      *     <xs:attribute name="tool_name" type="xs:string" />
@@ -616,10 +916,300 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     virtual void finish_load() final {
     }
 
+    /**
+     * @brief Report an error found while loading the constraints file, with XML
+     *        file/line context when available.
+     */
+    void report_constraints_load_error(const std::string& msg) {
+        if (report_error_ == nullptr) {
+            VPR_ERROR(VPR_ERROR_PLACE, "\n%s\n", msg.c_str());
+        } else {
+            report_error_->operator()(msg.c_str());
+        }
+    }
+
+    /**
+     * @brief Compile the current add_atom name pattern into a regex, reporting a
+     *        load error if the pattern is not a valid regular expression.
+     *        std::regex throws std::regex_error on malformed patterns (e.g. "["),
+     *        which no caller of the constraints loader catches; without this,
+     *        VPR would abort with no file/line context.
+     *
+     * @param error_context  Prefix identifying the constraint being loaded (e.g.
+     *                       the partition or relative macro name), used in the
+     *                       error message.
+     */
+    std::regex compile_atom_name_regex(const std::string& error_context) {
+        try {
+            return std::regex(name_pattern_);
+        } catch (const std::regex_error& e) {
+            report_constraints_load_error(error_context + ": invalid atom name_pattern regex '"
+                                          + name_pattern_ + "' (" + e.what() + ").");
+            // report_constraints_load_error() throws, so this is unreachable; it
+            // only satisfies the compiler's return-path check.
+            return std::regex();
+        }
+    }
+
+    /**
+     * @brief Resolve the current add_atom name pattern (exact or regex, same
+     *        semantics as partition atoms) and append the matched atoms to the
+     *        relative placement group being loaded.
+     */
+    void resolve_atoms_into_loaded_relative_group() {
+        const auto& atom_ctx = g_vpr_ctx.atom();
+        bool found = false;
+
+        // A site path that is present but empty, or that contains whitespace,
+        // can never match a primitive. Rejecting it here is what stops a
+        // hand-written or hand-edited constraints file from silently degrading
+        // to "unlocked" (an absent attribute) or to a site that never matches.
+        // The scripts that write constraints files enforce the same rule, but a
+        // constraints file does not have to come from them.
+        if (site_path_present_
+            && (site_path_.empty() || site_path_.find_first_of(" \t\n\v\f\r") != std::string::npos)) {
+            report_constraints_load_error("Relative macro '" + loaded_relative_macro_.name + "', "
+                                          + loaded_group_description()
+                                          + ": the site_path of atom pattern '" + name_pattern_ + "' is '"
+                                          + site_path_
+                                          + "', which is empty or contains whitespace. A site path is the "
+                                            "hierarchical path of one primitive, e.g. "
+                                            "'clb[0][default]/fle[3][n1_lut6]/ble6[0][default]/lut6[0]'. Omit the "
+                                            "attribute entirely to leave the atom unlocked.");
+        }
+
+        // A site path must name a primitive of some logical block type, or it
+        // could never be honored. Checked once per pattern, since it does not
+        // depend on the matched atom.
+        const t_pb_graph_node* site = site_path_.empty() ? nullptr : find_primitive_site_or_error();
+
+        if (!is_regex_) { // the name pattern is not a regex, look for an exact match for the atom name
+            AtomBlockId atom_id = atom_ctx.netlist().find_block(name_pattern_);
+            if (atom_id != AtomBlockId::INVALID()) {
+                add_atom_to_loaded_relative_group(atom_id, site);
+                found = true;
+            }
+        } else { // the name pattern is a regex, look for all atoms matching the regex pattern
+            std::regex atom_name_regex = compile_atom_name_regex("Relative macro '" + loaded_relative_macro_.name + "'");
+            size_t num_matched = 0;
+            for (AtomBlockId block_id : atom_ctx.netlist().blocks()) {
+                if (std::regex_search(atom_ctx.netlist().block_name(block_id), atom_name_regex)) {
+                    add_atom_to_loaded_relative_group(block_id, site);
+                    found = true;
+                    num_matched++;
+                }
+            }
+            if (!site_path_.empty() && num_matched > 1) {
+                // every matched atom would be locked to the same primitive,
+                // which no two atoms can share
+                report_constraints_load_error("Relative macro '" + loaded_relative_macro_.name
+                                              + "': name_pattern '" + name_pattern_ + "' with site_path '"
+                                              + site_path_ + "' matched " + std::to_string(num_matched)
+                                              + " atoms. A site_path locks one atom to one primitive, so a pattern "
+                                                "that carries one may match at most one atom.");
+            }
+        }
+
+        if (!logical_block_location_.empty()) {
+            VTR_LOG_WARN("Relative macro '%s': logical_block_location is not supported on relative macro atoms, ignoring it for atom pattern %s.\n",
+                         loaded_relative_macro_.name.c_str(), name_pattern_.c_str());
+        }
+
+        if (!found) {
+            // A missed pattern (e.g. a typo'd name or regex) silently discards
+            // placement intent, so name the macro and the pattern; the pattern
+            // is also referenced again if the whole group ends up empty.
+            VTR_LOG_WARN("Relative macro '%s': no atom matched name_pattern '%s', skipping the pattern.\n",
+                         loaded_relative_macro_.name.c_str(), name_pattern_.c_str());
+            loaded_relative_group_failed_patterns_.push_back(name_pattern_);
+        }
+    }
+
+    /**
+     * @brief Join name patterns into a single quoted, comma-separated string
+     *        for warning/error messages.
+     */
+    static std::string join_name_patterns(const std::vector<std::string>& patterns) {
+        std::string joined;
+        for (size_t i = 0; i < patterns.size(); i++) {
+            if (i != 0)
+                joined += ", ";
+            joined += "'" + patterns[i] + "'";
+        }
+        return joined;
+    }
+
+    /**
+     * @brief Append an atom, with the site it is locked to, to the relative
+     *        placement group being loaded.
+     *
+     * An atom matched by several patterns of the same group is stored once. A
+     * pattern without a site_path has no opinion on the atom's site, so it
+     * neither conflicts with nor clears an earlier lock, and a locked pattern
+     * upgrades an earlier unlocked match. Two different sites for the same atom
+     * are contradictory placement intent, so that is a load error rather than a
+     * silent first-wins.
+     *
+     * The feasibility check requires a compressed atom netlist, which VPR
+     * guarantees before the constraints file is read.
+     *
+     * @param blk_id  The matched atom.
+     * @param site    The primitive named by the current site_path, or nullptr
+     *                when the pattern has no site_path.
+     */
+    void add_atom_to_loaded_relative_group(AtomBlockId blk_id, const t_pb_graph_node* site) {
+        const AtomNetlist& netlist = g_vpr_ctx.atom().netlist();
+
+        if (site != nullptr && !primitive_type_feasible(blk_id, site->pb_type)) {
+            report_constraints_load_error("Relative macro '" + loaded_relative_macro_.name + "': atom '"
+                                          + netlist.block_name(blk_id) + "' (model '"
+                                          + g_vpr_ctx.device().arch->models.model_name(netlist.block_model(blk_id))
+                                          + "') cannot be placed on the primitive site '" + site_path_ + "' (a '"
+                                          + std::string(site->pb_type->name)
+                                          + "' primitive): the primitive's model or pin count does not match the atom.");
+        }
+
+        std::vector<AtomBlockId>& atoms = loaded_relative_group_.atoms;
+        std::vector<std::string>& atom_site_paths = loaded_relative_group_.atom_site_paths;
+        auto [itr, first_time] = loaded_relative_group_atom_index_.insert({blk_id, atoms.size()});
+        if (first_time) {
+            atoms.push_back(blk_id);
+            atom_site_paths.push_back(site_path_);
+            return;
+        }
+
+        if (site_path_.empty()) {
+            return;
+        }
+        std::string& prev_site_path = atom_site_paths[itr->second];
+        if (prev_site_path.empty()) {
+            prev_site_path = site_path_;
+        } else if (prev_site_path != site_path_) {
+            report_constraints_load_error("Relative macro '" + loaded_relative_macro_.name
+                                          + "': atom '" + netlist.block_name(blk_id)
+                                          + "' is matched twice in the same group with two different site paths ('"
+                                          + prev_site_path + "' and '" + site_path_
+                                          + "'); an atom can only be locked to one primitive site.");
+        }
+    }
+
+    /**
+     * @brief Look up the primitive named by the site_path of the add_atom being
+     *        read, reporting a load error if no logical block type has a
+     *        primitive at that hierarchical path.
+     *
+     * The table of all primitives of all logical block types is built on first
+     * use, so constraints files without site paths pay nothing for it.
+     */
+    const t_pb_graph_node* find_primitive_site_or_error() {
+        if (!primitive_sites_built_) {
+            for (const t_logical_block_type& lb_type : g_vpr_ctx.device().logical_block_types) {
+                if (lb_type.pb_graph_head != nullptr) {
+                    collect_primitive_sites(lb_type.pb_graph_head, primitive_sites_);
+                }
+            }
+            primitive_sites_built_ = true;
+        }
+
+        auto itr = primitive_sites_.find(site_path_);
+        if (itr == primitive_sites_.end()) {
+            report_constraints_load_error("Relative macro '" + loaded_relative_macro_.name + "', "
+                                          + loaded_group_description() + ": the site_path '" + site_path_
+                                          + "' of atom pattern '" + name_pattern_
+                                          + "' does not name a primitive of any logical block type. The site paths "
+                                            "of a placed design are written by --write_flat_place with "
+                                            "--flat_place_verbosity 2.");
+            return nullptr;
+        }
+        return itr->second;
+    }
+
+    /**
+     * @brief Record every primitive below a pb_graph node under its hierarchical
+     *        type name, which is the form site paths are written in.
+     */
+    static void collect_primitive_sites(const t_pb_graph_node* node, std::unordered_map<std::string, const t_pb_graph_node*>& sites) {
+        if (node->is_primitive()) {
+            sites.emplace(node->hierarchical_type_name(), node);
+            return;
+        }
+
+        const t_pb_type* pb_type = node->pb_type;
+        for (int imode = 0; imode < pb_type->num_modes; imode++) {
+            const t_mode& mode = pb_type->modes[imode];
+            for (int ichild = 0; ichild < mode.num_pb_type_children; ichild++) {
+                for (int ipb = 0; ipb < mode.pb_type_children[ichild].num_pb; ipb++) {
+                    collect_primitive_sites(&node->child_pb_graph_nodes[imode][ichild][ipb], sites);
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Reset the per-add_atom temporary state before a new add_atom is read.
+     */
+    void clear_loaded_add_atom() {
+        name_pattern_.clear();
+        logical_block_location_.clear();
+        is_regex_ = false;
+        site_path_.clear();
+        site_path_present_ = false;
+    }
+
+    /**
+     * @brief Reset the per-group temporary state before a new reference or
+     *        relative group is read.
+     */
+    void begin_loaded_relative_group() {
+        loaded_relative_group_ = t_user_relative_group();
+        loaded_relative_group_failed_patterns_.clear();
+        loaded_relative_group_atom_index_.clear();
+    }
+
+    /**
+     * @brief Describe a group offset for diagnostics, e.g. "offset (1, 0, sub_tile 0)".
+     */
+    static std::string offset_description(const t_pl_offset& offset) {
+        return "offset (" + std::to_string(offset.x) + ", " + std::to_string(offset.y)
+               + ", sub_tile " + std::to_string(offset.sub_tile) + ")";
+    }
+
+    /**
+     * @brief Describe a group of a fully read macro for diagnostics, by its offset
+     *        rather than its index: indices shift when an empty relative group is
+     *        dropped, so they would not match the file.
+     */
+    static std::string group_description(const std::vector<t_user_relative_group>& groups, size_t igroup) {
+        if (igroup == 0) {
+            return "the reference group";
+        }
+        return "the relative_group at " + offset_description(groups[igroup].offset);
+    }
+
+    /**
+     * @brief Describe the group currently being read for diagnostics.
+     */
+    std::string loaded_group_description() const {
+        // the reference group is read first and pushed when finished, so the
+        // macro has no group yet while it is being read
+        if (loaded_relative_macro_.groups.empty()) {
+            return "reference group";
+        }
+        return "relative_group at " + offset_description(loaded_relative_group_.offset);
+    }
+
+    /**
+     * @brief Return the group identified by a (macro id, group index) read context.
+     */
+    const t_user_relative_group& get_relative_group_from_ctx(const std::pair<UserRelativeMacroId, int>& group_ctx) const {
+        return constraints_.relative_macros().get_macro(group_ctx.first).groups[group_ctx.second];
+    }
+
     //temp data for writes
     std::string temp_atom_string_;
     std::string temp_part_string_;
     std::string temp_name_string_;
+    std::string temp_macro_string_;
 
     /*
      * Temp data for loads and writes.
@@ -635,6 +1225,26 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     Partition loaded_partition;
     PartitionRegion loaded_part_region;
     std::pair<std::string, RoutingScheme> loaded_route_constraint;
+    t_user_relative_macro loaded_relative_macro_;
+    t_user_relative_group loaded_relative_group_;
+    // atom -> index into loaded_relative_group_.atoms, to merge an atom matched
+    // by several patterns of the same group without a linear search
+    std::unordered_map<AtomBlockId, size_t> loaded_relative_group_atom_index_;
+
+    // site path -> primitive, over all logical block types; built on first use
+    std::unordered_map<std::string, const t_pb_graph_node*> primitive_sites_;
+    bool primitive_sites_built_ = false;
+
+    // set while the relative macros are written out: add_atom is shared with
+    // partitions, whose atoms must not be written with a site_path
+    bool writing_relative_macros_ = false;
+
+    // name patterns of the relative group being loaded that matched no atom,
+    // referenced in the warning/error emitted when the whole group is empty
+    std::vector<std::string> loaded_relative_group_failed_patterns_;
+    // same, kept for the macro's reference group until the whole macro is read
+    // (an empty reference group is only diagnosed then)
+    std::vector<std::string> loaded_reference_group_failed_patterns_;
 
     //temp string used when a method must return a const char*
     std::string temp_ = "vpr";
@@ -643,11 +1253,16 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     int num_partitions_ = 0;
 
     //used when reading in atom names and regular expressions for atoms
-    bool is_regex_;
+    bool is_regex_ = false;
     std::string name_pattern_;
     std::string logical_block_location_;
+    // the hierarchical path of the primitive site the add_atom being read is
+    // locked to, and whether the attribute was present at all (an empty value
+    // is a malformed constraint, an absent one means unlocked)
+    std::string site_path_;
+    bool site_path_present_ = false;
 
     // Used when reading in regex LB type constraints for a partition.
-    bool lb_type_is_regex_;
+    bool lb_type_is_regex_ = false;
     std::string lb_type_name_pattern_;
 };

--- a/vpr/src/base/vpr_constraints_serializer.h
+++ b/vpr/src/base/vpr_constraints_serializer.h
@@ -166,8 +166,10 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
         name_pattern_ = name_pattern;
     }
 
-    virtual inline const char* get_add_atom_logical_block_location(AtomBlockId& /*blk_id*/) final {
-        return logical_block_location_.c_str();
+    virtual inline const char* get_add_atom_logical_block_location(AtomBlockId& blk_id) final {
+        // The generated writer skips this optional attribute when nullptr is returned
+        temp_logical_block_location_string_ = constraints_.place_constraints().get_atom_logical_block_location(blk_id);
+        return temp_logical_block_location_string_.empty() ? nullptr : temp_logical_block_location_string_.c_str();
     }
 
     virtual inline void set_add_atom_logical_block_location(const char* logical_block_location, void*& /*ctx*/) final {
@@ -1210,6 +1212,7 @@ class VprConstraintsSerializer final : public uxsd::VprConstraintsBase<VprConstr
     std::string temp_part_string_;
     std::string temp_name_string_;
     std::string temp_macro_string_;
+    std::string temp_logical_block_location_string_;
 
     /*
      * Temp data for loads and writes.

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -10,6 +10,7 @@
 #include "physical_types.h"
 #include "place_macro.h"
 #include "user_place_constraints.h"
+#include "user_relative_macros.h"
 #include "user_route_constraints.h"
 #include "vpr_types.h"
 #include "vtr_cache.h"
@@ -680,6 +681,13 @@ struct FloorplanningContext : public Context {
      * The constraints are input into vpr and do not change.
      */
     UserPlaceConstraints constraints;
+
+    /**
+     * @brief Stores user-defined relative placement macros.
+     *
+     * The relative macros are input into vpr and do not change.
+     */
+    UserRelativeMacros relative_macros;
 
     /**
      * @brief Constraints for each cluster

--- a/vpr/test/test_vpr_constraints.cpp
+++ b/vpr/test/test_vpr_constraints.cpp
@@ -1,15 +1,23 @@
+#include <cstdio>
+#include <fstream>
 #include <sstream>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "../src/base/partition_region.h"
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_string.hpp"
 
+#include "globals.h"
 #include "user_place_constraints.h"
+#include "user_relative_macros.h"
 #include "partition.h"
 #include "region.h"
 #include "place_constraints.h"
+#include "vpr_constraints_serializer.h"
+#include "vpr_constraints_uxsdcxx.h"
 
 /**
  * This file contains unit tests that check the functionality of all classes related to vpr constraints. These classes include
@@ -571,6 +579,369 @@ TEST_CASE("MacroConstraints", "[vpr]") {
     REQUIRE(mac_first_reg_coord.ymin() == 3);
     REQUIRE(mac_first_reg_coord.xmax() == 11);
     REQUIRE(mac_first_reg_coord.ymax() == 7);
+}
+
+// Test the UserRelativeMacros storage class: macro storage and the
+// atom -> (macro, group) reverse lookup
+TEST_CASE("UserRelativeMacros", "[vpr]") {
+    UserRelativeMacros relative_macros;
+    REQUIRE(relative_macros.get_num_macros() == 0);
+
+    // An atom that belongs to no macro resolves to an invalid group
+    std::pair<UserRelativeMacroId, int> no_group = relative_macros.get_atom_group(AtomBlockId(42));
+    REQUIRE(!no_group.first.is_valid());
+    REQUIRE(no_group.second == -1);
+
+    // Build a macro: reference group (2 atoms), one relative group (1 atom)
+    t_user_relative_macro macro1;
+    macro1.name = "macro1";
+
+    t_user_relative_group ref_group;
+    ref_group.atoms = {AtomBlockId(0), AtomBlockId(1)};
+    ref_group.offset = t_pl_offset(0, 0, 0, 0);
+    macro1.groups.push_back(ref_group);
+
+    t_user_relative_group rel_group;
+    rel_group.atoms = {AtomBlockId(2)};
+    rel_group.offset = t_pl_offset(1, -2, 0, 0);
+    macro1.groups.push_back(rel_group);
+
+    UserRelativeMacroId macro1_id = relative_macros.add_macro(macro1);
+    REQUIRE(relative_macros.get_num_macros() == 1);
+
+    // Stored macro matches what was added
+    const t_user_relative_macro& stored_macro = relative_macros.get_macro(macro1_id);
+    REQUIRE(stored_macro.name == "macro1");
+    REQUIRE(stored_macro.groups.size() == 2);
+    REQUIRE(stored_macro.groups[0].offset == t_pl_offset(0, 0, 0, 0));
+    REQUIRE(stored_macro.groups[1].offset == t_pl_offset(1, -2, 0, 0));
+
+    // Reverse lookup: each atom maps to its (macro, group index)
+    REQUIRE(relative_macros.get_atom_group(AtomBlockId(0)) == std::make_pair(macro1_id, 0));
+    REQUIRE(relative_macros.get_atom_group(AtomBlockId(1)) == std::make_pair(macro1_id, 0));
+    REQUIRE(relative_macros.get_atom_group(AtomBlockId(2)) == std::make_pair(macro1_id, 1));
+
+    // A second macro gets a distinct id and its atoms resolve to it
+    t_user_relative_macro macro2;
+    macro2.name = "macro2";
+    t_user_relative_group ref_group2;
+    ref_group2.atoms = {AtomBlockId(3)};
+    macro2.groups.push_back(ref_group2);
+    t_user_relative_group rel_group2;
+    rel_group2.atoms = {AtomBlockId(4)};
+    rel_group2.offset = t_pl_offset(0, 3, 0, 0);
+    macro2.groups.push_back(rel_group2);
+
+    UserRelativeMacroId macro2_id = relative_macros.add_macro(macro2);
+    REQUIRE(relative_macros.get_num_macros() == 2);
+    REQUIRE(macro2_id != macro1_id);
+    REQUIRE(relative_macros.get_atom_group(AtomBlockId(3)) == std::make_pair(macro2_id, 0));
+    REQUIRE(relative_macros.get_atom_group(AtomBlockId(4)) == std::make_pair(macro2_id, 1));
+
+    // Atoms of the first macro are unaffected
+    REQUIRE(relative_macros.get_atom_group(AtomBlockId(2)) == std::make_pair(macro1_id, 1));
+
+    // Atoms of macros authored without site information are unlocked
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(0)).empty());
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(2)).empty());
+
+    // A third macro pins some of its atoms to primitive sites, given as the
+    // hierarchical path of the primitive inside the cluster; atom_site_paths[i]
+    // is the site of atoms[i], and an empty path leaves that atom free
+    const std::string site_a = "clb[0][default]/lab[0][default]/fle[0][n1_lut6]/ble6[0][default]/lut6[0]";
+    const std::string site_b = "clb[0][default]/lab[0][default]/fle[3][n1_lut6]/ble6[0][default]/lut6[0]";
+    t_user_relative_macro macro3;
+    macro3.name = "macro3";
+    t_user_relative_group ref_group3;
+    ref_group3.atoms = {AtomBlockId(5), AtomBlockId(6)};
+    ref_group3.atom_site_paths = {site_a, ""};
+    macro3.groups.push_back(ref_group3);
+    t_user_relative_group rel_group3;
+    rel_group3.atoms = {AtomBlockId(7)};
+    rel_group3.atom_site_paths = {site_b};
+    rel_group3.offset = t_pl_offset(0, 1, 0, 0);
+    macro3.groups.push_back(rel_group3);
+
+    UserRelativeMacroId macro3_id = relative_macros.add_macro(macro3);
+    REQUIRE(relative_macros.get_num_macros() == 3);
+
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(5)) == site_a);
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(6)).empty());
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(7)) == site_b);
+
+    // The site paths are stored on the group, parallel to its atoms
+    const t_user_relative_macro& stored_macro3 = relative_macros.get_macro(macro3_id);
+    REQUIRE(stored_macro3.groups[0].atom_site_paths == std::vector<std::string>{site_a, ""});
+    REQUIRE(stored_macro3.groups[1].atom_site_paths == std::vector<std::string>{site_b});
+
+    // Adding a macro with sites does not pin the atoms of the earlier macros
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(0)).empty());
+
+    // An atom outside every macro is unlocked
+    REQUIRE(relative_macros.get_atom_locked_site_path(AtomBlockId(42)).empty());
+}
+
+namespace {
+
+// Load a constraints file holding the given <relative_macro_list> body through
+// the same uxsdcxx path as --read_vpr_constraints, and return what was read.
+// The XML goes through a real file because uxsdcxx reopens it to compute the
+// line number it reports with an error.
+VprConstraints load_relative_macro_constraints(const std::string& macro_list_body) {
+    const char* filename = "test_relative_macro_constraints.xml";
+    {
+        std::ofstream xml(filename);
+        xml << "<vpr_constraints tool_name=\"vpr\">\n"
+            << "<relative_macro_list>\n"
+            << macro_list_body
+            << "</relative_macro_list>\n"
+            << "</vpr_constraints>\n";
+    }
+
+    VprConstraintsSerializer reader;
+    std::ifstream xml(filename);
+    void* context = nullptr;
+    try {
+        uxsd::load_vpr_constraints_xml(reader, context, filename, xml);
+    } catch (...) {
+        std::remove(filename);
+        throw;
+    }
+    std::remove(filename);
+    return reader.constraints_;
+}
+
+// Fill the global atom netlist with atoms of the given names, so the loader's
+// name patterns have something to resolve against.
+void setup_test_atom_netlist(const std::vector<std::string>& atom_names) {
+    AtomNetlist& netlist = g_vpr_ctx.mutable_atom().mutable_netlist();
+    netlist = AtomNetlist("test_netlist", "");
+    for (const std::string& atom_name : atom_names) {
+        netlist.create_block(atom_name, LogicalModelId::INVALID());
+    }
+}
+
+} // namespace
+
+// Test the relative placement macro loader: how a <relative_macro_list> is
+// turned into UserRelativeMacros, and which malformed inputs are rejected
+TEST_CASE("RelativeMacroConstraintsLoader", "[vpr]") {
+    using Catch::Matchers::ContainsSubstring;
+
+    setup_test_atom_netlist({"dsp0_out_0", "lb_0", "lb_1", "lb_2", "lb_3", "lb_4", "ff_a", "ff_b"});
+    const AtomNetlist& netlist = g_vpr_ctx.atom().netlist();
+    AtomBlockId dsp0 = netlist.find_block("dsp0_out_0");
+    AtomBlockId lb_0 = netlist.find_block("lb_0");
+    AtomBlockId lb_1 = netlist.find_block("lb_1");
+    AtomBlockId lb_2 = netlist.find_block("lb_2");
+    AtomBlockId lb_3 = netlist.find_block("lb_3");
+    AtomBlockId lb_4 = netlist.find_block("lb_4");
+    AtomBlockId ff_b = netlist.find_block("ff_b");
+
+    SECTION("groups, offsets and atom lookups") {
+        VprConstraints constraints = load_relative_macro_constraints(R"(
+            <relative_macro name="m1">
+                <reference_group>
+                    <add_atom name_pattern="dsp0_out_0"/>
+                </reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0">
+                    <add_atom name_pattern="^lb_[0-2]$" is_regex="true"/>
+                </relative_group>
+                <relative_group x_offset="-1" y_offset="2" sub_tile_offset="1" layer_offset="0">
+                    <add_atom name_pattern="lb_3"/>
+                    <add_atom name_pattern="lb_4"/>
+                    <add_atom name_pattern="lb_3"/>
+                </relative_group>
+            </relative_macro>
+            <relative_macro name="m2">
+                <reference_group>
+                    <add_atom name_pattern="ff_a"/>
+                </reference_group>
+                <relative_group x_offset="0" y_offset="1" sub_tile_offset="0">
+                    <add_atom name_pattern="ff_b"/>
+                    <add_atom name_pattern="no_such_atom"/>
+                </relative_group>
+            </relative_macro>
+        )");
+        const UserRelativeMacros& macros = constraints.relative_macros();
+        REQUIRE(macros.get_num_macros() == 2);
+        UserRelativeMacroId m1_id(0);
+        UserRelativeMacroId m2_id(1);
+
+        const t_user_relative_macro& m1 = macros.get_macro(m1_id);
+        REQUIRE(m1.name == "m1");
+        REQUIRE(m1.groups.size() == 3);
+        // groups[0] is the reference group at the implicit zero offset
+        REQUIRE(m1.groups[0].offset == t_pl_offset(0, 0, 0, 0));
+        REQUIRE(m1.groups[0].atoms == std::vector<AtomBlockId>{dsp0});
+        REQUIRE(m1.groups[1].offset == t_pl_offset(1, 0, 0, 0));
+        REQUIRE(m1.groups[1].atoms == std::vector<AtomBlockId>{lb_0, lb_1, lb_2});
+        REQUIRE(m1.groups[2].offset == t_pl_offset(-1, 2, 1, 0));
+        // lb_3 is matched twice by the same group and stored once
+        REQUIRE(m1.groups[2].atoms == std::vector<AtomBlockId>{lb_3, lb_4});
+        // no site_path anywhere: one unlocked entry per atom
+        REQUIRE(m1.groups[2].atom_site_paths == std::vector<std::string>{"", ""});
+
+        const t_user_relative_macro& m2 = macros.get_macro(m2_id);
+        REQUIRE(m2.name == "m2");
+        REQUIRE(m2.groups.size() == 2);
+        // the pattern that matched nothing is skipped, the group survives
+        REQUIRE(m2.groups[1].atoms == std::vector<AtomBlockId>{ff_b});
+
+        // reverse lookups
+        REQUIRE(macros.get_atom_group(dsp0) == std::make_pair(m1_id, 0));
+        REQUIRE(macros.get_atom_group(lb_2) == std::make_pair(m1_id, 1));
+        REQUIRE(macros.get_atom_group(lb_3) == std::make_pair(m1_id, 2));
+        REQUIRE(macros.get_atom_group(ff_b) == std::make_pair(m2_id, 1));
+        REQUIRE(macros.get_atom_locked_site_path(lb_3).empty());
+    }
+
+    SECTION("groups and macros that match no atom are dropped") {
+        VprConstraints constraints = load_relative_macro_constraints(R"(
+            <relative_macro name="keeps_one_group">
+                <reference_group>
+                    <add_atom name_pattern="lb_0"/>
+                </reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0">
+                    <add_atom name_pattern="no_such_atom"/>
+                </relative_group>
+                <relative_group x_offset="2" y_offset="0" sub_tile_offset="0">
+                    <add_atom name_pattern="lb_1"/>
+                </relative_group>
+            </relative_macro>
+            <relative_macro name="no_relative_group_left">
+                <reference_group>
+                    <add_atom name_pattern="lb_2"/>
+                </reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0">
+                    <add_atom name_pattern="no_such_atom"/>
+                </relative_group>
+            </relative_macro>
+            <relative_macro name="nothing_matched">
+                <reference_group>
+                    <add_atom name_pattern="no_such_atom"/>
+                </reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0">
+                    <add_atom name_pattern="no_such_atom_either"/>
+                </relative_group>
+            </relative_macro>
+        )");
+        const UserRelativeMacros& macros = constraints.relative_macros();
+        REQUIRE(macros.get_num_macros() == 1);
+        const t_user_relative_macro& macro = macros.get_macro(UserRelativeMacroId(0));
+        REQUIRE(macro.name == "keeps_one_group");
+        REQUIRE(macro.groups.size() == 2);
+        REQUIRE(macro.groups[1].offset == t_pl_offset(2, 0, 0, 0));
+        REQUIRE(macro.groups[1].atoms == std::vector<AtomBlockId>{lb_1});
+        // atoms of a dropped macro are left unconstrained
+        REQUIRE(!macros.get_atom_group(lb_2).first.is_valid());
+    }
+
+    SECTION("malformed macros are rejected with a specific error") {
+        // duplicate macro name
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_2"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_3"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("Relative macro name 'm' is used more than once"));
+
+        // cross-layer macros are not supported
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0" layer_offset="1"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("layer_offset must be 0"));
+
+        // a relative group on top of the reference group
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="0" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("a relative_group is at offset (0, 0, sub_tile 0), the reference group's location"));
+
+        // two relative groups at the same offset, reported by offset even though
+        // an empty group before them was dropped
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="no_such_atom"/></relative_group>
+                <relative_group x_offset="2" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+                <relative_group x_offset="2" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_2"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("two relative groups are at the same offset (2, 0, sub_tile 0)"));
+
+        // an atom in two groups of one macro
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="^lb_[0-1]$" is_regex="true"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("atom 'lb_0' appears in the reference group and in the relative_group at offset (1, 0, sub_tile 0)"));
+
+        // an atom in two macros
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m1">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+            <relative_macro name="m2">
+                <reference_group><add_atom name_pattern="lb_1"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_2"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("Atom 'lb_1' appears in relative macro 'm2' and in relative macro 'm1'"));
+
+        // a reference group that matches nothing while a relative group does
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="no_such_atom"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("The macro has no anchor"));
+
+        // an invalid regular expression
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_[" is_regex="true"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("invalid atom name_pattern regex 'lb_['"));
+
+        // a present but empty site_path
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0" site_path=""/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("reference group: the site_path of atom pattern 'lb_0' is '', which is empty or contains whitespace"));
+
+        // a site_path naming no primitive
+        REQUIRE_THROWS_WITH(load_relative_macro_constraints(R"(
+            <relative_macro name="m">
+                <reference_group><add_atom name_pattern="lb_0"/></reference_group>
+                <relative_group x_offset="1" y_offset="0" sub_tile_offset="0"><add_atom name_pattern="lb_1" site_path="no_such_type[0][default]/nope[0]"/></relative_group>
+            </relative_macro>
+        )"),
+                            ContainsSubstring("relative_group at offset (1, 0, sub_tile 0): the site_path 'no_such_type[0][default]/nope[0]' of atom pattern 'lb_1' does not name a primitive of any logical block type"));
+    }
+
+    // leave the global atom netlist as other tests expect to find it
+    g_vpr_ctx.mutable_atom().mutable_netlist() = AtomNetlist();
 }
 
 #if 0


### PR DESCRIPTION
Second of four PRs splitting #3717 (relatively placed macros) ; #3787 was the first.

Add a `<relative_macro_list>` section to the VPR constraints file, the `UserRelativeMacros` storage class, the uxsdcxx-based loader with its load-time validation, documentation and unit tests. A relative macro fixes groups of atoms relative to each other without pinning them to absolute locations: each group is packed into one cluster, and the clusters are placed at the given offsets from the reference group's cluster.

Packing and placement support follow in the next two PRs. Until they land, VPR stops with an error when a constraints file contains relative macros, so they are never silently ignored.

```xml
<vpr_constraints tool_name="vpr">
    <relative_macro_list>
        <relative_macro name="dsp_with_ctrl_logic">
            <reference_group>
                <add_atom name_pattern="mult_36.out_reg"/>
            </reference_group>
            <relative_group x_offset="1" y_offset="0" sub_tile_offset="0">
                <add_atom name_pattern="^ctrl_lut_[0-4]$" is_regex="true"/>
                <add_atom name_pattern="ctrl_lut_5" site_path="clb[0][default]/lab[0][default]/fle[3][n1_lut6]/ble6[0][default]/lut6[0]"/>
            </relative_group>
        </relative_macro>
    </relative_macro_list>
</vpr_constraints>
```

`site_path` optionally locks an atom to a primitive site inside its cluster, given as the hierarchical path that `--write_flat_place` prints with `--flat_place_verbosity 2`.

Testing: new `UserRelativeMacros` and `RelativeMacroConstraintsLoader` cases in `test_vpr`; the loader was also exercised with valid and malformed constraints files on `k6_frac_N10_frac_chain_mem32K_40nm`.
