### PR TITLE
[APPack] Improved detection of device size change

### DIFF
--- a/vpr/src/analytical_place/full_legalization/full_legalizer.cpp
+++ b/vpr/src/analytical_place/full_legalization/full_legalizer.cpp
@@ -998,6 +998,12 @@ void FlatRecon::legalize(const PartialPlacement& p_placement) {
     // Start a scoped timer for the Full Legalizer stage.
     vtr::ScopedStartFinishTimer full_legalizer_timer("AP Full Legalizer");
 
+    // Snapshot the device grid size before clustering runs below.
+    const DeviceGrid& pre_pack_grid = g_vpr_ctx.device().grid;
+    size_t prev_grid_width = pre_pack_grid.width();
+    size_t prev_grid_height = pre_pack_grid.height();
+    size_t prev_grid_num_layers = pre_pack_grid.get_num_layers();
+
     // The target external pin utilization is set to 1.0 to avoid over-restricting
     // reconstruction due to conservative pin feasibility. The SKIP_INTRA_LB_ROUTE
     // strategy speeds up reconstruction by skipping intra-LB routing checks.
@@ -1031,7 +1037,7 @@ void FlatRecon::legalize(const PartialPlacement& p_placement) {
                   num_clustering_errors);
     }
 
-    recreate_device_if_needed();
+    recreate_device_if_needed(prev_grid_width, prev_grid_height, prev_grid_num_layers);
 
     // Perform the initial placement on created clusters.
     place_clusters(p_placement);
@@ -1205,6 +1211,12 @@ void NaiveFullLegalizer::legalize(const PartialPlacement& p_placement) {
     // Create a scoped timer for the full legalizer
     vtr::ScopedStartFinishTimer full_legalizer_timer("AP Full Legalizer");
 
+    // Snapshot the device grid size before clustering runs below.
+    const DeviceGrid& pre_pack_grid = g_vpr_ctx.device().grid;
+    size_t prev_grid_width = pre_pack_grid.width();
+    size_t prev_grid_height = pre_pack_grid.height();
+    size_t prev_grid_num_layers = pre_pack_grid.get_num_layers();
+
     // Pack the atoms into clusters based on the partial placement.
     create_clusters(p_placement);
     // Verify that the clustering created by the full legalizer is valid.
@@ -1218,7 +1230,7 @@ void NaiveFullLegalizer::legalize(const PartialPlacement& p_placement) {
                   num_clustering_errors);
     }
 
-    recreate_device_if_needed();
+    recreate_device_if_needed(prev_grid_width, prev_grid_height, prev_grid_num_layers);
 
     // Get the clustering from the global context.
     // TODO: Eventually should be returned from the create_clusters method.
@@ -1256,6 +1268,12 @@ void NaiveFullLegalizer::legalize(const PartialPlacement& p_placement) {
 void APPack::legalize(const PartialPlacement& p_placement) {
     // Create a scoped timer for the full legalizer
     vtr::ScopedStartFinishTimer full_legalizer_timer("AP Full Legalizer");
+
+    // Snapshot the device grid size before clustering runs below.
+    const DeviceGrid& pre_pack_grid = g_vpr_ctx.device().grid;
+    size_t prev_grid_width = pre_pack_grid.width();
+    size_t prev_grid_height = pre_pack_grid.height();
+    size_t prev_grid_num_layers = pre_pack_grid.get_num_layers();
 
     // Convert the Partial Placement (APNetlist) to a flat placement (AtomNetlist).
     FlatPlacementInfo flat_placement_info(atom_netlist_);
@@ -1296,7 +1314,7 @@ void APPack::legalize(const PartialPlacement& p_placement) {
     // FIXME: This should be removed. Reading from a file is strange.
     vpr_load_packing(vpr_setup_, arch_);
 
-    recreate_device_if_needed();
+    recreate_device_if_needed(prev_grid_width, prev_grid_height, prev_grid_num_layers);
 
     // Setup NoCs
     // TODO: We have some flow divergence. When the device grid is created the
@@ -1365,7 +1383,7 @@ void FullLegalizer::update_drawing_data_structures() {
 #endif
 }
 
-void FullLegalizer::recreate_device_if_needed() {
+void FullLegalizer::recreate_device_if_needed(size_t prev_grid_width, size_t prev_grid_height, size_t prev_grid_num_layers) {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     // Capture before grid recreation: vpr_create_device_grid only writes
     // device_ctx.grid and does not touch the RR graph, so this flag remains
@@ -1392,28 +1410,22 @@ void FullLegalizer::recreate_device_if_needed() {
         return;
     }
 
-    size_t old_width = device_ctx.grid.width();
-    size_t old_height = device_ctx.grid.height();
-
     vpr_create_device_grid(vpr_setup_, arch_);
 
-    bool device_size_changed = (device_ctx.grid.width() != old_width
-                                || device_ctx.grid.height() != old_height);
+    // Detect if the device size has changed.
+    bool device_size_changed = (prev_grid_width != device_ctx.grid.width()
+                                || prev_grid_height != device_ctx.grid.height()
+                                || prev_grid_num_layers != device_ctx.grid.get_num_layers());
 
-    // If the device grid was resized, the dedicated clock network geometry
-    // (computed from grid width/height when it was first set up, earlier in
-    // run_analytical_placement_flow()) is now stale. Regenerate it before any
-    // RR graph is (re)built below, since the RR graph embeds the clock
-    // network as a subgraph. This is a no-op unless dedicated clock networks
-    // are in use.
     if (device_size_changed) {
+        // The dedicated clock network geometry is computed from the grid width/height,
+        // so it must be rebuilt to match the final device size before the RR graph
+        // (which embeds the clock network as a subgraph) is (re)built below.
         // TODO: Cleanup these const casts. See comment below.
         vpr_setup_clock_networks(const_cast<t_vpr_setup&>(vpr_setup_), arch_);
     }
 
     // Build or rebuild the RR graph if needed. It must exist before placement.
-    // Rebuild only when the device size changed (to avoid the high cost of
-    // rebuilding unnecessarily on large architectures).
     if (vpr_setup_.PlacerOpts.place_chan_width != NO_FIXED_CHANNEL_WIDTH) {
         if (!rr_graph_exists || device_size_changed) {
             // vpr_create_rr_graph takes t_vpr_setup& even though it only reads from it.

--- a/vpr/src/analytical_place/full_legalization/full_legalizer.h
+++ b/vpr/src/analytical_place/full_legalization/full_legalizer.h
@@ -74,8 +74,12 @@ class FullLegalizer {
      * The device grid estimated before packing may differ from the one needed
      * after final clustering. This method finalizes the device size and ensures
      * the RR graph matches it before placement begins.
+     *
+     * @param prev_grid_width   The device grid width before packing.
+     * @param prev_grid_height  The device grid height before packing.
+     * @param prev_grid_num_layers  The device grid's number of layers before packing.
      */
-    void recreate_device_if_needed();
+    void recreate_device_if_needed(size_t prev_grid_width, size_t prev_grid_height, size_t prev_grid_num_layers);
 
     /// @brief The AP Netlist to fully legalize the flat placement of.
     const APNetlist& ap_netlist_;


### PR DESCRIPTION
I found that when the auto-sizer resizes the device, it was not re-setting up the clock networks. This pointed me to a flaw in the detection logic for the device size changing. It was not accounting for the device size changing during packing.

Updated the logic to account for the device size changing during packing.