### PR TITLE
[Clocks] Fixed RR Graph Caching

### DIFF
--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -1347,6 +1347,7 @@ void free_device(const t_det_routing_arch& /*routing_arch*/) {
     device_ctx.chan_width.x_list.clear();
     device_ctx.chan_width.y_list.clear();
     device_ctx.chan_width.max = device_ctx.chan_width.x_max = device_ctx.chan_width.y_max = device_ctx.chan_width.x_min = device_ctx.chan_width.y_min = 0;
+    device_ctx.requested_chan_width = t_chan_width();
 
     device_ctx.arch_switch_inf.clear();
 

--- a/vpr/src/base/vpr_context.h
+++ b/vpr/src/base/vpr_context.h
@@ -214,6 +214,14 @@ struct DeviceContext : public Context {
     ///@brief chan_width is for x|y-directed channels; i.e. between rows
     t_chan_width chan_width;
 
+    /**
+     * @brief The channel width that was requested the last time the RR graph was (re)built.
+     *
+     * May be different than chan_width above since some architectures add to the requested
+     * channel width (for example, dedicated clock networks).
+     */
+    t_chan_width requested_chan_width;
+
     /*
      * Structures to define the routing architecture of the FPGA.
      */

--- a/vpr/src/route/rr_graph_generation/rr_graph.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph.cpp
@@ -340,8 +340,9 @@ void create_rr_graph(e_graph_type graph_type,
     const char* echo_file_name = getEchoFileName(E_ECHO_RR_GRAPH_INDEXED_DATA);
     bool load_rr_graph = !det_routing_arch.read_rr_graph_filename.empty();
 
-    if (device_ctx.chan_width == nodes_per_chan && !device_ctx.rr_graph.empty()) {
-        // No change in channel width, so skip re-building RR graph
+    if (device_ctx.requested_chan_width == nodes_per_chan && !device_ctx.rr_graph.empty()) {
+        // The requested channel width is unchanged from the last build, so the existing RR
+        // graph is still valid and can be reused as-is.
         if (is_flat && !device_ctx.rr_graph_is_flat) {
             VTR_LOG("RR graph channel widths unchanged, intra-cluster resources should be added...\n");
         } else {
@@ -349,6 +350,8 @@ void create_rr_graph(e_graph_type graph_type,
             return;
         }
     } else {
+        mutable_device_ctx.requested_chan_width = nodes_per_chan;
+
         if (load_rr_graph) {
             if (device_ctx.loaded_rr_graph_filename != det_routing_arch.read_rr_graph_filename) {
                 free_rr_graph();


### PR DESCRIPTION
The RR graph is cached using the channel width as a key for if it needs to be regenerated or not. The issue is that it compares the requested channel width with the current channel width in the RR graph. Since clock networks change the channel width, this always invalidates the cache.

I separated out the requested channel width from the actual channel width. Now the cache checks if the requested channel width matches the cached RR graph instead.

Building the RR graph is usually the long-pole for my clock network experiments, so this easily speeds up my experiments by 3x.