### PR TITLE
[Clocks] Removed self-edges from generated RR graph

### DIFF
--- a/vpr/src/route/rr_graph_generation/clock_connection_builders.cpp
+++ b/vpr/src/route/rr_graph_generation/clock_connection_builders.cpp
@@ -170,12 +170,16 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
         // Connect to x-channel wires
         unsigned num_wires_x = x_wire_indices.size() * fc;
         for (size_t i = 0; i < num_wires_x; i++) {
+            // Prevent self-edges.
+            if (x_wire_indices[i] == RRNodeId(clock_index)) continue;
             clock_graph.add_edge(rr_edges_to_create, x_wire_indices[i], RRNodeId(clock_index), arch_switch_idx, false);
         }
 
         // Connect to y-channel wires
         unsigned num_wires_y = y_wire_indices.size() * fc;
         for (size_t i = 0; i < num_wires_y; i++) {
+            // Prevent self-edges.
+            if (y_wire_indices[i] == RRNodeId(clock_index)) continue;
             clock_graph.add_edge(rr_edges_to_create, y_wire_indices[i], RRNodeId(clock_index), arch_switch_idx, false);
         }
 

--- a/vpr/src/route/rr_graph_generation/rr_graph_clock.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_graph_clock.cpp
@@ -279,6 +279,11 @@ void ClockRRGraphBuilder::add_edge(t_rr_edge_info_set* rr_edges_to_create,
                                    RRNodeId sink_node,
                                    int arch_switch_idx,
                                    bool edge_remapped) const {
+    // This self-edge check was added since adding self-edges caused some routing
+    // algorithms to create an infinite loop. Self-edges should not occur naturally
+    // in an RR-graph, so added an assert here to prevent them from being created.
+    VTR_ASSERT_MSG(src_node != sink_node, "Should not add an edge from a node to itself.");
+
     VTR_ASSERT(edge_remapped == false);
     const auto& device_ctx = g_vpr_ctx.device();
     VTR_ASSERT(arch_switch_idx < (int)device_ctx.arch_switch_inf.size());


### PR DESCRIPTION
While working on the low-skew RCV algorithm, I found that there were self-edges in the dedicated clock network RR-graph. This means that there were nodes with edges that connected to themselves. These should not exist in a normal RR-graph.

I found the issue to be a mistake in how clock switch boxes were connected and resolved it. I also added an assert to prevent this mistake from happening again in the future.