### PR TITLE
Fix RRSpatialLookup over-allocation

### DIFF
--- a/libs/librrgraph/src/base/rr_spatial_lookup.cpp
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.cpp
@@ -1,6 +1,7 @@
 #include "rr_graph_fwd.h"
 #include "vtr_assert.h"
 #include "rr_spatial_lookup.h"
+#include <array>
 #include <set>
 
 RRNodeId RRSpatialLookup::find_node(int layer,
@@ -235,7 +236,7 @@ void RRSpatialLookup::reserve_nodes(int layer,
         VTR_ASSERT(side == TOTAL_2D_SIDES[0]);
     }
 
-    resize_nodes(layer, x, y, type, side);
+    VTR_ASSERT(is_in_range(layer, x, y, type, side));
 
     rr_node_indices_[type][layer][x][y][side].reserve(num_nodes);
 }
@@ -255,14 +256,14 @@ void RRSpatialLookup::add_node(RRNodeId node,
         VTR_ASSERT(side == TOTAL_2D_SIDES[0]);
     }
 
-    resize_nodes(layer, x, y, type, side);
+    VTR_ASSERT(is_in_range(layer, x, y, type, side));
 
     if (size_t(ptc) >= rr_node_indices_[type][layer][x][y][side].size()) {
         /* Deposit invalid ids to newly allocated elements while original elements are untouched */
         rr_node_indices_[type][layer][x][y][side].resize(ptc + 1, RRNodeId::INVALID());
     }
 
-    /* Resize on demand finished; Register the node */
+    /* Register the node */
     rr_node_indices_[type][layer][x][y][side][ptc] = node;
 }
 
@@ -303,33 +304,52 @@ void RRSpatialLookup::mirror_nodes(const int layer,
                                    e_rr_type type,
                                    e_side side) {
     VTR_ASSERT(e_rr_type::SOURCE == type || e_rr_type::SINK == type);
-    resize_nodes(layer, des_coord.x(), des_coord.y(), type, side);
+    VTR_ASSERT(is_in_range(layer, des_coord.x(), des_coord.y(), type, side));
     rr_node_indices_[type][layer][des_coord.x()][des_coord.y()][side] = rr_node_indices_[type][layer][src_coord.x()][src_coord.y()][side];
 }
 
-void RRSpatialLookup::resize_nodes(int layer,
-                                   int x,
-                                   int y,
-                                   e_rr_type type,
-                                   e_side side) {
-    /* Expand the fast look-up if the new node is out-of-range
-     * This may seldom happen because the rr_graph building function
-     * should ensure the fast look-up well organized  
-     */
+void RRSpatialLookup::resize_nodes(size_t num_layers,
+                                   size_t width,
+                                   size_t height,
+                                   e_rr_type type) {
     VTR_ASSERT((size_t)type < rr_node_indices_.size());
-    VTR_ASSERT(x >= 0);
-    VTR_ASSERT(y >= 0);
-    VTR_ASSERT(layer >= 0);
 
-    if ((layer >= int(rr_node_indices_[type].dim_size(0)))
-        || (x >= int(rr_node_indices_[type].dim_size(1)))
-        || (y >= int(rr_node_indices_[type].dim_size(2)))
-        || (size_t(side) >= rr_node_indices_[type].dim_size(3))) {
-        rr_node_indices_[type].resize({std::max(rr_node_indices_[type].dim_size(0), size_t(layer)+1),
-                                       std::max(rr_node_indices_[type].dim_size(1), size_t(x) + 1),
-                                       std::max(rr_node_indices_[type].dim_size(2), size_t(y) + 1),
-                                       std::max(rr_node_indices_[type].dim_size(3), size_t(side) + 1)});
+    // Only IPIN and OPIN nodes are stored per side. Every other type uses side index 0 only,
+    // following the convention in add_node() and find_node().
+    size_t num_sides = 1;
+    if (type == e_rr_type::IPIN || type == e_rr_type::OPIN) {
+        num_sides = NUM_2D_SIDES;
     }
+
+    std::array<size_t, 4> dim_sizes = {num_layers, width, height, num_sides};
+
+    // NdMatrix::resize() discards the existing contents, so refuse to change the dimensions of a populated lookup
+    if (!rr_node_indices_[type].empty()) {
+        for (size_t dim = 0; dim < dim_sizes.size(); dim++) {
+            VTR_ASSERT_MSG(rr_node_indices_[type].dim_size(dim) == dim_sizes[dim],
+                           "Cannot resize a populated RRSpatialLookup");
+        }
+        return;
+    }
+
+    rr_node_indices_[type].resize(dim_sizes);
+}
+
+bool RRSpatialLookup::is_in_range(int layer,
+                                  int x,
+                                  int y,
+                                  e_rr_type type,
+                                  e_side side) const {
+    if (layer < 0 || x < 0 || y < 0) {
+        return false;
+    }
+    if (size_t(type) >= rr_node_indices_.size()) {
+        return false;
+    }
+    return size_t(layer) < rr_node_indices_[type].dim_size(0)
+           && size_t(x) < rr_node_indices_[type].dim_size(1)
+           && size_t(y) < rr_node_indices_[type].dim_size(2)
+           && size_t(side) < rr_node_indices_[type].dim_size(3);
 }
 
 void RRSpatialLookup::reorder(const vtr::vector<RRNodeId, RRNodeId>& dest_order) {

--- a/libs/librrgraph/src/base/rr_spatial_lookup.h
+++ b/libs/librrgraph/src/base/rr_spatial_lookup.h
@@ -171,6 +171,8 @@ class RRSpatialLookup {
      *
      * @note a node added with this call will not create a node in the rr_graph_storage node list
      * You MUST add the node in the rr_graph_storage so that the node is valid  
+     *
+     * @note The lookup must be sized with resize_nodes() before nodes are added. (layer, x, y, side) must be in range.
      */
     /*
      * TODO: Consider to try to return a reference to *this so that we can do chain calls
@@ -257,21 +259,15 @@ class RRSpatialLookup {
                       e_side side);
 
     /**
-     * @brief Resize the given 4 dimensions (layer, x, y, side) of the RRSpatialLookup data structure for the given type
+     * @brief Size the lookup of the given type to num_layers layers, a width x height grid and the sides that type uses
      *
-     * This function will keep any existing data
-     *
-     * @note Strongly recommend to use when the sizes of dimensions are deterministic
+     * IPIN and OPIN nodes are stored per side. All other types use a single side entry.
+     * Existing data is not preserved, so the lookup of the type must be empty or already have these dimensions.
      */
-    /*
-     * TODO: should have a reserve function but vtd::ndmatrix does not have such API
-     *       as a result, resize can be an internal one while reserve function is a public mutator
-     */
-    void resize_nodes(int layer,
-                      int x,
-                      int y,
-                      e_rr_type type,
-                      e_side side);
+    void resize_nodes(size_t num_layers,
+                      size_t width,
+                      size_t height,
+                      e_rr_type type);
 
     /** @brief Reorder the internal look up to be more memory efficient */
     void reorder(const vtr::vector<RRNodeId, RRNodeId>& dest_order);
@@ -291,6 +287,13 @@ class RRSpatialLookup {
                                      int y,
                                      e_rr_type type,
                                      e_side side = TOTAL_2D_SIDES[0]) const;
+
+    /* Returns true if (layer, x, y, side) is inside the allocated dimensions of the lookup for the given type */
+    bool is_in_range(int layer,
+                     int x,
+                     int y,
+                     e_rr_type type,
+                     e_side side) const;
 
     /* -- Internal data storage -- */
   private:

--- a/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
+++ b/libs/librrgraph/src/io/rr_graph_uxsdcxx_serializer.h
@@ -1858,7 +1858,7 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
         // Alloc the lookup table
         for (e_rr_type rr_type : RR_TYPES) {
-            rr_graph_builder.node_lookup().resize_nodes(grid_.get_num_layers(), grid_.width(), grid_.height(), rr_type, NUM_2D_SIDES);
+            rr_graph_builder.node_lookup().resize_nodes(grid_.get_num_layers(), grid_.width(), grid_.height(), rr_type);
         }
 
         // Add the correct node into the vector

--- a/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
+++ b/vpr/src/route/rr_graph_generation/rr_node_indices.cpp
@@ -314,7 +314,7 @@ void alloc_and_load_rr_node_indices(RRGraphBuilder& rr_graph_builder,
                                     const t_chan_details& chan_details_y) {
     // Alloc the lookup table
     for (e_rr_type rr_type : RR_TYPES) {
-        rr_graph_builder.node_lookup().resize_nodes(grid.get_num_layers(), grid.width(), grid.height(), rr_type, NUM_2D_SIDES);
+        rr_graph_builder.node_lookup().resize_nodes(grid.get_num_layers(), grid.width(), grid.height(), rr_type);
     }
 
     // Assign indices for block nodes

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_builder.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_builder.cpp
@@ -359,8 +359,7 @@ static void remove_dangling_chan_nodes(const DeviceGrid& grid,
         node_lookup.resize_nodes(grid.get_num_layers(),
                                  grid.width(),
                                  grid.height(),
-                                 rr_type,
-                                 NUM_2D_SIDES);
+                                 rr_type);
     }
 
     // Update other data structures related to lookup after removing dangling chan nodes

--- a/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_node_builder.cpp
+++ b/vpr/src/route/rr_graph_generation/tileable_rr_graph/tileable_rr_graph_node_builder.cpp
@@ -1263,11 +1263,9 @@ void create_tileable_rr_graph_nodes(const RRGraphView& rr_graph,
     // index of an rr_node.  rr_node_indices is a matrix containing the index
     // of the *first* rr_node at a given (i,j) location.
 
-    // Alloc the lookup table
-    // .. warning: It is mandatory. There are bugs in resize() when called incrementally in RRSpatialLookup.
-    //             When comment the following block out, you will see errors
+    // Alloc the lookup table. The lookup must be sized before any node is added to it.
     for (e_rr_type rr_type : RR_TYPES) {
-        rr_graph_builder.node_lookup().resize_nodes(layer, grids.width(), grids.height(), rr_type, NUM_2D_SIDES);
+        rr_graph_builder.node_lookup().resize_nodes(grids.get_num_layers(), grids.width(), grids.height(), rr_type);
     }
 
     load_grid_nodes_basic_info(rr_graph_builder,


### PR DESCRIPTION
RRSpatialLookup used to allocate multiple side entries for all nodes types. This PR changes this behavior by avoiding over-allocation for node types other than IPIN/OPIN.